### PR TITLE
arm: DT: 8226-regulator: Enable 8226_s1_corner, set min uV to 5

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-regulator.dtsi
@@ -129,10 +129,13 @@
 			compatible = "qcom,rpm-smd-regulator";
 			regulator-name = "8226_s1_corner";
 			qcom,set = <3>;
-			regulator-min-microvolt = <1>;
+			regulator-min-microvolt = <5>;
 			regulator-max-microvolt = <7>;
 			qcom,use-voltage-corner;
 			qcom,consumer-supplies = "vdd_dig", "";
+			proxy-supply = <&pm8226_s1_corner>;
+			qcom,proxy-consumer-voltage = <7 7>;
+                        qcom,proxy-consumer-enable;
 		};
 		pm8226_s1_corner_ao: regulator-s1-corner-ao {
 			compatible = "qcom,rpm-smd-regulator";


### PR DESCRIPTION
The minimum uV is 5 for the proxy consumer and this is what actually
makes the regulator stable.
Also, enable the regulator when probed, so that wcnss hardware will
have the required time to finish its powerup sequence and when we
are actually probing and uploading the firmware, we'll find it ready.
