### PR TITLE
Yukon: Add dummy SPKDRV supply

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-regulator.dtsi
@@ -512,6 +512,17 @@
 			status = "okay";
 		};
 	};
+
+	/*
+	 * vph_pwr_vreg represents the unregulated battery voltage supply
+	 * VPH_PWR that is present whenever the device is powered on.
+	 */
+	vph_pwr_vreg: vph_pwr_vreg {
+		compatible = "regulator-fixed";
+		status = "disabled";
+		regulator-name = "vph_pwr";
+		regulator-always-on;
+	};
 };
 
 &pm8226_chg_boost {

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
@@ -388,6 +388,10 @@
 	qcom,clamp-soc-max-count = <0>;
 };
 
+&vph_pwr_vreg {
+	status = "ok";
+};
+
 &slim_msm {
 	tapan_codec {
 		qcom,cdc-micbias1-ext-cap;

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
@@ -391,6 +391,16 @@
 &slim_msm {
 	tapan_codec {
 		qcom,cdc-micbias1-ext-cap;
+
+		/*
+		 * Yukon has external spkrdrv supply. Give a dummy
+		 * supply to make codec driver's happy.
+		 */
+		cdc-vdd-spkdrv-supply = <&vph_pwr_vreg>;
+		qcom,cdc-vdd-spkdrv-voltage = <0 0>;
+		qcom,cdc-vdd-spkdrv-current = <0>;
+
+		qcom,cdc-on-demand-supplies = "cdc-vdd-spkdrv";
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
@@ -388,6 +388,12 @@
 	qcom,clamp-soc-max-count = <0>;
 };
 
+&slim_msm {
+	tapan_codec {
+		qcom,cdc-micbias1-ext-cap;
+	};
+};
+
 &mdss_mdp {
 	qcom,mdss-pref-prim-intf = "dsi";
 	batfet-supply = <&pm8226_chg_batif>;

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dtsi
@@ -373,12 +373,6 @@
 	qcom,battery-data = <&mtp_batterydata>;
 };
 
-&slim_msm {
-	tapan_codec {
-		qcom,cdc-micbias1-ext-cap;
-	};
-};
-
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_innolux_qhd_vid>;
 };

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -279,12 +279,6 @@
 	qcom,init-voltage = <1800000>;
 };
 
-&slim_msm {
-	tapan_codec {
-		qcom,cdc-micbias1-ext-cap;
-	};
-};
-
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_truly_hx8379c_fwvga_vid>;
 	vdddsi-supply = <&pm8226_lvs1>;

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
@@ -421,12 +421,6 @@
 	qcom,btc-disabled = <1>;
 };
 
-&slim_msm {
-	tapan_codec {
-		qcom,cdc-micbias1-ext-cap;
-	};
-};
-
 &mdss_dsi0 {
 	qcom,platform-enable-gpio = <&msmgpio 52 0>;
 	qcom,dsi-pref-prim-pan = <&dsi_nt35521_720_vid_truly63>;

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_tianchi.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_tianchi.dtsi
@@ -342,12 +342,6 @@
 	qcom,duty-cycle-100p;
 };
 
-&slim_msm {
-	tapan_codec {
-		qcom,cdc-micbias1-ext-cap;
-	};
-};
-
 &rpm_bus {
 	rpm-regulator-ldoa28 {
 		pm8226_l28: regulator-l28 {


### PR DESCRIPTION
Required by https://github.com/sonyxperiadev/kernel/commit/50ba29460a0d77aad43d15d06e3c8f59124df318

Fixes:
<4>[   28.064799] ------------[ cut here ]------------
<4>[   28.068668] WARNING: at ../../../../../../kernel/sony/k-new/sound/soc/codecs/wcd9306.c:2512 tapan_codec_enable_vdd_spkr+0x8c/0x1fc()
<6>[   28.080561] SPKDRV supply cdc-vdd-spkdrv isn't defined
<6>[   28.080580] CPU: 0 PID: 645 Comm: AudioOut_2 Tainted: G        W    3.10.40-gcd11aca-00570-g351c812 #1

Dummy regulator is added with this to prevent error.
<6>[   10.301288] tapan-slim tapan-slim-pgd: cdc-vdd-spkdrv: vol=[0 0]uV, curr=[0]uA, ond 1
