### PR TITLE
arm: dt: dsi-panel-eagle: Modify h-pulse width to fix display

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
@@ -32,7 +32,7 @@
 		qcom,mdss-dsi-h-sync-skew = <0>;
 		qcom,mdss-dsi-v-back-porch = <16>;
 		qcom,mdss-dsi-v-front-porch = <56>;
-		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-v-pulse-width = <1>; // This was <2> on copyleft
 		qcom,mdss-dsi-h-left-border = <0>;
 		qcom,mdss-dsi-h-right-border = <0>;
 		qcom,mdss-dsi-v-top-border = <0>;
@@ -233,7 +233,7 @@
 		qcom,mdss-dsi-panel-height = <960>;
 		qcom,mdss-dsi-h-front-porch = <130>;
 		qcom,mdss-dsi-h-back-porch = <30>;
-		qcom,mdss-dsi-h-pulse-width = <2>;
+		qcom,mdss-dsi-h-pulse-width = <1>; // This was <2> on copyleft
 		qcom,mdss-dsi-h-sync-skew = <0>;
 		qcom,mdss-dsi-v-back-porch = <16>;
 		qcom,mdss-dsi-v-front-porch = <56>;


### PR DESCRIPTION
It was set to 2 on copyleft kernel, where we took those parameters.
Unfortunately, at least on 3.10, setting it at 2 gives us display
tearing problems, with horizontal black lines on the whole image
that is being shown (or rendered).
