### PR TITLE
arm: DT: pm8226/8941: Add external-manageable labels to all PWM nodes

### DIFF
--- a/arch/arm/boot/dts/qcom/msm-pm8226.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-pm8226.dtsi
@@ -800,7 +800,7 @@
 			#pwm-cells = <2>;
 		};
 
-		pwm@b200 {
+		pm8226_pwm_2: pwm@b200 {
 			compatible = "qcom,qpnp-pwm";
 			reg = <0xb200 0x100>,
 			      <0xb042 0x7e>;
@@ -811,7 +811,7 @@
 			#pwm-cells = <2>;
 		};
 
-		pwm@b300 {
+		msm8226_pwm_3: pwm@b300 {
 			compatible = "qcom,qpnp-pwm";
 			reg = <0xb300 0x100>,
 			      <0xb042 0x7e>;
@@ -822,7 +822,7 @@
 			#pwm-cells = <2>;
 		};
 
-		pwm@b400 {
+		msm8226_pwm_4: pwm@b400 {
 			compatible = "qcom,qpnp-pwm";
 			reg = <0xb400 0x100>,
 			      <0xb042 0x7e>;
@@ -833,7 +833,7 @@
 			#pwm-cells = <2>;
 		};
 
-		pwm@b500 {
+		msm8226_pwm_5: pwm@b500 {
 			compatible = "qcom,qpnp-pwm";
 			reg = <0xb500 0x100>,
 			      <0xb042 0x7e>;

--- a/arch/arm/boot/dts/qcom/msm-pm8941.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-pm8941.dtsi
@@ -1362,7 +1362,7 @@
 		label = "kpdbl";
 	};
 
-	pwm@b100 {
+	pm8941_pwm_1: pwm@b100 {
 		compatible = "qcom,qpnp-pwm";
 		reg = <0xb100 0x100>,
 		      <0xb042 0x7e>;
@@ -1373,7 +1373,7 @@
 		#pwm-cells = <2>;
 	};
 
-	pwm@b200 {
+	pm8941_pwm_2: pwm@b200 {
 		compatible = "qcom,qpnp-pwm";
 		reg = <0xb200 0x100>,
 		      <0xb042 0x7e>;
@@ -1384,7 +1384,7 @@
 		#pwm-cells = <2>;
 	};
 
-	pwm@b300 {
+	pm8941_pwm_3: pwm@b300 {
 		compatible = "qcom,qpnp-pwm";
 		reg = <0xb300 0x100>,
 		      <0xb042 0x7e>;
@@ -1395,7 +1395,7 @@
 		#pwm-cells = <2>;
 	};
 
-	pwm@b400 {
+	pm8941_pwm_4: pwm@b400 {
 		compatible = "qcom,qpnp-pwm";
 		reg = <0xb400 0x100>,
 		      <0xb042 0x7e>;
@@ -1439,7 +1439,7 @@
 		#pwm-cells = <2>;
 	};
 
-	pwm@b800 {
+	pm8941_pwm_8: pwm@b800 {
 		compatible = "qcom,qpnp-pwm";
 		reg = <0xb800 0x100>,
 		      <0xb042 0x7e>;


### PR DESCRIPTION
Seriously, Qualcomm? We DO use other PWMs, we need all of 'em.
