### PR TITLE
mach-msm/board-sony_shinano: Fix race condition

### DIFF
--- a/arch/arm/mach-msm/board-sony_shinano-wifi.c
+++ b/arch/arm/mach-msm/board-sony_shinano-wifi.c
@@ -325,6 +325,8 @@ static int shinano_wifi_get_mac_addr(unsigned char *buf)
 				macbin[3], macbin[4], macbin[5]);
 
 		memcpy(buf, macbin, ETHER_ADDR_LEN);
+	} else {
+		goto random_mac;
 	}
 
 	filp_close(fp, NULL);


### PR DESCRIPTION
Wifi with random mac does not work because of missing else condition
which matches an empty sysfs file.
