### PR TITLE
fix copy location of dtb files

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -174,7 +174,7 @@ kernelconfig: $(KERNEL_OUT) $(KERNEL_CONFIG)
 ## Install it
 INSTALLED_KERNEL_TARGET ?= $(PRODUCT_OUT)/kernel
 
-DTB_DIR := $(KERNEL_OUT)/arch/arm/boot
+DTB_DIR := $(KERNEL_OUT)/arch/arm/boot/dts
 DTB_FILES := $(shell find -L $(DTB_DIR) -name "*.dtb")
 DTB_OUT_DIR := $(PRODUCT_OUT)/dtbs
 DTBS := $(foreach dtb,$(DTB_FILES),$(DTB_OUT_DIR)/$(notdir $(dtb)))


### PR DESCRIPTION
cherry-pick from the 3.4 branch does not take into account the new dts location

Signed-off-by: Adam Farden adam@farden.cz
