### PR TITLE
yukon: Add tianchi_dsds support

### DIFF
--- a/arch/arm/boot/dts/msm8226-v1-yukon_tianchi_dsds.dts
+++ b/arch/arm/boot/dts/msm8226-v1-yukon_tianchi_dsds.dts
@@ -1,0 +1,25 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ * Copyright (C) 2014 Sony Mobile Communications AB.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * NOTE: This file has been modified by Sony Mobile Communications AB.
+ * Modifications are licensed under the License.
+ */
+
+/dts-v1/;
+/include/ "msm8226-v1.dtsi"
+/include/ "msm8226-yukon_tianchi.dtsi"
+
+/ {
+	model = "SOMC TIANCHI_DSDS";
+	compatible = "somc,tianchi_dsds", "qcom,msm8226", "qcom,mtp";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/boot/dts/msm8226-v2-yukon_tianchi_dsds.dts
+++ b/arch/arm/boot/dts/msm8226-v2-yukon_tianchi_dsds.dts
@@ -1,0 +1,25 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ * Copyright (C) 2014 Sony Mobile Communications AB.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * NOTE: This file has been modified by Sony Mobile Communications AB.
+ * Modifications are licensed under the License.
+ */
+
+/dts-v1/;
+/include/ "msm8226-v2.dtsi"
+/include/ "msm8226-yukon_tianchi.dtsi"
+
+/ {
+	model = "SOMC TIANCHI_DSDS";
+	compatible = "somc,tianchi_dsds", "qcom,msm8226", "qcom,mtp";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/mach-msm/Makefile.boot
+++ b/arch/arm/mach-msm/Makefile.boot
@@ -11,6 +11,8 @@
    zreladdr-$(CONFIG_ARCH_MSM8226)	:= 0x00008000
 	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
+        dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-v1-yukon_tianchi_dsds.dtb
+        dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-v2-yukon_tianchi_dsds.dtb
 	dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8926-yukon_tianchi.dtb
 	dtb-$(CONFIG_MACH_SONY_SEAGULL) += msm8926-yukon_seagull-720p-mtp.dtb
 

--- a/arch/arm/mach-msm/board-8226-yukon_tianchi-gpiomux.c
+++ b/arch/arm/mach-msm/board-8226-yukon_tianchi-gpiomux.c
@@ -184,7 +184,14 @@ static struct msm_gpiomux_config msm_lcd_configs[] __initdata = {
 			[GPIOMUX_ACTIVE]    = &lcd_vsn_act_cfg,
 			[GPIOMUX_SUSPENDED] = &lcd_vsn_sus_cfg,
 		},
-	}
+	},
+	{
+		.gpio = 36,
+		.settings = {
+			[GPIOMUX_ACTIVE]    = &lcd_rst_act_cfg,
+			[GPIOMUX_SUSPENDED] = &lcd_rst_sus_cfg,
+		},
+	},
 };
 
 static struct msm_gpiomux_config msm_blsp_configs[] __initdata = {

--- a/arch/arm/mach-msm/board-8226.c
+++ b/arch/arm/mach-msm/board-8226.c
@@ -105,7 +105,7 @@ void __init msm8226_clocks_config(void)
 		msm_clock_init(&msm8226_flamingo_clock_init_data);
 	else if (of_machine_is_compatible("somc,seagull"))
 		msm_clock_init(&msm8226_seagull_clock_init_data);
-	else if (of_machine_is_compatible("somc,tianchi"))
+	else if (of_machine_is_compatible("somc,tianchi")||of_machine_is_compatible("somc,tianchi_dsds"))
 		msm_clock_init(&msm8226_tianchi_clock_init_data);
 }
 


### PR DESCRIPTION
Cleaner and better way of implementing dual sim support. All compiled dtbs included in dt image so device itself selects the correct one, thus separate defconfigs for single sim and dual sim variants are not required.
Signed-off-by: Abhinav1997 abhinav.jhanwar.august2@gmail.com
