### PR TITLE
arm: DT: msm8226: Use contiguous memory for framebuffer and splash

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
@@ -102,7 +102,10 @@
 		mdss_fb0: qcom,mdss_fb_primary {
 			cell-index = <0>;
 			compatible = "qcom,mdss-fb";
-			qcom,memblock-reserve = <0x03200000 0xFA0000>;
+			qcom,memblock-reserve = <0x03400000 0xFA0000>;
+			qcom,cont-splash-memory {
+				linux,contiguous-region = <&cont_splash_mem>;
+			};
 		};
 
 		mdss_fb1: qcom,mdss_fb_wfd {

--- a/arch/arm/boot/dts/qcom/msm8226.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226.dtsi
@@ -91,6 +91,13 @@
 			reg = <0 0x314000>;
 			label = "audio_mem";
 		};
+
+		cont_splash_mem: cont_splash_mem@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve,region;
+			reg = <0 0x03400000 0 0xFA0000>;
+			label = "cont_splash_mem";
+		};
 	};
 
 	soc: soc { };


### PR DESCRIPTION
Change the address where the memory is being allocated to avoid
conflicts with other things, like memory used by the bootloader's
continuous splash feature and other kernel drivers.
