### PR TITLE
leds-qpnp: reduce WLED max brightness to 255, as dictated by led-class

### DIFF
--- a/drivers/leds/leds-qpnp.c
+++ b/drivers/leds/leds-qpnp.c
@@ -76,7 +76,7 @@
 
 #define WLED_SET_ILIM_CODE		0x01
 
-#define WLED_MAX_LEVEL			4095
+#define WLED_MAX_LEVEL			LED_FULL
 #define WLED_8_BIT_MASK			0xFF
 #define WLED_4_BIT_MASK			0x0F
 #define WLED_8_BIT_SHFT			0x08


### PR DESCRIPTION
Signed-off-by: Courtney Cavin courtney.cavin@sonymobile.com
Signed-off-by: Adam Farden adam@farden.cz
