### PR TITLE
spmi: use more appropriate name for spmi devices

### DIFF
--- a/drivers/spmi/spmi.c
+++ b/drivers/spmi/spmi.c
@@ -252,7 +252,10 @@ int spmi_add_device(struct spmi_device *spmidev)
 	}
 
 	/* Set the device name */
-	dev_set_name(dev, "%s-%p", spmidev->name, spmidev);
+	if (spmidev->res.resource)
+		dev_set_name(dev, "%02x-%s-%04x", spmidev->sid, spmidev->dev.of_node->name, spmidev->res.resource[0].start);
+	else
+		dev_set_name(dev, "%02x-%s", spmidev->sid, spmidev->dev.of_node->name);
 
 	/* Device may be bound to an active driver when this returns */
 	rc = device_add(dev);


### PR DESCRIPTION
Using a pointer for the name makes devices near impossible to access
from sysfs reliably without an alias. Change this to either use the
unique of_node name or the of_node name and the device's address.

Signed-off-by: Bjorn Andersson bjorn.andersson@sonymobile.com
