### PR TITLE
arm: DT: msm8974-v2.2: Update min-default adreno frequency to be 200MHz

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-gpu.dtsi
@@ -22,7 +22,7 @@
 
 		qcom,chipid = <0x03000510>;
 
-		qcom,initial-pwrlevel = <1>;
+		qcom,initial-pwrlevel = <2>;
 
 		qcom,idle-timeout = <8>; //<HZ/12>
 		qcom,strtstp-sleepwake;

--- a/arch/arm/boot/dts/qcom/msm8974-v2.2.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-v2.2.dtsi
@@ -23,7 +23,7 @@
 	/* Updated chip ID */
 	qcom,chipid = <0x03030001>;
 
-	qcom,initial-pwrlevel = <2>;
+	qcom,initial-pwrlevel = <3>;
 
 	/* Updated bus bandwidth requirements */
 	qcom,msm-bus,vectors-KBps =


### PR DESCRIPTION
It's useless to stay at higher frequency by default, adreno is
efficient enough to render the 2D UI just fine at that frequency.

Higher default frequency means waste of power and, for environments
where power-efficiency is critical (applications such as handheld
battery-powered devices like smartphones), this is something that
should have be done a long time ago.

In any case, the governors are already deciding to use 200MHz, but
only when the GPU isn't _totally_ idle... and that's really poor,
because the lowest frequency wasn't being used for most of the uptime.

Update the "default" frequency (governor idling) to be 200MHz to get
the most battery power-saving, without the UI to feel sluggish at all.
