### PR TITLE
arm: msm8974pro: Remove modem_mem memory node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974pro-ion.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ion.dtsi
@@ -23,7 +23,8 @@
 		qcom,ion-heap@26 { /* MODEM HEAP */
 			compatible = "qcom,msm-ion-reserve";
 			reg = <26>;
-			linux,contiguous-region = <&modem_mem>;
+			qcom,heap-align = <0x1000>;
+			qcom,memory-fixed = <0x08000000 0x5100000>;
                         qcom,ion-heap-type = "DMA";
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8974pro.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro.dtsi
@@ -44,15 +44,6 @@
 			label = "tz_apps";
 
 		};
-
-		modem_mem: modem_region@0x8000000 {
-			linux,reserve-contiguous-region;
-			linux,reserve-region;
-			linux,remove-completely;
-			reg = <0x8000000 0x5200000>;
-			label = "modem_mem";
-
-		};
         };
 };
 
@@ -1651,10 +1642,6 @@
 
 	qcom,lpass@fe200000 {
 		linux,contiguous-region = <&alt_peripheral_mem>;
-	};
-
-	qcom,mss@fc880000 {
-		linux,contiguous-region = <&modem_mem>;
 	};
 
 	qcom,venus@fdce0000 {


### PR DESCRIPTION
It's not necessary and this is only giving problems to us...for now.
Fall back to standard 8974 peripheral_mem for allocating memory
for loading MBA OS to MBA HW.
