### PR TITLE
ARM: dt: togari: disable max1187x resume_por

### DIFF
--- a/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
@@ -70,7 +70,7 @@
 			gpio_tirq = <61>;
 			gpio_reset = <85>;
 			reset_l2h = <0>;
-			enable_resume_por = <1>;
+			enable_resume_por = <0>;
 			defaults_allow = <0>;
 			default_config_id = <0>;
 			default_chip_id = <0>;


### PR DESCRIPTION
- Leaving it enabled resets power on resume,
  after which it cannot recover.
- Disable it so that only the settings are re-inited,
  which matches the behaviour of the stock driver.
