### PR TITLE
[3.10] Rhine DT cleanup, qcrypto warning solved, compile warning fix

### DIFF
--- a/arch/arm/boot/dts/qcom/apq8084.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8084.dtsi
@@ -659,7 +659,7 @@
        qcom,qcedev@fd440000 {
 		compatible = "qcom,qcedev";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x1b000>;
+		      <0xfd444000 0x8000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 		qcom,bam-pipe-pair = <1>;
@@ -673,10 +673,10 @@
 				<56 512 3936000 393600>;
 	};
 
-        qcom,qcrypto@fd440000 {
+        qcom,qcrypto@fd444000 {
 		compatible = "qcom,qcrypto";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x1b000>;
+		      <0xfd444000 0x8000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 		qcom,bam-pipe-pair = <2>;

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_amami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_amami_row.dtsi
@@ -666,8 +666,7 @@
 			compatible = "qcom,msm-ion-reserve";
 			reg = <20>;
 			qcom,heap-align = <0x1000>;
-			qcom,memory-reservation-type = "EBI1"; /* reserve EBI memory */
-			qcom,memory-reservation-size = <0x6400000>;
+			linux,contiguous-region = <&camera_mem>;
 			qcom,ion-heap-type = "CARVEOUT";
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_amami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_amami_row.dtsi
@@ -14,63 +14,13 @@
  * GNU General Public License for more details.
  */
 
-/include/ "dsi-panel-amami.dtsi"
+#include "dsi-panel-amami.dtsi"
+#include "msm8974-rhine_common.dtsi"
 
 &soc {
-	ramoops {
-		compatible = "ramoops";
-		status = "ok";
-
-		android,ramoops-buffer-start = <0x7fe00000>;
-		android,ramoops-buffer-size = <0x100000>;
-		android,ramoops-console-size = <0x80000>;
-		android,ramoops-record-size = <0x7F800>;
-		android,ramoops-annotate-size = <0x800>;
-		android,ramoops-dump-oops = <0x1>;
-		android,ramoops-hole {
-			 compatible = "qcom,msm-contig-mem";
-			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
-		};
-	};
-
-	qcom,hdmi_tx@fd922100 {
-		status = "ok";
-	};
-
-	/* BLSP2 */
-	serial@f991e000 {
-		status = "ok";
-	};
-
-	/* BLSP7 */
-	uart7: uart@f995d000 {
-		status = "disabled";
-	};
-
 	/* BLSP2 */
 	i2c_2: i2c@f9924000 {
-		cell-index = <0>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9924000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 96 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,scl-gpio = <&msmgpio 7 0x00>;
-		qcom,sda-gpio = <&msmgpio 6 0x00>;
-		qcom,master-id = <86>;
-		status = "ok";
 		synaptics_clearpad@2c {
-			compatible = "synaptics,clearpad";
-			reg = <0x2c>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <61 0x2>;
-			touch_vdd-supply = <&pm8941_l22>;
-			touch_vio-supply = <&pm8941_s3>;
-			synaptics,irq_gpio = <&msmgpio 61 0x00>;
 			chip_id = <0x35>;
 			num_sensor_rx = <20>;
 			num_sensor_tx = <10>;
@@ -83,102 +33,10 @@
 			touch_orientation_enabled = <0>;
 			preset_x_max = <719>;
 			preset_y_max = <1279>;
-			preset_n_fingers = <10>;
 			preset_n_bytes_per_object = <5>;
 			por_delay_after = <200>;
 			wakeup_gesture_supported = <0>;
 			wakeup_gesture_timeout = <0>;
-		};
-
-		atmel_mxt_ts@4a {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP4 */
-	i2c@f9926000 {
-		cell-index = <1>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9926000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 98 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-	};
-
-	/* BLSP6 */
-	i2c@f9928000 {
-		cell-index = <2>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9928000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 100 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-		nfc@28 {
-			compatible = "nxp,pn544";
-			reg = <0x28>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <59 0x0>;
-			nxp,pvdd_en = <&msmgpio 76 0x00>;
-			nxp,irq_gpio = <&msmgpio 59 0x00>;
-			nxp,dwld_en = <&msmgpio 77 0x00>;
-			nxp,ven = <&pm8941_gpios 23 0x01>;
-			gpio_fwdl_enable = <0 0 0 2>;
-			gpio_fwdl_disable = <0 0 1 0>;
-		};
-	};
-
-	/* BLSP11 */
-	i2c_0: i2c@f9967000 {
-		cell-index = <4>;
-		qcom,i2c-bus-freq = <355000>;
-		status = "ok";
-		sii8334@72 {
-			compatible = "qcom,mhl-sii8334";
-			reg = <0x72>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <64 0x2008>;
-			mhl-intr-gpio = <&msmgpio 64 0>;
-			mhl-pwr-gpio = <&msmgpio 60 0>;
-			mhl-rst-gpio = <&msmgpio 16 0>;
-			avcc_18-supply = <&pm8941_l24>;
-			avcc_12-supply = <&pm8941_l2>;
-			smps3a-supply = <&pm8941_s3>;
-			vdda-supply = <&pm8941_l12>;
-			qcom,hdmi-tx-map = <&mdss_hdmi_tx>;
-		};
-
-		isa1200@48 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP1 */
-	spi_0: spi@f9923000 {
-		status = "disabled";
-
-		ethernet-switch@2 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP10 */
-	spi_7: spi_epm: spi@f9966000 {
-		status = "disabled";
-
-		epm-adc@0 {
-			status = "disabled";
 		};
 	};
 
@@ -187,15 +45,6 @@
 		input-name = "gpio-keys";
 		interrupt-parent = <&msmgpio>;
 		interrupts = <9 0>;
-
-		vol_dn {
-			label = "volume_down";
-			gpios = <&pm8941_gpios 2 0x1>;
-			linux,input-type = <1>;
-			linux,code = <114>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
 
 		camera_snapshot {
 			label = "camera_snapshot";
@@ -213,24 +62,6 @@
 			linux,code = <0x210>;
 			gpio-key,wakeup;
 			debounce-interval = <15>;
-		};
-
-		vol_up {
-			label = "volume_up";
-			gpios = <&pm8941_gpios 5 0x1>;
-			linux,input-type = <1>;
-			linux,code = <115>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
-
-		sim_det {
-			label = "sim-detection";
-			gpios = <&msmgpio 9 0x0>;
-			linux,input-type = <5>;
-			linux,code = <7>;
-			gpio-key,wakeup;
-			debounce-interval = <10>;
 		};
 	};
 
@@ -658,122 +489,24 @@
 			status = "disabled";
 		};
 	};
-
-	qcom,ion {
-		compatible = "qcom,msm-ion";
-
-		qcom,ion-heap@20 { /* CAMERA HEAP */
-			compatible = "qcom,msm-ion-reserve";
-			reg = <20>;
-			qcom,heap-align = <0x1000>;
-			linux,contiguous-region = <&camera_mem>;
-			qcom,ion-heap-type = "CARVEOUT";
-		};
-	};
-
-	sound {
-		qcom,audio-routing =
-			"RX_BIAS", "MCLK",
-			"LDO_H", "MCLK",
-			"Ext Spk Bottom Pos", "LINEOUT1",
-			"Ext Spk Bottom Neg", "LINEOUT3",
-			"Ext Spk Top Pos", "LINEOUT2",
-			"Ext Spk Top Neg", "LINEOUT4",
-			"AMIC1", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC2", "MIC BIAS2 External",
-			"MIC BIAS2 External", "Headset Mic",
-			"AMIC3", "MIC BIAS3 External",
-			"MIC BIAS3 External", "ANCLeft Headset Mic",
-			"AMIC4", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC5", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Secondary Mic",
-			"AMIC6", "MIC BIAS4 External",
-			"MIC BIAS4 External", "Handset FB ANC Mic";
-		qcom,mbhc-audio-jack-type = "4-pole-jack";
-	};
-
-	gpio_hw_ids {
-		compatible = "gpio_hw_ids";
-
-		gpios = <&pm8941_gpios 1 0>,
-			<&pm8941_gpios 6 0>,
-			<&pm8941_gpios 7 0>,
-			<&pm8941_gpios 14 0>;
-	};
-
-	qcom,msm-thermal {
-		qcom,pmic-sw-mode-regs = "vdd_dig";
-	};
-};
-
-&memory_hole {
-	qcom,memblock-remove = <0x5d00000 0xa200000>; /* Address and size of the hole */
-};
-
-&mdss_hdmi_tx {
-	/* rhine doesn't use hpd-5v */
-	qcom,supply-names = "hpd-gdsc", "core-vdda", "core-vcc";
-	qcom,min-voltage-level = <0 1800000 1800000>;
-	qcom,max-voltage-level = <0 1800000 1800000>;
-	qcom,enable-load = <0 300000 0>;
 };
 
 &pm8941_chg {
-	qcom,vddmax-mv = <4350>;
-	qcom,vddsafe-mv = <4400>;
 	qcom,ibatmax-ma = <1300>;
 	qcom,ibatterm-ma = <115>;
 	qcom,ibatsafe-ma = <1300>;
 	qcom,maxinput-dc-ma = <1300>;
 	qcom,maxinput-usb-ma = <1300>;
-	qcom,cool-bat-mv = <4350>;
 	qcom,ibatmax-warm-ma = <650>;
-	qcom,warm-bat-mv = <4200>;
 	qcom,ibatmax-cool-ma = <650>;
-	qcom,vbatdet-delta-mv = <20>;
-	qcom,vbatdet-delta-soc = <1>;
 	qcom,thermal-mitigation = <1300 1300 1100 900 700 500 300 200 100 0>;
-	qcom,tchg-mins = <512>;
 };
 
 &pm8941_bms {
-	qcom,v-cutoff-uv = <3200000>;
-	qcom,max-voltage-uv = <4350000>;
-	qcom,r-conn-mohm = <0>;
-	qcom,low-soc-calculate-soc-threshold = <5>;
-	qcom,low-soc-calculate-soc-ms = <1000>;
-	qcom,calculate-soc-ms = <30000>;
 	qcom,chg-term-ua = <115000>;
-	qcom,use-external-rsense;
-	qcom,use-ocv-thresholds;
-	qcom,batt-type = <3>;
-	qcom,shutdown-soc-valid-limit = <40>;
-	qcom,clamp-soc-max-count = <2>;
 };
 
 &pm8941_gpios {
-	/* GPIO_1: HW_ID_0 */
-	gpio@c000 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_2: VOL_DN */
-	gpio@c100 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
 	/* GPIO_3: SNAPSHOT */
 	gpio@c200 {
 		qcom,src-sel = <0>;		/* GPIO */
@@ -794,167 +527,6 @@
 		status = "ok";
 	};
 
-	/* GPIO_5: VOL_UP */
-	gpio@c400 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_6: HW_ID_1 */
-	gpio@c500 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_7: HW_ID_2 */
-	gpio@c600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_8: NC */
-	gpio@c700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_9: RF_ID_EN */
-	gpio@c800 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <3>;	/* High */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_10: NC (FCHG_CNT) */
-	gpio@c900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_11: NC (AUD_DSP_PWR_EN) */
-	gpio@ca00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_12: RF_ID_EXTENTION */
-	gpio@cb00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_13: NC (TUNER_STATUS0) */
-	gpio@cc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_14: HW_ID_3 */
-	gpio@cd00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_15: DIVCLK1_CODEC */
-	/* Follow QCT */
-
-	/* GPIO_16: NC */
-	gpio@cf00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_17: (DIVCLK3) QPA_XO */
-	/* Follow QCT */
-
-	/* GPIO_18: NC (TUNER_STATUS1) */
-	gpio@d100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_19: DISP_RESET_N */
-	gpio@d200 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_20: NC (IR_LEVEL_EN) */
-	gpio@d300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_21: BOOST_BYP_EN */
-	/* Follow QCT */
-
-	/* GPIO_22: NC (HS_DET) */
-	gpio@d500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_23: NFC_VEN */
-	gpio@d600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <1>;		/* High */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_24: NC (NFC_EXT_LDO_EN) */
-	gpio@d700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_25: NC (IR_RESET) */
-	gpio@d800 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_26: NC (TUNER_ANT_SW_EN) */
-	gpio@d900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
 	/* GPIO_27: FLASH_LED_NOW */
 	gpio@da00 {
 		qcom,src-sel = <2>;		/* Alternate function 1 */
@@ -965,123 +537,6 @@
 		status = "ok";
 	};
 
-	/* GPIO_28: TX_GTR_THRES */
-	/* Follow QCT */
-
-	/* GPIO_29: NC */
-	gpio@dc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_30: NC */
-	gpio@dd00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_31: BATT_REM_ALERM */
-	/* Follow QCT */
-
-	/* GPIO_32: NC (TUNER_ANT_SW1) */
-	gpio@df00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_33: NC (FELICA_FF) */
-	gpio@e000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_34: NC (FELICA_LOCK) */
-	gpio@e100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_35: NC (Reserved for ANC_HS_DET) */
-	gpio@e200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_36: NC */
-	gpio@e300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8941_mpps {
-	/* MPP_1: SDC_UIM_VBIAS */
-	/* Follow QCT */
-
-	/* MPP_2: NC */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: TXDAC0_VREF */
-	/* Follow QCT */
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_5: NC */
-	mpp@a400 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_6: NC (ACC_ADC) */
-	mpp@a500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_7: RF_ID */
-	mpp@a600 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_8: NC */
-	mpp@a700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8841_mpps {
-	/* MPP_1: NC (LMU_EN) */
-	mpp@a000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_2: NC (FLASH_DR_RST_N) */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: NC */
-	mpp@a200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
 };
 
 &spmi_bus {
@@ -1092,105 +547,23 @@
 	};
 
 	qcom,pm8941@1 {
-		qcom,vib@c000 {
-			status = "okay";
-			compatible = "qcom,qpnp-vibrator";
-			reg = <0xc000 0x100>;
-			label = "vibrator";
-			qcom,qpnp-vib-vtg-level-mV = <3100>;
-		};
-
-		qcom,vibrator@c100 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c200 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c300 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c400 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c500 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c600 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c700 {
-			status = "disabled";
-		};
-
 		qcom,leds@d800 {
-			status = "okay";
 			qcom,wled_0 {
-				label = "wled";
-				linux,name = "wled:backlight";
-				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
-				qcom,cabc-en = <1>;
-				qcom,op-fdbck = <0>;
-				qcom,default-state = "on";
 				qcom,default-br = <1000>;
-				qcom,max-current = <20>;
-				qcom,ctrl-delay-us = <0>;
-				qcom,boost-curr-lim = <3>;
-				qcom,cp-sel = <0>;
-				qcom,switch-freq = <2>;
-				qcom,ovp-val = <2>;
-				qcom,num-strings = <2>;
-				qcom,id = <0>;
 			};
 		};
 
 		qcom,leds@d000 {
-			status = "okay";
-			qcom,rgb_sync = <1>;
-
 			qcom,rgb_0 {
-				label = "rgb";
-				linux,name = "led:rgb_red";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <6>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <170>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <3>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_1 {
-				label = "rgb";
-				linux,name = "led:rgb_green";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <5>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <170>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <4>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_2 {
-				label = "rgb";
-				linux,name = "led:rgb_blue";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <4>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <170>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <5>;
-				linux,default-trigger = "none";
 			};
 		};
 
@@ -1212,158 +585,10 @@
 				somc,debounce-time = <2>;
 			};
 		};
-
-		qcom,leds@d300 {
-			status = "disabled";
-		};
-
-		qcom,leds@e200 {
-			status = "disabled";
-		};
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
-&sdhc_2 {
-	qcom,pad-drv-on = <0x4 0x2 0x2>; /* 10mA, 6mA, 6mA */
-	qcom,vdd-current-level = <400000 400000>;
-};
-
 /* Regulator config */
-&pm8941_s1 {
-	status = "ok";
-};
-
-&pm8941_s2 {
-	status = "ok";
-};
-
-&pm8941_s3 {
-	status = "ok";
-};
-
-&pm8941_boost { /* VREG_5V */
-	regulator-min-microvolt = <5100000>;
-	regulator-max-microvolt = <5100000>;
-	status = "ok";
-};
-
-&pm8941_l1 {
-	status = "ok";
-};
-
-&pm8941_l2 {
-	status = "ok";
-};
-
-&pm8941_l3 {
-	regulator-min-microvolt = <1200000>;
-	regulator-max-microvolt = <1200000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <1200000>;
-	status = "ok";
-};
-
-&pm8941_l4 {
-	status = "ok";
-};
-
-&pm8941_l5 {
-	status = "ok";
-};
-
-&pm8941_l6 {
-	status = "ok";
-};
-
-&pm8941_l7 {
-	status = "ok";
-};
-
-&pm8941_l8 {
-	status = "ok";
-};
-
-&pm8941_l9 {
-	status = "ok";
-};
-
-&pm8941_l10 {
-	status = "disabled";
-};
-
-&pm8941_l11 {
-	status = "ok";
-};
-
-&pm8941_l12 {
-	status = "ok";
-};
-
-&pm8941_l13 {
-	status = "ok";
-};
-
-&pm8941_l14 {
-	status = "ok";
-};
-
-&pm8941_l15 {
-	status = "ok";
-};
-
-&pm8941_l16 {
-	status = "ok";
-};
-
-&pm8941_l17 {
-	regulator-min-microvolt = <2700000>;
-	regulator-max-microvolt = <2700000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2700000>;
-	status = "ok";
-};
-
-&pm8941_l18 {
-	regulator-min-microvolt = <2850000>;
-	regulator-max-microvolt = <2850000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2850000>;
-	status = "ok";
-};
-
-&pm8941_l19 {
-	regulator-min-microvolt = <3300000>;
-	regulator-max-microvolt = <3300000>;
-	qcom,init-voltage = <3300000>;
-	status = "ok";
-};
-
-&pm8941_l20 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l21 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l22 {
-	regulator-min-microvolt = <3000000>;
-	regulator-max-microvolt = <3000000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <3000000>;
-	status = "ok";
-};
-
 &pm8941_l23 {
 	regulator-min-microvolt = <2800000>;
 	regulator-max-microvolt = <2800000>;
@@ -1372,170 +597,12 @@
 	status = "ok";
 };
 
-&pm8941_l24 {
-	status = "ok";
-};
-
-&pm8941_lvs1 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs2 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs3 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
 &pm8941_mvs1 { /* VREG_OTG */
 	qcom,ocp-enable = <1>;
-	qcom,pull-down-enable = <1>;
-	status = "ok";
-};
-
-&pm8941_mvs2 { /* VREG_HDMI */
-	status = "disabled";
-};
-
-&pm8841_s1 {
-	status = "ok";
-};
-
-&pm8841_s2 {
-	status = "ok";
-};
-
-&pm8841_s3 {
-	status = "ok";
-};
-
-&pm8841_s4 {
-	status = "ok";
-};
-
-&krait0_vreg { /* PM8821 VREG_S5 */
-	status = "ok";
-};
-
-&krait1_vreg { /* PM8821 VREG_S6 */
-	status = "ok";
-};
-
-&krait2_vreg { /* PM8821 VREG_S7 */
-	status = "ok";
-};
-
-&krait3_vreg { /* PM8821 VREG_S8 */
-	status = "ok";
-};
-
-&slim_msm {
-	taiko_codec {
-		qcom,cdc-micbias-ldoh-v = <0x3>;
-		qcom,cdc-micbias-cfilt1-mv = <2700>;
-		qcom,cdc-micbias-cfilt2-mv = <2700>;
-		qcom,cdc-micbias-cfilt3-mv = <2700>;
-		qcom,cdc-micbias1-cfilt-sel = <0x1>;
-		qcom,cdc-micbias2-cfilt-sel = <0x1>;
-		qcom,cdc-micbias3-cfilt-sel = <0x1>;
-		qcom,cdc-micbias4-cfilt-sel = <0x1>;
-	};
-};
-
-&hsphy {
-	qcom,hsphy-init = <0x00D0CC27>;
-};
-
-&spmi_bus {
-	qcom,pm8941@0 {
-		vadc@3100 {
-			chan@b4 {
-				qcom,scale-function = <8>;
-			};
-		};
-
-		qcom,vadc@3400 {
-			chan@30 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@8 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@6 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@b4 {
-				qcom,scale-function = <4>;
-			};
-		};
-	};
-};
-
-&mdss_mdp {
-	qcom,mdss-pref-prim-intf = "dsi";
 };
 
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_novatek_default>;
-	vdd-supply = <&pm8941_lvs3>;
 	qcom,platform-enable-gpio = <&msmgpio 58 1>;
 	qcom,platform-te-gpio = <&msmgpio 12 1>;
-	qcom,platform-lane-config = [];
-
-	qcom,ctrl-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,ctrl-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdda";
-			qcom,supply-min-voltage = <1200000>;
-			qcom,supply-max-voltage = <1200000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-	};
-
-	qcom,panel-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,panel-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdd";
-			qcom,supply-min-voltage = <0>;
-			qcom,supply-max-voltage = <0>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-		qcom,panel-supply-entry@1 {
-			reg = <1>;
-			qcom,supply-name = "vddio";
-			qcom,supply-min-voltage = <1800000>;
-			qcom,supply-max-voltage = <1800000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-	};
 };

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -1,0 +1,1039 @@
+/* Copyright (c) 2012-2013, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2014 Sony Mobile Communications AB.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	ramoops {
+		compatible = "ramoops";
+		status = "ok";
+
+		android,ramoops-buffer-start = <0x7fe00000>;
+		android,ramoops-buffer-size = <0x100000>;
+		android,ramoops-console-size = <0x80000>;
+		android,ramoops-record-size = <0x7F800>;
+		android,ramoops-annotate-size = <0x800>;
+		android,ramoops-dump-oops = <0x1>;
+		android,ramoops-hole {
+			 compatible = "qcom,msm-contig-mem";
+			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
+		};
+	};
+
+	qcom,hdmi_tx@fd922100 {
+		status = "ok";
+	};
+
+	/* BLSP2 */
+	serial@f991e000 {
+		status = "ok";
+	};
+
+	/* BLSP7 */
+	uart7: uart@f995d000 {
+		status = "disabled";
+	};
+
+	/* BLSP2 */
+	i2c_2: i2c@f9924000 {
+		cell-index = <0>;
+		compatible = "qcom,i2c-qup";
+		reg = <0xf9924000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		interrupts = <0 96 0>;
+		interrupt-names = "qup_err_intr";
+		qcom,i2c-bus-freq = <355000>;
+		qcom,i2c-src-freq = <50000000>;
+		qcom,scl-gpio = <&msmgpio 7 0x00>;
+		qcom,sda-gpio = <&msmgpio 6 0x00>;
+		qcom,master-id = <86>;
+		status = "ok";
+
+		atmel_mxt_ts@4a {
+			status = "disabled";
+		};
+
+		synaptics_clearpad@2c {
+			compatible = "synaptics,clearpad";
+			reg = <0x2c>;
+			interrupt-parent = <&msmgpio>;
+			interrupts = <61 0x2>;
+			touch_vdd-supply = <&pm8941_l22>;
+			touch_vio-supply = <&pm8941_s3>;
+			synaptics,irq_gpio = <&msmgpio 61 0x00>;
+
+			preset_n_fingers = <10>;
+		};
+	};
+
+	/* BLSP4 */
+	i2c@f9926000 {
+		cell-index = <1>;
+		compatible = "qcom,i2c-qup";
+		reg = <0xf9926000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		interrupts = <0 98 0>;
+		interrupt-names = "qup_err_intr";
+		qcom,i2c-bus-freq = <355000>;
+		qcom,i2c-src-freq = <50000000>;
+		qcom,master-id = <86>;
+		status = "ok";
+	};
+
+	/* BLSP6 */
+	i2c@f9928000 {
+		cell-index = <2>;
+		compatible = "qcom,i2c-qup";
+		reg = <0xf9928000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		interrupts = <0 100 0>;
+		interrupt-names = "qup_err_intr";
+		qcom,i2c-bus-freq = <355000>;
+		qcom,i2c-src-freq = <50000000>;
+		qcom,master-id = <86>;
+		status = "ok";
+		nfc@28 {
+			compatible = "nxp,pn544";
+			reg = <0x28>;
+			interrupt-parent = <&msmgpio>;
+			interrupts = <59 0x0>;
+			nxp,pvdd_en = <&msmgpio 76 0x00>;
+			nxp,irq_gpio = <&msmgpio 59 0x00>;
+			nxp,dwld_en = <&msmgpio 77 0x00>;
+			nxp,ven = <&pm8941_gpios 23 0x01>;
+			gpio_fwdl_enable = <0 0 0 2>;
+			gpio_fwdl_disable = <0 0 1 0>;
+		};
+	};
+
+	/* BLSP11 */
+	i2c_0: i2c@f9967000 {
+		cell-index = <4>;
+		qcom,i2c-bus-freq = <355000>;
+		status = "ok";
+		sii8334@72 {
+			compatible = "qcom,mhl-sii8334";
+			reg = <0x72>;
+			interrupt-parent = <&msmgpio>;
+			interrupts = <64 0x2008>;
+			mhl-intr-gpio = <&msmgpio 64 0>;
+			mhl-pwr-gpio = <&msmgpio 60 0>;
+			mhl-rst-gpio = <&msmgpio 16 0>;
+			avcc_18-supply = <&pm8941_l24>;
+			avcc_12-supply = <&pm8941_l2>;
+			smps3a-supply = <&pm8941_s3>;
+			vdda-supply = <&pm8941_l12>;
+			qcom,hdmi-tx-map = <&mdss_hdmi_tx>;
+		};
+
+		isa1200@48 {
+			status = "disabled";
+		};
+	};
+
+	/* BLSP1 */
+	spi_0: spi@f9923000 {
+		status = "disabled";
+
+		ethernet-switch@2 {
+			status = "disabled";
+		};
+	};
+
+	/* BLSP10 */
+	spi_7: spi_epm: spi@f9966000 {
+		status = "disabled";
+
+		epm-adc@0 {
+			status = "disabled";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		input-name = "gpio-keys";
+		interrupt-parent = <&msmgpio>;
+		interrupts = <9 0>;
+
+		vol_dn {
+			label = "volume_down";
+			gpios = <&pm8941_gpios 2 0x1>;
+			linux,input-type = <1>;
+			linux,code = <114>;
+			gpio-key,wakeup;
+			debounce-interval = <15>;
+		};
+
+		vol_up {
+			label = "volume_up";
+			gpios = <&pm8941_gpios 5 0x1>;
+			linux,input-type = <1>;
+			linux,code = <115>;
+			gpio-key,wakeup;
+			debounce-interval = <15>;
+		};
+
+		sim_det {
+			label = "sim-detection";
+			gpios = <&msmgpio 9 0x0>;
+			linux,input-type = <5>;
+			linux,code = <7>;
+			gpio-key,wakeup;
+			debounce-interval = <10>;
+		};
+	};
+
+	qcom,ion {
+		compatible = "qcom,msm-ion";
+
+		qcom,ion-heap@20 { /* CAMERA HEAP */
+			compatible = "qcom,msm-ion-reserve";
+			reg = <20>;
+			qcom,heap-align = <0x1000>;
+			linux,contiguous-region = <&camera_mem>;
+			qcom,ion-heap-type = "CARVEOUT";
+		};
+	};
+
+	sound {
+		qcom,audio-routing =
+			"RX_BIAS", "MCLK",
+			"LDO_H", "MCLK",
+			"Ext Spk Bottom Pos", "LINEOUT1",
+			"Ext Spk Bottom Neg", "LINEOUT3",
+			"Ext Spk Top Pos", "LINEOUT2",
+			"Ext Spk Top Neg", "LINEOUT4",
+			"AMIC1", "MIC BIAS1 External",
+			"MIC BIAS1 External", "Handset Mic",
+			"AMIC2", "MIC BIAS2 External",
+			"MIC BIAS2 External", "Headset Mic",
+			"AMIC3", "MIC BIAS3 External",
+			"MIC BIAS3 External", "ANCLeft Headset Mic",
+			"AMIC4", "MIC BIAS1 External",
+			"MIC BIAS1 External", "Handset Mic",
+			"AMIC5", "MIC BIAS1 External",
+			"MIC BIAS1 External", "Secondary Mic",
+			"AMIC6", "MIC BIAS4 External",
+			"MIC BIAS4 External", "Handset FB ANC Mic";
+		qcom,mbhc-audio-jack-type = "4-pole-jack";
+	};
+
+	gpio_hw_ids {
+		compatible = "gpio_hw_ids";
+
+		gpios = <&pm8941_gpios 1 0>,
+			<&pm8941_gpios 6 0>,
+			<&pm8941_gpios 7 0>,
+			<&pm8941_gpios 14 0>;
+	};
+
+	qcom,msm-thermal {
+		qcom,pmic-sw-mode-regs = "vdd_dig";
+	};
+};
+
+&memory_hole {
+	qcom,memblock-remove = <0x5d00000 0xa200000>; /* Address and size of the hole */
+};
+
+&mdss_hdmi_tx {
+	/* rhine doesn't use hpd-5v */
+	qcom,supply-names = "hpd-gdsc", "core-vdda", "core-vcc";
+	qcom,min-voltage-level = <0 1800000 1800000>;
+	qcom,max-voltage-level = <0 1800000 1800000>;
+	qcom,enable-load = <0 300000 0>;
+};
+
+&pm8941_chg {
+	qcom,vddmax-mv = <4350>;
+	qcom,vddsafe-mv = <4400>;
+	qcom,cool-bat-mv = <4350>;
+	qcom,warm-bat-mv = <4200>;
+	qcom,vbatdet-delta-mv = <20>;
+	qcom,vbatdet-delta-soc = <1>;
+	qcom,tchg-mins = <512>;
+};
+
+&pm8941_bms {
+	qcom,v-cutoff-uv = <3200000>;
+	qcom,max-voltage-uv = <4350000>;
+	qcom,r-conn-mohm = <0>;
+	qcom,low-soc-calculate-soc-threshold = <5>;
+	qcom,low-soc-calculate-soc-ms = <1000>;
+	qcom,calculate-soc-ms = <30000>;
+	qcom,use-external-rsense;
+	qcom,use-ocv-thresholds;
+	qcom,batt-type = <3>;
+	qcom,shutdown-soc-valid-limit = <40>;
+	qcom,clamp-soc-max-count = <2>;
+};
+
+&pm8941_gpios {
+	/* GPIO_1: HW_ID_0 */
+	gpio@c000 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <5>;		/* NP */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_2: VOL_DN */
+	gpio@c100 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <0>;		/* PU */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_5: VOL_UP */
+	gpio@c400 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <0>;		/* PU */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_6: HW_ID_1 */
+	gpio@c500 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <5>;		/* NP */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_7: HW_ID_2 */
+	gpio@c600 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <5>;		/* NP */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_8: NC */
+	gpio@c700 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_9: RF_ID_EN */
+	gpio@c800 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <1>;		/* Out */
+		qcom,output-type = <0>;		/* CMOS */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,out-strength = <3>;	/* High */
+		qcom,invert = <0>;		/* Low */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_10: NC (FCHG_CNT) */
+	gpio@c900 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_11: NC (AUD_DSP_PWR_EN) */
+	gpio@ca00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_12: RF_ID_EXTENTION */
+	gpio@cb00 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <4>;		/* PD */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_13: NC (TUNER_STATUS0) */
+	gpio@cc00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_14: HW_ID_3 */
+	gpio@cd00 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <4>;		/* PD */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_15: DIVCLK1_CODEC */
+	/* Follow QCT */
+
+	/* GPIO_16: NC */
+	gpio@cf00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_17: (DIVCLK3) QPA_XO */
+	/* Follow QCT */
+
+	/* GPIO_18: NC (TUNER_STATUS1) */
+	gpio@d100 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_19: DISP_RESET_N */
+	gpio@d200 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <1>;		/* Out */
+		qcom,output-type = <0>;		/* CMOS */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,out-strength = <1>;	/* Low */
+		qcom,invert = <0>;		/* Low */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_20: NC (IR_LEVEL_EN) */
+	gpio@d300 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_21: BOOST_BYP_EN */
+	/* Follow QCT */
+
+	/* GPIO_22: NC (HS_DET) */
+	gpio@d500 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_23: NFC_VEN */
+	gpio@d600 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <1>;		/* Out */
+		qcom,output-type = <0>;		/* CMOS */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,out-strength = <1>;	/* Low */
+		qcom,invert = <1>;		/* High */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_24: NC (NFC_EXT_LDO_EN) */
+	gpio@d700 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_25: NC (IR_RESET) */
+	gpio@d800 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_5: VOL_UP */
+	gpio@c400 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <0>;		/* PU */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_6: HW_ID_1 */
+	gpio@c500 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <5>;		/* NP */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_7: HW_ID_2 */
+	gpio@c600 {
+		qcom,src-sel = <0>;		/* GPIO */
+		qcom,mode = <0>;		/* In */
+		qcom,vin-sel = <2>;		/* S3 */
+		qcom,pull = <5>;		/* NP */
+		qcom,master-en = <1>;		/* Enable */
+		status = "ok";
+	};
+
+	/* GPIO_8: NC */
+	gpio@c700 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_28: TX_GTR_THRES */
+	/* Follow QCT */
+
+	/* GPIO_29: NC */
+	gpio@dc00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_30: NC */
+	gpio@dd00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_31: BATT_REM_ALERM */
+	/* Follow QCT */
+
+	/* GPIO_32: NC (TUNER_ANT_SW1) */
+	gpio@df00 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_33: NC (FELICA_FF) */
+	gpio@e000 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_34: NC (FELICA_LOCK) */
+	gpio@e100 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_35: NC (Reserved for ANC_HS_DET) */
+	gpio@e200 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* GPIO_36: NC */
+	gpio@e300 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+};
+
+&pm8941_mpps {
+	/* MPP_1: SDC_UIM_VBIAS */
+	/* Follow QCT */
+
+	/* MPP_2: NC */
+	mpp@a100 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_3: TXDAC0_VREF */
+	/* Follow QCT */
+
+	/* MPP_4: NC */
+	mpp@a300 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_5: NC */
+	mpp@a400 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_6: NC (ACC_ADC) */
+	mpp@a500 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_7: RF_ID */
+	mpp@a600 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_8: NC */
+	mpp@a700 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+};
+
+&pm8841_mpps {
+	/* MPP_1: NC (LMU_EN) */
+	mpp@a000 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_2: NC (FLASH_DR_RST_N) */
+	mpp@a100 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_3: NC */
+	mpp@a200 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+
+	/* MPP_4: NC */
+	mpp@a300 {
+		qcom,master-en = <0>;		/* Disable */
+		status = "ok";
+	};
+};
+
+&spmi_bus {
+	qcom,pm8941@1 {
+		qcom,vib@c000 {
+			status = "okay";
+			compatible = "qcom,qpnp-vibrator";
+			reg = <0xc000 0x100>;
+			label = "vibrator";
+			qcom,qpnp-vib-vtg-level-mV = <3100>;
+		};
+
+		qcom,vibrator@c100 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c200 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c300 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c400 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c500 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c600 {
+			status = "disabled";
+		};
+
+		qcom,vibrator@c700 {
+			status = "disabled";
+		};
+
+		qcom,leds@d800 {
+			status = "okay";
+			qcom,wled_0 {
+				label = "wled";
+				linux,name = "wled:backlight";
+				linux,default-trigger = "bkl-trigger";
+				qcom,cs-out-en = <1>;
+				qcom,cabc-en = <1>;
+				qcom,op-fdbck = <0>;
+				qcom,default-state = "on";
+				qcom,max-current = <20>;
+				qcom,ctrl-delay-us = <0>;
+				qcom,boost-curr-lim = <3>;
+				qcom,cp-sel = <0>;
+				qcom,switch-freq = <2>;
+				qcom,ovp-val = <2>;
+				qcom,num-strings = <2>;
+				qcom,id = <0>;
+			};
+		};
+
+		qcom,leds@d000 {
+			status = "okay";
+			qcom,rgb_sync = <1>;
+
+			qcom,rgb_0 {
+				label = "rgb";
+				linux,name = "led:rgb_red";
+				qcom,mode = "pwm";
+				qcom,pwm-channel = <6>;
+				qcom,pwm-us = <1000>;
+				qcom,max-current = <12>;
+				qcom,default-state = "off";
+				qcom,id = <3>;
+				linux,default-trigger = "none";
+			};
+
+			qcom,rgb_1 {
+				label = "rgb";
+				linux,name = "led:rgb_green";
+				qcom,mode = "pwm";
+				qcom,pwm-channel = <5>;
+				qcom,pwm-us = <1000>;
+				qcom,max-current = <12>;
+				qcom,default-state = "off";
+				qcom,id = <4>;
+				linux,default-trigger = "none";
+			};
+
+			qcom,rgb_2 {
+				label = "rgb";
+				linux,name = "led:rgb_blue";
+				qcom,mode = "pwm";
+				qcom,pwm-channel = <4>;
+				qcom,pwm-us = <1000>;
+				qcom,max-current = <12>;
+				qcom,default-state = "off";
+				qcom,id = <5>;
+				linux,default-trigger = "none";
+			};
+		};
+
+		qcom,leds@d300 {
+			status = "disabled";
+		};
+
+		qcom,leds@e200 {
+			status = "disabled";
+		};
+	};
+};
+
+&sdhc_1 {
+	qcom,bus-speed-mode = "DDR_1p8v";
+};
+
+&sdhc_2 {
+	qcom,pad-drv-on = <0x4 0x2 0x2>; /* 10mA, 6mA, 6mA */
+	qcom,vdd-current-level = <400000 400000>;
+};
+
+/* Regulator config */
+&pm8941_s1 {
+	status = "ok";
+};
+
+&pm8941_s2 {
+	status = "ok";
+};
+
+&pm8941_s3 {
+	status = "ok";
+};
+
+&pm8941_boost { /* VREG_5V */
+	regulator-min-microvolt = <5100000>;
+	regulator-max-microvolt = <5100000>;
+	status = "ok";
+};
+
+&pm8941_l1 {
+	status = "ok";
+};
+
+&pm8941_l2 {
+	status = "ok";
+};
+
+&pm8941_l3 {
+	regulator-min-microvolt = <1200000>;
+	regulator-max-microvolt = <1200000>;
+	qcom,init-enable = <0>;
+	qcom,init-voltage = <1200000>;
+	status = "ok";
+};
+
+&pm8941_l4 {
+	status = "ok";
+};
+
+&pm8941_l5 {
+	status = "ok";
+};
+
+&pm8941_l6 {
+	status = "ok";
+};
+
+&pm8941_l7 {
+	status = "ok";
+};
+
+&pm8941_l8 {
+	status = "ok";
+};
+
+&pm8941_l9 {
+	status = "ok";
+};
+
+&pm8941_l10 {
+	status = "disabled";
+};
+
+&pm8941_l11 {
+	status = "ok";
+};
+
+&pm8941_l12 {
+	status = "ok";
+};
+
+&pm8941_l13 {
+	status = "ok";
+};
+
+&pm8941_l14 {
+	status = "ok";
+};
+
+&pm8941_l15 {
+	status = "ok";
+};
+
+&pm8941_l16 {
+	status = "ok";
+};
+
+&pm8941_l17 {
+	regulator-min-microvolt = <2700000>;
+	regulator-max-microvolt = <2700000>;
+	qcom,init-enable = <0>;
+	qcom,init-voltage = <2700000>;
+	status = "ok";
+};
+
+&pm8941_l18 {
+	regulator-min-microvolt = <2850000>;
+	regulator-max-microvolt = <2850000>;
+	qcom,init-enable = <0>;
+	qcom,init-voltage = <2850000>;
+	status = "ok";
+};
+
+&pm8941_l19 {
+	regulator-min-microvolt = <3300000>;
+	regulator-max-microvolt = <3300000>;
+	qcom,init-voltage = <3300000>;
+	status = "ok";
+};
+
+&pm8941_l20 {
+	regulator-min-microvolt = <2950000>;
+	regulator-max-microvolt = <2950000>;
+	qcom,init-voltage = <2950000>;
+	status = "ok";
+};
+
+&pm8941_l21 {
+	regulator-min-microvolt = <2950000>;
+	regulator-max-microvolt = <2950000>;
+	qcom,init-voltage = <2950000>;
+	status = "ok";
+};
+
+&pm8941_l22 {
+	regulator-min-microvolt = <3000000>;
+	regulator-max-microvolt = <3000000>;
+	qcom,init-enable = <0>;
+	qcom,init-voltage = <3000000>;
+	status = "ok";
+};
+
+&pm8941_l24 {
+	status = "ok";
+};
+
+&pm8941_lvs1 {
+	qcom,init-enable = <0>;
+	status = "ok";
+};
+
+&pm8941_lvs2 {
+	qcom,init-enable = <0>;
+	status = "ok";
+};
+
+&pm8941_lvs3 {
+	qcom,init-enable = <0>;
+	status = "ok";
+};
+
+&pm8941_mvs1 { /* VREG_OTG */
+	qcom,pull-down-enable = <1>;
+	status = "ok";
+};
+
+&pm8941_mvs2 { /* VREG_HDMI */
+	status = "disabled";
+};
+
+&pm8841_s1 {
+	status = "ok";
+};
+
+&pm8841_s2 {
+	status = "ok";
+};
+
+&pm8841_s3 {
+	status = "ok";
+};
+
+&pm8841_s4 {
+	status = "ok";
+};
+
+&krait0_vreg { /* PM8821 VREG_S5 */
+	status = "ok";
+};
+
+&krait1_vreg { /* PM8821 VREG_S6 */
+	status = "ok";
+};
+
+&krait2_vreg { /* PM8821 VREG_S7 */
+	status = "ok";
+};
+
+&krait3_vreg { /* PM8821 VREG_S8 */
+	status = "ok";
+};
+
+&slim_msm {
+	taiko_codec {
+		qcom,cdc-micbias-ldoh-v = <0x3>;
+		qcom,cdc-micbias-cfilt1-mv = <2700>;
+		qcom,cdc-micbias-cfilt2-mv = <2700>;
+		qcom,cdc-micbias-cfilt3-mv = <2700>;
+		qcom,cdc-micbias1-cfilt-sel = <0x1>;
+		qcom,cdc-micbias2-cfilt-sel = <0x1>;
+		qcom,cdc-micbias3-cfilt-sel = <0x1>;
+		qcom,cdc-micbias4-cfilt-sel = <0x1>;
+
+		/*
+		 * Rhine has external spkrdrv supply. Give a dummy
+		 * supply to make codec driver's happy.
+		 */
+		cdc-vdd-spkdrv-supply = <&vph_pwr_vreg>;
+		qcom,cdc-vdd-spkdrv-voltage = <0 0>;
+		qcom,cdc-vdd-spkdrv-current = <0>;
+
+		qcom,cdc-on-demand-supplies = "cdc-vdd-spkdrv";
+	};
+};
+
+&hsphy {
+	qcom,hsphy-init = <0x00D0CC27>;
+};
+
+&spmi_bus {
+	qcom,pm8941@0 {
+		vadc@3100 {
+			chan@b4 {
+				qcom,scale-function = <8>;
+			};
+		};
+
+		qcom,vadc@3400 {
+			chan@30 {
+				qcom,hw-settle-time = <15>;
+			};
+
+			chan@8 {
+				qcom,hw-settle-time = <15>;
+			};
+
+			chan@6 {
+				qcom,hw-settle-time = <15>;
+			};
+
+			chan@b4 {
+				qcom,scale-function = <4>;
+			};
+		};
+	};
+};
+
+&mdss_mdp {
+	qcom,mdss-pref-prim-intf = "dsi";
+};
+
+&mdss_dsi0 {
+	vdd-supply = <&pm8941_lvs3>;
+	qcom,platform-lane-config = [];
+
+	qcom,ctrl-supply-entries {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,ctrl-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "vdda";
+			qcom,supply-min-voltage = <1200000>;
+			qcom,supply-max-voltage = <1200000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+		};
+	};
+
+	qcom,panel-supply-entries {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,panel-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "vdd";
+			qcom,supply-min-voltage = <0>;
+			qcom,supply-max-voltage = <0>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+		};
+
+		qcom,panel-supply-entry@1 {
+			reg = <1>;
+			qcom,supply-name = "vddio";
+			qcom,supply-min-voltage = <1800000>;
+			qcom,supply-max-voltage = <1800000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-pre-on-sleep = <0>;
+			qcom,supply-post-on-sleep = <0>;
+			qcom,supply-pre-off-sleep = <0>;
+			qcom,supply-post-off-sleep = <0>;
+		};
+
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_honami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_honami_row.dtsi
@@ -14,63 +14,13 @@
  * GNU General Public License for more details.
  */
 
-/include/ "dsi-panel-honami.dtsi"
+#include "dsi-panel-honami.dtsi"
+#include "msm8974-rhine_common.dtsi"
 
 &soc {
-	ramoops {
-		compatible = "ramoops";
-		status = "ok";
-
-		android,ramoops-buffer-start = <0x7fe00000>;
-		android,ramoops-buffer-size = <0x100000>;
-		android,ramoops-console-size = <0x80000>;
-		android,ramoops-record-size = <0x7F800>;
-		android,ramoops-annotate-size = <0x800>;
-		android,ramoops-dump-oops = <0x1>;
-		android,ramoops-hole {
-			 compatible = "qcom,msm-contig-mem";
-			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
-		};
-	};
-
-	qcom,hdmi_tx@fd922100 {
-		status = "ok";
-	};
-
-	/* BLSP2 */
-	serial@f991e000 {
-		status = "ok";
-	};
-
-	/* BLSP7 */
-	uart7: uart@f995d000 {
-		status = "disabled";
-	};
-
 	/* BLSP2 */
 	i2c_2: i2c@f9924000 {
-		cell-index = <0>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9924000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 96 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,scl-gpio = <&msmgpio 7 0x00>;
-		qcom,sda-gpio = <&msmgpio 6 0x00>;
-		qcom,master-id = <86>;
-		status = "ok";
 		synaptics_clearpad@2c {
-			compatible = "synaptics,clearpad";
-			reg = <0x2c>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <61 0x2>;
-			touch_vdd-supply = <&pm8941_l22>;
-			touch_vio-supply = <&pm8941_s3>;
-			synaptics,irq_gpio = <&msmgpio 61 0x00>;
 			chip_id = <0x36>;
 			num_sensor_rx = <28>;
 			num_sensor_tx = <15>;
@@ -83,102 +33,10 @@
 			touch_orientation_enabled = <0>;
 			preset_x_max = <1079>;
 			preset_y_max = <1919>;
-			preset_n_fingers = <10>;
 			preset_n_bytes_per_object = <8>;
 			por_delay_after = <200>;
 			wakeup_gesture_supported = <0>;
 			wakeup_gesture_timeout = <0>;
-		};
-
-		atmel_mxt_ts@4a {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP4 */
-	i2c@f9926000 {
-		cell-index = <1>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9926000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 98 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-	};
-
-	/* BLSP6 */
-	i2c@f9928000 {
-		cell-index = <2>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9928000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 100 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-		nfc@28 {
-			compatible = "nxp,pn544";
-			reg = <0x28>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <59 0x0>;
-			nxp,pvdd_en = <&msmgpio 76 0x00>;
-			nxp,irq_gpio = <&msmgpio 59 0x00>;
-			nxp,dwld_en = <&msmgpio 77 0x00>;
-			nxp,ven = <&pm8941_gpios 23 0x01>;
-			gpio_fwdl_enable = <0 0 0 2>;
-			gpio_fwdl_disable = <0 0 1 0>;
-		};
-	};
-
-	/* BLSP11 */
-	i2c_0: i2c@f9967000 {
-		cell-index = <4>;
-		qcom,i2c-bus-freq = <355000>;
-		status = "ok";
-		sii8334@72 {
-			compatible = "qcom,mhl-sii8334";
-			reg = <0x72>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <64 0x2008>;
-			mhl-intr-gpio = <&msmgpio 64 0>;
-			mhl-pwr-gpio = <&msmgpio 60 0>;
-			mhl-rst-gpio = <&msmgpio 16 0>;
-			avcc_18-supply = <&pm8941_l24>;
-			avcc_12-supply = <&pm8941_l2>;
-			smps3a-supply = <&pm8941_s3>;
-			vdda-supply = <&pm8941_l12>;
-			qcom,hdmi-tx-map = <&mdss_hdmi_tx>;
-		};
-
-		isa1200@48 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP1 */
-	spi_0: spi@f9923000 {
-		status = "disabled";
-
-		ethernet-switch@2 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP10 */
-	spi_7: spi_epm: spi@f9966000 {
-		status = "disabled";
-
-		epm-adc@0 {
-			status = "disabled";
 		};
 	};
 
@@ -187,15 +45,6 @@
 		input-name = "gpio-keys";
 		interrupt-parent = <&msmgpio>;
 		interrupts = <9 0>;
-
-		vol_dn {
-			label = "volume_down";
-			gpios = <&pm8941_gpios 2 0x1>;
-			linux,input-type = <1>;
-			linux,code = <114>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
 
 		camera_snapshot {
 			label = "camera_snapshot";
@@ -213,24 +62,6 @@
 			linux,code = <0x210>;
 			gpio-key,wakeup;
 			debounce-interval = <15>;
-		};
-
-		vol_up {
-			label = "volume_up";
-			gpios = <&pm8941_gpios 5 0x1>;
-			linux,input-type = <1>;
-			linux,code = <115>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
-
-		sim_det {
-			label = "sim-detection";
-			gpios = <&msmgpio 9 0x0>;
-			linux,input-type = <5>;
-			linux,code = <7>;
-			gpio-key,wakeup;
-			debounce-interval = <10>;
 		};
 	};
 
@@ -658,124 +489,26 @@
 			status = "disabled";
 		};
 	};
-
-	qcom,ion {
-		compatible = "qcom,msm-ion";
-
-		qcom,ion-heap@20 { /* CAMERA HEAP */
-			compatible = "qcom,msm-ion-reserve";
-			reg = <20>;
-			qcom,heap-align = <0x1000>;
-			linux,contiguous-region = <&camera_mem>;
-			qcom,ion-heap-type = "CARVEOUT";
-		};
-	};
-
-	sound {
-		qcom,audio-routing =
-			"RX_BIAS", "MCLK",
-			"LDO_H", "MCLK",
-			"Ext Spk Bottom Pos", "LINEOUT1",
-			"Ext Spk Bottom Neg", "LINEOUT3",
-			"Ext Spk Top Pos", "LINEOUT2",
-			"Ext Spk Top Neg", "LINEOUT4",
-			"AMIC1", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC2", "MIC BIAS2 External",
-			"MIC BIAS2 External", "Headset Mic",
-			"AMIC3", "MIC BIAS3 External",
-			"MIC BIAS3 External", "ANCLeft Headset Mic",
-			"AMIC4", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC5", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Secondary Mic",
-			"AMIC6", "MIC BIAS4 External",
-			"MIC BIAS4 External", "Handset FB ANC Mic";
-		qcom,mbhc-audio-jack-type = "4-pole-jack";
-	};
-
-	gpio_hw_ids {
-		compatible = "gpio_hw_ids";
-
-		gpios = <&pm8941_gpios 1 0>,
-			<&pm8941_gpios 6 0>,
-			<&pm8941_gpios 7 0>,
-			<&pm8941_gpios 14 0>;
-	};
-
-	qcom,msm-thermal {
-		qcom,pmic-sw-mode-regs = "vdd_dig";
-	};
-};
-
-&memory_hole {
-	qcom,memblock-remove = <0x5d00000 0xa200000>; /* Address and size of the hole */
-};
-
-&mdss_hdmi_tx {
-	/* rhine doesn't use hpd-5v */
-	qcom,supply-names = "hpd-gdsc", "core-vdda", "core-vcc";
-	qcom,min-voltage-level = <0 1800000 1800000>;
-	qcom,max-voltage-level = <0 1800000 1800000>;
-	qcom,enable-load = <0 300000 0>;
 };
 
 &pm8941_chg {
-	qcom,vddmax-mv = <4350>;
-	qcom,vddsafe-mv = <4400>;
 	qcom,ibatmax-ma = <1500>;
 	qcom,ibatterm-ma = <150>;
 	qcom,ibatsafe-ma = <1500>;
 	qcom,maxinput-dc-ma = <1800>;
 	qcom,maxinput-usb-ma = <1500>;
-	qcom,cool-bat-mv = <4350>;
 	qcom,ibatmax-warm-ma = <900>;
-	qcom,warm-bat-mv = <4200>;
 	qcom,ibatmax-cool-ma = <900>;
-	qcom,vbatdet-delta-mv = <20>;
-	qcom,vbatdet-delta-soc = <1>;
 	qcom,thermal-mitigation = <1500 1500 1100 900 700 500 300 200 100 0>;
-	qcom,tchg-mins = <512>;
 };
 
 &pm8941_bms {
 	qcom,r-sense-uohm = <10005>;
-	qcom,v-cutoff-uv = <3200000>;
-	qcom,max-voltage-uv = <4350000>;
-	qcom,r-conn-mohm = <0>;
-	qcom,low-soc-calculate-soc-threshold = <5>;
-	qcom,low-soc-calculate-soc-ms = <1000>;
-	qcom,calculate-soc-ms = <30000>;
-	qcom,chg-term-ua = <150000>;
-	qcom,use-external-rsense;
-	qcom,use-ocv-thresholds;
-	qcom,batt-type = <3>;
-	qcom,shutdown-soc-valid-limit = <40>;
-	qcom,clamp-soc-max-count = <2>;
 	qcom,fcc-resolution = <13>;
+	qcom,chg-term-ua = <150000>;
 };
 
 &pm8941_gpios {
-	/* GPIO_1: HW_ID_0 */
-	gpio@c000 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_2: VOL_DN */
-	gpio@c100 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
 	/* GPIO_3: SNAPSHOT */
 	gpio@c200 {
 		qcom,src-sel = <0>;		/* GPIO */
@@ -796,167 +529,6 @@
 		status = "ok";
 	};
 
-	/* GPIO_5: VOL_UP */
-	gpio@c400 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_6: HW_ID_1 */
-	gpio@c500 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_7: HW_ID_2 */
-	gpio@c600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_8: NC */
-	gpio@c700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_9: RF_ID_EN */
-	gpio@c800 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <3>;	/* High */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_10: NC (FCHG_CNT) */
-	gpio@c900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_11: NC (AUD_DSP_PWR_EN) */
-	gpio@ca00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_12: RF_ID_EXTENTION */
-	gpio@cb00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_13: NC (TUNER_STATUS0) */
-	gpio@cc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_14: HW_ID_3 */
-	gpio@cd00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_15: DIVCLK1_CODEC */
-	/* Follow QCT */
-
-	/* GPIO_16: NC */
-	gpio@cf00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_17: (DIVCLK3) QPA_XO */
-	/* Follow QCT */
-
-	/* GPIO_18: NC (TUNER_STATUS1) */
-	gpio@d100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_19: DISP_RESET_N */
-	gpio@d200 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_20: NC (IR_LEVEL_EN) */
-	gpio@d300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_21: BOOST_BYP_EN */
-	/* Follow QCT */
-
-	/* GPIO_22: NC (HS_DET) */
-	gpio@d500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_23: NFC_VEN */
-	gpio@d600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <1>;		/* High */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_24: NC (NFC_EXT_LDO_EN) */
-	gpio@d700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_25: NC (IR_RESET) */
-	gpio@d800 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_26: NC (TUNER_ANT_SW_EN) */
-	gpio@d900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
 	/* GPIO_27: FLASH_LED_NOW */
 	gpio@da00 {
 		qcom,src-sel = <2>;		/* Alternate function 1 */
@@ -967,123 +539,6 @@
 		status = "ok";
 	};
 
-	/* GPIO_28: TX_GTR_THRES */
-	/* Follow QCT */
-
-	/* GPIO_29: NC */
-	gpio@dc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_30: NC */
-	gpio@dd00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_31: BATT_REM_ALERM */
-	/* Follow QCT */
-
-	/* GPIO_32: NC (TUNER_ANT_SW1) */
-	gpio@df00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_33: NC (FELICA_FF) */
-	gpio@e000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_34: NC (FELICA_LOCK) */
-	gpio@e100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_35: NC (Reserved for ANC_HS_DET) */
-	gpio@e200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_36: NC */
-	gpio@e300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8941_mpps {
-	/* MPP_1: SDC_UIM_VBIAS */
-	/* Follow QCT */
-
-	/* MPP_2: NC */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: TXDAC0_VREF */
-	/* Follow QCT */
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_5: NC */
-	mpp@a400 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_6: NC (ACC_ADC) */
-	mpp@a500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_7: RF_ID */
-	mpp@a600 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_8: NC */
-	mpp@a700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8841_mpps {
-	/* MPP_1: NC (LMU_EN) */
-	mpp@a000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_2: NC (FLASH_DR_RST_N) */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: NC */
-	mpp@a200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
 };
 
 &spmi_bus {
@@ -1094,104 +549,17 @@
 	};
 
 	qcom,pm8941@1 {
-		qcom,vib@c000 {
-			status = "okay";
-			compatible = "qcom,qpnp-vibrator";
-			reg = <0xc000 0x100>;
-			label = "vibrator";
-			qcom,qpnp-vib-vtg-level-mV = <3100>;
-		};
-
-		qcom,vibrator@c100 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c200 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c300 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c400 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c500 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c600 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c700 {
-			status = "disabled";
-		};
-
-		qcom,leds@d800 {
-			status = "okay";
-			qcom,wled_0 {
-				label = "wled";
-				linux,name = "wled:backlight";
-				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
-				qcom,cabc-en = <1>;
-				qcom,op-fdbck = <0>;
-				qcom,default-state = "on";
-				qcom,max-current = <20>;
-				qcom,ctrl-delay-us = <0>;
-				qcom,boost-curr-lim = <3>;
-				qcom,cp-sel = <0>;
-				qcom,switch-freq = <2>;
-				qcom,ovp-val = <2>;
-				qcom,num-strings = <2>;
-				qcom,id = <0>;
-			};
-		};
-
 		qcom,leds@d000 {
-			status = "okay";
-			qcom,rgb_sync = <1>;
-
 			qcom,rgb_0 {
-				label = "rgb";
-				linux,name = "led:rgb_red";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <6>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <304>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <3>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_1 {
-				label = "rgb";
-				linux,name = "led:rgb_green";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <5>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <511>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <4>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_2 {
-				label = "rgb";
-				linux,name = "led:rgb_blue";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <4>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <368>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <5>;
-				linux,default-trigger = "none";
 			};
 		};
 
@@ -1213,158 +581,10 @@
 				somc,debounce-time = <2>;
 			};
 		};
-
-		qcom,leds@d300 {
-			status = "disabled";
-		};
-
-		qcom,leds@e200 {
-			status = "disabled";
-		};
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
-&sdhc_2 {
-	qcom,pad-drv-on = <0x4 0x2 0x2>; /* 10mA, 6mA, 6mA */
-	qcom,vdd-current-level = <400000 400000>;
-};
-
 /* Regulator config */
-&pm8941_s1 {
-	status = "ok";
-};
-
-&pm8941_s2 {
-	status = "ok";
-};
-
-&pm8941_s3 {
-	status = "ok";
-};
-
-&pm8941_boost { /* VREG_5V */
-	regulator-min-microvolt = <5100000>;
-	regulator-max-microvolt = <5100000>;
-	status = "ok";
-};
-
-&pm8941_l1 {
-	status = "ok";
-};
-
-&pm8941_l2 {
-	status = "ok";
-};
-
-&pm8941_l3 {
-	regulator-min-microvolt = <1200000>;
-	regulator-max-microvolt = <1200000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <1200000>;
-	status = "ok";
-};
-
-&pm8941_l4 {
-	status = "ok";
-};
-
-&pm8941_l5 {
-	status = "ok";
-};
-
-&pm8941_l6 {
-	status = "ok";
-};
-
-&pm8941_l7 {
-	status = "ok";
-};
-
-&pm8941_l8 {
-	status = "ok";
-};
-
-&pm8941_l9 {
-	status = "ok";
-};
-
-&pm8941_l10 {
-	status = "disabled";
-};
-
-&pm8941_l11 {
-	status = "ok";
-};
-
-&pm8941_l12 {
-	status = "ok";
-};
-
-&pm8941_l13 {
-	status = "ok";
-};
-
-&pm8941_l14 {
-	status = "ok";
-};
-
-&pm8941_l15 {
-	status = "ok";
-};
-
-&pm8941_l16 {
-	status = "ok";
-};
-
-&pm8941_l17 {
-	regulator-min-microvolt = <2700000>;
-	regulator-max-microvolt = <2700000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2700000>;
-	status = "ok";
-};
-
-&pm8941_l18 {
-	regulator-min-microvolt = <2850000>;
-	regulator-max-microvolt = <2850000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2850000>;
-	status = "ok";
-};
-
-&pm8941_l19 {
-	regulator-min-microvolt = <3300000>;
-	regulator-max-microvolt = <3300000>;
-	qcom,init-voltage = <3300000>;
-	status = "ok";
-};
-
-&pm8941_l20 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l21 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l22 {
-	regulator-min-microvolt = <3000000>;
-	regulator-max-microvolt = <3000000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <3000000>;
-	status = "ok";
-};
-
 &pm8941_l23 {
 	regulator-min-microvolt = <2800000>;
 	regulator-max-microvolt = <2800000>;
@@ -1373,117 +593,10 @@
 	status = "ok";
 };
 
-&pm8941_l24 {
-	status = "ok";
-};
-
-&pm8941_lvs1 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs2 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs3 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_mvs1 { /* VREG_OTG */
-	qcom,pull-down-enable = <1>;
-	status = "ok";
-};
-
-&pm8941_mvs2 { /* VREG_HDMI */
-	status = "disabled";
-};
-
-&pm8841_s1 {
-	status = "ok";
-};
-
-&pm8841_s2 {
-	status = "ok";
-};
-
-&pm8841_s3 {
-	status = "ok";
-};
-
-&pm8841_s4 {
-	status = "ok";
-};
-
-&krait0_vreg { /* PM8821 VREG_S5 */
-	status = "ok";
-};
-
-&krait1_vreg { /* PM8821 VREG_S6 */
-	status = "ok";
-};
-
-&krait2_vreg { /* PM8821 VREG_S7 */
-	status = "ok";
-};
-
-&krait3_vreg { /* PM8821 VREG_S8 */
-	status = "ok";
-};
-
 &slim_msm {
 	taiko_codec {
-		qcom,cdc-micbias-ldoh-v = <0x3>;
-		qcom,cdc-micbias-cfilt1-mv = <2700>;
-		qcom,cdc-micbias-cfilt2-mv = <2700>;
-		qcom,cdc-micbias-cfilt3-mv = <2700>;
-		qcom,cdc-micbias1-cfilt-sel = <0x1>;
-		qcom,cdc-micbias2-cfilt-sel = <0x1>;
-		qcom,cdc-micbias3-cfilt-sel = <0x1>;
-		qcom,cdc-micbias4-cfilt-sel = <0x1>;
 		qcom,cdc-micbias2-headset-only;
 	};
-};
-
-//&usb3 {
-//	qcom,dwc-hsphy-init = <0x00D0CC27>;
-//};
-&hsphy {
-	qcom,hsphy-init = <0x00D0CC27>;
-};
-
-&spmi_bus {
-	qcom,pm8941@0 {
-		vadc@3100 {
-			chan@b4 {
-				qcom,scale-function = <8>;
-			};
-		};
-
-		qcom,vadc@3400 {
-			chan@30 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@8 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@6 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@b4 {
-				qcom,scale-function = <4>;
-			};
-		};
-	};
-};
-
-&mdss_mdp {
-	qcom,mdss-pref-prim-intf = "dsi";
 };
 
 &mdss_fb0 {
@@ -1492,56 +605,5 @@
 
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_renesas_default>;
-	vdd-supply = <&pm8941_lvs3>;
 	qcom,platform-enable-gpio = <&msmgpio 46 1>;
-	qcom,platform-lane-config = [];
-	qcom,ctrl-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,ctrl-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdda";
-			qcom,supply-min-voltage = <1200000>;
-			qcom,supply-max-voltage = <1200000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-	};
-
-	qcom,panel-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,panel-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdd";
-			qcom,supply-min-voltage = <0>;
-			qcom,supply-max-voltage = <0>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-		qcom,panel-supply-entry@1 {
-			reg = <1>;
-			qcom,supply-name = "vddio";
-			qcom,supply-min-voltage = <1800000>;
-			qcom,supply-max-voltage = <1800000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-	};
 };

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_togari_row.dtsi
@@ -626,8 +626,7 @@
 			compatible = "qcom,msm-ion-reserve";
 			reg = <20>;
 			qcom,heap-align = <0x1000>;
-			qcom,memory-reservation-type = "EBI1"; /* reserve EBI memory */
-			qcom,memory-reservation-size = <0x6400000>;
+			linux,contiguous-region = <&camera_mem>;
 			qcom,ion-heap-type = "CARVEOUT";
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_togari_row.dtsi
@@ -14,66 +14,15 @@
  * GNU General Public License for more details.
  */
 
-/include/ "dsi-panel-togari.dtsi"
+#include "dsi-panel-togari.dtsi"
+#include "msm8974-rhine_common.dtsi"
 
 &soc {
-	ramoops {
-		compatible = "ramoops";
-		status = "ok";
-
-		android,ramoops-buffer-start = <0x7fe00000>;
-		android,ramoops-buffer-size = <0x100000>;
-		android,ramoops-console-size = <0x80000>;
-		android,ramoops-record-size = <0x7F800>;
-		android,ramoops-annotate-size = <0x800>;
-		android,ramoops-dump-oops = <0x1>;
-		android,ramoops-hole {
-			 compatible = "qcom,msm-contig-mem";
-			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
-		};
-	};
-
-	qcom,hdmi_tx@fd922100 {
-		status = "ok";
-	};
-
-	/* BLSP2 */
-	serial@f991e000 {
-		status = "ok";
-	};
-
-	/* BLSP7 */
-	uart7: uart@f995d000 {
-		status = "disabled";
-	};
-
 	/* BLSP2 */
 	i2c_2: i2c@f9924000 {
-		cell-index = <0>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9924000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 96 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,scl-gpio = <&msmgpio 7 0x00>;
-		qcom,sda-gpio = <&msmgpio 6 0x00>;
-		qcom,master-id = <86>;
-		status = "ok";
 		synaptics_clearpad@2c {
-			compatible = "synaptics,clearpad";
-			reg = <0x2c>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <61 0x2>;
-			touch_vdd-supply = <&pm8941_l22>;
-			touch_vio-supply = <&pm8941_s3>;
-			synaptics,irq_gpio = <&msmgpio 61 0x00>;
 			preset_x_max = <1079>;
 			preset_y_max = <1919>;
-			preset_n_fingers = <10>;
 			preset_n_bytes_per_object = <8>;
 		};
 		maxim_max1187x_tsc@48 {
@@ -113,97 +62,6 @@
 			wakeup_gesture_support = <0>;
 			wakeup_gesture_timeout = <0>;
 		};
-
-		atmel_mxt_ts@4a {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP4 */
-	i2c@f9926000 {
-		cell-index = <1>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9926000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 98 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-	};
-
-	/* BLSP6 */
-	i2c@f9928000 {
-		cell-index = <2>;
-		compatible = "qcom,i2c-qup";
-		reg = <0xf9928000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg-names = "qup_phys_addr";
-		interrupts = <0 100 0>;
-		interrupt-names = "qup_err_intr";
-		qcom,i2c-bus-freq = <355000>;
-		qcom,i2c-src-freq = <50000000>;
-		qcom,master-id = <86>;
-		status = "ok";
-		nfc@28 {
-			compatible = "nxp,pn544";
-			reg = <0x28>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <59 0x0>;
-			nxp,pvdd_en = <&msmgpio 76 0x00>;
-			nxp,irq_gpio = <&msmgpio 59 0x00>;
-			nxp,dwld_en = <&msmgpio 77 0x00>;
-			nxp,ven = <&pm8941_gpios 23 0x01>;
-			gpio_fwdl_enable = <0 0 0 2>;
-			gpio_fwdl_disable = <0 0 1 0>;
-		};
-	};
-
-	/* BLSP11 */
-	i2c_0: i2c@f9967000 {
-		cell-index = <4>;
-		qcom,i2c-bus-freq = <355000>;
-		status = "ok";
-		sii8334@72 {
-			compatible = "qcom,mhl-sii8334";
-			reg = <0x72>;
-			interrupt-parent = <&msmgpio>;
-			interrupts = <64 0x2008>;
-			mhl-intr-gpio = <&msmgpio 64 0>;
-			mhl-pwr-gpio = <&msmgpio 60 0>;
-			mhl-rst-gpio = <&msmgpio 16 0>;
-			avcc_18-supply = <&pm8941_l24>;
-			avcc_12-supply = <&pm8941_l2>;
-			smps3a-supply = <&pm8941_s3>;
-			vdda-supply = <&pm8941_l12>;
-			qcom,hdmi-tx-map = <&mdss_hdmi_tx>;
-		};
-
-		isa1200@48 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP1 */
-	spi_0: spi@f9923000 {
-		status = "disabled";
-
-		ethernet-switch@2 {
-			status = "disabled";
-		};
-	};
-
-	/* BLSP10 */
-	spi_7: spi_epm: spi@f9966000 {
-		status = "disabled";
-
-		epm-adc@0 {
-			status = "disabled";
-		};
 	};
 
 	gpio_keys {
@@ -212,39 +70,12 @@
 		interrupt-parent = <&msmgpio>;
 		interrupts = <9 0>;
 
-		vol_dn {
-			label = "volume_down";
-			gpios = <&pm8941_gpios 2 0x1>;
-			linux,input-type = <1>;
-			linux,code = <114>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
-
 		camera_snapshot {
 			status = "disabled";
 		};
 
 		camera_focus {
 			status = "disabled";
-		};
-
-		vol_up {
-			label = "volume_up";
-			gpios = <&pm8941_gpios 5 0x1>;
-			linux,input-type = <1>;
-			linux,code = <115>;
-			gpio-key,wakeup;
-			debounce-interval = <15>;
-		};
-
-		sim_det {
-			label = "sim-detection";
-			gpios = <&msmgpio 9 0x0>;
-			linux,input-type = <5>;
-			linux,code = <7>;
-			gpio-key,wakeup;
-			debounce-interval = <10>;
 		};
 	};
 
@@ -618,123 +449,26 @@
 			status = "disabled";
 		};
 	};
-
-	qcom,ion {
-		compatible = "qcom,msm-ion";
-
-		qcom,ion-heap@20 { /* CAMERA HEAP */
-			compatible = "qcom,msm-ion-reserve";
-			reg = <20>;
-			qcom,heap-align = <0x1000>;
-			linux,contiguous-region = <&camera_mem>;
-			qcom,ion-heap-type = "CARVEOUT";
-		};
-	};
-
-	sound {
-		qcom,audio-routing =
-			"RX_BIAS", "MCLK",
-			"LDO_H", "MCLK",
-			"Ext Spk Bottom Pos", "LINEOUT1",
-			"Ext Spk Bottom Neg", "LINEOUT3",
-			"Ext Spk Top Pos", "LINEOUT2",
-			"Ext Spk Top Neg", "LINEOUT4",
-			"AMIC1", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC2", "MIC BIAS2 External",
-			"MIC BIAS2 External", "Headset Mic",
-			"AMIC3", "MIC BIAS3 External",
-			"MIC BIAS3 External", "ANCLeft Headset Mic",
-			"AMIC4", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Handset Mic",
-			"AMIC5", "MIC BIAS1 External",
-			"MIC BIAS1 External", "Secondary Mic",
-			"AMIC6", "MIC BIAS4 External",
-			"MIC BIAS4 External", "Handset FB ANC Mic";
-		qcom,mbhc-audio-jack-type = "4-pole-jack";
-	};
-
-	gpio_hw_ids {
-		compatible = "gpio_hw_ids";
-
-		gpios = <&pm8941_gpios 1 0>,
-			<&pm8941_gpios 6 0>,
-			<&pm8941_gpios 7 0>,
-			<&pm8941_gpios 14 0>;
-	};
-
-	qcom,msm-thermal {
-		qcom,pmic-sw-mode-regs = "vdd_dig";
-	};
-};
-
-&memory_hole {
-	qcom,memblock-remove = <0x5d00000 0xa200000>; /* Address and size of the hole */
-};
-
-&mdss_hdmi_tx {
-	/* rhine doesn't use hpd-5v */
-	qcom,supply-names = "hpd-gdsc", "core-vdda", "core-vcc";
-	qcom,min-voltage-level = <0 1800000 1800000>;
-	qcom,max-voltage-level = <0 1800000 1800000>;
-	qcom,enable-load = <0 300000 0>;
 };
 
 &pm8941_chg {
-	qcom,vddmax-mv = <4350>;
-	qcom,vddsafe-mv = <4400>;
 	qcom,ibatmax-ma = <2000>;
 	qcom,ibatterm-ma = <150>;
 	qcom,ibatsafe-ma = <2000>;
 	qcom,maxinput-dc-ma = <1800>;
 	qcom,maxinput-usb-ma = <1500>;
-	qcom,cool-bat-mv = <4350>;
 	qcom,ibatmax-warm-ma = <900>;
-	qcom,warm-bat-mv = <4200>;
 	qcom,ibatmax-cool-ma = <900>;
-	qcom,vbatdet-delta-mv = <20>;
-	qcom,vbatdet-delta-soc = <1>;
 	qcom,thermal-mitigation = <2000 1500 1100 900 700 500 300 200 100 0>;
-	qcom,tchg-mins = <512>;
 	qcom,warm-disable-charging;
 };
 
 &pm8941_bms {
-	qcom,v-cutoff-uv = <3200000>;
-	qcom,max-voltage-uv = <4350000>;
-	qcom,r-conn-mohm = <0>;
-	qcom,low-soc-calculate-soc-threshold = <5>;
-	qcom,low-soc-calculate-soc-ms = <1000>;
-	qcom,calculate-soc-ms = <30000>;
-	qcom,chg-term-ua = <150000>;
-	qcom,use-external-rsense;
-	qcom,use-ocv-thresholds;
-	qcom,batt-type = <3>;
-	qcom,shutdown-soc-valid-limit = <40>;
-	qcom,clamp-soc-max-count = <2>;
 	qcom,fcc-resolution = <13>;
+	qcom,chg-term-ua = <150000>;
 };
 
 &pm8941_gpios {
-	/* GPIO_1: HW_ID_0 */
-	gpio@c000 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_2: VOL_DN */
-	gpio@c100 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
 
 	/* GPIO_3: NC (SNAPSHOT) */
 	gpio@c200 {
@@ -748,290 +482,12 @@
 		status = "ok";
 	};
 
-	/* GPIO_5: VOL_UP */
-	gpio@c400 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <0>;		/* PU */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_6: HW_ID_1 */
-	gpio@c500 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_7: HW_ID_2 */
-	gpio@c600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <5>;		/* NP */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_8: NC */
-	gpio@c700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_9: RF_ID_EN */
-	gpio@c800 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <3>;	/* High */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_10: NC (FCHG_CNT) */
-	gpio@c900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_11: NC (AUD_DSP_PWR_EN) */
-	gpio@ca00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_12: RF_ID_EXTENTION */
-	gpio@cb00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_13: NC (TUNER_STATUS0) */
-	gpio@cc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_14: HW_ID_3 */
-	gpio@cd00 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <0>;		/* In */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,pull = <4>;		/* PD */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_15: DIVCLK1_CODEC */
-	/* Follow QCT */
-
-	/* GPIO_16: NC */
-	gpio@cf00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_17: (DIVCLK3) QPA_XO */
-	/* Follow QCT */
-
-	/* GPIO_18: NC (TUNER_STATUS1) */
-	gpio@d100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_19: DISP_RESET_N */
-	gpio@d200 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <0>;		/* Low */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_20: NC (IR_LEVEL_EN) */
-	gpio@d300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_21: BOOST_BYP_EN */
-	/* Follow QCT */
-
-	/* GPIO_22: NC (HS_DET) */
-	gpio@d500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_23: NFC_VEN */
-	gpio@d600 {
-		qcom,src-sel = <0>;		/* GPIO */
-		qcom,mode = <1>;		/* Out */
-		qcom,output-type = <0>;		/* CMOS */
-		qcom,vin-sel = <2>;		/* S3 */
-		qcom,out-strength = <1>;	/* Low */
-		qcom,invert = <1>;		/* High */
-		qcom,master-en = <1>;		/* Enable */
-		status = "ok";
-	};
-
-	/* GPIO_24: NC (NFC_EXT_LDO_EN) */
-	gpio@d700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_25: NC (IR_RESET) */
-	gpio@d800 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_26: NC (TUNER_ANT_SW_EN) */
-	gpio@d900 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
 	/* GPIO_27: NC (FLASH_LED_NOW) */
 	gpio@da00 {
 		qcom,master-en = <0>;		/* Disable */
 		status = "ok";
 	};
 
-	/* GPIO_28: TX_GTR_THRES */
-	/* Follow QCT */
-
-	/* GPIO_29: NC */
-	gpio@dc00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_30: NC */
-	gpio@dd00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_31: BATT_REM_ALERM */
-	/* Follow QCT */
-
-	/* GPIO_32: NC (TUNER_ANT_SW1) */
-	gpio@df00 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_33: NC (FELICA_FF) */
-	gpio@e000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_34: NC (FELICA_LOCK) */
-	gpio@e100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_35: NC (Reserved for ANC_HS_DET) */
-	gpio@e200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* GPIO_36: NC */
-	gpio@e300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8941_mpps {
-	/* MPP_1: SDC_UIM_VBIAS */
-	/* Follow QCT */
-
-	/* MPP_2: NC */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: TXDAC0_VREF */
-	/* Follow QCT */
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_5: NC */
-	mpp@a400 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_6: NC (ACC_ADC) */
-	mpp@a500 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_7: RF_ID */
-	mpp@a600 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_8: NC */
-	mpp@a700 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-};
-
-&pm8841_mpps {
-	/* MPP_1: NC (LMU_EN) */
-	mpp@a000 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_2: NC (FLASH_DR_RST_N) */
-	mpp@a100 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_3: NC */
-	mpp@a200 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
-
-	/* MPP_4: NC */
-	mpp@a300 {
-		qcom,master-en = <0>;		/* Disable */
-		status = "ok";
-	};
 };
 
 &spmi_bus {
@@ -1045,258 +501,27 @@
 	};
 
 	qcom,pm8941@1 {
-		qcom,vib@c000 {
-			status = "okay";
-			compatible = "qcom,qpnp-vibrator";
-			reg = <0xc000 0x100>;
-			label = "vibrator";
-			qcom,qpnp-vib-vtg-level-mV = <3100>;
-		};
-
-		qcom,vibrator@c100 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c200 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c300 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c400 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c500 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c600 {
-			status = "disabled";
-		};
-
-		qcom,vibrator@c700 {
-			status = "disabled";
-		};
-
-		qcom,leds@d800 {
-			status = "okay";
-			qcom,wled_0 {
-				label = "wled";
-				linux,name = "wled:backlight";
-				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
-				qcom,cabc-en = <1>;
-				qcom,op-fdbck = <0>;
-				qcom,default-state = "on";
-				qcom,max-current = <20>;
-				qcom,ctrl-delay-us = <0>;
-				qcom,boost-curr-lim = <3>;
-				qcom,cp-sel = <0>;
-				qcom,switch-freq = <2>;
-				qcom,ovp-val = <2>;
-				qcom,num-strings = <2>;
-				qcom,id = <0>;
-			};
-		};
-
 		qcom,leds@d000 {
-			status = "okay";
-			qcom,rgb_sync = <1>;
-
 			qcom,rgb_0 {
-				label = "rgb";
-				linux,name = "led:rgb_red";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <6>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <31>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <3>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_1 {
-				label = "rgb";
-				linux,name = "led:rgb_green";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <5>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <32>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <4>;
-				linux,default-trigger = "none";
 			};
 
 			qcom,rgb_2 {
-				label = "rgb";
-				linux,name = "led:rgb_blue";
-				qcom,mode = "pwm";
-				qcom,pwm-channel = <4>;
-				qcom,pwm-us = <1000>;
 				qcom,pwm-max-value = <24>;
-				qcom,max-current = <12>;
-				qcom,default-state = "off";
-				qcom,id = <5>;
-				linux,default-trigger = "none";
 			};
-		};
-
-		qcom,leds@d300 {
-			status = "disabled";
-		};
-
-		qcom,leds@e200 {
-			status = "disabled";
 		};
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
 &sdhc_2 {
 	qcom,pad-drv-on = <0x7 0x2 0x2>; /* 16mA, 6mA, 6mA */
-	qcom,vdd-current-level = <400000 400000>;
 };
 
 /* Regulator config */
-&pm8941_s1 {
-	status = "ok";
-};
-
-&pm8941_s2 {
-	status = "ok";
-};
-
-&pm8941_s3 {
-	status = "ok";
-};
-
-&pm8941_boost { /* VREG_5V */
-	regulator-min-microvolt = <5100000>;
-	regulator-max-microvolt = <5100000>;
-	status = "ok";
-};
-
-&pm8941_l1 {
-	status = "ok";
-};
-
-&pm8941_l2 {
-	status = "ok";
-};
-
-&pm8941_l3 {
-	regulator-min-microvolt = <1200000>;
-	regulator-max-microvolt = <1200000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <1200000>;
-	status = "ok";
-};
-
-&pm8941_l4 {
-	status = "ok";
-};
-
-&pm8941_l5 {
-	status = "ok";
-};
-
-&pm8941_l6 {
-	status = "ok";
-};
-
-&pm8941_l7 {
-	status = "ok";
-};
-
-&pm8941_l8 {
-	status = "ok";
-};
-
-&pm8941_l9 {
-	status = "ok";
-};
-
-&pm8941_l10 {
-	status = "disabled";
-};
-
-&pm8941_l11 {
-	status = "ok";
-};
-
-&pm8941_l12 {
-	status = "ok";
-};
-
-&pm8941_l13 {
-	status = "ok";
-};
-
-&pm8941_l14 {
-	status = "ok";
-};
-
-&pm8941_l15 {
-	status = "ok";
-};
-
-&pm8941_l16 {
-	status = "ok";
-};
-
-&pm8941_l17 {
-	regulator-min-microvolt = <2700000>;
-	regulator-max-microvolt = <2700000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2700000>;
-	status = "ok";
-};
-
-&pm8941_l18 {
-	regulator-min-microvolt = <2850000>;
-	regulator-max-microvolt = <2850000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <2850000>;
-	status = "ok";
-};
-
-&pm8941_l19 {
-	regulator-min-microvolt = <3300000>;
-	regulator-max-microvolt = <3300000>;
-	qcom,init-voltage = <3300000>;
-	status = "ok";
-};
-
-&pm8941_l20 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l21 {
-	regulator-min-microvolt = <2950000>;
-	regulator-max-microvolt = <2950000>;
-	qcom,init-voltage = <2950000>;
-	status = "ok";
-};
-
-&pm8941_l22 {
-	regulator-min-microvolt = <3000000>;
-	regulator-max-microvolt = <3000000>;
-	qcom,init-enable = <0>;
-	qcom,init-voltage = <3000000>;
-	status = "ok";
-};
-
 &pm8941_l23 {
 	regulator-min-microvolt = <2600000>;
 	regulator-max-microvolt = <2600000>;
@@ -1305,172 +530,11 @@
 	status = "ok";
 };
 
-&pm8941_l24 {
-	status = "ok";
-};
-
-&pm8941_lvs1 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs2 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_lvs3 {
-	qcom,init-enable = <0>;
-	status = "ok";
-};
-
-&pm8941_mvs1 { /* VREG_OTG */
-	qcom,pull-down-enable = <1>;
-	status = "ok";
-};
-
-&pm8941_mvs2 { /* VREG_HDMI */
-	status = "disabled";
-};
-
-&pm8841_s1 {
-	status = "ok";
-};
-
-&pm8841_s2 {
-	status = "ok";
-};
-
-&pm8841_s3 {
-	status = "ok";
-};
-
-&pm8841_s4 {
-	status = "ok";
-};
-
-&krait0_vreg { /* PM8821 VREG_S5 */
-	status = "ok";
-};
-
-&krait1_vreg { /* PM8821 VREG_S6 */
-	status = "ok";
-};
-
-&krait2_vreg { /* PM8821 VREG_S7 */
-	status = "ok";
-};
-
-&krait3_vreg { /* PM8821 VREG_S8 */
-	status = "ok";
-};
-
-&slim_msm {
-	taiko_codec {
-		qcom,cdc-micbias-ldoh-v = <0x3>;
-		qcom,cdc-micbias-cfilt1-mv = <2700>;
-		qcom,cdc-micbias-cfilt2-mv = <2700>;
-		qcom,cdc-micbias-cfilt3-mv = <2700>;
-		qcom,cdc-micbias1-cfilt-sel = <0x1>;
-		qcom,cdc-micbias2-cfilt-sel = <0x1>;
-		qcom,cdc-micbias3-cfilt-sel = <0x1>;
-		qcom,cdc-micbias4-cfilt-sel = <0x1>;
-	};
-};
-
-&hsphy {
-	qcom,hsphy-init = <0x00D0CC27>;
-};
-
-&spmi_bus {
-	qcom,pm8941@0 {
-		vadc@3100 {
-			chan@b4 {
-				qcom,scale-function = <8>;
-			};
-		};
-
-		qcom,vadc@3400 {
-			chan@30 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@8 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@6 {
-				qcom,hw-settle-time = <15>;
-			};
-
-			chan@b4 {
-				qcom,scale-function = <4>;
-			};
-		};
-	};
-};
-
-&mdss_mdp {
-	qcom,mdss-pref-prim-intf = "dsi";
-};
-
 &mdss_fb0 {
 	qcom,memory-reservation-size = <0x1000000>; /* size 16MB */
 };
 
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_renesas_default>;
-	vdd-supply = <&pm8941_lvs3>;
 	qcom,platform-enable-gpio = <&msmgpio 46 1>;
-	qcom,platform-lane-config = [];
-
-	qcom,ctrl-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,ctrl-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdda";
-			qcom,supply-min-voltage = <1200000>;
-			qcom,supply-max-voltage = <1200000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-	};
-
-	qcom,panel-supply-entries {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		qcom,panel-supply-entry@0 {
-			reg = <0>;
-			qcom,supply-name = "vdd";
-			qcom,supply-min-voltage = <0>;
-			qcom,supply-max-voltage = <0>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-		qcom,panel-supply-entry@1 {
-			reg = <1>;
-			qcom,supply-name = "vddio";
-			qcom,supply-min-voltage = <1800000>;
-			qcom,supply-max-voltage = <1800000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-
-	};
 };

--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2231,7 +2231,7 @@
         qcom,qcedev@fd440000 {
 		compatible = "qcom,qcedev";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x1b000>;
+		      <0xfd444000 0x8000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 		qcom,bam-pipe-pair = <1>;
@@ -2245,35 +2245,15 @@
 				<56 512 3936000 393600>;
 	};
 
-        qcom,qcrypto@fd440000 {
+        qcom,qcrypto@fd444000 {
 		compatible = "qcom,qcrypto";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x1b000>;
+		      <0xfd444000 0x8000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 		qcom,bam-pipe-pair = <2>;
 		qcom,ce-hw-instance = <1>;
 		qcom,ce-device = <0>;
-		qcom,clk-mgmt-sus-res;
-                qcom,msm-bus,name = "qcrypto-noc";
-		qcom,msm-bus,num-cases = <2>;
-		qcom,msm-bus,num-paths = <1>;
-		qcom,use-sw-aes-cbc-ecb-ctr-algo;
-		qcom,use-sw-aes-xts-algo;
-		qcom,use-sw-ahash-algo;
-		qcom,msm-bus,vectors-KBps =
-				<56 512 0 0>,
-				<56 512 3936000 393600>;
-	};
-        qcom,qcrypto1@fd440000 {
-		compatible = "qcom,qcrypto";
-		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x1b000>;
-		reg-names = "crypto-base","crypto-bam-base";
-		interrupts = <0 236 0>;
-		qcom,bam-pipe-pair = <0>;
-		qcom,ce-hw-instance = <1>;
-		qcom,ce-device = <1>;
 		qcom,clk-mgmt-sus-res;
                 qcom,msm-bus,name = "qcrypto-noc";
 		qcom,msm-bus,num-cases = <2>;

--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -93,7 +93,7 @@
 			linux,reserve-contiguous-region;
 			linux,reserve-region;
 			reg = <0 0x614000>;
-			lable = "audio_mem";
+			label = "audio_mem";
 		};
 
 		camera_mem: camera_region@0 {
@@ -2225,13 +2225,7 @@
 
 	qcom,msm-rtb {
 		compatible = "qcom,msm-rtb";
-		qcom,rtb-size = <0x100000>; /* 1M EBI1 buffer */
-	};
-
-	qcom,msm-contig-mem {
-		compatible = "qcom,msm-contig-mem";
-		qcom,memory-reservation-type = "EBI1";
-		qcom,memory-reservation-size = <0x280000>; /* 2.5M EBI1 buffer */
+		qcom,rtb-size = <0x100000>;
 	};
 
         qcom,qcedev@fd440000 {

--- a/drivers/power/qpnp-charger.c
+++ b/drivers/power/qpnp-charger.c
@@ -2492,7 +2492,6 @@ get_prop_capacity(struct qpnp_chg_chip *chip)
 {
 	union power_supply_propval ret = {0,};
 	int battery_status, bms_status, soc, charger_in;
-	struct qpnp_somc_params *sp = &chip->somc_params;
 
 	if (chip->fake_battery_soc >= 0)
 		return chip->fake_battery_soc;


### PR DESCRIPTION
Massive Rhine DT cleanup: there were really too many common properties in Rhine device-specific DTs. Create a rhine_common DT and use it.

qcrypto warning: There were two instances of qcrypto on msm8974, this should be a new design but it's not correctly implemented, so, remove the new instance

compile warning fix: qpnp-charger warning, introduced by the previous feature-removal commit, fixed now.

Also, this fixes the WCD codec warning about the speaker drive regulator by adding a dummy regulator.
