### PR TITLE
Fix eagle deepsleep

### DIFF
--- a/drivers/staging/iio/magnetometer/bma250e.c
+++ b/drivers/staging/iio/magnetometer/bma250e.c
@@ -161,7 +161,6 @@ static int yas_get_enable(void);
 static int yas_set_enable(int enable);
 static int yas_get_position(void);
 static int yas_set_position(int position);
-static int yas_self_test(void);
 static int yas_measure(struct yas_data *raw, int num);
 static int yas_ext(int32_t cmd, void *result);
 
@@ -235,7 +234,7 @@ yas_init(void)
 	}
 	printk("who_am_i_val:%02x\n", id);
 	accel_product_id = id;
-	
+
 	if (id != YAS_BGW_CHIPID_VAL) {
 		module.cbk.device_close(YAS_TYPE_ACC);
 		return YAS_ERROR_CHIP_ID;
@@ -340,12 +339,6 @@ yas_set_position(int position)
 }
 
 static int
-yas_self_test(void)
-{
-    return YAS_NO_ERROR;
-}
-
-static int
 yas_measure(struct yas_data *raw, int num)
 {
 	uint8_t buf[6];
@@ -410,7 +403,6 @@ yas_acc_driver_init(struct yas_acc_driver *f)
 	f->set_enable = yas_set_enable;
 	f->get_position = yas_get_position;
 	f->set_position = yas_set_position;
-	f->self_test = yas_self_test;
 	f->measure = yas_measure;
 	f->ext = yas_ext;
 	module.cbk = f->callback;
@@ -946,7 +938,7 @@ static int yas_probe(struct i2c_client *i2c, const struct i2c_device_id *id)
 		goto error_driver_term;
 	}
 	printk("[CCI]%s: yas_bosch_accel_probe end ---\n", __FUNCTION__);
-	
+
 	return 0;
 
 error_driver_term:


### PR DESCRIPTION
dev_get_drvdata is apperently needed to prevent a reboot on deepsleep.
If I use dev_to_iio_dev it reboots

edit: corrected in CONFIG_PM
dev_to_iio_dev can be used after all
