### PR TITLE
eagle: fix the dancing menu's

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_pipe.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pipe.c
@@ -1074,7 +1074,7 @@ static int mdss_mdp_image_setup(struct mdss_mdp_pipe *pipe,
 			pipe->mfd->panel_info->pdest == DISPLAY_1)
 			dst_xy = ((pipe->mixer_left->height -
 				   (pipe->dst.y + pipe->dst.h)) << 16) |
-				pipe->dst.x;
+				(pipe->mixer_left->width - pipe->dst.x - pipe->dst.w);
 		else
 			dst_xy = (pipe->dst.y << 16) | pipe->dst.x;
 	} else


### PR DESCRIPTION
- M2 users should not have to chase menu's
- rotation is much smoother now
- @kholk @jerpelea can adapt this to the unified kernel
- thanks to @galaxyfreak for simplifying original code
  Change-Id: I9ba1a09af764580d292cbd761fda4b5d13df2d96
