### PR TITLE
tianchi: Enable kernel logo from common tianchi dtsi

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_tianchi.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_tianchi.dtsi
@@ -394,3 +394,7 @@
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_novatek_jdi>;
 };
+
+&mdss_fb0 {
+        qcom,mdss-fb-splash-logo-enabled;
+};

--- a/arch/arm/boot/dts/qcom/msm8926-yukon_tianchi.dts
+++ b/arch/arm/boot/dts/qcom/msm8926-yukon_tianchi.dts
@@ -24,7 +24,3 @@
 	compatible = "somc,tianchi", "qcom,msm8926", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
-
-&mdss_fb0 {
-	qcom,mdss-fb-splash-logo-enabled;
-};


### PR DESCRIPTION
Its better to enable kernel logo from a dtsi both ss and ds variants use.
