### PR TITLE
msm: Add somc,panel-pwron-reset property to DT and use it.

### DIFF
--- a/arch/arm/boot/dts/dsi-panel-tianchi.dtsi
+++ b/arch/arm/boot/dts/dsi-panel-tianchi.dtsi
@@ -98,6 +98,7 @@
 		somc,panel-detect = <1>;
 		somc,mdss-dsi-cabc-enabled = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <20>;
+		somc,panel-pwron-reset;
 	};
 
 	dsi_novatek_jdi: somc,novatek_jdi_panel {
@@ -203,6 +204,7 @@
 		somc,panel-detect = <1>;
 		somc,mdss-dsi-cabc-enabled = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <20>;
+		somc,panel-pwron-reset;
 	};
 
 	novatek_720p_video_tianma: somc,novatek_tianma_panel {
@@ -292,6 +294,7 @@
 		somc,panel-detect = <1>;
 		somc,mdss-dsi-cabc-enabled = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <20>;
+		somc,panel-pwron-reset;
 	};
 	renesas_720p_video_lgd: somc,renesas_LG_panel {
 		qcom,mdss-dsi-panel-name = "R63313 LG 720p video mode panel";
@@ -384,5 +387,6 @@
 		somc,panel-detect = <1>;
 		somc,mdss-dsi-cabc-enabled = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <20>;
+		somc,panel-pwron-reset;
 	};
 };

--- a/arch/arm/boot/dts/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/msm8226-yukon_flamingo-mtp.dtsi
@@ -324,11 +324,13 @@
 &dsi_truly_hx8379c_fwvga_vid {
 	somc,first-boot-aware;
 	somc,panel-id-read-cmds;
+	somc,panel-pwron-reset;
 	qcom,cont-splash-enabled;
 };
 
 &dsi_ofilm_hx8379c_fwvga_vid {
 	somc,first-boot-aware;
 	somc,panel-id-read-cmds;
+	somc,panel-pwron-reset;
 	qcom,cont-splash-enabled;
 };

--- a/drivers/video/msm/mdss/mdss_dsi.h
+++ b/drivers/video/msm/mdss/mdss_dsi.h
@@ -265,9 +265,9 @@ struct mdss_panel_specific_pdata {
 	int cabc_enabled;
 	int cabc_active;
 	int lcm_bl_gpio;
-	int mipi_rst;
 	int disp_p5;
 	int disp_n5;
+	bool pwron_reset;
 	bool dsi_seq_hack;
 
 	struct dsi_panel_cmds cabc_early_on_cmds;

--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -1354,6 +1354,9 @@ static int mdss_dsi_panel_power_on_ex(struct mdss_panel_data *pdata, int enable)
 
 			gpio_set_value(vsn_gpio, 1);
 			gpio_set_value(vsp_gpio, 1);
+		}
+
+		if (spec_pdata->pwron_reset) {
 			ret = mdss_dsi_panel_reset_seq(pdata, 1);
 			if (ret)
 				pr_err("%s: Failed to enable gpio.\n",
@@ -2743,13 +2746,8 @@ static int mdss_panel_parse_dt(struct device_node *np,
 			"somc,chenge-fps-payload-num", &tmp);
 		pinfo->lcdc.chenge_fps_payload_num = !rc ? tmp : 0;
 
-		rc = of_get_named_gpio(next,
-				"somc,mipi-rst-gpio", 0);
-		if (gpio_is_valid(rc))
-			spec_pdata->mipi_rst = rc;
-		else
-			pr_warn("%s:%d Unable to get valid GPIO for MIPI RST\n",
-								__func__, __LINE__);
+		spec_pdata->pwron_reset = of_property_read_bool(next,
+					"somc,panel-pwron-reset");
 
 		spec_pdata->dsi_seq_hack = of_property_read_bool(next,
 						"somc,dsi-restart-hack");


### PR DESCRIPTION
Flamingo had a random problem in the display resume path where
sometimes it wasn't being resumed correctly.
Fix it by forcing panel reset when powering it on.

Also, cleanup the code required for Tianchi and use the same
property there too, as it also needs the reset (previously
implemented).
