### PR TITLE
arm: DT: Flamingo: Use XO autodetection for WCNSS

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -125,6 +125,12 @@
 		qcom,cdc-mclk-gpios = <&pm8226_gpios 1 0>;
 		qcom,cdc-vdd-spkr-gpios = <&pm8226_gpios 2 0>;
 	};
+
+	qcom,wcnss-wlan@fb000000 {
+		/delete-property/ qcom,has-48mhz-xo;
+		qcom,has-autodetect-xo;
+		qcom,wcnss-adc_tm = <&pm8226_adc_tm>;
+	};
 };
 
 &modem_mem {


### PR DESCRIPTION
Flamingo needs it because of the ADC probe.
This makes WCNSS to be initialized correctly and
consequently WiFi to work.
