### PR TITLE
mmc: block: Remove call to mmc_blk_set_blksize

### DIFF
--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -2608,7 +2608,6 @@ static int mmc_blk_issue_rq(struct mmc_queue *mq, struct request *req)
 #ifdef CONFIG_MMC_BLOCK_DEFERRED_RESUME
 	if (mmc_bus_needs_resume(card->host)) {
 		mmc_resume_bus(card->host);
-		mmc_blk_set_blksize(md, card);
 	}
 #endif
 


### PR DESCRIPTION
It no longer exists.

Fixes togari build
