### PR TITLE
cam-sensor: allow compilation of imx135

### DIFF
--- a/drivers/media/platform/msm/camera_v2/Kconfig
+++ b/drivers/media/platform/msm/camera_v2/Kconfig
@@ -110,6 +110,15 @@ config IMX134
 		HFR @60fps and @120fps
 		Video HDR support.
 
+config IMX135
+	bool "Sensor IMX135 (BAYER 12M)"
+	depends on MSMB_CAMERA
+	---help---
+		Sony 12 MP Bayer Sensor with auto focus, uses
+		4 mipi lanes, preview config = 2104 x 1560 at 49 fps,
+		snapshot config = 4208 x 3120 at 24 fps,
+		Video HDR support.
+
 config IMX188
 	bool "Sensor imx188 (Sony 1.07MP)"
 	depends on MSMB_CAMERA

--- a/drivers/media/platform/msm/camera_v2/sensor/Makefile
+++ b/drivers/media/platform/msm/camera_v2/sensor/Makefile
@@ -6,6 +6,7 @@ ccflags-y += -Idrivers/media/platform/msm/camera_v2/sensor/cci
 obj-$(CONFIG_MSMB_CAMERA) += cci/ io/ csiphy/ csid/ actuator/ flash/ eeprom/
 obj-$(CONFIG_MSM_CAMERA_SENSOR) += msm_sensor_init.o msm_sensor_driver.o msm_sensor.o
 obj-$(CONFIG_IMX134) += imx134.o
+obj-$(CONFIG_IMX135) += imx135.o
 obj-$(CONFIG_IMX188) += imx188.o
 obj-$(CONFIG_OV8825) += ov8825.o
 obj-$(CONFIG_OV8865) += ov8865.o


### PR DESCRIPTION
The makefile and Kconfig had no entry of the IMX135 sensor, the sensor won't get compiled without it for those who enable it.
