### PR TITLE
ARM: dt: rhine: Move PIL HEAP to avoid conflict with ADSP image

### DIFF
--- a/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
@@ -639,6 +639,11 @@
 			qcom,memory-reservation-size = <0x6400000>;
 			qcom,ion-heap-type = "CARVEOUT";
 		};
+
+		/* Move PIL HEAP to avoid conflict with ADSP image */
+		qcom,ion-heap@23 { /* OTHER PIL HEAP */
+			qcom,memory-fixed = <0x08900000 0x1e00000>;
+		};
 	};
 
 	sound {
@@ -675,6 +680,11 @@
 	qcom,msm-thermal {
 		qcom,pmic-sw-mode-regs = "vdd_dig";
 	};
+};
+
+/* Increase memory hole since PIL HEAP moved */
+&memory_hole {
+	qcom,memblock-remove = <0x08900000 0x7600000>; /* Address and size of the hole */
 };
 
 &mdss_hdmi_tx {

--- a/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
@@ -679,6 +679,11 @@
 			qcom,memory-reservation-size = <0x6400000>;
 			qcom,ion-heap-type = "CARVEOUT";
 		};
+
+		/* Move PIL HEAP to avoid conflict with ADSP image */
+		qcom,ion-heap@23 { /* OTHER PIL HEAP */
+			qcom,memory-fixed = <0x08900000 0x1e00000>;
+		};
 	};
 
 	sound {
@@ -715,6 +720,11 @@
 	qcom,msm-thermal {
 		qcom,pmic-sw-mode-regs = "vdd_dig";
 	};
+};
+
+/* Increase memory hole since PIL HEAP moved */
+&memory_hole {
+	qcom,memblock-remove = <0x08900000 0x7600000>; /* Address and size of the hole */
 };
 
 &mdss_hdmi_tx {

--- a/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
@@ -610,6 +610,11 @@
 			qcom,memory-reservation-size = <0x6400000>;
 			qcom,ion-heap-type = "CARVEOUT";
 		};
+
+		/* Move PIL HEAP to avoid conflict with ADSP image */
+		qcom,ion-heap@23 { /* OTHER PIL HEAP */
+			qcom,memory-fixed = <0x08900000 0x1e00000>;
+		};
 	};
 
 	sound {
@@ -646,6 +651,11 @@
 	qcom,msm-thermal {
 		qcom,pmic-sw-mode-regs = "vdd_dig";
 	};
+};
+
+/* Increase memory hole since PIL HEAP moved */
+&memory_hole {
+	qcom,memblock-remove = <0x08900000 0x7600000>; /* Address and size of the hole */
 };
 
 &mdss_hdmi_tx {


### PR DESCRIPTION
Fixes:
<3>[   10.357588] pil-q6v5-lpass fe200000.qcom,lpass: adsp: kernel memory would be overwritten [0xdc00000,0xe0e3870)
