### PR TITLE
arm: DT: Rhine: Add v2.1 entries to msm-id

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_amami_row.dts
+++ b/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_amami_row.dts
@@ -26,7 +26,10 @@
 	compatible = "somc,amami-row", "qcom,msm8974";
 	qcom,board-id = <8 0>;
 
-	qcom,msm-id = <126 0x20002>,
+	qcom,msm-id = <126 0x20001>,
+		      <185 0x20001>,
+		      <186 0x20001>,
+		      <126 0x20002>,
 		      <185 0x20002>,
 		      <186 0x20002>;
 };

--- a/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_honami_row.dts
+++ b/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_honami_row.dts
@@ -26,7 +26,10 @@
 	compatible = "somc,honami-row", "qcom,msm8974";
 	qcom,board-id = <8 0>;
 
-	qcom,msm-id = <126 0x20002>,
+	qcom,msm-id = <126 0x20001>,
+		      <185 0x20001>,
+		      <186 0x20001>,
+		      <126 0x20002>,
 		      <185 0x20002>,
 		      <186 0x20002>;
 };

--- a/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_togari_row.dts
+++ b/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_togari_row.dts
@@ -26,7 +26,10 @@
 	compatible = "somc,togari-row", "qcom,msm8974";
 	qcom,board-id = <8 0>;
 
-	qcom,msm-id = <126 0x20002>,
+	qcom,msm-id = <126 0x20001>,
+		      <185 0x20001>,
+		      <186 0x20001>,
+		      <126 0x20002>,
 		      <185 0x20002>,
 		      <186 0x20002>;
 };


### PR DESCRIPTION
Some Rhine devices have got v2.1 SoC.
