### PR TITLE
msm: pm: Fix cpu collapse timeout

### DIFF
--- a/arch/arm/mach-msm/msm-pm.c
+++ b/arch/arm/mach-msm/msm-pm.c
@@ -817,7 +817,7 @@ int msm_cpu_pm_enter_sleep(enum msm_pm_sleep_mode mode, bool from_idle)
 
 int msm_pm_wait_cpu_shutdown(unsigned int cpu)
 {
-	int timeout = 10;
+	int timeout = 0;
 
 	if (!msm_pm_slp_sts)
 		return 0;


### PR DESCRIPTION
Looks like caf mismerged. This may fix the following warning:

<4>[  124.983957] ------------[ cut here ]------------
<4>[  124.984381] WARNING: at arch/arm/mach-msm/msm-pm.c:837 msm_pm_wait_cpu_shu
tdown+0x9c/0xb0()
<4>[  124.984661] CPU2 didn't collapse in 2 ms
<4>[  124.984869] [<c010e10c>](unwind_backtrace+0x0/0x144) from [<c0a1c68c>](d
ump_stack+0x20/0x24)
<4>[  124.985170] [<c0a1c68c>](dump_stack+0x20/0x24) from [<c019ab44>](warn_sl
owpath_common+0x58/0x70)
<4>[  124.985464] [<c019ab44>](warn_slowpath_common+0x58/0x70) from [<c019abd8>
](warn_slowpath_fmt+0x40/0x48)
<4>[  124.985943] [<c019abd8>](warn_slowpath_fmt+0x40/0x48) from [<c0179d30>](msm_pm_wait_cpu_shutdown+0x9c/0xb0)
<4>[  124.986287] [<c0179d30>](msm_pm_wait_cpu_shutdown+0x9c/0xb0) from [<c0126
750>](platform_cpu_kill+0x38/0x48)
<4>[  124.986591] [<c0126750>](platform_cpu_kill+0x38/0x48) from [<c010c6fc>](__cpu_die+0x4c/0x98)
<4>[  124.986778] [<c010c6fc>](__cpu_die+0x4c/0x98) from [<c09ee9cc>](_cpu_dow
n+0xf8/0x2e0)
<4>[  124.987074] [<c09ee9cc>](_cpu_down+0xf8/0x2e0) from [<c09eec58>](cpu_dow
n+0x34/0x50)
<4>[  124.987383] [<c09eec58>](cpu_down+0x34/0x50) from [<c0194250>](cpu_down_
work+0xc4/0xd8)
<4>[  124.987564] [<c0194250>](cpu_down_work+0xc4/0xd8) from [<c01b4e44>](proc
ess_one_work+0x178/0x4f4)
<4>[  124.987861] [<c01b4e44>](process_one_work+0x178/0x4f4) from [<c01b5540>](worker_thread+0x174/0x448)
<4>[  124.988152] [<c01b5540>](worker_thread+0x174/0x448) from [<c01bb8ac>](kt
hread+0xb4/0xc0)
<4>[  124.988450] [<c01bb8ac>](kthread+0xb4/0xc0) from [<c0108060>](kernel_thr
ead_exit+0x0/0x8)
<4>[  124.988725] ---[ end trace 77427e632785e345 ]---

Change-Id: I40ea4459f333d44b3f1f11ebcec85466a896d974
