### PR TITLE
Yukon clocks cleanup and mdss logic fix

### DIFF
--- a/arch/arm/boot/dts/msm8926-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_eagle-720p-mtp.dts
@@ -18,7 +18,7 @@
 
 / {
 	model = "Qualcomm MSM 8926 MTP";
-	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp";
+	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,eagle";
 	qcom,board-id = <8 0>;
 
 	qcom,msm-id = <200 0>,

--- a/arch/arm/boot/dts/msm8926-yukon_flamingo-8926ss_ap.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_flamingo-8926ss_ap.dts
@@ -18,7 +18,7 @@
 
 / {
 	model = "Qualcomm MSM 8926 MTP (Arima 8926SS AP)";
-	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp";
+	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,flamingo";
 	qcom,board-id = <8 0>;
 	qcom,msm-id = <200 0>,
 		      <224 0>,

--- a/arch/arm/boot/dts/msm8926-yukon_seagull-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_seagull-720p-mtp.dts
@@ -19,7 +19,7 @@
 
 / {
 	model = "Qualcomm MSM 8926 MTP";
-	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp";
+	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,seagull";
 	qcom,board-id = <8 0>;
 
 	qcom,msm-id = <200 0>,

--- a/arch/arm/mach-msm/board-8226.c
+++ b/arch/arm/mach-msm/board-8226.c
@@ -58,6 +58,7 @@
 #include "pm.h"
 #include "modem_notifier.h"
 #include "spm-regulator.h"
+#include "sony_board.h"
 
 static struct memtype_reserve msm8226_reserve_table[] __initdata = {
 	[MEMTYPE_SMI] = {
@@ -118,6 +119,23 @@ static void __init msm8226_reserve(void)
 	msm_reserve();
 }
 
+void __init msm8226_clocks_config(void)
+{
+	if (of_board_is_rumi()) {
+		msm_clock_init(&msm8226_rumi_clock_init_data);
+		return;
+	};
+
+	msm_clock_init(&msm8226_clock_init_data);
+
+	if (of_machine_is_compatible("somc,eagle"))
+		msm_clock_init(&msm8226_eagle_clock_init_data);
+	else if (of_machine_is_compatible("somc,flamingo"))
+		msm_clock_init(&msm8226_flamingo_clock_init_data);
+	else if (of_machine_is_compatible("somc,seagull"))
+		msm_clock_init(&msm8226_seagull_clock_init_data);
+}
+
 /*
  * Used to satisfy dependencies for devices that need to be
  * run early or in a particular order. Most likely your device doesn't fall
@@ -135,10 +153,7 @@ void __init msm8226_add_drivers(void)
 	rpm_regulator_smd_driver_init();
 	qpnp_regulator_init();
 	spm_regulator_init();
-	if (of_board_is_rumi())
-		msm_clock_init(&msm8226_rumi_clock_init_data);
-	else
-		msm_clock_init(&msm8226_clock_init_data);
+	msm8226_clocks_config();
 	msm_bus_fabric_init_driver();
 	qup_i2c_init_driver();
 	ncp6335d_regulator_init();

--- a/arch/arm/mach-msm/clock-8226.c
+++ b/arch/arm/mach-msm/clock-8226.c
@@ -3416,43 +3416,7 @@ static struct clk_lookup msm_clocks_8226[] = {
 	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "0.qcom,camera"),
 	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "1.qcom,camera"),
 
-#if defined (CONFIG_MACH_SONY_EAGLE)
-	CLK_LOOKUP("core_clk", gcc_blsp1_qup3_i2c_apps_clk.c, ""),
-
-	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9926000.i2c"),
-	CLK_LOOKUP("core_clk", gcc_blsp1_qup4_i2c_apps_clk.c, "f9926000.i2c"),
-
-	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9924000.i2c"),/* sensor */
-	CLK_LOOKUP("core_clk", gcc_blsp1_qup2_i2c_apps_clk.c, "f9924000.i2c"),/* sensor */
-
-	CLK_LOOKUP("cam_src_clk", mclk1_clk_src.c, "42.qcom,camera"), /* gc0339 */
-	CLK_LOOKUP("cam_clk", camss_mclk1_clk.c, "42.qcom,camera"), /* gc0339 */
-
-	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6d.qcom,camera"),
-	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "6d.qcom,camera"),
-
-	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "a1.qcom,eeprom"), /* EEPROM*/
-	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "a1.qcom,eeprom"), /* EEPROM*/
-#elif defined (CONFIG_MACH_SONY_FLAMINGO)
-	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9926000.i2c"),
-	CLK_LOOKUP("core_clk", gcc_blsp1_qup4_i2c_apps_clk.c, "f9926000.i2c"),
-
-        CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "20.qcom,eeprom"),
-        CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "20.qcom,eeprom"),
-
-	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6d.qcom,camera"),
-	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "6d.qcom,camera"),
-
-#elif defined (CONFIG_MACH_SONY_SEAGULL)
-	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9924000.i2c"),
-	CLK_LOOKUP("core_clk", gcc_blsp1_qup2_i2c_apps_clk.c, "f9924000.i2c"),
-
-	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "34.qcom,camera"),
-	CLK_LOOKUP("cam_src_clk", mclk1_clk_src.c, "6e.qcom,camera"),
-
-	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "34.qcom,camera"),
-	CLK_LOOKUP("cam_clk", camss_mclk1_clk.c, "6e.qcom,camera"),
-#else
+#if !defined(CONFIG_MACH_SONY_YUKON) && !defined(CONFIG_MACH_SONY_TIANCHI)
 	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9926000.i2c"),
 	CLK_LOOKUP("core_clk", gcc_blsp1_qup4_i2c_apps_clk.c, "f9926000.i2c"),
 
@@ -3463,6 +3427,7 @@ static struct clk_lookup msm_clocks_8226[] = {
 	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6c.qcom,eeprom"),
 	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "6c.qcom,eeprom"),
 #endif
+
 	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "18.qcom,eeprom"),
 	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "18.qcom,eeprom"),
 	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6b.qcom,eeprom"),
@@ -3684,6 +3649,62 @@ static struct clk_lookup msm_clocks_8226_rumi[] = {
 struct clock_init_data msm8226_rumi_clock_init_data __initdata = {
 	.table = msm_clocks_8226_rumi,
 	.size = ARRAY_SIZE(msm_clocks_8226_rumi),
+};
+
+static struct clk_lookup msm_clocks_8226_eagle[] = {
+	CLK_LOOKUP("core_clk", gcc_blsp1_qup3_i2c_apps_clk.c, ""),
+
+	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9926000.i2c"),
+	CLK_LOOKUP("core_clk", gcc_blsp1_qup4_i2c_apps_clk.c, "f9926000.i2c"),
+
+	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9924000.i2c"),/* sensor */
+	CLK_LOOKUP("core_clk", gcc_blsp1_qup2_i2c_apps_clk.c, "f9924000.i2c"),/* sensor */
+
+	CLK_LOOKUP("cam_src_clk", mclk1_clk_src.c, "42.qcom,camera"), /* gc0339 */
+	CLK_LOOKUP("cam_clk", camss_mclk1_clk.c, "42.qcom,camera"), /* gc0339 */
+
+	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6d.qcom,camera"),
+	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "6d.qcom,camera"),
+
+	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "a1.qcom,eeprom"), /* EEPROM*/
+	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "a1.qcom,eeprom"), /* EEPROM*/
+};
+
+static struct clk_lookup msm_clocks_8226_flamingo[] = {
+	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9926000.i2c"),
+	CLK_LOOKUP("core_clk", gcc_blsp1_qup4_i2c_apps_clk.c, "f9926000.i2c"),
+
+	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "20.qcom,eeprom"),
+	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "20.qcom,eeprom"),
+
+	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "6d.qcom,camera"),
+	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "6d.qcom,camera"),
+};
+
+static struct clk_lookup msm_clocks_8226_seagull[] = {
+	CLK_LOOKUP("iface_clk", gcc_blsp1_ahb_clk.c, "f9924000.i2c"),
+	CLK_LOOKUP("core_clk", gcc_blsp1_qup2_i2c_apps_clk.c, "f9924000.i2c"),
+
+	CLK_LOOKUP("cam_src_clk", mclk0_clk_src.c, "34.qcom,camera"),
+	CLK_LOOKUP("cam_src_clk", mclk1_clk_src.c, "6e.qcom,camera"),
+
+	CLK_LOOKUP("cam_clk", camss_mclk0_clk.c, "34.qcom,camera"),
+	CLK_LOOKUP("cam_clk", camss_mclk1_clk.c, "6e.qcom,camera"),
+};
+
+struct clock_init_data msm8226_eagle_clock_init_data __initdata = {
+	.table = msm_clocks_8226_eagle,
+	.size = ARRAY_SIZE(msm_clocks_8226_eagle),
+};
+
+struct clock_init_data msm8226_flamingo_clock_init_data __initdata = {
+	.table = msm_clocks_8226_flamingo,
+	.size = ARRAY_SIZE(msm_clocks_8226_flamingo),
+};
+
+struct clock_init_data msm8226_seagull_clock_init_data __initdata = {
+	.table = msm_clocks_8226_seagull,
+	.size = ARRAY_SIZE(msm_clocks_8226_seagull),
 };
 
 static void __init reg_init(void)

--- a/arch/arm/mach-msm/sony_board.h
+++ b/arch/arm/mach-msm/sony_board.h
@@ -1,0 +1,20 @@
+/* arch/arm/mach-msm/sony_board.h
+ *
+ * Copyright (C) 2014 Sony Mobile Communications AB.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __SONY_BOARD_H
+#define __SONY_BOARD_H
+
+#include <linux/kernel.h>
+
+extern struct clock_init_data msm8226_eagle_clock_init_data __initdata;
+extern struct clock_init_data msm8226_flamingo_clock_init_data __initdata;
+extern struct clock_init_data msm8226_seagull_clock_init_data __initdata;
+
+#endif

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -814,13 +814,13 @@ static int mdss_dsi_event_handler(struct mdss_panel_data *pdata,
 		break;
 	case MDSS_EVENT_PANEL_ON:
 		ctrl_pdata->ctrl_state |= CTRL_STATE_MDP_ACTIVE;
-		if (ctrl_pdata->on_cmds.link_state == DSI_HS_MODE)
-			rc = mdss_dsi_unblank(pdata);
 #if (defined(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL) && defined(CONFIG_MACH_SONY_YUKON))
 		if (ctrl_pdata->spec_pdata->disp_on_in_hs
 			&& ctrl_pdata->spec_pdata->disp_on)
 			rc = ctrl_pdata->spec_pdata->disp_on(pdata);
 #endif
+		if (ctrl_pdata->on_cmds.link_state == DSI_HS_MODE)
+			rc = mdss_dsi_unblank(pdata);
 		break;
 	case MDSS_EVENT_BLANK:
 		if (ctrl_pdata->off_cmds.link_state == DSI_HS_MODE)


### PR DESCRIPTION
The clocks cleanup eventually permits to compile one kernel for all, obviously including only the right DT in the boot image. That may be "funny" for Android build purposes, where we will be able to delete all the prebuild kernels from the device-specific trees.
This way we'll be able to distribute the zImage into the common yukon folder and only the DTB into the device-specific folder... oh, and we won't get overhead on the device itself, too. People won't download the same kernel (apart some bits) 4 times this way.
An eventual (not going to happen, I know) bootloader update could use different board-ids for the four Yukon devices to make us able to use the very same boot.img for all.

Apart this, I was examining the Flamingo badness a lil bit again, also because effeectively Seagull isn't suffering from this and, if it was eMMC, then... you know. Still not sure, but, well.
Was saying, logically, if the panel isn't on it can't receive the needed commands to display the actual "image", so, it's mentally insane to send the display ON command AFTER unblanking the display. Corrected this, but I still don't really know if this fixes what we want. Just logic.
