### PR TITLE
ARM: dts: msm: Remove dual configuration for CPU on msm8974

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-bus.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-bus.dtsi
@@ -1168,18 +1168,12 @@
 			qcom,masterp = <0>;
 			qcom,tier = <2>;
 			qcom,hw-sel = "BIMC";
-			qcom,mode = "Limiter";
+			qcom,mode = "Fixed";
 			qcom,qport = <0>;
 			qcom,ws = <10000>;
 			qcom,mas-hw-id = <0>;
 			qcom,prio-rd = <0>;
 			qcom,prio-wr = <0>;
-			qcom,mode-thresh = "Fixed";
-			qcom,thresh = <2000000 2456000>;
-			qcom,dual-conf;
-			qcom,bimc,bw = <300000 450000>;
-			qcom,bimc,gp = <5000>;
-			qcom,bimc,thmp = <50>;
 		};
 
 		mas-ampss-m1 {
@@ -1188,18 +1182,12 @@
 			qcom,masterp = <1>;
 			qcom,tier = <2>;
 			qcom,hw-sel = "BIMC";
-			qcom,mode = "Limiter";
+			qcom,mode = "Fixed";
 			qcom,qport = <1>;
 			qcom,ws = <10000>;
 			qcom,mas-hw-id = <0>;
 			qcom,prio-rd = <0>;
 			qcom,prio-wr = <0>;
-			qcom,mode-thresh = "Fixed";
-			qcom,thresh = <2000000 2456000>;
-			qcom,dual-conf;
-			qcom,bimc,bw = <300000 450000>;
-			qcom,bimc,gp = <5000>;
-			qcom,bimc,thmp = <50>;
 		};
 
 		mas-mss-proc {


### PR DESCRIPTION
Remove the dual configuration for CPU master on msm8974. The original
intent of this feature was to overcome some bus limitations in certain
usecases. However new desgin impovements have made this feature requirement
obsolete.

Change-Id: Ia0e61a59252c3f90fd32054fe1a5a9297afbc89c
Signed-off-by: Girish Mahadevan girishm@codeaurora.org
