### PR TITLE
tianchi: Call camera sensor dtsi from common tianchi dtsi

### DIFF
--- a/arch/arm/boot/dts/msm8226-yukon_tianchi.dtsi
+++ b/arch/arm/boot/dts/msm8226-yukon_tianchi.dtsi
@@ -16,6 +16,7 @@
 
 /include/ "msm8226-yukon_common.dtsi"
 /include/ "dsi-panel-tianchi.dtsi"
+/include/ "msm8226-yukon_tianchi-camera-sensor.dtsi"
 
 &soc {
 

--- a/arch/arm/boot/dts/msm8926-yukon_tianchi.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_tianchi.dts
@@ -17,7 +17,6 @@
 /dts-v1/;
 /include/ "msm8926.dtsi"
 /include/ "msm8226-yukon_tianchi.dtsi"
-/include/ "msm8226-yukon_tianchi-camera-sensor.dtsi"
 
 / {
 	model = "SOMC TIANCHI";


### PR DESCRIPTION
Both single sim and dual sim variants use same camera sensor so it would be better to call it from the common tianchi dtsi they both use.
