### PR TITLE
silence compilation warnings on use of void + return

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -1139,7 +1139,7 @@ static int __devexit mdss_dsi_ctrl_remove(struct platform_device *pdev)
 }
 
 
-void mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable)
+int mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable)
 {
 #ifdef CONFIG_MACH_SONY_RHINE
 	int ret;

--- a/drivers/video/msm/mdss/mdss_dsi.h
+++ b/drivers/video/msm/mdss/mdss_dsi.h
@@ -396,7 +396,7 @@ struct mdss_dsi_ctrl_pdata {
 
 int dsi_panel_device_register(struct device_node *pan_node,
 				struct mdss_dsi_ctrl_pdata *ctrl_pdata);
-void mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable);
+int mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable);
 
 int mdss_dsi_cmds_tx(struct mdss_dsi_ctrl_pdata *ctrl,
 		struct dsi_cmd_desc *cmds, int cnt);


### PR DESCRIPTION
it is enabled by default.

offcourse there could be an explicit reason to use void and return, then please explain me
