### PR TITLE
Kernel: fix some kmesg warnings

### DIFF
--- a/arch/arm/boot/dts/msm8974-v2-pm.dtsi
+++ b/arch/arm/boot/dts/msm8974-v2-pm.dtsi
@@ -176,7 +176,7 @@
 				qcom,ss-power = <163>;
 				qcom,energy-overhead = <577736>;
 				qcom,time-overhead = <1000>;
-				qcom,min-cpu-mode= "standalone_pc";
+				qcom,min-cpu-mode = "pc";
 				qcom,sync-cpus;
 
 			};

--- a/arch/arm/mach-msm/msm-pm.c
+++ b/arch/arm/mach-msm/msm-pm.c
@@ -817,7 +817,7 @@ int msm_cpu_pm_enter_sleep(enum msm_pm_sleep_mode mode, bool from_idle)
 
 int msm_pm_wait_cpu_shutdown(unsigned int cpu)
 {
-	int timeout = 10;
+	int timeout = 0;
 
 	if (!msm_pm_slp_sts)
 		return 0;


### PR DESCRIPTION
I'm seeing a whole bunch of warnings in kmesg, these patches address the issues.
