### PR TITLE
ARM: 8062/1: Modify ldrt fixup handler to re-execute the userspace instruction

### DIFF
--- a/arch/arm/kernel/entry-armv.S
+++ b/arch/arm/kernel/entry-armv.S
@@ -487,7 +487,8 @@ ENDPROC(__und_usr)
  */
 	.pushsection .fixup, "ax"
 	.align	2
-4:	mov	pc, r9
+4:	str     r4, [sp, #S_PC]			@ retry current instruction
+	mov	pc, r9
 	.popsection
 	.pushsection __ex_table,"a"
 	.long	1b, 4b


### PR DESCRIPTION
We will reach fixup handler when one thread(say cpu0) caused an undefined exception, while another thread(say cpu1) is unmmaping the page.

Fixup handler returns to the next userspace instruction which has caused the undef execption, rather than going to the same instruction.

ARM ARM says that after undefined exception, the PC will be pointing
to the next instruction. ie +4 offset in case of ARM and +2 in case of Thumb

And there is no correction offset passed to vector_stub in case of
undef exception.

File: arch/arm/kernel/entry-armv.S +1085
vector_stub     und, UND_MODE

During an undefined exception, in normal scenario(ie when ldrt
instruction does not cause an abort) after resorting the context in
VFP hardware, the PC is modified as show below before jumping to
ret_from_exception which is in r9.

File: arch/arm/vfp/vfphw.S +169
@ The context stored in the VFP hardware is up to date with this thread
vfp_hw_state_valid:
   tst     r1, #FPEXC_EX
   bne     process_exception     @ might as well handle the pending
                                 @ exception before retrying branch
                                 @ out before setting an FPEXC that
                                 @ stops us reading stuff
        VFPFMXR FPEXC, r1        @ Restore FPEXC last
        sub     r2, r2, #4       @ Retry current instruction - if Thumb
        str     r2, [sp, #S_PC]  @ mode it's two 16-bit instructions,
                                 @ else it's one 32-bit instruction, so
                                 @ always subtract 4 from the following
                                 @ instruction address.

But if ldrt results in an abort, we reach the fixup handler and return
to ret_from_execption without correcting the pc.

This patch modifes the fixup handler to re-execute the same instruction which caused undefined execption.

Signed-off-by: Vinayak Menon vinayakm.list@gmail.com
Signed-off-by: Arun KS getarunks@gmail.com
Acked-by: Catalin Marinas catalin.marinas@arm.com
Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
(cherry picked from commit 3780f7ab4928bc05897a7e30cf102c20045823ef)
Reviewed-by: Yuanyuan Zhong zyy@motorola.com
Reviewed-by: Ye Ouyang yeouyang@motorola.com
Reviewed-by: Igor Kovalenko igork@motorola.com
