### PR TITLE
arm: DT: Tianchi: Update Tianma panel reset sequences

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-tianchi.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-tianchi.dtsi
@@ -221,8 +221,8 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		somc,mdss-dsi-id-read-command = [06 01 00 01 05 00 01 A1];
 		somc,panel-id = [77 12 23 49];
-		qcom,mdss-dsi-reset-sequence = <0 6>, <1 16>;
-		somc,pw-on-rst-seq = <0 6>, <1 16>;
+		qcom,mdss-dsi-reset-sequence = <1 5>, <0 5>, <1 5>, <0 5>, <1 11>;
+		somc,pw-on-rst-seq = <1 5>, <0 5>, <1 5>, <0 5>, <1 11>;
 		somc,pw-off-rst-b-seq = <1 6>, <0 1>;
 		somc,disp-en-on-pre = <15>;
 		somc,disp-en-on-post = <21>;


### PR DESCRIPTION
This is needed to ensure we're resetting the panel
correctly and "for sure", as the bootloader MAY leave
the panel and/or mdss and/or reset GPIO in a bad or
unexpected state.

Reset twice to ensure stability in any case.
This will have ZERO overhead.
