### PR TITLE
ARM: dt: rhine: Indicate the audio jack type

### DIFF
--- a/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
@@ -676,6 +676,7 @@
 			"MIC BIAS1 External", "Secondary Mic",
 			"AMIC6", "MIC BIAS4 External",
 			"MIC BIAS4 External", "Handset FB ANC Mic";
+		qcom,mbhc-audio-jack-type = "4-pole-jack";
 	};
 
 	gpio_hw_ids {

--- a/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
@@ -676,6 +676,7 @@
 			"MIC BIAS1 External", "Secondary Mic",
 			"AMIC6", "MIC BIAS4 External",
 			"MIC BIAS4 External", "Handset FB ANC Mic";
+		qcom,mbhc-audio-jack-type = "4-pole-jack";
 	};
 
 	gpio_hw_ids {

--- a/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
@@ -636,6 +636,7 @@
 			"MIC BIAS1 External", "Secondary Mic",
 			"AMIC6", "MIC BIAS4 External",
 			"MIC BIAS4 External", "Handset FB ANC Mic";
+		qcom,mbhc-audio-jack-type = "4-pole-jack";
 	};
 
 	gpio_hw_ids {

--- a/arch/arm/boot/dts/msm8974.dtsi
+++ b/arch/arm/boot/dts/msm8974.dtsi
@@ -835,7 +835,6 @@
 		qcom,sec-auxpcm-gpio-sync = <&msmgpio 80 0>;
 		qcom,sec-auxpcm-gpio-din  = <&msmgpio 81 0>;
 		qcom,sec-auxpcm-gpio-dout = <&msmgpio 82 0>;
-		qcom,5-pole-jack;
 	};
 
 	spmi_bus: qcom,spmi@fc4c0000 {


### PR DESCRIPTION
Also remove "qcom,5-pole-jack" as that isn't used by our current driver.
