### PR TITLE
arm: DT: Seagull: Add 8226_l5 regulator custom constraints

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
@@ -275,6 +275,14 @@
 };
 
 &rpm_bus {
+	rpm-regulator-ldoa5 {
+		pm8226_l5: regulator-l5 {
+			regulator-min-microvolt = <1100000>;
+			regulator-max-microvolt = <1100000>;
+			qcom,init-voltage = <1100000>;
+		};
+	};
+
 	rpm-regulator-smpa3 {
 		pm8226_s3: regulator-s3 {
 			regulator-min-microvolt = <1100000>;


### PR DESCRIPTION
We need 1.1V for our camera.
