### PR TITLE
yukon: Proper dtsi include

### DIFF
--- a/arch/arm/boot/dts/msm8926-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_eagle-720p-mtp.dts
@@ -12,7 +12,7 @@
 
 
 /dts-v1/;
-/include/ "msm8926.dtsi"
+/include/ "msm8926-v1.dtsi"
 /include/ "msm8226-yukon_eagle-720p-mtp.dtsi"
 /include/ "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
 
@@ -20,9 +20,4 @@
 	model = "Qualcomm MSM 8926 MTP";
 	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,eagle";
 	qcom,board-id = <8 0>;
-
-	qcom,msm-id = <200 0>,
-		      <224 0>,
-		      <200 0x10001>,
-		      <224 0x10001>;
 };

--- a/arch/arm/boot/dts/msm8926-yukon_flamingo-8926ss_ap.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_flamingo-8926ss_ap.dts
@@ -12,7 +12,7 @@
 
 
 /dts-v1/;
-/include/ "msm8926.dtsi"
+/include/ "msm8926-v1.dtsi"
 /include/ "msm8226-yukon_flamingo-mtp.dtsi"
 /include/ "msm8226-yukon_flamingo-camera-sensor.dtsi"
 
@@ -20,9 +20,4 @@
 	model = "Qualcomm MSM 8926 MTP (Arima 8926SS AP)";
 	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,flamingo";
 	qcom,board-id = <8 0>;
-	qcom,msm-id = <200 0>,
-		      <224 0>,
-		      <200 0x10001>,
-		      <224 0x10001>;
-
 };

--- a/arch/arm/boot/dts/msm8926-yukon_seagull-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_seagull-720p-mtp.dts
@@ -12,7 +12,7 @@
 
 
 /dts-v1/;
-/include/ "msm8926.dtsi"
+/include/ "msm8926-v1.dtsi"
 /include/ "msm8226-yukon_seagull-720p-mtp.dtsi"
 /include/ "msm8226-yukon_seagull-camera-sensor.dtsi"
 
@@ -21,9 +21,4 @@
 	model = "Qualcomm MSM 8926 MTP";
 	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,seagull";
 	qcom,board-id = <8 0>;
-
-	qcom,msm-id = <200 0>,
-		      <224 0>,
-		      <200 0x10001>,
-		      <224 0x10001>;
 };

--- a/arch/arm/boot/dts/msm8926-yukon_tianchi.dts
+++ b/arch/arm/boot/dts/msm8926-yukon_tianchi.dts
@@ -22,9 +22,4 @@
 	model = "SOMC TIANCHI";
 	compatible = "somc,tianchi", "qcom,msm8926", "qcom,mtp";
 	qcom,board-id = <8 0>;
-
-	qcom,msm-id = <200 0>,
-		      <224 0>,
-		      <200 0x10001>,
-		      <224 0x10001>;
 };


### PR DESCRIPTION
qcom,msm-id is already present in msm8926-v1.dtsi so there is no need to define it again when simply the required dtsi could be included.
