### PR TITLE
eagle: fix the dancing menu's

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_pipe.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pipe.c
@@ -930,9 +930,14 @@ static int mdss_mdp_image_setup(struct mdss_mdp_pipe *pipe,
 	if (mdss_dsi_panel_flip_ud()) {
 		if (pipe->mfd && pipe->mfd->panel_info &&
 			pipe->mfd->panel_info->pdest == DISPLAY_1)
+#ifndef CONFIG_MACH_SONY_EAGLE
 			dst_xy = ((pipe->mixer->height -
 				   (pipe->dst.y + pipe->dst.h)) << 16) |
 				pipe->dst.x;
+#else
+			dst_xy = (((960- dst.y - dst.h) << 16) |
+			(540- dst.x - dst.w));
+#endif
 		else
 			dst_xy = (pipe->dst.y << 16) | pipe->dst.x;
 	} else


### PR DESCRIPTION
- M2 users should not have to chase menu's
- rotation is much smoother now
- @kholk @jerpelea can adapt this to the unified kernel

Change-Id: I9ba1a09af764580d292cbd761fda4b5d13df2d96
Signed-off-by: erikcas erikcas1972@gmail.com
