### PR TITLE
video: msm: MHL: Add SII8620 complete cleaned up driver for Shinano

### DIFF
--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/Makefile
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/Makefile
@@ -1,7 +1,13 @@
-ccflags-y += -Idrivers/video/msm/mdss
-
 obj-y += mhl_platform_base.o
 obj-y += mhl_platform_power.o
-obj-y += mhl_platform.o
-obj-y += mhl_platform_i2c.o
+
+obj-y +=  mhl_sii8620_8061_drv.o
+
+mhl_sii8620_8061_drv-objs := mhl_sii8620_8061_device.o mhl_sii8620_device_edid.o  mhl_platform.o  mhl_tx.o mhl_platform_i2c.o mhl_lib_edid.o mhl_cbus_control.o mhl_tx_rcp.o mhl_lib_infoframe.o mhl_lib_timer.o mhl_cbus_write_burst.o
+
+#Make ko object for development
+debug: mhl_sii8620_8061_device.c mhl_sii8620_device_edid.c mhl_platform.c mhl_tx.c mhl_platform_i2c.c mhl_lib_edid.c mhl_cbus_control.c mhl_tx_rcp.c mhl_lib_infoframe.c mhl_lib_timer.c mhl_cbus_write_burst.c
+	$(MAKE) -C ${KERNELPATH} M=$(PWD) modules
+clean:
+	$(MAKE) -C ${KERNELPATH} M=$(PWD) clean
 

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.c
@@ -1,0 +1,2605 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "mhl_cbus_control.h"
+#include "mhl_common.h"
+#include "mhl_platform.h"
+#include "mhl_sii8620_8061_devcap.h"
+#include "mhl_sii8620_8061_device.h"
+#include "mhl_tx.h"
+#include "mhl_defs.h"
+#include "mhl_lib_timer.h"
+#include "mhl_lib_infoframe.h"
+#include "si_emsc.h"
+
+#define BIT_COC_PLL_LOCK_STATUS_CHANGE			0x01
+#define BIT_COC_CALIBRATION_DONE				0x02
+#define BIT_COC_8b_10b_ERROR					0x04
+#define BIT_COC_CALIBRATION_COMMA1				0x08
+#define BIT_COC_CALIBRATION_COMMA2				0x10
+
+#define VAL_PAGE_3_M3_CTRL_MHL1_2_VALUE (BIT_PAGE_3_M3_CTRL_SW_MHL3_SEL \
+						| BIT_PAGE_3_M3_CTRL_ENC_TMDS)
+
+#define FEATURE_ID_E_MSC			0x00
+#define FEATURE_ID_USB				0x01
+#define FEATURE_ID_AUDIO			0x02
+#define FEATURE_ID_IP				0x03
+#define FEATURE_ID_COMP_VIDEO			0x04
+#define FEATURE_ID_HID				0x05
+#define FEATURE_ID_LAST				FEATURE_ID_HID
+#define VC_RESPONSE_ACCEPT			0x00
+#define VC_RESPONSE_BAD_VC_NUM			0x01
+#define VC_RESPONSE_BAD_FEATURE_ID		0x02
+#define VC_RESPONSE_BAD_CHANNEL_SIZE		0x03
+
+/* Others */
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN_PP         0x08
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN_NORM       0x00
+
+
+/* DEVCAP */
+static void read_devcap_fifo(uint8_t *dev_cap_buf, u8 size_dev, bool xdev);
+
+/* Timer */
+static int mhl_create_timer(void);
+static int mhl_release_timer(void);
+
+/* rap control */
+static int send_content_on(void);
+static bool is_rap_supported(void);
+
+/* cbus context */
+static struct cbus_control_context cbus_context;
+
+/* cbus error */
+#define DDC_ABORT_THRESHOLD	10
+#define MSC_ABORT_THRESHOLD	10
+
+#define MAX_I2C_PAYLOAD_SIZE	256
+#define MAX_I2C_CMD_SIZE		0
+#define MAX_I2C_EMSC_BLOCK_SIZE (MAX_I2C_CMD_SIZE + MAX_I2C_PAYLOAD_SIZE)
+
+static void process_cbus_abort(void);
+static void cbus_abort_timer_callback(void *callback_param);
+
+struct i2c_xfer_mem {
+	uint8_t *block_tx_buffers;
+} i2c_mem;
+
+struct cbus_req {
+	struct list_head	link;
+	union {
+		struct {
+			uint8_t	cancel:1;
+			uint8_t	resvd:7;
+		} flags;
+		uint8_t	as_uint8;
+	} status;
+	uint8_t	retry_count;
+	uint8_t	command;	/* VS_CMD or RCP opcode */
+	uint8_t	reg;
+	uint8_t	reg_data;
+	uint8_t	offset;		/* register offset */
+	uint8_t	length;		/* Only applicable to write burst */
+	uint8_t	msg_data[16];	/* scratch pad data area. */
+	int	sequence;
+};
+
+struct SI_PACK_THIS_STRUCT tport_hdr_and_burst_id_t {
+	/*
+	   waste two bytes to save on memory copying
+	   when submitting BLOCK transactions
+	*/
+	struct SI_PACK_THIS_STRUCT standard_transport_header_t tport_hdr;
+
+	/* sub-payloads start here */
+	MHL_burst_id_t	burst_id;
+};
+
+union SI_PACK_THIS_STRUCT emsc_payload_t {
+	struct SI_PACK_THIS_STRUCT tport_hdr_and_burst_id_t hdr_and_burst_id;
+	uint8_t as_bytes[256];
+};
+
+struct SI_PACK_THIS_STRUCT block_req {
+	struct list_head	link;
+	const char *function;
+	int line;
+	int	sequence;
+	uint8_t count; /* (size - 1) see MHL spec section 13.5.7.2 */
+	uint8_t space_remaining;
+	uint8_t	sub_payload_size;
+	uint8_t *platform_header;
+	union SI_PACK_THIS_STRUCT emsc_payload_t *payload;
+};
+
+struct cbus_control_context {
+	/* status register*/
+	u8			status_0;
+	u8			status_1;
+	u8			status_2;
+	u8			xstatus_1;
+	u8			xstatus_3;
+	u8			link_mode;
+	u8			cbus_status;
+	MHLDevCap_u		devcap;
+	MHLXDevCap_u	xdevcap;
+
+
+	/* cbus queue */
+	struct list_head	cbus_queue;
+	struct list_head	cbus_free_list;
+	struct cbus_req		cbus_req_entries[NUM_CBUS_EVENT_QUEUE_EVENTS];
+	struct cbus_req		*current_cbus_req;
+	int			sequence;
+
+	/* flag control */
+	struct {
+		bool devcap_all;
+		bool path_en;
+		bool hpd;
+		bool video_ready;
+		bool cbus_mode_up;
+		bool dcap_chg_rcv;
+		bool hdcp_ready;
+		bool tmds_ready;
+	} flag;
+
+	/* RAP*/
+	u8	msc_msg_last_send_data;
+	u8	msc_msg_last_rcv_data;
+
+	/* TDM allocation */
+	uint8_t	virt_chan_slot_counts[TDM_VC_MAX];
+
+	/* cbus abort */
+	void *cbus_abort_timer;
+	bool cbus_abort_delay_active;
+	int msc_abort_count;
+	int ddc_abort_count;
+
+	struct {
+		int				sequence;
+		unsigned long local_blk_rx_buffer_size;
+		struct list_head	queue;
+		struct list_head	free_list;
+		struct block_req	*marshalling_req;
+		struct block_req	req_entries[NUM_BLOCK_QUEUE_REQUESTS];
+	} block_protocol;
+
+	struct		{
+		uint16_t received_byte_count;
+		unsigned long peer_blk_rx_buffer_avail;
+
+#define NUM_BLOCK_INPUT_BUFFERS 8
+		uint8_t		input_buffers[NUM_BLOCK_INPUT_BUFFERS][256];
+		int		input_buffer_lengths[NUM_BLOCK_INPUT_BUFFERS];
+		uint16_t	head;
+		uint16_t	tail;
+	} hw_block_protocol;
+
+};
+
+uint8_t dev_cap_values[] = {
+	DEVCAP_VAL_DEV_STATE,
+	DEVCAP_VAL_MHL_VERSION,
+	DEVCAP_VAL_DEV_CAT,
+	DEVCAP_VAL_ADOPTER_ID_H,
+	DEVCAP_VAL_ADOPTER_ID_L,
+	DEVCAP_VAL_VID_LINK_MODE,
+	DEVCAP_VAL_AUD_LINK_MODE,
+	DEVCAP_VAL_VIDEO_TYPE,
+	DEVCAP_VAL_LOG_DEV_MAP,
+	DEVCAP_VAL_BANDWIDTH,
+	DEVCAP_VAL_FEATURE_FLAG,
+	DEVCAP_VAL_DEVICE_ID_H,
+	DEVCAP_VAL_DEVICE_ID_L,
+	DEVCAP_VAL_SCRATCHPAD_SIZE,
+	DEVCAP_VAL_INT_STAT_SIZE,
+	DEVCAP_VAL_RESERVED
+};
+
+uint8_t xdev_cap_values[] = {
+	XDEVCAP_VAL_ECBUS_SPEEDS,
+	XDEVCAP_VAL_TMDS_SPEEDS,
+	XDEVCAP_VAL_DEV_ROLES,
+	XDEVCAP_VAL_LOG_DEV_MAPX,
+	XDEVCAP_VAL_RESERVE
+};
+
+static char *get_cbus_command_string(int command)
+{
+#define CBUS_COMMAND_CASE(command) case command: return #command;
+	switch (command) {
+	CBUS_COMMAND_CASE(MHL_ACK)
+	CBUS_COMMAND_CASE(MHL_NACK)
+	CBUS_COMMAND_CASE(MHL_ABORT)
+	CBUS_COMMAND_CASE(MHL_WRITE_STAT)
+	CBUS_COMMAND_CASE(MHL_SET_INT)
+	CBUS_COMMAND_CASE(MHL_READ_DEVCAP)
+	CBUS_COMMAND_CASE(MHL_GET_STATE)
+	CBUS_COMMAND_CASE(MHL_GET_VENDOR_ID)
+	CBUS_COMMAND_CASE(MHL_SET_HPD)
+	CBUS_COMMAND_CASE(MHL_CLR_HPD)
+	CBUS_COMMAND_CASE(MHL_SET_CAP_ID)
+	CBUS_COMMAND_CASE(MHL_GET_CAP_ID)
+	CBUS_COMMAND_CASE(MHL_MSC_MSG)
+	CBUS_COMMAND_CASE(MHL_GET_SC1_ERRORCODE)
+	CBUS_COMMAND_CASE(MHL_GET_DDC_ERRORCODE)
+	CBUS_COMMAND_CASE(MHL_GET_MSC_ERRORCODE)
+	CBUS_COMMAND_CASE(MHL_WRITE_BURST)
+	CBUS_COMMAND_CASE(MHL_GET_SC3_ERRORCODE)
+	CBUS_COMMAND_CASE(MHL_WRITE_XSTAT)
+	CBUS_COMMAND_CASE(MHL_READ_XDEVCAP)
+	CBUS_COMMAND_CASE(MHL_READ_EDID_BLOCK)
+	CBUS_COMMAND_CASE(MHL_READ_XDEVCAP_REG)
+	CBUS_COMMAND_CASE(MHL_SEND_3D_REQ_OR_FEAT_REQ)
+	}
+	return "unknown";
+}
+
+#define RAP_RECEIVE_TIME 1000
+static void *rapk_receive_timer;
+
+static void mhl_rapk_receive_timer(void *callback_param)
+{
+	pr_warn("%s: expired\n", __func__);
+	mhl_dev_clear_cbusp_cond_processing(DEV_RAP_SEND);
+	pr_warn("%s: msc_msg_last_send_data = 0x%2x\n",
+		__func__, cbus_context.msc_msg_last_send_data);
+	cbus_context.current_cbus_req = NULL;
+	exe_cbus_command();
+}
+
+static void mhl_rapk_receive_timer_start(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_start(rapk_receive_timer, RAP_RECEIVE_TIME);
+	if (ret != 0)
+		pr_err("%s: Failed to start rapk receive timer!\n", __func__);
+}
+
+static void mhl_rapk_receive_timer_stop(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_stop(rapk_receive_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to stop rapk receive timer!\n", __func__);
+}
+
+static void mhl_rapk_receive_timer_init(void)
+{
+	int ret;
+
+	pr_debug("%s:\n", __func__);
+
+	ret = mhl_lib_timer_create(mhl_rapk_receive_timer,
+					NULL,
+					&rapk_receive_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to create rapk receive timer!\n", __func__);
+}
+
+static void mhl_rapk_receive_timer_release(void)
+{
+	int ret;
+
+	pr_debug("%s:\n", __func__);
+
+	ret = mhl_lib_timer_delete(&rapk_receive_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to delete rapk receive timer!\n", __func__);
+}
+
+void mhl_pf_get_block_buffer_info(
+			struct block_buffer_info_t  *block_buffer_info)
+{
+	block_buffer_info->buffer = i2c_mem.block_tx_buffers;
+	block_buffer_info->req_size = MAX_I2C_EMSC_BLOCK_SIZE;
+	block_buffer_info->payload_offset = MAX_I2C_CMD_SIZE;
+}
+
+static bool is_SamsungTV(void)
+{
+	if (cbus_context.devcap.mdc.mhl_version == 0x10 &&
+		cbus_context.devcap.mdc.int_state_size == 0x44)
+		return true;
+	else
+		return false;
+}
+
+/*
+ *  CBUS QUEUE CONTROL
+ *  NOTE : following cbus queue control is not
+ *  thread safe (list_xx). So, those API must not
+ *  be used in multithread context.
+ */
+
+void init_cbus_queue(void)
+{
+	struct cbus_req	*entry;
+	int idx;
+
+	INIT_LIST_HEAD(&cbus_context.cbus_queue);
+	INIT_LIST_HEAD(&cbus_context.cbus_free_list);
+
+	if (list_empty(&cbus_context.cbus_queue)) {
+		pr_debug("%s:Queue empty\n", __func__);
+	}
+
+	cbus_context.current_cbus_req = NULL;
+
+	/* Place pre-allocated CBUS queue entries on the free list */
+	for (idx = 0; idx < NUM_CBUS_EVENT_QUEUE_EVENTS; idx++) {
+
+		entry = &cbus_context.cbus_req_entries[idx];
+		memset(entry, 0, sizeof(struct cbus_req));
+		list_add(&entry->link, &cbus_context.cbus_free_list);
+	}
+}
+
+struct cbus_req *get_free_cbus_queue_entry(void)
+{
+	struct cbus_req *req;
+	struct list_head *entry;
+
+	if (list_empty(&cbus_context.cbus_free_list)) {
+		int i;
+		list_for_each(entry, &cbus_context.cbus_queue)
+		{
+			req = list_entry(entry, struct cbus_req, link);
+		}
+		for (i = 0; i < ARRAY_SIZE(cbus_context.cbus_req_entries); ++i) {
+			req = &cbus_context.cbus_req_entries[i];
+		}
+		return NULL;
+	}
+
+	entry = cbus_context.cbus_free_list.next;
+	list_del(entry);
+	req = list_entry(entry, struct cbus_req, link);
+
+	/* Start clean */
+	req->status.flags.cancel = 0;
+	req->sequence = cbus_context.sequence++;
+
+	return req;
+}
+
+void return_cbus_queue_entry(struct cbus_req *pReq)
+{
+	list_add(&pReq->link, &cbus_context.cbus_free_list);
+}
+
+void queue_cbus_transaction(struct cbus_req *pReq)
+{
+	list_add_tail(&pReq->link, &cbus_context.cbus_queue);
+	exe_cbus_command();
+}
+
+void queue_priority_cbus_transaction(struct cbus_req *req)
+{
+	list_add(&req->link, &cbus_context.cbus_queue);
+}
+
+struct cbus_req *get_next_cbus_transaction(void)
+{
+	struct cbus_req *req;
+	struct list_head *entry;
+
+	if (list_empty(&cbus_context.cbus_queue)) {
+		pr_debug("%s:Queue empty\n", __func__);
+		return NULL;
+	}
+
+	entry = cbus_context.cbus_queue.next;
+	list_del(entry);
+	req = list_entry(entry, struct cbus_req, link);
+
+	return req;
+}
+
+/*
+ *
+ *  COMMAND SET & EXECUTION Utility
+ *
+ */
+
+void mhl_msc_init()
+{
+	init_cbus_queue();
+	init_cond_in_cbus_control();
+	cbus_context.status_0 = 0;
+	cbus_context.status_1 = 0;
+	cbus_context.xstatus_1 = 0;
+	cbus_context.xstatus_3 = 0;
+	cbus_context.cbus_status = 0;
+	cbus_context.link_mode = MHL_STATUS_CLK_MODE_NORMAL;
+	memset(&cbus_context.devcap , 0x00 , sizeof(cbus_context.devcap));
+	memset(&cbus_context.xdevcap , 0x00 , sizeof(cbus_context.xdevcap));
+
+	cbus_context.cbus_abort_delay_active = false;
+	cbus_context.msc_abort_count = 0;
+	cbus_context.ddc_abort_count = 0;
+
+	cbus_wb_init();
+}
+
+bool set_cbus_command(uint8_t command, uint8_t reg, uint8_t reg_data)
+{
+	struct cbus_req *req;
+
+	req = get_free_cbus_queue_entry();
+
+	if (req == NULL) {
+		pr_debug("%s:CBUS free queue exhausted\n", __func__);
+		return false;
+	}
+
+	req->retry_count	= 2;
+	req->command		= command;
+	req->reg		= reg;
+	req->reg_data		= reg_data;
+
+	pr_info("[CBUS] set %s reg: %X reg_data %X\n",
+		 get_cbus_command_string(req->command),
+		 req->reg, req->reg_data);
+
+	if ((command == MHL_SET_INT)
+		&& (reg == MHL_RCHANGE_INT)
+		&& (reg_data == MHL_INT_GRT_WRT)) {
+		pr_debug("%s:Priority cbus transaction\n", __func__);
+		queue_priority_cbus_transaction(req);
+	} else {
+		queue_cbus_transaction(req);
+	}
+
+	return true;
+}
+
+bool set_cbus_command_block(
+	uint8_t command, uint8_t length, uint8_t burst_offset, void *buffer)
+{
+	struct cbus_req *req;
+
+	req = get_free_cbus_queue_entry();
+
+	if (req == NULL) {
+		pr_warn("%s:CBUS free queue exhausted\n", __func__);
+		return false;
+	}
+
+	req->retry_count	= 1;
+	req->command		= command;
+	req->length		= length;
+	req->offset		= burst_offset;
+	memcpy(req->msg_data, buffer, length);
+
+	pr_info("[CBUS] set %s\n", get_cbus_command_string(req->command));
+
+	queue_cbus_transaction(req);
+
+	return true;
+}
+
+static void mhl_cbus_send_cbus_mode_up(void)
+{
+	/* Correspondence not to transmit CBUS_MODE_UP two time */
+	if (cbus_context.flag.cbus_mode_up != true) {
+		set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RAP,
+					MHL_RAP_CBUS_MODE_UP);
+		cbus_context.flag.cbus_mode_up = true;
+	} else
+		pr_warn("%s: already CBUS_MODE_UP\n", __func__);
+}
+
+void exe_cbus_command(void){
+	struct cbus_req *req;
+
+	if (cbus_context.cbus_abort_delay_active) {
+		pr_warn("%s CBUS abort delay in progress "		\
+			 "can't send any messages\n", __func__);
+		return;
+	}
+
+	req = cbus_context.current_cbus_req;
+
+	if (req != NULL) {
+		pr_info("%s:%s is in progress\n",
+			 __func__, get_cbus_command_string(req->command));
+		return;
+	}
+
+	req = get_next_cbus_transaction();
+
+	if (req == NULL) {
+		return;
+	}
+
+	if (MHL_MSC_MSG == req->command) {
+		cbus_context.msc_msg_last_send_data = req->reg_data;
+	}
+
+	if (req) {
+		bool success = true;
+
+		cbus_context.current_cbus_req = req;
+
+		pr_info("[CBUS] exe %s reg: %X reg_data %X\n",
+			 get_cbus_command_string(req->command),
+			 req->reg, req->reg_data);
+
+		switch (req->command) {
+		case MHL_WRITE_STAT:
+		case MHL_WRITE_XSTAT:
+		case MHL_SET_INT:
+		case MHL_SEND_3D_REQ_OR_FEAT_REQ:
+			if (MHL3_INT_FEAT_COMPLETE == req->reg_data)
+				pr_debug("%s: Sent FEAT_COMPLETE\n", __func__);
+
+			mhl_pf_write_reg(REG_PAGE_5_MSC_CMD_OR_OFFSET,
+					 req->reg);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_1ST_TRANSMIT_DATA,
+					 req->reg_data);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_COMMAND_START,
+					 BIT_PAGE_5_MSC_COMMAND_START_MSC_WRITE_STAT_CMD);
+			break;
+		case MHL_READ_DEVCAP:
+				pr_debug("%s: Trigger DEVCAP Read\n", __func__);
+				mhl_pf_modify_reg(REG_EDID_FIFO_INT_MASK,
+					BIT_INTR9_DEVCAP_DONE_MASK,
+					VAL_INTR9_DEVCAP_DONE_MASK_ENABLE);
+
+				/* don't call si_mhl_tx_drv_reset_ddc_fifo here */
+				mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+					VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE |
+					VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_DEVCAP |
+					VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE |
+					VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE
+				);
+
+			/* read the entire DEVCAP array	in one command */
+				mhl_pf_write_reg(REG_PAGE_2_TPI_CBUS_START,
+				BIT_PAGE_2_TPI_CBUS_START_GET_DEVCAP_START);
+			break;
+		case MHL_READ_XDEVCAP:
+			pr_debug("%s: Trigger XDEVCAP Read\n", __func__);
+				mhl_pf_modify_reg(REG_EDID_FIFO_INT_MASK,
+					BIT_INTR9_DEVCAP_DONE_MASK,
+					VAL_INTR9_DEVCAP_DONE_MASK_ENABLE);
+
+				/* don't call si_mhl_tx_drv_reset_ddc_fifo here */
+				mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+					VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE |
+					BIT_PAGE_2_EDID_CTRL_XDEVCAP_EN |
+					VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_DEVCAP |
+					VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE |
+					VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE
+				);
+
+			/* read the entire DEVCAP array	in one command */
+				mhl_pf_write_reg(REG_PAGE_2_TPI_CBUS_START,
+				BIT_PAGE_2_TPI_CBUS_START_GET_DEVCAP_START);
+			break;
+		case MHL_READ_XDEVCAP_REG:
+			pr_debug("%s: Read XDEVCAP_REG (0x%02x)\n", __func__,
+				req->reg);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_CMD_OR_OFFSET,
+				req->reg);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_COMMAND_START,
+			BIT_PAGE_5_MSC_COMMAND_START_MSC_READ_DEVCAP_CMD);
+			break;
+		case MHL_MSC_MSG:
+			if (req->reg == MHL_MSC_MSG_RAP) {
+				mhl_dev_set_cbusp_cond_processing(DEV_RAP_SEND);
+				mhl_rapk_receive_timer_start();
+			}
+
+			mhl_pf_write_reg(REG_PAGE_5_MSC_CMD_OR_OFFSET,
+					MHL_MSC_MSG);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_1ST_TRANSMIT_DATA,
+					req->reg);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_2ND_TRANSMIT_DATA,
+					req->reg_data);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_COMMAND_START,
+				BIT_PAGE_5_MSC_COMMAND_START_MSC_MSC_MSG_CMD);
+			break;
+		case MHL_READ_EDID_BLOCK:
+			mhl_device_start_edid_read();
+			break;
+		case MHL_WRITE_BURST:
+			pr_debug("%s: Sent WRITE_BURST\n", __func__);
+			cbus_wb_enable_gen2_write_burst_xmit();
+			cbus_wb_write_gen2_xfifo(req->length, req->msg_data);
+			break;
+		case MHL_GET_STATE:
+		case MHL_GET_VENDOR_ID:
+		case MHL_SET_HPD:
+		case MHL_CLR_HPD:
+		case MHL_GET_SC1_ERRORCODE:
+		case MHL_GET_DDC_ERRORCODE:
+		case MHL_GET_MSC_ERRORCODE:
+		case MHL_GET_SC3_ERRORCODE:
+			pr_debug("%s: Sending MSC command %02x, %02x, %02x\n",
+				 __func__, req->command, req->reg, req->reg_data);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_CMD_OR_OFFSET, req->command);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_1ST_TRANSMIT_DATA, req->reg_data);
+			mhl_pf_write_reg(REG_PAGE_5_MSC_COMMAND_START,
+					 BIT_PAGE_5_MSC_COMMAND_START_MSC_PEER_CMD);
+			break;
+		default:
+			success = false;
+			pr_err("%s:Not Implemented\n", __func__);
+		}
+
+		if (!success) {
+			return_cbus_queue_entry(req);
+			cbus_context.current_cbus_req = NULL;
+		}
+	}
+}
+
+/*
+ *
+ *  CBUS Communication Logic
+ *
+ */
+
+void mhl_msc_cbus_communication_start()
+{
+	set_cbus_command(MHL_WRITE_STAT,
+			 MHL_STATUS_REG_VERSION_STAT,
+			 MHL_VERSION);
+
+	set_cbus_command(MHL_WRITE_STAT,
+			 MHL_STATUS_REG_CONNECTED_RDY,
+			 MHL_STATUS_DCAP_RDY
+			 | MHL_STATUS_XDEVCAPP_SUPP
+			 | ((DEVCAP_VAL_DEV_CAT
+			     &
+			     (MHL_DEV_CATEGORY_PLIM2_0
+			      | MHL_DEV_CATEGORY_POW_BIT)
+			     )>>2)
+			 );
+	set_cbus_command(MHL_SET_INT,
+			 MHL_RCHANGE_INT,
+			 MHL_INT_DCAP_CHG);
+}
+
+void mhl_cbus_communication_eCBUS_start(void)
+{
+	pr_debug("%s called\n", __func__);
+
+	if (MHL_STATUS_DCAP_RDY & cbus_context.status_0) {
+		set_cbus_command(MHL_READ_XDEVCAP, 0, 0);
+	}
+
+	cbus_wb_start_gen2_write_burst();
+
+#ifdef EMSC_WORKAROUND
+	/*
+	 * This register should be set
+	 * in si_mhl_tx_initialize_block_transport().
+	 */
+	mhl_pf_modify_reg(REG_PAGE_3_GENCTL, BIT_PAGE_3_GENCTL_EMSC_EN, 0x01);
+#endif
+	/* FIXME
+	   We're investigating whether block transaction is
+	   mandatory or not
+	   si_mhl_tx_initialize_block_transport(dev_context); */
+}
+
+static bool mhl_cbus_support_e_cbus_d(void)
+{
+	return false;
+}
+
+static void mhl_cbus_slot_init(bool ecbus_d_speeds)
+{
+	/*
+	 * Set default eCBUS virtual channel slot assignments
+	 * based on the capabilities of both the transmitter
+	 * and receiver.
+	 */
+	if ((ecbus_d_speeds == true) && mhl_cbus_support_e_cbus_d()) {
+		pr_debug("CBUS slot set to eCBUS_D\n");
+		cbus_context.virt_chan_slot_counts[TDM_VC_CBUS1] = 1;
+		cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC] = 39;
+		cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS] = 160;
+	} else {
+		pr_debug("CBUS slot set to eCBUS_S\n");
+		cbus_context.virt_chan_slot_counts[TDM_VC_CBUS1] = 1;
+		cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC] = 4;
+		cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS] = 20;
+	}
+}
+
+static int mhl_cbus_set_tdm_slot_allocation(
+				uint8_t *vc_slot_counts, bool resync)
+{
+	int		status = -EINVAL;
+	uint16_t	slot_total = 0;
+	uint8_t		idx;
+
+	/* To the extent we can sanity check the slot allocation request */
+	if (vc_slot_counts[TDM_VC_CBUS1] != 1) {
+		pr_err("%s: CBUS slot size is not 1\n", __func__);
+		goto done;
+	}
+
+	for (idx = 0; idx < TDM_VC_MAX; idx++)
+		slot_total += vc_slot_counts[idx];
+	if (slot_total > 200) {
+		pr_err("%s: Total slot size is more than 200\n", __func__);
+		goto done;
+	}
+
+	if (!resync) {
+		/*
+		 * Since we're not being asked to perform TDM re-synchronization
+		 * we don't know which eCBUS mode will be used with this slot
+		 * allocation so we can't sanity check it further.  Just save
+		 * it for later use.
+		 */
+		status = 0;
+	} else {
+		switch (mhl_device_get_cbus_mode()) {
+		case CBUS_eCBUS_S:
+			if (slot_total > 25) {
+				pr_err("%s: Total slot size is more than 25\n",
+					__func__);
+				goto done;
+			}
+			break;
+		case CBUS_eCBUS_D:
+			break;
+		default:
+			pr_err("%s: CBUS mode is not eCBUS\n", __func__);
+			goto done;
+		}
+		status = 0;
+
+		mhl_pf_write_reg(REG_PAGE_1_TTXSPINUMS,
+			cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC]);
+		mhl_pf_write_reg(REG_PAGE_1_TTXHSICNUMS,
+			cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS]);
+		mhl_pf_write_reg(REG_PAGE_1_TTXTOTNUMS, slot_total - 1);
+	}
+
+done:
+	return status;
+}
+
+void mhl_cbus_process_vc_assign(uint8_t *write_burst_data)
+{
+	struct tdm_alloc_burst	*tdm_burst;
+	uint8_t			save_channel_size;
+	uint8_t			idx;
+
+	tdm_burst = (struct tdm_alloc_burst *)write_burst_data;
+
+	/*
+	 * The virtual channel assignment in the WRITE_BURST may contain one,
+	 * two or three channel allocations
+	*/
+	if (tdm_burst->num_ent > 3) {
+		pr_err("%s: Bad number of assignment requests in virtual channel assign",
+				__func__);
+		return;
+	}
+
+	for (idx = 0; idx < tdm_burst->num_ent; idx++) {
+		tdm_burst->vc_info[idx].req_resp.response = VC_RESPONSE_ACCEPT;
+
+		if (tdm_burst->vc_info[idx].feature_id > FEATURE_ID_LAST) {
+			pr_warn("%s: Source rejected request to assign"\
+					"CBUS virtual channel %d, invalid feature id 0x%02x\n",
+					__func__,
+					tdm_burst->vc_info[idx].vc_num,
+					tdm_burst->vc_info[idx].feature_id);
+			tdm_burst->vc_info[idx].req_resp.response
+					= VC_RESPONSE_BAD_FEATURE_ID;
+			continue;
+		}
+
+		if ((tdm_burst->vc_info[idx].feature_id == FEATURE_ID_E_MSC)
+			|| (tdm_burst->vc_info[idx].feature_id
+						== FEATURE_ID_USB)) {
+			/*
+			 * changing slot allocations may result in a loss
+			 * of data; however, link should self-synchronize
+			*/
+			save_channel_size = 0;
+
+			switch (tdm_burst->vc_info[idx].feature_id) {
+			case FEATURE_ID_E_MSC:
+				save_channel_size
+					= cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC];
+				cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC]
+					= tdm_burst->vc_info[idx].req_resp.channel_size;
+				break;
+			case FEATURE_ID_USB:
+				save_channel_size
+					= cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS];
+				cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS]
+					= tdm_burst->vc_info[idx].req_resp.channel_size;
+				break;
+			}
+
+			if (mhl_cbus_set_tdm_slot_allocation(
+				cbus_context.virt_chan_slot_counts, true)) {
+				pr_warn("%s: Source rejected request to assign"\
+					"CBUS virtual channel %d, bad channel size: 0x%02x\n",
+					__func__,
+					tdm_burst->vc_info[idx].vc_num,
+					tdm_burst->vc_info[idx].req_resp.channel_size);
+				switch (tdm_burst->vc_info[idx].feature_id) {
+				case FEATURE_ID_E_MSC:
+					cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC]
+						= save_channel_size;
+					break;
+				case FEATURE_ID_USB:
+					cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS]
+						= save_channel_size;
+					break;
+				}
+				tdm_burst->vc_info[idx].req_resp.response
+					= VC_RESPONSE_BAD_CHANNEL_SIZE;
+			}
+		} else {
+			pr_warn("%s: Source rejected request to assign"\
+					"CBUS virtual channel %d, bad virtual channel\n",
+					__func__,
+					tdm_burst->vc_info[idx].vc_num);
+			tdm_burst->vc_info[idx].req_resp.response
+					= VC_RESPONSE_BAD_VC_NUM;
+		}
+
+		if (tdm_burst->vc_info[idx].req_resp.response
+						== VC_RESPONSE_ACCEPT) {
+			pr_debug("%s: Source accepted requested virtual"\
+					"channel %d reassignment\n",
+					__func__,
+					tdm_burst->vc_info[idx].vc_num);
+		}
+	}
+
+	/* Respond back to requester to indicate acceptance or rejection */
+	tdm_burst->burst_id_h = burst_id_VC_CONFIRM >> 8;
+	tdm_burst->burst_id_l = (uint8_t)burst_id_VC_CONFIRM;
+	tdm_burst->checksum = calculate_generic_checksum(
+				(uint8_t *)(tdm_burst), 0, sizeof(*tdm_burst));
+
+	cbus_wb_request_write_burst(
+				0, sizeof(*tdm_burst), (uint8_t *)(tdm_burst));
+}
+
+void mhl_msc_command_done(bool is_Msc_Msg_Ack)
+{
+	struct cbus_req *req;
+
+	req = cbus_context.current_cbus_req;
+	if (req == NULL) {
+		pr_warn("No message to associate with completion notification\n");
+		return;
+	}
+
+	pr_info("complete cbus req: %s reg: %X reg_data %X\n",
+			get_cbus_command_string(req->command),
+			req->reg, req->reg_data);
+
+	/* In the case of NACK,
+	   re-try process must be executed otherwise
+	   if one command is executing,
+	   the command done process is skipped. */
+	if (is_Msc_Msg_Ack) {
+		/* skip if command is not finished */
+		if (mhl_device_is_cbusb_executing()) {
+			pr_info("%s:cbus is executing. skip!", __func__);
+			return;
+		}
+	}
+
+	cbus_context.current_cbus_req = NULL;
+
+	/* FIXME
+	   Cancel Process needs to be implemented */
+
+	if (MHL_WRITE_STAT == req->command) {
+		if (MHL_STATUS_REG_CONNECTED_RDY == req->reg) {
+			if (MHL_STATUS_DCAP_RDY == req->reg_data) {
+				set_cbus_command(MHL_SET_INT,
+						 MHL_RCHANGE_INT,
+						 MHL_INT_DCAP_CHG);
+			}
+		} else if (MHL_STATUS_REG_LINK_MODE == req->reg) {
+			if (MHL_STATUS_PATH_ENABLED & req->reg_data) {
+			}
+		}
+	} else if (MHL_WRITE_XSTAT == req->command) {
+	} else if (MHL_READ_DEVCAP == req->command) {
+		bool temp;
+		int i;
+		MHLDevCap_u	old_devcap, devcap_changes;
+
+		old_devcap = cbus_context.devcap;
+		read_devcap_fifo(cbus_context.devcap.devcap_cache,
+			DEVCAP_SIZE,
+			false/*devcap*/);
+
+		/* devcap log */
+		pr_info("devcap");
+		for (i = 0; i < sizeof(cbus_context.devcap.devcap_cache); i++) {
+			pr_info(" [0x%X:%.2X]", i,
+				 cbus_context.devcap.devcap_cache[i]);
+		}
+
+		mhl_platform_power_start_charge(
+			cbus_context.devcap.devcap_cache);
+
+		/* Generate a change mask between the old and new devcaps */
+		for (i = 0; i < sizeof(old_devcap); ++i) {
+			devcap_changes.devcap_cache[i]
+				= cbus_context.devcap.devcap_cache[i]
+				^ old_devcap.devcap_cache[i];
+		}
+
+		temp = 0;
+		for (i = 0; i < sizeof(devcap_changes); ++i) {
+			temp |= devcap_changes.devcap_cache[i];
+		}
+		if (temp) {
+			set_cond_in_cbus_control(DEVCAP_ALL_READ_DONE);
+		} else {
+			pr_debug("%s:devcap did not change\n", __func__);
+		}
+
+		/*
+		 * To distinguish Samsung MHL 1.0 Sink, followings
+		 * in device capability register values are referred.
+		 *
+		 * 1.MHL_VERSION = 0x10
+		 * 2.INT_STAT_SIZE = 0x44
+		 *
+		 * In SOMC investigation, only this Samsung model has the
+		 * INT_STAT_SIZE value (0x44).
+		 */
+		if (is_SamsungTV()) {
+			pr_debug("Samsung TV detected\n");
+			set_cond_in_cbus_control(SENT_PATH_EN_1);
+		}
+	} else if (MHL_READ_XDEVCAP == req->command) {
+		bool temp;
+		int i;
+		MHLXDevCap_u old_xdevcap, xdevcap_changes;
+
+		old_xdevcap = cbus_context.xdevcap;
+		read_devcap_fifo(cbus_context.xdevcap.xdevcap_cache,
+			XDEVCAP_OFFSET(XDEVCAP_LIMIT),
+			true/*xdevcap*/);
+
+		/* xdevcap log */
+		pr_info("xdevcap");
+		for (i = 0; i < XDEVCAP_OFFSET(XDEVCAP_LIMIT); i++) {
+			pr_info(" [0x%X:%.2X]", i,
+				cbus_context.xdevcap.xdevcap_cache[i]);
+		}
+
+		/* Generate a change mask between the old and new devcaps */
+		for (i = 0; i < XDEVCAP_OFFSET(XDEVCAP_LIMIT); ++i) {
+			xdevcap_changes.xdevcap_cache[i]
+				= cbus_context.xdevcap.xdevcap_cache[i]
+				^ old_xdevcap.xdevcap_cache[i];
+		}
+
+		temp = 0;
+		for (i = 0; i < sizeof(xdevcap_changes); ++i)
+			temp |= xdevcap_changes.xdevcap_cache[i];
+		if (temp)
+			/* Not implemented */
+			pr_debug("%s:Not implemented\n", __func__);
+		else
+			pr_debug("%s:xdevcap did not change\n", __func__);
+
+			set_cbus_command(MHL_READ_DEVCAP, 0, 0);
+			pr_debug("%s: DEVCAP Read, after XDEVCAP Read.\n",
+				__func__);
+	} else if (MHL_READ_XDEVCAP_REG == req->command) {
+		MHLXDevCap_u xdev_cap_cache;
+
+		xdev_cap_cache.xdevcap_cache[XDEVCAP_OFFSET(req->reg)] =
+			mhl_pf_read_reg(REG_PAGE_5_MSC_MT_RCVD_DATA0);
+
+		if (XDEVCAP_ADDR_ECBUS_SPEEDS == req->reg) {
+			mhl_cbus_slot_init((xdev_cap_cache.mxdc.ecbus_speeds
+						& MHL_XDC_ECBUS_D_150) != 0);
+
+			mhl_cbus_set_tdm_slot_allocation(
+				cbus_context.virt_chan_slot_counts, false);
+
+			pr_debug("%s: ECUBS_SPEED: %02X\n",
+				 __func__,
+				 xdev_cap_cache.mxdc.ecbus_speeds);
+
+			set_cond_in_cbus_control(READ_ECBUS_SPEED);
+		}
+
+	} else if (MHL_READ_EDID_BLOCK == req->command) {
+		if (!mhl_drv_connection_is_mhl3())
+			mhl_device_edid_set_upstream_edid();
+		else
+			set_cbus_command(MHL_SEND_3D_REQ_OR_FEAT_REQ,
+				MHL_RCHANGE_INT, MHL3_INT_FEAT_REQ);
+	} else if (MHL_SET_INT == req->command) {
+		/* FIXME Needs to be implemented */
+		/* Related to Write Burst */
+	} else if (MHL_MSC_MSG == req->command) {
+		if (is_Msc_Msg_Ack == false) {
+			msleep(1000);
+			pr_debug("%s: MSC_NAK, re-trying...\n", __func__);
+			/*
+			 * Request must be retried, so place it back
+			 * on the front of the queue.
+			*/
+			req->status.as_uint8 = 0;
+			queue_priority_cbus_transaction(req);
+			req = NULL;
+		} else {
+			if (MHL_MSC_MSG_RCPK == req->reg) {
+			} else if (MHL_MSC_MSG_RCPE == req->reg) {
+			} else if (MHL_MSC_MSG_RAP == req->reg) {
+			} else if (MHL_MSC_MSG_RAPK == req->reg) {
+				if (MHL_RAP_CBUS_MODE_DOWN == cbus_context.msc_msg_last_rcv_data) {
+					mhl_device_switch_cbus_mode(CBUS_oCBUS_PEER_IS_MHL3);
+					cbus_context.flag.cbus_mode_up = false;
+				} else if (MHL_RAP_CBUS_MODE_UP == cbus_context.msc_msg_last_rcv_data) {
+					mhl_cbus_send_cbus_mode_up();
+				}
+			} else if (MHL_MSC_MSG_BIST_REQUEST_STAT == req->reg) {
+			} else if (MHL_MSC_MSG_BIST_READY == req->reg) {
+			} else {
+			}
+		}
+	} else if (MHL_WRITE_BURST == req->command) {
+		/* FIXME Needs to be implemented */
+		/* Related to Write Burst */
+		cbus_wb_disable_gen2_write_burst_xmit();
+	} else if (MHL_SEND_3D_REQ_OR_FEAT_REQ == req->command) {
+		pr_debug("%s: Got FEAT_REQ ACK\n", __func__);
+	}
+
+	if (req != NULL)
+		return_cbus_queue_entry(req);
+
+}
+
+void mhl_msc_hpd_receive()
+{
+	uint8_t cbus_status;
+	uint8_t status;
+
+	cbus_status = mhl_pf_read_reg(REG_PAGE_5_CBUS_STATUS);
+	status = cbus_status & BIT_PAGE_5_CBUS_STATUS_CBUS_HPD;
+
+	if (BIT_PAGE_5_CBUS_STATUS_CBUS_HPD
+		& (cbus_context.cbus_status ^ cbus_status)) {
+		/* bugzilla 27396
+		 * No HPD interrupt has been missed yet.
+		 * Clear BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT2.
+		 */
+		mhl_pf_write_reg(REG_PAGE_5_CBUS_INT_0,
+					BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT2);
+		pr_debug("%s: HPD change\n", __func__);
+	} else {
+		pr_err("%s: missed HPD change\n", __func__);
+
+		/* leave the BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT2 interrupt
+		 * uncleared, so that we get another interrupt
+		 */
+		/* whatever we missed, it's the inverse of what we got */
+		status ^= BIT_PAGE_5_CBUS_STATUS_CBUS_HPD;
+		cbus_status ^= BIT_PAGE_5_CBUS_STATUS_CBUS_HPD;
+	}
+
+	if (0 == status) {
+		pr_info("[CBUS] got CLR_HPD\n");
+		clear_cond_in_cbus_control(RCV_HPD);
+
+		/* FIXME
+		   Stop EDID Read if EDID read is being done
+		   Clear EDID (this process seems to be not necessary
+		   if clear is done before EDID read starts) */
+
+	} else {
+		pr_info("[CBUS] got SET_HPD\n");
+		set_cond_in_cbus_control(RCV_HPD);
+	}
+
+	cbus_context.cbus_status = cbus_status;
+}
+
+void mhl_msc_write_stat_receive()
+{
+	uint8_t status_change_bit_mask_0;
+	uint8_t status_change_bit_mask_1;
+	uint8_t xstatus_change_bit_mask_1;
+	uint8_t xstatus_change_bit_mask_3;
+
+	uint8_t status_0;
+	uint8_t status_1;
+	uint8_t status_2;
+	uint8_t xstatus_1;
+	uint8_t xstatus_3;
+
+	uint8_t		write_stat[3];
+	uint8_t		write_xstat[4];
+
+	mhl_pf_read_reg_block(REG_PAGE_4_MHL_STAT_0,
+			      ARRAY_SIZE(write_stat),
+			      write_stat);
+
+	mhl_pf_read_reg_block(REG_PAGE_4_MHL_EXTSTAT_0,
+			      ARRAY_SIZE(write_xstat),
+			      write_xstat);
+
+	status_0 = write_stat[0];
+	status_1 = write_stat[1];
+	status_2 = write_stat[2];
+	xstatus_1 = write_xstat[1];
+	xstatus_3 = write_xstat[3];
+
+	status_change_bit_mask_0 = status_0 ^ cbus_context.status_0;
+	status_change_bit_mask_1 = status_1 ^ cbus_context.status_1;
+	xstatus_change_bit_mask_1 = xstatus_1 ^ cbus_context.xstatus_1;
+	xstatus_change_bit_mask_3 = xstatus_3 ^ cbus_context.xstatus_3;
+
+	cbus_context.status_0 = status_0;
+	cbus_context.status_1 = status_1;
+	cbus_context.status_2 = status_2;
+	cbus_context.xstatus_1 = xstatus_1;
+	cbus_context.xstatus_3 = xstatus_3;
+
+	pr_info("  write_stat [0:0x%02x][1:0x%02x][2:0x%02x]\n",
+		write_stat[0], write_stat[1], write_stat[2]);
+	pr_info("  Wwrite_stat[0:0x%02x][1:0x%02x][2:0x%02x][3:0x%02x]\n",
+		write_xstat[0], write_xstat[1], write_xstat[2], write_xstat[3]);
+
+	if (MHL_STATUS_DCAP_RDY & status_change_bit_mask_0) {
+		pr_info("DCAP_RDY changed\n");
+		if (MHL_STATUS_DCAP_RDY & status_0) {
+			pr_debug("got DCAP_RDY\n");
+
+			switch (mhl_device_get_cbus_mode()) {
+			case CBUS_oCBUS_PEER_VERSION_PENDING:
+				if (cbus_context.status_2 >= 0x30) {
+					if (MHL_STATUS_XDEVCAPP_SUPP & status_0) {
+						pr_debug("%s: speer is MHL3 or newer\n",
+							__func__);
+						/* Our peer is an MHL3.0 or newer device.
+						   Here we enable DEVCAP_X and STATUS_X operations */
+						mhl_device_set_cbus_mode(CBUS_oCBUS_PEER_IS_MHL3);
+
+						mhl_pf_write_reg( REG_PAGE_3_M3_CTRL,
+							VAL_PAGE_3_M3_CTRL_MHL3_VALUE);
+					}
+				}
+				break;
+			default:
+				break;
+			}
+
+			/* after the above does not indicate MHL3,
+			   then it's MHL1.x or MHL2.x */
+			if (CBUS_oCBUS_PEER_VERSION_PENDING == mhl_device_get_cbus_mode()) {
+				pr_debug("%s: speer is MHL2 or older\n",
+					__func__);
+
+				mhl_device_switch_cbus_mode(
+					CBUS_oCBUS_PEER_IS_MHL1_2);
+			}
+
+			switch (mhl_device_get_cbus_mode()) {
+			case CBUS_oCBUS_PEER_IS_MHL1_2:
+				set_cbus_command(MHL_READ_DEVCAP, 0, 0);
+				break;
+			case CBUS_oCBUS_PEER_IS_MHL3:
+				set_cbus_command(MHL_READ_XDEVCAP_REG,
+					XDEVCAP_ADDR_ECBUS_SPEEDS,
+					0);
+				break;
+			default:
+				break;
+			}
+			/*
+				Now that we have positively identified
+					the MHL version of the peer,
+					we re-evaluate our settings.
+			*/
+
+			peer_specific_init();
+
+			mhl_pf_write_reg(REG_EDID_FIFO_INT_MASK,
+					 (BIT_INTR9_DEVCAP_DONE_MASK
+					 | BIT_INTR9_EDID_DONE_MASK
+					 | BIT_INTR9_EDID_ERROR));
+		}
+	}
+
+	if (MHL_STATUS_PATH_ENABLED & status_change_bit_mask_1) {
+		pr_info("PATH_EN changed\n");
+
+		if (MHL_STATUS_PATH_ENABLED & status_1) {
+			pr_info("got PATH_EN 1\n");
+
+			set_cond_in_cbus_control(SENT_PATH_EN_1);
+			cbus_context.link_mode |= MHL_STATUS_PATH_ENABLED;
+			set_cbus_command(MHL_WRITE_STAT, MHL_STATUS_REG_LINK_MODE,
+					 cbus_context.link_mode);
+
+		} else{
+			pr_info("got PATH_EN 0\n");
+
+			clear_cond_in_cbus_control(SENT_PATH_EN_1);
+			cbus_context.link_mode &= ~MHL_STATUS_PATH_ENABLED;
+			set_cbus_command(MHL_WRITE_STAT, MHL_STATUS_REG_LINK_MODE,
+					 cbus_context.link_mode);
+		}
+	}
+
+	if (MHL_XDS_LINK_STATUS_TMDS_NORMAL & xstatus_1) {
+		if (mhl_device_get_hdcp_status()) {
+			pr_debug("AV LINK_MODE_STATUS is NORMAL\n");
+
+			set_cond_in_cbus_control(TMDS_READY);
+			if (get_cond_in_cbus_control(HDCP_READY)) {
+				pr_debug("Start HDCP\n");
+				start_hdcp();
+			} else {
+				pr_debug("HDCP is not ready\n");
+			}
+		}
+	} else {
+		pr_debug("AV LINK_MODE_STATUS not NORMAL\n");
+	}
+
+}
+
+void mhl_msc_msg_receive()
+{
+	int st = 0;
+	uint8_t sub_cmd, cmd_data;
+	sub_cmd = mhl_pf_read_reg(REG_PAGE_5_MSC_MR_MSC_MSG_RCVD_1ST_DATA);
+	cmd_data = mhl_pf_read_reg(REG_PAGE_5_MSC_MR_MSC_MSG_RCVD_2ND_DATA);
+
+	switch (sub_cmd) {
+	case MHL_MSC_MSG_RCP:
+		pr_info("%s: MHL: receive RCP(0x%02x)\n", __func__, cmd_data);
+		st = mhl_tx_rcp_input(cmd_data);
+		if (st == 0) {
+			set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RCPK,
+					cmd_data);
+		} else{
+			if (set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RCPE,
+					MHL_RCPE_STATUS_INEFFECTIVE_KEY_CODE)){
+				set_cbus_command(MHL_MSC_MSG,
+						MHL_MSC_MSG_RCPK, cmd_data);
+			}
+		}
+		break;
+	case MHL_MSC_MSG_RCPK:
+		pr_info("%s: MHL: receive RCPK(0x%02x)\n",
+				__func__, cmd_data);
+		break;
+	case MHL_MSC_MSG_RCPE:
+		pr_info("%s: MHL: receive RCPE(0x%02x)\n",
+				__func__, cmd_data);
+		break;
+	case MHL_MSC_MSG_RAP:
+		pr_info("%s: MHL: receive RAP(0x%02x)\n",
+				__func__, cmd_data);
+		cbus_context.msc_msg_last_rcv_data = cmd_data;
+		set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RAPK,
+						MHL_RAPK_NO_ERR);
+
+		switch (cmd_data) {
+		case MHL_RAP_CONTENT_ON:
+			if (cbus_context.flag.video_ready) {
+				if (is_video_muted() && (is_tmds_active() == false))
+					start_video();
+			}
+			break;
+		case MHL_RAP_CONTENT_OFF:
+			if (cbus_context.flag.video_ready) {
+				if (is_video_muted() == false) {
+					stop_video();
+				} else {
+					pr_debug("%s:Video has been already muted\n",
+						 __func__);
+				}
+			} else {
+			pr_debug("%s:Video has been not ready yet\n", __func__);
+			}
+			break;
+		}
+		break;
+	case MHL_MSC_MSG_RAPK:
+		pr_info("%s: MHL: receive RAPK(0x%02x)\n",
+				__func__, cmd_data);
+		mhl_rapk_receive_timer_stop();
+		mhl_dev_clear_cbusp_cond_processing(DEV_RAP_SEND);
+
+		if (MHL_RAP_CBUS_MODE_DOWN == cbus_context.msc_msg_last_send_data) {
+			mhl_device_switch_cbus_mode(CBUS_oCBUS_PEER_IS_MHL3);
+			cbus_context.flag.cbus_mode_up = false;
+		} else if (MHL_RAP_CBUS_MODE_UP == cbus_context.msc_msg_last_send_data) {
+			if (MHL_RAPK_NO_ERR == cmd_data) {
+				pr_debug("%s: CBUS_MODE_UP register setting starts\n", __func__);
+				mhl_device_switch_cbus_mode(CBUS_eCBUS_S);
+			} else if (MHL_RAPK_BUSY == cmd_data) {
+				set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RAP,
+						 MHL_RAP_CBUS_MODE_UP);
+			} else {
+				pr_debug("%s: waiting from RAP{CBUS_MODE_UP} from sink\n",
+					 __func__);
+			}
+		}
+		break;
+	default:
+		pr_warn("%s: MHL: receive invalid command 0x%02x (0x%02x)\n",
+				__func__, sub_cmd, cmd_data);
+		break;
+	}
+}
+
+void mhl_msc_set_int_receive()
+{
+	uint8_t		int_msg[2];
+	uint8_t intr_0;
+	uint8_t intr_1;
+
+	/* read SET_INT bits */
+	mhl_pf_read_reg_block(REG_PAGE_4_MHL_INT_0,
+			      ARRAY_SIZE(int_msg),
+			      int_msg);
+
+	/* clear the individual SET_INT bits */
+	mhl_pf_write_reg_block(REG_PAGE_4_MHL_INT_0,
+			       ARRAY_SIZE(int_msg),
+			       int_msg);
+
+	intr_0 = int_msg[0];
+	intr_1 = int_msg[1];
+
+	if (MHL_INT_DCAP_CHG & intr_0) {
+		pr_info("got DCAP_CHG\n");
+
+		if (MHL_STATUS_DCAP_RDY & cbus_context.status_0) {
+			pr_debug("got DCAP_CHG & DCAP_RDY\n");
+
+			if (mhl_device_is_peer_device_mhl3()) {
+				if (mhl_device_get_cbus_mode() < CBUS_eCBUS_S) {
+					set_cond_in_cbus_control(RCV_DCAP_CHG);
+					set_cbus_command(MHL_READ_XDEVCAP_REG, XDEVCAP_ADDR_ECBUS_SPEEDS, 0);
+				} else {
+					set_cbus_command(MHL_READ_XDEVCAP, 0, 0);
+				}
+			} else {
+				set_cbus_command(MHL_READ_DEVCAP, 0, 0);
+			}
+		}
+	}
+
+	if ((MHL_INT_DSCR_CHG | MHL_INT_REQ_WRT
+		| MHL3_INT_FEAT_COMPLETE| MHL3_INT_FEAT_REQ)
+		& intr_0) {
+		cbus_wb_event_handler(intr_0);
+	}
+
+	if (MHL_INT_EDID_CHG & intr_1) {
+		pr_info("got EDID_CHG\n");
+		clear_cond_in_cbus_control(RCV_HPD);
+		set_cond_in_cbus_control(RCV_HPD);
+	}
+}
+
+/*
+ *
+ *  Others
+ *
+ */
+
+
+
+int get_device_id(void)
+{
+	int ret_val;
+	uint16_t number;
+
+	ret_val = mhl_pf_read_reg(REG_PAGE_0_DEV_IDH);
+	if (ret_val < 0) {
+		pr_err("%s:I2C error 0x%x\n", __func__, ret_val);
+		return ret_val;
+	}
+	number = ret_val << 8;
+
+	ret_val = mhl_pf_read_reg(REG_PAGE_0_DEV_IDL);
+	if (ret_val < 0) {
+		pr_err("%s:I2C error 0x%x\n", __func__, ret_val);
+		return ret_val;
+	}
+	ret_val |= number;
+
+	return ret_val;
+}
+
+#define DEVCAP_REG(x) REG_PAGE_4_MHL_DEVCAP_0 | DEVCAP_OFFSET_##x
+#define XDEVCAP_REG(x) REG_PAGE_4_MHL_EXTDEVCAP_0 | XDEVCAP_OFFSET(XDEVCAP_ADDR_##x)
+
+void init_devcap(void){
+	/* Setup local DEVCAP registers */
+
+	mhl_pf_write_reg_block(DEVCAP_REG(DEV_STATE),
+			       ARRAY_SIZE(dev_cap_values), dev_cap_values);
+
+	/* Setup local XDEVCAP registers */
+
+	mhl_pf_write_reg_block(XDEVCAP_REG(ECBUS_SPEEDS),
+			       ARRAY_SIZE(xdev_cap_values), xdev_cap_values);
+}
+
+static void read_devcap_fifo(uint8_t *dev_cap_buf, u8 size_dev, bool xdev)
+{
+	pr_debug("%s called\n", __func__);
+
+	mhl_pf_write_reg(REG_EDID_FIFO_INT_MASK,
+			 (BIT_INTR9_DEVCAP_DONE_MASK
+			 | BIT_INTR9_EDID_DONE_MASK
+			 | BIT_INTR9_EDID_ERROR));
+
+	if (xdev)
+		/* choose xdevcap instead of EDID to appear at the FIFO */
+		mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+			VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE |
+			BIT_PAGE_2_EDID_CTRL_XDEVCAP_EN |
+			VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_DEVCAP |
+			VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE |
+			VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE
+		);
+	else
+		/* choose devcap instead of EDID to appear at the FIFO */
+		mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+			VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE |
+			VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_DEVCAP |
+			VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE |
+			VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE
+		);
+
+		mhl_pf_write_reg(REG_PAGE_2_EDID_FIFO_ADDR, 0);
+
+		/* Retrieve the DEVCAP register values from the FIFO */
+		mhl_pf_read_reg_block(REG_PAGE_2_EDID_FIFO_RD_DATA,
+		size_dev,
+		dev_cap_buf);
+}
+
+void mhl_cbus_abort(uint8_t cbus_err_int)
+{
+	uint8_t msc_abort_reason = 0;
+
+	if (cbus_err_int & BIT_CBUS_DDC_ABORT) {
+		uint8_t ddc_abort_reason = 0;
+
+		ddc_abort_reason = mhl_pf_read_reg(REG_PAGE_5_DDC_ABORT_INT);
+		pr_err("%s: CBUS DDC ABORT. Reason = %02X\n",
+			__func__, ddc_abort_reason);
+
+		if (DDC_ABORT_THRESHOLD < ++cbus_context.ddc_abort_count) {
+			mhl_sii8620_device_edid_reset_ddc_fifo();
+			cbus_context.ddc_abort_count = 0;
+			pr_err("%s: Please Reset Sink Device\n", __func__);
+			/* FIMXE
+			   if error persists, reset the chip. */
+		} else if (cbus_context.current_cbus_req != NULL) {
+			if (MHL_READ_EDID_BLOCK ==
+				cbus_context.current_cbus_req->command) {
+				mhl_sii8620_device_edid_reset_ddc_fifo();
+				pr_warn("%s: CBUS DDC ABORT. Count = %d\n",
+					__func__, cbus_context.ddc_abort_count);
+			/* FIXME
+			   hw_context->intr_info->flags |= DRV_INTR_FLAG_MSC_DONE;
+			   setting 1 indicates there was an error
+			   hw_context->intr_info->msc_done_data =1; */
+			}
+		}
+	}
+	if (cbus_err_int & BIT_CBUS_MSC_ABORT_RCVD) {
+		/*
+		 * For MSC Receive time ABORTs
+		 * - Defer submission of new commands by 2 seconds per MHL specs
+		 * - This is not even worth reporting to SoC. Action is in the hands of peer.
+		 */
+
+		msc_abort_reason = mhl_pf_read_reg(REG_PAGE_5_MSC_MR_ABORT_INT);
+		++cbus_context.msc_abort_count;
+		pr_debug("%s: #%d: ABORT during MSC RCV. Reason = %02X\n",
+			 __func__, cbus_context.msc_abort_count, msc_abort_reason);
+		/* Retry CBUS command*/
+		process_cbus_abort();
+
+		/* FIXME
+		   msc_abort_count is not initialized anywhere */
+	}
+	if (cbus_err_int & BIT_CBUS_CMD_ABORT) {
+		/*
+		 * 1. Defer submission of new commands by 2 seconds per MHL specs
+		 * 2. For API operations such as RCP/UCP etc., report the situation to
+		 *    SoC and let the decision be there. Internal retries have been already
+		 *    done.
+		 */
+
+		msc_abort_reason = mhl_pf_read_reg(REG_PAGE_5_MSC_MT_ABORT_INT);
+		pr_debug("%s: CBUS ABORT during MSC SEND. Reason = %02X\n",
+			 __func__, msc_abort_reason);
+		mhl_pf_write_reg(REG_PAGE_5_MSC_MT_ABORT_INT, msc_abort_reason);
+		/* Retry CBUS command*/
+		process_cbus_abort();
+	}
+
+/* Print the reason for information */
+	if (msc_abort_reason) {
+		if (BIT_CBUS_MSC_MT_ABORT_INT_MAX_FAIL & msc_abort_reason) {
+			pr_warn("%s: Retry threshold exceeded\n", __func__);
+		}
+		if (BIT_CBUS_MSC_MT_ABORT_INT_PROTO_ERR & msc_abort_reason) {
+			pr_warn("%s: Protocol Error\n", __func__);
+		}
+		if (BIT_CBUS_MSC_MT_ABORT_INT_TIMEOUT & msc_abort_reason) {
+			pr_warn("%s: Translation layer timeout\n", __func__);
+		}
+		if (BIT_CBUS_MSC_MT_ABORT_INT_UNDEF_CMD & msc_abort_reason) {
+			pr_warn("%s: Undefined opcode\n", __func__);
+		}
+		if (BIT_CBUS_MSC_MT_ABORT_INT_MSC_MT_PEER_ABORT & msc_abort_reason) {
+			pr_warn("%s: MSC Peer sent an ABORT\n", __func__);
+		}
+	}
+}
+
+static void process_cbus_abort(void)
+{
+	struct cbus_req *req;
+
+	/*
+	 * Place the CBUS message that errored back on
+	 * transmit queue if it has any retries left.
+	 */
+	if (cbus_context.current_cbus_req != NULL) {
+		req = cbus_context.current_cbus_req;
+		cbus_context.current_cbus_req = NULL;
+		if (req->retry_count) {
+			req->retry_count -= 1;
+			queue_priority_cbus_transaction(req);
+		} else {
+			return_cbus_queue_entry(req);
+		}
+	}
+
+	/* Delay the sending of any new CBUS messages for 2 seconds */
+	cbus_context.cbus_abort_delay_active = true;
+	mhl_lib_timer_start(cbus_context.cbus_abort_timer, 2000);
+
+}
+
+bool mhl_cbus_is_sink_support_scratchpad(void)
+{
+	return cbus_context.devcap.mdc.featureFlag & MHL_FEATURE_SP_SUPPORT;
+}
+
+bool mhl_cbus_is_sink_support_ppixel(void)
+{
+	return (cbus_context.devcap.mdc.vid_link_mode &
+		MHL_DEV_VID_LINK_SUPP_PPIXEL);
+}
+
+bool mhl_cbus_is_source_support_ppixel(void)
+{
+	return DEVCAP_VAL_VID_LINK_MODE & MHL_DEV_VID_LINK_SUPP_PPIXEL;
+}
+
+bool mhl_cbus_packed_pixel_available(void)
+{
+	if (mhl_cbus_is_sink_support_ppixel() &&
+	    mhl_cbus_is_source_support_ppixel()) {
+		return true;
+	} else{
+		return false;
+	}
+}
+
+bool mhl_cbus_is_sink_support_16bpp(void)
+{
+	return cbus_context.devcap.mdc.vid_link_mode
+			& MHL_DEV_VID_LINK_SUPP_16BPP;
+}
+
+bool mhl_cbus_is_source_support_16bpp(void)
+{
+	return DEVCAP_VAL_VID_LINK_MODE & MHL_DEV_VID_LINK_SUPP_16BPP;
+}
+
+bool mhl_cbus_16bpp_available(void)
+{
+	if (mhl_cbus_is_sink_support_16bpp() &&
+	    mhl_cbus_is_source_support_16bpp()) {
+		return true;
+	} else{
+		return false;
+	}
+}
+
+static int send_content_on(void)
+{
+	bool ret = false;
+	pr_debug("%s called\n", __func__);
+
+	ret = set_cbus_command(MHL_MSC_MSG, MHL_MSC_MSG_RAP,
+			MHL_RAP_CONTENT_ON);
+	if (!ret) {
+		pr_err("%s: Failed to send rap_content_on\n", __func__);
+		return MHL_FAIL;
+	}
+
+	return 0;
+}
+
+static bool is_rap_supported(void)
+{
+	bool ret;
+	int rap;
+
+	rap = cbus_context.devcap.devcap_cache[MHL_DEV_FEATURE_FLAG_OFFSET] &
+			MHL_FEATURE_RAP_SUPPORT;
+	if (MHL_FEATURE_RAP_SUPPORT == rap) {
+		ret = true;
+	} else {
+		pr_debug("%s: Not supported RAP\n", __func__);
+		ret = false;
+	}
+
+	return ret;
+}
+
+static bool is_ready_for_edid_read(void)
+{
+	bool ret = false;
+
+	if (get_cond_in_cbus_control(DEVCAP_ALL_READ_DONE) &
+	    get_cond_in_cbus_control(RCV_HPD)) {
+		ret = true;
+	}
+
+	return ret;
+}
+
+void init_cond_in_cbus_control(void)
+{
+	cbus_context.flag.devcap_all = false;
+	cbus_context.flag.path_en = false;
+	cbus_context.flag.hpd = false;
+	cbus_context.flag.video_ready = false;
+	cbus_context.flag.dcap_chg_rcv = false;
+	cbus_context.flag.cbus_mode_up = false;
+	cbus_context.flag.hdcp_ready = false;
+	cbus_context.flag.tmds_ready = false;
+}
+
+void set_cond_in_cbus_control(CBUS_CONTROL_COND cond)
+{
+	pr_debug("%s()\n", __func__);
+	show_cond_in_cbus_control();
+
+	switch (cond) {
+	case DEVCAP_ALL_READ_DONE:
+		pr_debug("%s:devcap_all\n", __func__);
+		cbus_context.flag.devcap_all = true;
+		if (is_ready_for_edid_read())
+			set_cbus_command(MHL_READ_EDID_BLOCK, 0, 0);
+
+		if (is_rap_supported()) {
+			pr_debug("%s:rap_content_on request started\n",
+					__func__);
+			send_content_on();
+		}
+		break;
+
+	case SENT_PATH_EN_1:
+		pr_debug("%s:path en\n", __func__);
+		cbus_context.flag.path_en = true;
+		if (cbus_context.flag.video_ready) {
+			if (is_video_muted() && (is_tmds_active() == false))
+				start_video();
+		}
+		break;
+
+	case RCV_HPD:
+		pr_debug("%s:receive hpd\n", __func__);
+		cbus_context.flag.hpd = true;
+
+		if (is_ready_for_edid_read())
+			set_cbus_command(MHL_READ_EDID_BLOCK, 0, 0);
+		else
+			pr_debug("%s:Waiting for the complete of DEVCAP Read\n", __func__);
+		break;
+
+	case UPSTREAM_VIDEO_READY:
+		pr_debug("%s:video ready\n", __func__);
+		cbus_context.flag.video_ready = true;
+		break;
+	case RCV_DCAP_CHG:
+		pr_debug("%s:receive DCAP_CHG\n", __func__);
+		cbus_context.flag.dcap_chg_rcv = true;
+		break;
+	case READ_ECBUS_SPEED:
+		pr_debug("%s:read ECBUS_SPEED\n", __func__);
+		if (cbus_context.flag.dcap_chg_rcv)
+			mhl_cbus_send_cbus_mode_up();
+		break;
+	case HDCP_READY:
+		cbus_context.flag.hdcp_ready = true;
+		break;
+	case TMDS_READY:
+		cbus_context.flag.tmds_ready = true;
+		break;
+	default:
+		pr_warn("%s: unknown condition=%d\n", __func__, cond);
+		return;
+	}
+
+	show_cond_in_cbus_control();
+}
+
+void clear_cond_in_cbus_control(CBUS_CONTROL_COND cond)
+{
+	pr_debug("%s()\n", __func__);
+
+	show_cond_in_cbus_control();
+
+	switch (cond) {
+	case DEVCAP_ALL_READ_DONE:
+		pr_debug("%s:devcap_all\n", __func__);
+		cbus_context.flag.devcap_all = false;
+		break;
+
+	case SENT_PATH_EN_1:
+		pr_debug("%s:path en\n", __func__);
+		cbus_context.flag.path_en = false;
+		if (cbus_context.flag.video_ready) {
+			if (is_video_muted() == false) {
+				stop_video();
+			} else {
+				pr_debug("%s:Video has been already muted\n",
+					 __func__);
+			}
+		} else {
+			pr_debug("%s:Video has been not ready yet\n", __func__);
+		}
+		break;
+
+	case RCV_HPD:
+		pr_debug("%s:receice hpd\n", __func__);
+		cbus_context.flag.hpd = false;
+		cbus_context.flag.video_ready = false;
+		cbus_context.flag.tmds_ready = false;
+		cbus_context.flag.hdcp_ready = false;
+		stop_video();
+		drive_hpd_low();
+
+		break;
+
+	case UPSTREAM_VIDEO_READY:
+		pr_debug("%s:video ready\n", __func__);
+		cbus_context.flag.video_ready = false;
+		break;
+
+	case RCV_DCAP_CHG:
+		pr_debug("%s:receive DCAP_CHG\n", __func__);
+		cbus_context.flag.dcap_chg_rcv = false;
+		break;
+
+	case HDCP_READY:
+		cbus_context.flag.hdcp_ready = false;
+		break;
+
+	case TMDS_READY:
+		cbus_context.flag.tmds_ready = false;
+		break;
+
+	default:
+		pr_warn("%s: unknown condition=%d\n", __func__, cond);
+	}
+
+	show_cond_in_cbus_control();
+}
+
+bool get_cond_in_cbus_control(CBUS_CONTROL_COND cond)
+{
+	bool flag = false;
+
+	pr_debug("%s()\n", __func__);
+
+	switch (cond) {
+	case DEVCAP_ALL_READ_DONE:
+		pr_debug("%s:devcap_all\n", __func__);
+		flag = cbus_context.flag.devcap_all;
+		break;
+	case SENT_PATH_EN_1:
+		pr_debug("%s:path en\n", __func__);
+		flag = cbus_context.flag.path_en;
+		break;
+	case RCV_HPD:
+		pr_debug("%s:receice hpd\n", __func__);
+		flag = cbus_context.flag.hpd;
+		break;
+	case UPSTREAM_VIDEO_READY:
+		pr_debug("%s:video ready\n", __func__);
+		flag = cbus_context.flag.video_ready;
+		break;
+	case RCV_DCAP_CHG:
+		pr_debug("%s:receive DCAP_CHG\n", __func__);
+		flag = cbus_context.flag.dcap_chg_rcv;
+		break;
+	case HDCP_READY:
+		pr_debug("%s:hdcp ready\n", __func__);
+		flag = cbus_context.flag.hdcp_ready;
+		break;
+	case TMDS_READY:
+		pr_debug("%s:tmds ready\n", __func__);
+		flag = cbus_context.flag.tmds_ready;
+		break;
+	default:
+		pr_warn("%s: unknown condition=%d\n", __func__, cond);
+	}
+
+	return flag;
+}
+
+void show_cond_in_cbus_control(void){
+	pr_debug("%s DEVCAP_ALL_READ_DONE %d\n",
+		 __func__, cbus_context.flag.devcap_all);
+	pr_debug("%s SENT_PATH_EN_1       %d\n",
+		 __func__, cbus_context.flag.path_en);
+	pr_debug("%s RCV_HPD              %d\n",
+		 __func__, cbus_context.flag.hpd);
+	pr_debug("%s UPSTREAM_VIDEO_READY %d\n",
+		 __func__, cbus_context.flag.video_ready);
+	pr_debug("%s receive DCAP_CHG %d\n",
+		 __func__, cbus_context.flag.dcap_chg_rcv);
+	pr_debug("%s HDCP2.2_READY %d\n",
+		 __func__, cbus_context.flag.hdcp_ready);
+	pr_debug("%s TMDS_READY %d\n",
+		 __func__, cbus_context.flag.tmds_ready);
+}
+
+int mhl_cbus_control_initialize(void)
+{
+	int rc = 0;
+
+	mhl_create_timer();
+
+	i2c_mem.block_tx_buffers
+		= kmalloc(MAX_I2C_EMSC_BLOCK_SIZE
+				* NUM_BLOCK_QUEUE_REQUESTS, GFP_KERNEL);
+	if (NULL == i2c_mem.block_tx_buffers) {
+		kfree(i2c_mem.block_tx_buffers);
+		rc = -ENOMEM;
+	}
+
+	mhl_rapk_receive_timer_init();
+
+	return rc;
+}
+
+void mhl_cbus_control_release(void)
+{
+	mhl_release_timer();
+
+	if (!i2c_mem.block_tx_buffers) {
+		kfree(i2c_mem.block_tx_buffers);
+	}
+
+	mhl_rapk_receive_timer_release();
+}
+
+static int mhl_release_timer(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_delete(&cbus_context.cbus_abort_timer);
+
+	if (ret != 0) {
+		pr_err("%s: Failed to release CBUS abort timer!\n", __func__);
+		return ret;
+	}
+
+	return ret;
+}
+
+static int mhl_create_timer(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_create(cbus_abort_timer_callback,
+				  NULL,
+				  &cbus_context.cbus_abort_timer);
+
+	if (ret != 0) {
+		pr_err("%s: Failed to allocate CBUS abort timer!\n", __func__);
+		return ret;
+	}
+
+	return ret;
+}
+
+static void cbus_abort_timer_callback(void *callback_param)
+{
+	pr_warn("%s: CBUS abort timer expired, enable CBUS messaging\n",
+		 __func__);
+
+	cbus_context.cbus_abort_delay_active = false;
+	exe_cbus_command();
+}
+
+uint8_t mhl_get_tdm_virt_chan_slot_counts(enum tdm_vc_assignments vc)
+{
+	uint8_t ret = 1;
+	switch (vc) {
+	case TDM_VC_CBUS1:
+		ret = cbus_context.virt_chan_slot_counts[TDM_VC_CBUS1];
+		break;
+	case TDM_VC_E_MSC:
+		ret = cbus_context.virt_chan_slot_counts[TDM_VC_E_MSC];
+		break;
+	case TDM_VC_T_CBUS:
+		ret = cbus_context.virt_chan_slot_counts[TDM_VC_T_CBUS];
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+void send_link_mode_to_sink(void)
+{
+	if (!is_SamsungTV())
+		set_cbus_command(MHL_WRITE_STAT, MHL_STATUS_REG_LINK_MODE,
+				cbus_context.link_mode);
+}
+
+void set_link_mode(u8 link_mode)
+{
+	cbus_context.link_mode = link_mode;
+}
+
+u8 get_link_mode(void)
+{
+	return 	cbus_context.link_mode;
+}
+
+int mhl_cbus_get_highest_tmds_link_speed(void)
+{
+	int link_speed = MHL_XDC_TMDS_000;
+
+	if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_600)
+		link_speed = MHL_XDC_TMDS_600;
+	else if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_300)
+		link_speed = MHL_XDC_TMDS_300;
+	else if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_150)
+		link_speed = MHL_XDC_TMDS_150;
+
+	return link_speed;
+}
+
+void mhl_cbus_set_lowest_tmds_link_speed(uint32_t pixel_clock_frequency,
+											uint8_t bits_per_pixel)
+{
+	uint32_t link_clock_frequency;
+	/* That is based on the MHL protocol limitation.
+	Safety value is recommended as default.*/
+	uint32_t top_clock_frequency = 147000000;
+	uint8_t reg_val;
+	bool found_fit;
+
+	link_clock_frequency = pixel_clock_frequency * ((uint32_t)(bits_per_pixel >> 3));
+	found_fit = false;
+
+	/*
+	  find lowest fit giving up only if module parameter
+	  forces us into a supported link speed
+	*/
+	if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_150) {
+
+		pr_debug("%s: XDEVCAP TMDS Link Speed = 1.5Gbps is supported\n",
+				__func__);
+		top_clock_frequency = 147000000;/* 1500000 * 98 */
+
+		if (xdev_cap_values[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)]
+				& MHL_XDC_TMDS_150) {
+			if ((link_clock_frequency <= 150000000)
+				&& (!found_fit)) {
+				pr_info("%s: Mode fits TMDS Link Speed = 1.5Gbps (%d)\n",
+					__func__, link_clock_frequency);
+				reg_val = VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_1_5GBPS;
+				found_fit = true;
+			}
+		}
+	}
+	if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_300) {
+
+		pr_debug("%s: XDEVCAP TMDS Link Speed = 3.0Gbps is supported\n",
+				__func__);
+		top_clock_frequency = 294000000;/* 3000000 * 98 */
+
+		if (xdev_cap_values[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)]
+				& MHL_XDC_TMDS_300) {
+			if ((link_clock_frequency <= 300000000)
+				&& (!found_fit)) {
+				pr_info("%s: Mode fits TMDS Link Speed = 3.0Gbps (%d)\n",
+					__func__, link_clock_frequency);
+				reg_val = VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_3GBPS;
+				found_fit = true;
+			}
+		}
+	}
+	if (cbus_context.xdevcap.xdevcap_cache[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)] & MHL_XDC_TMDS_600) {
+
+		pr_debug("%s: XDEVCAP TMDS Link Speed = 6.0Gbps is supported\n",
+				__func__);
+		top_clock_frequency = 588000000;/* 6000000 * 98 */
+
+		if (xdev_cap_values[XDEVCAP_OFFSET(XDEVCAP_ADDR_TMDS_SPEEDS)]
+			& MHL_XDC_TMDS_600) {
+			if ((link_clock_frequency <= 600000000)
+				&& (!found_fit)) {
+				pr_info("%s: Mode fits TMDS Link Speed = 6.0Gbps (%d)\n",
+					__func__, link_clock_frequency);
+				reg_val = VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_6GBPS;
+				found_fit = true;
+			}
+		}
+	}
+
+	if (!found_fit) {
+		pr_info("%s: Cannot fit mode to any supported TMDS Link Speeds\n",
+				__func__);
+		pr_info("%s: Forcing TMDS Link Speed = 6.0Gbps\n",
+				__func__);
+		reg_val = VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_6GBPS;
+	}
+
+	mhl_pf_write_reg(REG_PAGE_3_MHL3_TX_ZONE_CTL, reg_val);
+
+	/* set unlimited packet size only if not enough overhead */
+	pr_debug("%s: lcf = %d, tcf = %d\n",
+		__func__,
+		link_clock_frequency,
+		top_clock_frequency);
+
+	if (link_clock_frequency >= top_clock_frequency) {
+		pr_debug("%s: Program 3E1[3] = 1 --- UNLIMITED MODE ON\n",
+			__func__);
+		mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PORT_EN |
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PORT_EN |
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN_PP);
+	} else {
+		pr_debug("%s: Program 3E1[3] = 0 --- UNLIMITED MODE OFF\n",
+			__func__);
+		mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PORT_EN |
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PORT_EN |
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN_NORM);
+	}
+
+	/* set write stat indicating this change */
+	switch (reg_val) {
+	case VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_6GBPS:
+		set_cbus_command(MHL_WRITE_XSTAT,
+			MHL_STATUS_REG_AV_LINK_MODE_CONTROL,
+			0x02);
+		break;
+	case VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_3GBPS:
+		set_cbus_command(MHL_WRITE_XSTAT,
+			MHL_STATUS_REG_AV_LINK_MODE_CONTROL,
+			0x01);
+		break;
+	case VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_1_5GBPS:
+		set_cbus_command(MHL_WRITE_XSTAT,
+			MHL_STATUS_REG_AV_LINK_MODE_CONTROL,
+			0x00);
+		break;
+	}
+
+}
+
+int block_input_buffer_available(void)
+{
+	uint16_t head, tail;
+	head = cbus_context.hw_block_protocol.head;
+	tail = cbus_context.hw_block_protocol.tail;
+	if (head == (tail+1)) {
+		/* full case */
+		return 0;
+	}
+	return 1;
+}
+
+int alloc_block_input_buffer(uint8_t **pbuffer)
+{
+	uint16_t head, tail;
+	int index;
+	head = cbus_context.hw_block_protocol.head;
+	tail = cbus_context.hw_block_protocol.tail;
+
+	if (!block_input_buffer_available()) {
+		/* full case */
+		return MHL_FAIL;
+	}
+	index = tail;
+
+	if (++tail >= NUM_BLOCK_INPUT_BUFFERS)
+		tail = 0;
+
+	cbus_context.hw_block_protocol.tail = tail;
+
+	*pbuffer = &cbus_context.hw_block_protocol.input_buffers[index][0];
+	return index;
+}
+
+void set_block_input_buffer_length(int block, int length)
+{
+	if ((block < 0) || (block > (NUM_BLOCK_INPUT_BUFFERS - 1)))
+		return;
+
+	cbus_context.hw_block_protocol.input_buffer_lengths[block] = length;
+}
+
+void add_received_byte_count(uint16_t size)
+{
+	cbus_context.hw_block_protocol.received_byte_count += size;
+	pr_debug("%s: received_byte_count->%d",
+			__func__,
+			cbus_context.hw_block_protocol.received_byte_count);
+}
+
+void add_peer_blk_rx_buffer_avail(unsigned long size)
+{
+	cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail += size;
+}
+
+static void return_block_queue_entry_impl(struct block_req *pReq,
+							const char *function,
+							int line)
+{
+	list_add(&pReq->link, &cbus_context.block_protocol.free_list);
+
+}
+#define return_block_queue_entry(req) return_block_queue_entry_impl(req, __func__, __LINE__)
+
+/*
+ * mhl_tx_drv_send_block
+ *
+ * Write the specified Sideband Channel command to the CBUS.
+ * such as READ_DEVCAP, SET_INT, WRITE_STAT, etc.
+ * Command can be a MSC_MSG command (RCP/RAP/RCPK/RCPE/RAPK), or another command
+ * Parameters:
+ *              req     - Pointer to a cbus_req_t structure containing the
+ *                        command to write
+ * Returns:     true    - successful write
+ *              false   - write failed
+ */
+void mhl_tx_drv_send_block(struct block_req *req)
+{
+	uint8_t count;
+
+	count = req->sub_payload_size;
+	pr_debug(" req->sub_payload_size: %d req->count: %d\n",
+			count, req->count);
+
+	pr_debug("total bytes to ack: %d\n",
+			cbus_context.hw_block_protocol.received_byte_count);
+	if (cbus_context.hw_block_protocol.received_byte_count >= 256) {
+
+		/*
+		  'can't represent numbers >= 256 in 8 bits,
+		  so ack as much as we can ...
+		*/
+		req->payload->hdr_and_burst_id.tport_hdr.rx_unload_ack = 255;
+		cbus_context.hw_block_protocol.received_byte_count -= 255;
+	} else {
+		req->payload->hdr_and_burst_id.tport_hdr.rx_unload_ack
+			= (uint8_t)cbus_context.
+				hw_block_protocol.received_byte_count;
+		cbus_context.hw_block_protocol.received_byte_count = 0;
+	}
+
+	pr_debug("rx_unload_ack: %d\n",
+			req->payload->hdr_and_burst_id.tport_hdr.rx_unload_ack);
+	/* Enable I2C communication with EMSC instead of SPI */
+	mhl_pf_modify_reg(REG_PAGE_3_COMMECNT
+			, BIT_PAGE_3_COMMECNT_I2C_TO_EMSC_EN
+			, BIT_PAGE_3_COMMECNT_I2C_TO_EMSC_EN);
+	/* eMSC Transmitter Write Port for I2C */
+	mhl_pf_write_reg_block(REG_PAGE_3_EMSC_XMIT_WRITE_PORT
+						, req->count
+						, &req->payload->as_bytes[0]
+						);
+}
+
+static struct block_req *start_new_block_marshalling_req(void)
+{
+	struct block_req *req;
+	struct list_head *entry;
+	union SI_PACK_THIS_STRUCT emsc_payload_t *payload;
+
+	if (list_empty(&cbus_context.block_protocol.free_list)) {
+		int i;
+		pr_debug("%s: No free block queue entries available\n",
+				__func__);
+		list_for_each(entry, &cbus_context.block_protocol.queue)
+		{
+			req = list_entry(entry, struct block_req, link);
+		}
+		for (i = 0; i < ARRAY_SIZE(cbus_context.block_protocol.req_entries); ++i)
+			req = &cbus_context.block_protocol.req_entries[i];
+
+		return NULL;
+	}
+
+	entry = cbus_context.block_protocol.free_list.next;
+	list_del(entry);
+	req = list_entry(entry, struct block_req, link);
+
+	payload = req->payload;
+	req->function = __func__;
+	req->line = __LINE__;
+	req->sequence = cbus_context.block_protocol.sequence++;
+	req->sub_payload_size = 0;
+	req->space_remaining = sizeof(payload->as_bytes)
+				- sizeof(struct SI_PACK_THIS_STRUCT
+					standard_transport_header_t);
+	cbus_context.block_protocol.marshalling_req = req;
+	pr_debug("%s: q %d get:0x%p\n", __func__, req->sequence, req);
+	return req;
+}
+
+void mhl_tx_push_block_transactions(void)
+{
+	struct block_req *req;
+	struct list_head *entry;
+	uint16_t ack_byte_count;
+
+	/*
+		Send the requests out, starting with those in the queue
+	*/
+	ack_byte_count = cbus_context.hw_block_protocol.received_byte_count;
+	req = cbus_context.block_protocol.marshalling_req;
+	if (NULL == req) {
+		pr_debug("%s: wayward pointer\n", __func__);
+		return;
+	}
+	pr_debug("================= sub_payload_size: %d, ack count: %d, queue empty %d\n",
+			req->sub_payload_size,
+			ack_byte_count,
+			list_empty(&cbus_context.block_protocol.queue)
+			);
+	/* Need to send the unload count even if no other payload.	*/
+    /* If there is no payload and 2 or less unload bytes, don't bother --
+     * they will be unloaded with the next payload write.
+     * This could violate the MHL3 eMSC block transfer protocol requirement
+     * to ACK within 50ms, but it can also cause an CK feedback loop
+     * between the two peer devices.  If the unload count is larger,
+     * go ahead and send it even if it does cause an extra response
+     * from the other side.
+     */
+	if ((ack_byte_count > BLK_STD_HEADER_LENGTH) || req->sub_payload_size) {
+		/* don't use queue_block_transaction here */
+		list_add_tail(&req->link, &cbus_context.block_protocol.queue);
+		cbus_context.block_protocol.marshalling_req = NULL;
+	}
+	while (!list_empty(&cbus_context.block_protocol.queue)) {
+		uint8_t payload_size;
+		entry = cbus_context.block_protocol.queue.next;
+		req = list_entry(entry, struct block_req, link);
+		payload_size = sizeof(req->payload->hdr_and_burst_id.tport_hdr)
+					+ req->sub_payload_size;
+		if (cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+			< payload_size) {
+			/* not enough space in peer's receive buffer,
+				so wait to send until later
+			*/
+			pr_debug("==== not enough space in peer's receive buffer, send later\n"
+			);
+			break;
+		}
+		list_del(entry);
+		cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+			-= payload_size;
+
+		req->payload->hdr_and_burst_id.tport_hdr.length_remaining
+			= req->sub_payload_size;
+		req->count = payload_size;
+		/* The driver layer will fill in the rx_unload_ack field */
+		mhl_tx_drv_send_block(req);
+		/* return request to free list */
+		return_block_queue_entry(req);
+
+	}
+	if (NULL == cbus_context.block_protocol.marshalling_req) {
+		/* now start a new marshalling request */
+		req =  start_new_block_marshalling_req();
+		if (NULL == req)
+			pr_debug("%s: block free list exhausted!\n", __func__);
+	}
+}
+
+void *mhl_tx_get_sub_payload_buffer(uint8_t size)
+{
+	void *buffer;
+	struct SI_PACK_THIS_STRUCT block_req *req;
+	union SI_PACK_THIS_STRUCT emsc_payload_t *payload;
+	req = cbus_context.block_protocol.marshalling_req;
+	if (NULL == req) {
+		/* this can only happen if we run out of free requests */
+		mhl_tx_push_block_transactions();
+
+		/*
+		  TODO: Lee - can't call this here, because the first
+			thing it does is chewck to see
+			if dev_context->block_protocol.marshalling_req == NULL,
+			which we know it is, and if it finds NULL,
+			it prints an error and returns.  So why bother?
+		*/
+
+		req = cbus_context.block_protocol.marshalling_req;
+		if (NULL == req) {
+			pr_debug("%s: block free list exhausted!\n", __func__);
+			return NULL;
+		}
+	}
+	/* check to see if there is enough space in the marshalling request */
+	if (size > req->space_remaining) {
+		/*
+		  TODO: Lee - this assumes that (size < 254), if it is not,
+			the code after this 'if' will fail dramatically
+		*/
+		/* not enough space, so queue the current req */
+
+		list_add_tail(&req->link, &cbus_context.block_protocol.queue);
+
+		/* try to send immediately, if possible */
+		mhl_tx_push_block_transactions();
+
+		/* now start a new marshalling request */
+		req =  start_new_block_marshalling_req();
+		if (NULL == req) {
+			pr_debug("%s: block free list exhausted!\n", __func__);
+			return NULL;
+		}
+	}
+	payload = req->payload;
+	buffer = &payload->as_bytes[sizeof(payload->as_bytes)
+						- req->space_remaining];
+	req->space_remaining -= size;
+	req->sub_payload_size += size;
+	return buffer;
+}
+
+uint16_t mhl_tx_drv_get_blk_rcv_buf_size(void)
+{
+	return 288;
+}
+
+/*
+ * Enable interrupts and turn on the engine
+ *
+ * Clearly this must be moved to si_8620_drv.c because all
+ * the definitions I need are there.
+ */
+void mhl_tx_drv_enable_emsc_block(void)
+{
+	uint8_t	intStatus;
+	pr_debug("%s: Enabling EMSC and EMSC interrupts\n", __func__);
+
+	mhl_pf_modify_reg(REG_PAGE_3_GENCTL,
+		BIT_PAGE_3_GENCTL_EMSC_EN |
+		BIT_PAGE_3_GENCTL_CLR_EMSC_RFIFO |
+		BIT_PAGE_3_GENCTL_CLR_EMSC_XFIFO,
+		BIT_PAGE_3_GENCTL_EMSC_EN |
+		BIT_PAGE_3_GENCTL_CLR_EMSC_RFIFO |
+		BIT_PAGE_3_GENCTL_CLR_EMSC_XFIFO);
+	mhl_pf_modify_reg(REG_PAGE_3_GENCTL,
+		BIT_PAGE_3_GENCTL_CLR_EMSC_RFIFO
+			| BIT_PAGE_3_GENCTL_CLR_EMSC_XFIFO,
+		0);
+	mhl_pf_modify_reg(REG_PAGE_3_COMMECNT,
+		BIT_PAGE_3_COMMECNT_I2C_TO_EMSC_EN,
+		BIT_PAGE_3_COMMECNT_I2C_TO_EMSC_EN);
+	intStatus = mhl_pf_read_reg(REG_PAGE_3_EMSCINTR);
+	mhl_pf_write_reg(REG_PAGE_3_EMSCINTR, intStatus);
+	mhl_pf_write_reg(REG_PAGE_3_EMSCINTRMASK,
+		BIT_PAGE_3_EMSCINTR_SPI_DVLD);
+}
+
+void mhl_tx_initialize_block_transport(void)
+{
+	struct SI_PACK_THIS_STRUCT block_req *req;
+	uint8_t buffer_size;
+	int idx;
+	struct block_buffer_info_t  block_buffer_info;
+	struct SI_PACK_THIS_STRUCT block_rcv_buffer_info_t *blk_rcv_buf_info;
+
+	cbus_context.hw_block_protocol.received_byte_count = 0;
+
+	mhl_pf_get_block_buffer_info(&block_buffer_info);
+
+	/* section 13.5.7.2.4 */
+
+	cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+		= EMSC_RCV_BUFFER_DEFAULT;
+
+	INIT_LIST_HEAD(&cbus_context.block_protocol.queue);
+	INIT_LIST_HEAD(&cbus_context.block_protocol.free_list);
+
+	/* Place pre-allocated BLOCK queue entries on the free list */
+	for (idx = 0; idx < NUM_BLOCK_QUEUE_REQUESTS; idx++) {
+
+		req = &cbus_context.block_protocol.req_entries[idx];
+		memset(req, 0, sizeof(*req));
+		req->platform_header = block_buffer_info.buffer
+					+ block_buffer_info.req_size*idx;
+		req->payload = (union SI_PACK_THIS_STRUCT emsc_payload_t *)
+				(req->platform_header
+					+ block_buffer_info.payload_offset);
+		list_add(&req->link, &cbus_context.block_protocol.free_list);
+	}
+	buffer_size = sizeof(struct SI_PACK_THIS_STRUCT
+				standard_transport_header_t)
+				+sizeof(struct SI_PACK_THIS_STRUCT
+				block_rcv_buffer_info_t);
+	if (buffer_size != 6)
+		pr_debug("%s: check structure packing\n", __func__);
+
+	/* we just initialized the free list, this call cannot fail */
+	req = start_new_block_marshalling_req();
+
+	blk_rcv_buf_info
+		= mhl_tx_get_sub_payload_buffer(sizeof(*blk_rcv_buf_info));
+	if (NULL == blk_rcv_buf_info) {
+		pr_debug("%s: mhl_tx_get_sub_payload_buffer failed\n",
+			__func__);
+	} else {
+		uint16_t local_rcv_buffer_size;
+
+		blk_rcv_buf_info->burst_id.low
+			= (uint8_t)(burst_id_BLK_RCV_BUFFER_INFO & 0xFF);
+		blk_rcv_buf_info->burst_id.high
+			= (uint8_t)(burst_id_BLK_RCV_BUFFER_INFO >> 8);
+
+		local_rcv_buffer_size = mhl_tx_drv_get_blk_rcv_buf_size();
+		blk_rcv_buf_info->blk_rcv_buffer_size_low
+			= (uint8_t)(local_rcv_buffer_size & 0xFF);
+		blk_rcv_buf_info->blk_rcv_buffer_size_high
+			= (uint8_t)(local_rcv_buffer_size >> 8);
+		pr_debug("blk_rcv_buffer_info: id:0x%02x%02x size: 0x%02x%02x\n",
+				blk_rcv_buf_info->burst_id.high,
+				blk_rcv_buf_info->burst_id.low,
+				blk_rcv_buf_info->blk_rcv_buffer_size_high,
+				blk_rcv_buf_info->blk_rcv_buffer_size_low);
+	}
+
+	mhl_tx_drv_enable_emsc_block();
+}
+
+/*
+  call this from mhl_supp.c to during processing
+  of DRV_INTR_FLAG_EMSC_INCOMING
+*/
+int mhl_tx_drv_peek_block_input_buffer(uint8_t **buffer, int *length)
+{
+	uint16_t head, tail, index;
+	head = cbus_context.hw_block_protocol.head;
+	tail = cbus_context.hw_block_protocol.tail;
+	if (head == tail)
+		return MHL_FAIL;
+
+	index = head;
+
+	*buffer = &cbus_context.hw_block_protocol.input_buffers[index][0];
+	*length = cbus_context.hw_block_protocol.input_buffer_lengths[index];
+	return 0;
+}
+
+/*
+  call this from mhl_supp.c to during processing
+  of DRV_INTR_FLAG_EMSC_INCOMING
+*/
+void mhl_tx_drv_free_block_input_buffer(void)
+{
+	uint16_t head;
+	head = cbus_context.hw_block_protocol.head;
+	if (++head >= NUM_BLOCK_INPUT_BUFFERS)
+		head = 0;
+
+	cbus_context.hw_block_protocol.head = head;
+}
+
+/*
+ * Called from the Titan interrupt handler to parse data
+ * received from the eSMC BLOCK hardware. If multiple messages are
+ * sent in the same BLOCK Command buffer, they are sorted out here also.
+ */
+void mhl_tx_emsc_received(void)
+{
+	int ret, length, index;
+	uint16_t burst_id;
+	uint8_t *prbuf, *pmsg;
+
+	ret = mhl_tx_drv_peek_block_input_buffer(&prbuf, &length);
+	if (ret == 0) {
+		index = 0;
+		do {
+			pmsg = &prbuf[index];
+			burst_id = (((uint16_t)pmsg[0]) << 8) | pmsg[1];
+			index += 2;	/* Move past the BURST ID	*/
+
+			switch (burst_id) {
+			case burst_id_HID_PAYLOAD:
+				pr_debug("%s: burst_id_HID_PAYLOAD\n",
+					 __func__);
+				/* Include the payload length */
+				index += (1 + pmsg[2]);
+				break;
+
+			case burst_id_BLK_RCV_BUFFER_INFO:
+				cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+					= pmsg[3];
+				cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+					<<= 8;
+				cbus_context.hw_block_protocol.peer_blk_rx_buffer_avail
+					|= pmsg[2];
+				index += 2;
+				break;
+
+			case burst_id_BITS_PER_PIXEL_FMT:
+				/*
+				  TODO: Lee - What do we do with this data?
+				  TODO: Lee - Use #define values
+				*/
+				index += (4 + (2 * pmsg[5]));
+				break;
+			default:
+				pr_debug("Unsupported BURST ID: %04X\n",
+					burst_id);
+				index = length;
+				break;
+			}
+
+			length -= index;
+		} while (length > 0);
+		mhl_tx_drv_free_block_input_buffer();
+	}
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.h
@@ -1,0 +1,194 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_control.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Yasuyuki Kino <yasuyuki.kino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_CBUS_CONTROL_H__
+#define __MHL_CBUS_CONTROL_H__
+
+#include <linux/module.h>
+#include <linux/clk.h>
+#include <linux/of_platform.h>
+#include <linux/err.h>
+#include <linux/of_gpio.h>
+#include <linux/delay.h>
+#include <linux/slab.h>
+#include "mhl_defs.h"
+#include "si_infoframe.h"
+#include "mhl_sii8620_8061_devcap.h"
+
+#define NUM_CBUS_EVENT_QUEUE_EVENTS 16
+#define NUM_BLOCK_QUEUE_REQUESTS 4
+
+/* Discovery Interrupt Mask Register */
+#define REG_DISC_INTR_MASK						REG_PAGE_5_CBUS_DISC_INTR0_MASK
+#define BIT_RGND_READY_INT_MASK					BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK6
+#define BIT_CBUS_MHL12_DISCON_INT_MASK			BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK5
+#define BIT_CBUS_MHL3_DISCON_INT_MASK			BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK4
+#define BIT_NOT_MHL_EST_INT_MASK				BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK3
+#define BIT_MHL_EST_INT_MASK					BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK2
+#define BIT_MHL3_EST_INT_MASK					BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK1
+
+/* MSC Interrupt Mask Register */
+#define REG_MSC_INTR_MASK                                       REG_PAGE_5_CBUS_INT_0_MASK
+#define BIT_CBUS_MSC_MT_DONE_NACK				BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK7
+#define BIT_CBUS_MSC_MR_SET_INT					BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK6
+#define BIT_CBUS_MSC_MR_WRITE_BURST				BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK5
+#define BIT_CBUS_MSC_MR_MSC_MSG					BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK4
+#define BIT_CBUS_MSC_MR_WRITE_STAT				BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK3
+#define BIT_CBUS_HPD_CHG					BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK2
+#define BIT_CBUS_MSC_MT_DONE					BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK1
+#define BIT_CBUS_CNX_CHG						BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK0
+
+/* EDID FIFO Interrupt Register */
+#define REG_EDID_FIFO_INT_MASK                  REG_PAGE_2_INTR9_MASK /*TX_PAGE_2, 0xE1*/
+#define BIT_INTR9_EDID_ERROR					BIT_PAGE_2_INTR9_INTR9_STAT6
+#define BIT_INTR9_EDID_DONE						BIT_PAGE_2_INTR9_INTR9_STAT5
+#define BIT_INTR9_DEVCAP_DONE					BIT_PAGE_2_INTR9_INTR9_STAT4
+#define BIT_INTR9_EDID_ERROR_MASK				BIT_PAGE_2_INTR9_MASK_INTR9_MASK6
+#define BIT_INTR9_EDID_DONE_MASK				BIT_PAGE_2_INTR9_MASK_INTR9_MASK5
+#define BIT_INTR9_DEVCAP_DONE_MASK				BIT_PAGE_2_INTR9_MASK_INTR9_MASK4
+#define VAL_INTR9_DEVCAP_DONE_MASK_ENABLE		VAL_PAGE_2_INTR9_MASK_INTR9_MASK4_ENABLE
+
+/* MSC Error Interrupt Register */
+
+#define BIT_CBUS_CMD_ABORT						BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK6
+#define BIT_CBUS_MSC_ABORT_RCVD					BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK3
+#define BIT_CBUS_DDC_ABORT						BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK2
+#define BIT_CBUS_CEC_ABORT						BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK1
+
+/* Upstream TMDS Status Interrupt Register */
+
+#define BIT_INTR5_CKDT_CHANGE					BIT_PAGE_0_INTR5_INTR5_STAT1
+#define BIT_INTR5_SCDT_CHANGE					BIT_PAGE_0_INTR5_INTR5_STAT0
+
+/* Upstream HDMI InforFrame Control Register */
+#define	REG_RX_HDMI_CTRL2_DEFVAL_DVI			0x30
+#define REG_RX_HDMI_CTRL2_DEFVAL_HDMI			0x38
+
+/* Upstream InfoFrame Interupt Register */
+#define BIT_INTR8_CEA_NEW_VSI					BIT_PAGE_0_INTR8_MASK_INTR8_MASK2
+#define BIT_INTR8_CEA_NEW_AVI					BIT_PAGE_0_INTR8_MASK_INTR8_MASK1
+
+/* Cbus Abort Reason */
+
+#define BIT_CBUS_MSC_MT_ABORT_INT_MSC_MT_PEER_ABORT	BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT7
+#define BIT_PAGE_CBUS_REG_MSC_MT_ABORT_INT_STAT5	BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT5
+#define BIT_CBUS_MSC_MT_ABORT_INT_UNDEF_CMD		BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT3
+#define BIT_CBUS_MSC_MT_ABORT_INT_TIMEOUT		BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT2
+#define BIT_CBUS_MSC_MT_ABORT_INT_PROTO_ERR		BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT1
+#define BIT_CBUS_MSC_MT_ABORT_INT_MAX_FAIL		BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT0
+
+#define BIT_CBUS_DDC_PEER_ABORT					BIT_PAGE_5_DDC_ABORT_INT_DDC_ABORT_INT_STAT7
+
+/* Write Burst */
+#define BIT_MDT_RFIFO_DATA_RDY		BIT_PAGE_5_MDT_INT_0_MDT_INT_0_0
+#define BIT_MDT_IDLE_AFTER_HAWB_DISABLE	BIT_PAGE_5_MDT_INT_0_MDT_INT_0_2
+#define BIT_MDT_XFIFO_EMPTY		BIT_PAGE_5_MDT_INT_0_MDT_INT_0_3
+#define BIT_MDT_RCV_TIMEOUT		BIT_PAGE_5_MDT_INT_1_MDT_INT_1_0
+#define BIT_MDT_RCV_SM_ABORT_PKT_RCVD	BIT_PAGE_5_MDT_INT_1_MDT_INT_1_1
+#define BIT_MDT_RCV_SM_ERROR		BIT_PAGE_5_MDT_INT_1_MDT_INT_1_2
+#define BIT_MDT_XMIT_TIMEOUT		BIT_PAGE_5_MDT_INT_1_MDT_INT_1_5
+#define BIT_MDT_XMIT_SM_ABORT_PKT_RCVD	BIT_PAGE_5_MDT_INT_1_MDT_INT_1_6
+#define BIT_MDT_XMIT_SM_ERROR		BIT_PAGE_5_MDT_INT_1_MDT_INT_1_7
+
+/*
+ * The typedef is shared with test code.
+ * Only code of mhl_cbus_control.c and
+ * test code must use it.
+ */
+typedef enum {
+	DEVCAP_ALL_READ_DONE,
+	SENT_PATH_EN_1,
+	RCV_HPD,
+	UPSTREAM_VIDEO_READY,
+	RCV_DCAP_CHG,
+	READ_ECBUS_SPEED,
+	HDCP_READY,
+	TMDS_READY
+} CBUS_CONTROL_COND;
+
+struct block_buffer_info_t {
+	uint8_t	*buffer;
+	uint8_t payload_offset;
+	size_t req_size;
+};
+
+/* flag control*/
+void init_cond_in_cbus_control(void);
+void set_cond_in_cbus_control(CBUS_CONTROL_COND cond);
+void clear_cond_in_cbus_control(CBUS_CONTROL_COND cond);
+bool get_cond_in_cbus_control(CBUS_CONTROL_COND cond);
+void show_cond_in_cbus_control(void);
+
+/**/
+void mhl_msc_init(void);
+void mhl_msc_cbus_communication_start(void);
+void mhl_cbus_communication_eCBUS_start(void);
+void mhl_msc_command_done(bool is_Msc_Msg_Ack);
+void mhl_msc_hpd_receive(void);
+void mhl_msc_write_stat_receive(void);
+void mhl_msc_msg_receive(void);
+void mhl_msc_set_int_receive(void);
+void mhl_cbus_abort(uint8_t cbus_err_int);
+int  mhl_cbus_control_initialize(void);
+void mhl_cbus_control_release(void);
+uint8_t mhl_get_tdm_virt_chan_slot_counts(enum tdm_vc_assignments vc);
+void send_link_mode_to_sink(void);
+void set_link_mode(u8 link_mode);
+u8 get_link_mode(void);
+int mhl_cbus_get_highest_tmds_link_speed(void);
+void mhl_cbus_set_lowest_tmds_link_speed(uint32_t pixel_clock_frequency,
+											uint8_t bits_per_pixel);
+bool mhl_cbus_is_sink_support_scratchpad(void);
+void mhl_cbus_process_vc_assign(uint8_t *write_burst_data);
+void mhl_pf_get_block_buffer_info(
+		struct block_buffer_info_t  *block_buffer_info);
+
+
+/**/
+bool set_cbus_command(uint8_t command, uint8_t reg, uint8_t reg_data);
+bool set_cbus_command_block(
+	uint8_t command, uint8_t length, uint8_t burst_offset,
+	void *buffer);
+void exe_cbus_command(void);
+
+/**/
+void init_devcap(void);
+//int drive_hpd_high(void);
+int drive_hpd_low(void);
+
+/*
+ * cbus write burst : public
+ */
+void cbus_wb_init(void);
+void cbus_wb_event_handler(uint8_t intr_0);
+void cbus_wb_request_write_burst(
+	uint8_t burst_offset, uint8_t length, uint8_t *data);
+void cbus_wb_write_gen2_xfifo(uint8_t length, uint8_t *data);
+void cbus_wb_start_gen2_write_burst(void);
+void cbus_wb_write_burst_send_done(void);
+void cbus_wb_enable_gen2_write_burst_xmit(void);
+void cbus_wb_disable_gen2_write_burst_xmit(void);
+
+/* eMSC */
+int block_input_buffer_available(void);
+int alloc_block_input_buffer(uint8_t **pbuffer);
+void set_block_input_buffer_length(int block, int length);
+void add_received_byte_count(uint16_t size);
+void add_peer_blk_rx_buffer_avail(unsigned long size);
+int block_input_buffer_available(void);
+void mhl_tx_initialize_block_transport(void);
+void mhl_tx_push_block_transactions(void);
+void *mhl_tx_get_sub_payload_buffer(uint8_t size);
+void mhl_tx_emsc_received(void);
+
+#endif /* __MHL_CBUS_CONTROL_H__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_write_burst.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_write_burst.c
@@ -1,0 +1,225 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_cbus_write_burst.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "si_8620_regs.h"
+#include "mhl_sii8620_8061_device.h"
+#include "mhl_cbus_control.h"
+#include "mhl_platform.h"
+#include "mhl_lib_infoframe.h"
+#include "mhl_common.h"
+
+static uint8_t	write_burst_data[MHL_SCRATCHPAD_SIZE];
+static bool	gen2_write_burst_xmit_flag;
+
+/* This function is called when mhl connection started. */
+void cbus_wb_init(void)
+{
+	mhl_dev_clear_cbusp_cond_processing(DEV_WRITE_BURST_SEND);
+}
+
+/*
+* Calculte checksum of the 16 byte block pointed to by the
+* pointer passed as parameter
+*
+* p_HEV_VIC_block_data : Pointer to a 16 byte block whose checksum
+* needs to be calculated
+*
+* RETURNS : true if chcksum is 0. false if not.
+*/
+bool cbus_wb_is_valid_checksum(uint8_t *p_HEV_VIC_block_data)
+{
+	uint8_t i;
+	uint8_t checksum = 0;
+
+	for (i = 0; i < MHL_SCRATCHPAD_SIZE; i++)
+		checksum += p_HEV_VIC_block_data[i];
+
+	if (checksum) {
+		pr_err("%s: false, 0x%x\n", __func__, checksum);
+		return false;
+	}
+
+	return true;
+}
+
+uint8_t *cbus_wb_get_stored_scrpad(uint8_t *size)
+{
+	*size =  ARRAY_SIZE(write_burst_data);
+	return write_burst_data;
+}
+
+static uint8_t cbus_wb_get_vic(uint8_t *in_hev_vic, uint8_t *out_hev_vic)
+{
+	int i;
+	int length		= 0;
+	int HEV_VIC_MAX_SIZE	= 5;
+	int POS_NUM_ENT		= 5;
+	int POS_FIRST_VIC_DATA	= 7;
+	uint8_t vic;
+
+	if (!cbus_wb_is_valid_checksum(in_hev_vic))
+		return 0;
+
+	for (i = 0; i < in_hev_vic[POS_NUM_ENT] && i < HEV_VIC_MAX_SIZE; i++) {
+		vic = in_hev_vic[POS_FIRST_VIC_DATA+(i*2)];
+		if ((vic != 0) && (IsQualifiedMhlVIC(vic))){
+			out_hev_vic[i] = vic;
+			length++;
+			pr_debug("%s: HEV VIC Data: %d\n",
+					__func__, out_hev_vic[i]);
+		}
+	}
+
+	pr_debug("%s: HEV VIC Data length: %d\n", __func__, length);
+	return length;
+}
+
+static void cbus_wb_handle_scr_data(uint8_t *scrpad)
+{
+	BurstId_e burst_id;
+	uint8_t length = 0;
+	uint8_t out_data[MHL_SCRATCHPAD_SIZE];
+
+	burst_id = (BurstId_e)(((uint16_t)scrpad[0]<<8)|((uint16_t)scrpad[1]));
+
+	pr_debug("%s: BURST_ID: 0x%x\n", __func__, burst_id);
+
+	switch (burst_id) {
+	case burst_id_HEV_VIC:
+		length = cbus_wb_get_vic(scrpad, out_data);
+		mhl_device_edid_setup_sink_support_hev_vic(out_data, length);
+		break;
+	case burst_id_VC_ASSIGN:
+		if (!cbus_wb_is_valid_checksum(scrpad)) {
+			pr_err("%s: Bad checksum in virtual channel assign",
+				__func__);
+			return;
+		}
+		mhl_cbus_process_vc_assign(scrpad);
+		break;
+	case burst_id_3D_VIC:
+	case burst_id_3D_DTD:
+	case burst_id_HEV_DTDA:
+	case burst_id_HEV_DTDB:
+	case burst_id_VC_CONFIRM:
+	case burst_id_AUD_DELAY:
+	case burst_id_ADT_BURSTID:
+	case burst_id_BIST_SETUP:
+	case burst_id_BIST_RETURN_STAT:
+	case burst_id_EMSC_SUPPORT:
+	case burst_id_HID_PAYLOAD:
+	case burst_id_BLK_RCV_BUFFER_INFO:
+	case burst_id_BITS_PER_PIXEL_FMT:
+	case LOCAL_ADOPTER_ID:
+	case MHL_TEST_ADOPTER_ID:
+	case burst_id_16_BITS_REQUIRED:
+	default:
+		break;
+	}
+}
+
+void cbus_wb_event_handler(uint8_t intr_0)
+{
+	if (MHL_INT_REQ_WRT & intr_0) {
+		pr_debug("%s: got REQ_WRT\n", __func__);
+		set_cbus_command(MHL_SET_INT, MHL_RCHANGE_INT, MHL_INT_GRT_WRT);
+	}
+
+	if (MHL_INT_DSCR_CHG & intr_0) {
+		pr_debug("%s: got DSCR_CHG\n", __func__);
+		mhl_pf_read_reg_block(REG_PAGE_4_MHL_SCRPAD_0,
+			ARRAY_SIZE(write_burst_data), write_burst_data);
+		cbus_wb_handle_scr_data(write_burst_data);
+	}
+
+	if (MHL3_INT_FEAT_COMPLETE & intr_0) {
+		pr_debug("%s: got FEAT_COMPLETE\n", __func__);
+		mhl_device_edid_set_upstream_edid();
+	}
+
+	if (MHL3_INT_FEAT_REQ & intr_0) {
+		pr_debug("%s: got MHL3_INT_FEAT_REQ\n", __func__);
+
+		/*
+		  FIXME
+		  Should send EMSC_SUPPORT here,
+		  according to MHL3 specifications.
+		*/
+		set_cbus_command(MHL_SET_INT, MHL_RCHANGE_INT,
+					MHL3_INT_FEAT_COMPLETE);
+	}
+}
+
+void cbus_wb_request_write_burst(
+			uint8_t burst_offset, uint8_t length, uint8_t *data)
+{
+	if (mhl_device_is_peer_device_mhl3() &&
+		!mhl_cbus_is_sink_support_scratchpad()) {
+		pr_err("%s: failed SCRATCHPAD_NOT_SUPPORTED\n", __func__);
+	} else if ((burst_offset + length) > MHL_SCRATCHPAD_SIZE) {
+		pr_err("%s: invalid offset + length\n", __func__);
+	} else {
+		pr_debug("%s: Request Write Burst command.\n", __func__);
+		set_cbus_command_block(
+			MHL_WRITE_BURST, MHL_SCRATCHPAD_SIZE, 0, data);
+	}
+}
+
+void cbus_wb_write_gen2_xfifo(uint8_t length, uint8_t *data)
+{
+	mhl_pf_write_reg_block(REG_PAGE_5_MDT_XMIT_WRITE_PORT, length, data);
+	mhl_dev_set_cbusp_cond_processing(DEV_WRITE_BURST_SEND);
+}
+
+void cbus_wb_write_burst_send_done(void)
+{
+	pr_debug("%s: HAWB XFIFO empty. XFIFO_STAT: 0x%02x\n",
+		__func__, mhl_pf_read_reg(REG_PAGE_5_MDT_XFIFO_STAT));
+	mhl_dev_clear_cbusp_cond_processing(DEV_WRITE_BURST_SEND);
+}
+
+void cbus_wb_start_gen2_write_burst(void)
+{
+	mhl_pf_write_reg(REG_PAGE_5_MDT_INT_1_MASK,
+		 BIT_MDT_RCV_TIMEOUT | BIT_MDT_RCV_SM_ABORT_PKT_RCVD
+		 | BIT_MDT_RCV_SM_ERROR | BIT_MDT_XMIT_TIMEOUT
+		 | BIT_MDT_XMIT_SM_ABORT_PKT_RCVD | BIT_MDT_XMIT_SM_ERROR);
+	mhl_pf_write_reg(REG_PAGE_5_MDT_INT_0_MASK,
+		 BIT_MDT_XFIFO_EMPTY | BIT_MDT_IDLE_AFTER_HAWB_DISABLE
+		 | BIT_MDT_RFIFO_DATA_RDY);
+}
+
+void cbus_wb_enable_gen2_write_burst_xmit(void)
+{
+	/* enable Gen2 Write Burst interrupt, MSC and EDID interrupts. */
+	if (!gen2_write_burst_xmit_flag) {
+
+		mhl_pf_write_reg(REG_PAGE_5_MDT_XMIT_CONTROL,
+			 BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_EN
+			 |BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_FIXED_BURST_LEN
+			);
+		pr_debug("%s: enabled GEN2 xmit\n", __func__);
+		gen2_write_burst_xmit_flag = true;
+	}
+}
+
+void cbus_wb_disable_gen2_write_burst_xmit(void)
+{
+	if (gen2_write_burst_xmit_flag) {
+		/*
+		* disable Gen2 Write Burst engine to allow
+		* normal CBUS traffic
+		*/
+		mhl_pf_write_reg(REG_PAGE_5_MDT_XMIT_CONTROL, 0);
+		pr_debug("%s: disabled GEN2 xmit\n", __func__);
+		gen2_write_burst_xmit_flag = false;
+	}
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_common.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_common.h
@@ -1,0 +1,57 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_common.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_COMMON_H
+#define __MHL_COMMON_H
+
+#include <linux/types.h>
+
+/*
+ * Used in the unit test build
+ */
+#ifdef UNIT_TEST
+#define static
+#endif
+
+
+/*
+ * Debug print
+ */
+/* print all debug info */
+/* #define DEBUG_PRINT */
+
+#ifdef DEBUG_PRINT
+#undef pr_debug
+#define pr_debug pr_info
+#endif
+
+/* edid read printing with pr_info level*/
+#define EDID_DATA_DEBUG_PRINT
+
+/*
+ * FIXME
+ */
+#define EMSC_WORKAROUND
+/* #define HEARTBEAT */
+/*
+ * other
+ */
+#define MHL_UCHAR_MAX 255
+
+#define SI_PACK_THIS_STRUCT __attribute__((__packed__))
+#define MHL_DDC_RESET
+
+enum {
+	MHL_SUCCESS = 0,
+	MHL_FAIL = -1
+};
+
+#endif

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_defs.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_defs.h
@@ -1,0 +1,711 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_defs.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Yasuyuki Kino <yasuyuki.kino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_DEFS_H__
+#define __MHL_DEFS_H__
+
+#define SI_PUSH_STRUCT_PACKING
+#define SI_POP_STRUCT_PACKING
+#define SI_PACK_THIS_STRUCT	__attribute__((__packed__))
+
+enum {
+	DEVCAP_OFFSET_DEV_STATE			= 0x00
+	,DEVCAP_OFFSET_MHL_VERSION		= 0x01
+	,DEVCAP_OFFSET_DEV_CAT			= 0x02
+	,DEVCAP_OFFSET_ADOPTER_ID_H		= 0x03
+	,DEVCAP_OFFSET_ADOPTER_ID_L		= 0x04
+	,DEVCAP_OFFSET_VID_LINK_MODE	= 0x05
+	,DEVCAP_OFFSET_AUD_LINK_MODE	= 0x06
+	,DEVCAP_OFFSET_VIDEO_TYPE		= 0x07
+	,DEVCAP_OFFSET_LOG_DEV_MAP		= 0x08
+	,DEVCAP_OFFSET_BANDWIDTH		= 0x09
+	,DEVCAP_OFFSET_FEATURE_FLAG		= 0x0A
+	,DEVCAP_OFFSET_DEVICE_ID_H		= 0x0B
+	,DEVCAP_OFFSET_DEVICE_ID_L		= 0x0C
+	,DEVCAP_OFFSET_SCRATCHPAD_SIZE	= 0x0D
+	,DEVCAP_OFFSET_INT_STAT_SIZE	= 0x0E
+	,DEVCAP_OFFSET_RESERVED			= 0x0F
+	/* this one must be last */
+	,DEVCAP_SIZE
+};
+
+SI_PUSH_STRUCT_PACKING //(
+typedef struct SI_PACK_THIS_STRUCT _MHLDevCap_t {
+	uint8_t state;
+	uint8_t mhl_version;
+	uint8_t deviceCategory;
+	uint8_t adopterIdHigh;
+	uint8_t adopterIdLow;
+	uint8_t vid_link_mode;
+	uint8_t audLinkMode;
+	uint8_t videoType;
+	uint8_t logicalDeviceMap;
+	uint8_t bandWidth;
+	uint8_t featureFlag;
+	uint8_t deviceIdHigh;
+	uint8_t deviceIdLow;
+	uint8_t scratchPadSize;
+	uint8_t int_state_size;
+	uint8_t reserved;
+} MHLDevCap_t, *PMHLDevCap_t;
+
+typedef union {
+	MHLDevCap_t mdc;
+	uint8_t devcap_cache[DEVCAP_SIZE];
+} MHLDevCap_u, *PMHLDevCap_u;
+
+/* Device Power State */
+#define MHL_DEV_UNPOWERED				0x00
+#define MHL_DEV_INACTIVE				0x01
+#define MHL_DEV_QUIET					0x03
+#define MHL_DEV_ACTIVE					0x04
+
+/* Version that this chip supports */
+#define MHL_VER_MAJOR						0x30
+#define MHL_VER_MINOR						0x00
+#define MHL_VERSION							(MHL_VER_MAJOR | MHL_VER_MINOR)
+
+/* MHL Version mask */
+#define MHL_VER_MASK_MAJOR					0xF0
+#define MHL_VER_MASK_MINOR					0x0F
+
+/* MHL Version */
+#define MHL_DEV_MHL_VER_10					0x10
+#define MHL_DEV_MHL_VER_20					0x20
+#define MHL_DEV_MHL_VER_30					0x30
+
+/* Device Category mask */
+#define MHL_DEV_CATEGORY_MASK_DEV_TYPE		0x0F
+#define MHL_DEV_CATEGORY_MASK_POW			0x10
+#define MHL_DEV_CATEGORY_MASK_PLIM			0xE0
+
+/* Device Category */
+#define MHL_DEV_CATEGORY_OFFSET				DEVCAP_OFFSET_DEV_CAT
+#define MHL_DEV_CATEGORY_POW_BIT			0x10
+#define MHL_DEV_CATEGORY_PLIM2_0			0xE0
+
+#define MHL_DEV_CAT_SINK					0x01
+#define MHL_DEV_CAT_SOURCE					0x02
+#define MHL_DEV_CAT_DONGLE					0x03
+#define MHL_DEV_CAT_SELF_POWERED_DONGLE		0x13
+#define MHL_DEV_CAT_DIRECT_SINK				0x05
+#define MHL_DEV_CAT_DIRECT_SOURCE			0x06
+
+/* Device Category[PLIM] */
+#define MHL_DEV_CAT_PLIM_500				0x00
+#define MHL_DEV_CAT_PLIM_900				0x20
+#define MHL_DEV_CAT_PLIM_1500				0x40
+#define MHL_DEV_CAT_PLIM_100				0x60
+#define MHL_DEV_CAT_PLIM_2000				0x80
+
+/* Video Link Mode */
+#define MHL_DEV_VID_LINK_SUPPRGB444		0x01
+#define MHL_DEV_VID_LINK_SUPPYCBCR444		0x02
+#define MHL_DEV_VID_LINK_SUPPYCBCR422		0x04
+#define MHL_DEV_VID_LINK_SUPP_PPIXEL		0x08
+#define MHL_DEV_VID_LINK_SUPP_ISLANDS		0x10
+#define MHL_DEV_VID_LINK_SUPP_VGA		0x20
+#define MHL_DEV_VID_LINK_SUPP_16BPP		0x40
+
+/* Audio Link Mode Support */
+#define MHL_DEV_AUD_LINK_2CH				0x01
+#define MHL_DEV_AUD_LINK_8CH				0x02
+
+
+/* Feature Flag in the devcap */
+#define MHL_DEV_FEATURE_FLAG_OFFSET			DEVCAP_OFFSET_FEATURE_FLAG
+#define MHL_FEATURE_RCP_SUPPORT				0x01
+#define MHL_FEATURE_RAP_SUPPORT				0x02
+#define MHL_FEATURE_SP_SUPPORT				0x04
+#define MHL_FEATURE_UCP_SEND_SUPPORT		0x08
+#define MHL_FEATURE_UCP_RECV_SUPPORT		0x10
+
+/* VIDEO TYPES */
+#define MHL_VT_GRAPHICS						0x00
+#define MHL_VT_PHOTO						0x02
+#define MHL_VT_CINEMA						0x04
+#define MHL_VT_GAMES						0x08
+#define MHL_SUPP_VT							0x80
+
+/* Logical Dev Map */
+#define MHL_DEV_LD_DISPLAY					0x01
+#define MHL_DEV_LD_VIDEO					0x02
+#define MHL_DEV_LD_AUDIO					0x04
+#define MHL_DEV_LD_MEDIA					0x08
+#define MHL_DEV_LD_TUNER					0x10
+#define MHL_DEV_LD_RECORD					0x20
+#define MHL_DEV_LD_SPEAKER					0x40
+#define MHL_DEV_LD_GUI						0x80
+
+/* Bandwidth */
+#define MHL_BANDWIDTH_LIMIT					22		// 225 MHz
+
+
+#define MHL_STATUS_REG_CONNECTED_RDY		0x30
+#define MHL_STATUS_REG_LINK_MODE			0x31
+#define MHL_STATUS_REG_VERSION_STAT			0x32
+
+#define MHL_STATUS_REG_AV_LINK_MODE_CONTROL	0x92
+
+#define MHL_STATUS_DCAP_RDY					0x01
+#define MHL_STATUS_XDEVCAPP_SUPP			0x02
+#define MHL_STATUS_POW_STAT					0x04
+#define MHL_STATUS_PLIM_STAT_MASK			0x38
+
+#define MHL_STATUS_CLK_MODE_MASK			0x07
+#define MHL_STATUS_CLK_MODE_PACKED_PIXEL	0x02
+#define MHL_STATUS_CLK_MODE_NORMAL			0x03
+#define MHL_STATUS_PATH_EN_MASK				0x08
+#define MHL_STATUS_PATH_ENABLED				0x08
+#define MHL_STATUS_PATH_DISABLED			0x00
+#define MHL_STATUS_MUTED_MASK				0x10
+
+#define MHL_RCHANGE_INT						0x20
+#define MHL_DCHANGE_INT						0x21
+
+#define	MHL_INT_DCAP_CHG					0x01
+#define MHL_INT_DSCR_CHG					0x02
+#define MHL_INT_REQ_WRT						0x04
+#define MHL_INT_GRT_WRT						0x08
+#define MHL2_INT_3D_REQ						0x10
+#define MHL3_INT_FEAT_REQ					0x20
+#define MHL3_INT_FEAT_COMPLETE				0x40
+
+// On INTR_1 the EDID_CHG is located at BIT 0
+#define MHL_INT_EDID_CHG					0x02
+
+#define MHL_INT_AND_STATUS_SIZE				0x33	// This contains one nibble each - max offset
+#define MHL_SCRATCHPAD_SIZE					16
+#define MHL_MAX_BUFFER_SIZE					MHL_SCRATCHPAD_SIZE	// manually define highest number
+
+#define SILICON_IMAGE_ADOPTER_ID			322
+
+typedef enum {
+	MHL_TEST_ADOPTER_ID = 0
+	,burst_id_3D_VIC = 0x0010
+	,burst_id_3D_DTD = 0x0011
+	,burst_id_HEV_VIC = 0x0020
+	,burst_id_HEV_DTDA = 0x0021
+	,burst_id_HEV_DTDB = 0x0022
+	,burst_id_VC_ASSIGN = 0x0038
+	,burst_id_VC_CONFIRM = 0x0039
+	,burst_id_AUD_DELAY = 0x0040
+	,burst_id_ADT_BURSTID = 0x0041
+	,burst_id_BIST_SETUP = 0x0051
+	,burst_id_BIST_RETURN_STAT = 0x0052
+	,burst_id_EMSC_SUPPORT			= 0x0061
+	,burst_id_HID_PAYLOAD			= 0x0062
+	,burst_id_BLK_RCV_BUFFER_INFO	= 0x0063
+	,burst_id_BITS_PER_PIXEL_FMT	= 0x0064
+	,LOCAL_ADOPTER_ID = SILICON_IMAGE_ADOPTER_ID
+
+	// add new burst ID's above here
+
+	/* Burst ID's are a 16-bit big-endian quantity.
+	 * In order for the BURST_ID macro below to allow detection of
+            out-of-range values with KEIL 8051 compiler
+            we must have at least one enumerated value
+            that has one of the bits in the high order byte set.
+        Experimentally, we have found that the KEIL 8051 compiler
+         treats 0xFFFF as a special case (-1 perhaps...),
+         so we use a different value that has some upper bits set
+    */
+    ,burst_id_16_BITS_REQUIRED = 0x8000
+} BurstId_e;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL_high_low_t{
+	uint8_t high;
+	uint8_t low;
+} MHL_high_low_t, *PMHL_high_low_t;
+
+typedef MHL_high_low_t MHL_burst_id_t,*PMHL_burst_id_t;
+
+#define ENDIAN_CONVERT_16(a) ((((uint16_t)(a.high))<<8)|((uint16_t)(a.low)))
+#define BURST_ID(bid) (BurstId_e)(ENDIAN_CONVERT_16(bid))
+
+#define HIGH_BYTE_16(x) (uint8_t)((x >> 8) & 0xFF)
+#define LOW_BYTE_16(x)  (uint8_t)( x       & 0xFF)
+#define ENCODE_BURST_ID(id) {HIGH_BYTE_16(id),LOW_BYTE_16(id)}
+
+struct SI_PACK_THIS_STRUCT standard_transport_header_t{
+	uint8_t	rx_unload_ack;
+	uint8_t	length_remaining;
+};
+
+#define STD_TRANSPORT_HDR_SIZE sizeof(struct SI_PACK_THIS_STRUCT standard_transport_header_t)
+
+struct SI_PACK_THIS_STRUCT block_rcv_buffer_info_t{
+	MHL_burst_id_t	burst_id; /* use the BURST_ID macro to access this */
+	uint8_t blk_rcv_buffer_size_low;
+	uint8_t blk_rcv_buffer_size_high;
+};
+
+// see MHL2.0 spec section 5.9.1.2
+typedef struct SI_PACK_THIS_STRUCT _MHL2_video_descriptor_t {
+	uint8_t reserved_high;
+	unsigned char frame_sequential:1;    //FB_SUPP
+	unsigned char top_bottom:1;          //TB_SUPP
+	unsigned char left_right:1;          //LR_SUPP
+	unsigned char reserved_low:5;
+} MHL2_video_descriptor_t, *PMHL2_video_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_burst_header_t{
+	MHL_burst_id_t burst_id;
+	uint8_t checksum;
+	uint8_t total_entries;
+	uint8_t sequence_index;
+}MHL3_burst_header_t,*P_MHL3_burst_header_t;
+typedef struct SI_PACK_THIS_STRUCT _MHL2_video_format_data_t {
+	MHL3_burst_header_t	header;
+	uint8_t num_entries_this_burst;
+	MHL2_video_descriptor_t video_descriptors[5];
+} MHL2_video_format_data_t, *PMHL2_video_format_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_vic_descriptor_t {
+	uint8_t	vic_cea861f;
+	uint8_t reserved;
+}MHL3_hev_vic_descriptor_t,*PMHL3_hev_vic_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_vic_data_t {
+	MHL3_burst_header_t	header;
+	uint8_t num_entries_this_burst;
+	MHL3_hev_vic_descriptor_t video_descriptors[5];
+} MHL3_hev_vic_data_t, *PMHL3_hev_vic_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_dtd_a_payload_t {
+	MHL_high_low_t	pixel_clock_in_MHz;
+	MHL_high_low_t	h_active_in_pixels;
+	MHL_high_low_t	h_blank_in_pixels;
+	MHL_high_low_t	h_front_porch_in_pixels;
+	MHL_high_low_t	h_sync_width_in_pixels;
+	uint8_t			h_flags;
+} MHL3_hev_dtd_a_payload_t , *PMHL3_hev_dtd_a_payload_t ;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_dtd_b_payload_t {
+	MHL_high_low_t	v_total_in_lines;
+	uint8_t			v_blank_in_lines; /* note 7 for table 5-16 is wrong for this entry */
+	uint8_t			v_front_porch_in_lines; /* note 7 for table 5-16 is wrong for this entry */
+	uint8_t			v_sync_width_in_lines; /* note 7 for table 5-16 is wrong for this entry */
+	uint8_t			v_refresh_rate_in_fields_per_second;
+	uint8_t			v_flags;
+	uint8_t			reserved[4];
+} MHL3_hev_dtd_b_payload_t , *PMHL3_hev_dtd_b_payload_t ;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_dtd_a_data_t {
+	MHL3_burst_header_t	header;
+	MHL3_hev_dtd_a_payload_t	payload;
+} MHL3_hev_dtd_a_data_t, *PMHL3_hev_dtd_a_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_dtd_b_data_t {
+	MHL3_burst_header_t	header;
+	MHL3_hev_dtd_b_payload_t payload;
+} MHL3_hev_dtd_b_data_t, *PMHL3_hev_dtd_b_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_hev_dtd_item_t {
+	MHL3_hev_dtd_a_payload_t a;
+	MHL3_hev_dtd_b_payload_t b;
+}MHL3_hev_dtd_item_t, *PMHL3_hev_dtd_item_t;
+
+typedef struct SI_PACK_THIS_STRUCT  _MHL3_speaker_allocation_data_block_t{
+	uint8_t cea861f_spkr_alloc[3];
+}MHL3_speaker_allocation_data_block_t,*PMHL3_speaker_allocation_data_block_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_adt_payload_t{
+	uint8_t	format_flags;
+	union{
+		uint8_t	short_descs[9];
+		MHL3_speaker_allocation_data_block_t spkr_alloc_db[3];
+	}descriptors;
+	uint8_t reserved;
+}MHL3_adt_payload_t,*PMHL3_adt_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT  _MHL3_adt_data_t{
+	MHL3_burst_header_t	header;
+	MHL3_adt_payload_t	payload;
+}MHL3_adt_data_t,*PMHL3_adt_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_emsc_support_payload_t{
+	 MHL_burst_id_t burst_ids[5];
+}MHL3_emsc_support_payload_t,*PMHL3_emsc_support_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL3_emsc_support_data_t {
+	MHL3_burst_header_t	header;
+	uint8_t num_entries_this_burst;
+	MHL3_emsc_support_payload_t payload;
+}MHL3_emsc_support_data_t, *PMHL3_emsc_support_data_t ;
+
+enum view_pixel_fmt_e{
+	VIEW_PIX_FMT_24BPP = 0
+	,VIEW_PIX_FMT_16BPP =1
+};
+typedef struct SI_PACK_THIS_STRUCT _MHL3_bits_per_pixel_fmt_descriptor_t{
+	uint8_t	stream_id;
+	uint8_t	stream_pixel_format;
+}MHL3_bits_per_pixel_fmt_descriptor_t,*PMHL3_bits_per_pixel_fmt_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL_bits_per_pixel_fmt_data_t{
+	MHL3_burst_header_t	header;
+	uint8_t num_entries_this_burst;
+
+	/* reserve 5 for use with WRITE_BURST 
+		actual length is variable, indicated by
+		num_entries_this_burst
+	*/
+	MHL3_bits_per_pixel_fmt_descriptor_t descriptors[5]; 
+
+}MHL_bits_per_pixel_fmt_data_t,*PMHL_bits_per_pixel_fmt_data_t;
+
+typedef union SI_PACK_THIS_STRUCT {
+	MHL2_video_descriptor_t		mhl2_3d_descriptor;
+	MHL3_hev_vic_descriptor_t	mhl3_hev_vic_descriptor;
+	MHL3_hev_dtd_item_t			mhl3_hev_dtd;
+}video_burst_descriptor_u;
+
+SI_POP_STRUCT_PACKING //)
+
+enum {
+	MHL_MSC_MSG_RCP				= 0x10,	/* RCP sub-command */
+	MHL_MSC_MSG_RCPK			= 0x11,	/* RCP Acknowledge sub-command */
+	MHL_MSC_MSG_RCPE			= 0x12,	/* RCP Error sub-command */
+	MHL_MSC_MSG_RAP				= 0x20,	/* Mode Change Warning sub-command */
+	MHL_MSC_MSG_RAPK			= 0x21,	/* MCW Acknowledge sub-command */
+	MHL_MSC_MSG_RBP				= 0x22,	/* Remote Button Protocol sub-command */
+	MHL_MSC_MSG_RBPK			= 0x23,	/* RBP Acknowledge sub-command */
+	MHL_MSC_MSG_RBPE			= 0x24,	/* RBP Error sub-command */
+	MHL_MSC_MSG_UCP				= 0x30,	/* UCP sub-command */
+	MHL_MSC_MSG_UCPK			= 0x31,	/* UCP Acknowledge sub-command */
+	MHL_MSC_MSG_UCPE			= 0x32,	/* UCP Error sub-command */
+	MHL_MSC_MSG_RUSB			= 0x40,	/* Request USB host role */
+	MHL_MSC_MSG_RUSBK			= 0x41,	/* Acknowledge request for USB host role */
+	MHL_MSC_MSG_RHID			= 0x42,	/* Request HID host role */
+	MHL_MSC_MSG_RHIDK			= 0x43,	/* Acknowledge request for HID host role */
+	MHL_MSC_MSG_ATT				= 0x50,	/* Request attention sub-command */
+	MHL_MSC_MSG_ATTK			= 0x51,	/* ATT Acknowledge sub-command */
+	MHL_MSC_MSG_BIST_TRIGGER		= 0x60,
+	MHL_MSC_MSG_BIST_REQUEST_STAT	= 0x61,
+	MHL_MSC_MSG_BIST_READY			= 0x62,
+	MHL_MSC_MSG_BIST_STOP			= 0x63,
+};
+
+#define BIST_TRIGGER_E_CBUS_TX			0x01
+#define BIST_TRIGGER_E_CBUS_RX			0x02
+#define BIST_TRIGGER_E_CBUS_LOOPBACK	0x04
+#define BIST_TRIGGER_E_CBUS_TYPE_MASK	0x08
+#define BIST_TRIGGER_TEST_E_CBUS_S		0x00
+#define BIST_TRIGGER_TEST_E_CBUS_D		0x08
+#define BIST_TRIGGER_AVLINK_TX			0x10
+#define BIST_TRIGGER_AVLINK_RX			0x20
+#define BIST_TRIGGER_IMPEDANCE_TEST		0x40
+
+
+#define BIST_READY_E_CBUS_READY		0x01
+#define BIST_READY_AVLINK_READY		0x02
+#define BIST_READY_TERM_READY		0x04
+#define BIST_READY_E_CBUS_ERROR		0x10
+#define BIST_READY_AVLINK_ERROR		0x20
+#define BIST_READY_TERM_ERROR		0x40
+
+#define	RCPE_NO_ERROR				0x00
+#define	RCPE_INEEFECTIVE_KEY_CODE	0x01
+#define	RCPE_BUSY					0x02
+
+#define MHL_RCP_KEY_RELEASED_MASK	0x80
+#define MHL_RCP_KEY_ID_MASK			0x7F
+
+#define T_PRESS_MODE				300
+
+#define T_HOLD_MAINTAIN				2000
+#define T_RAP_WAIT_MIN				100
+#define T_RAP_WAIT_MAX				1000
+//
+// MHL spec related defines
+//
+enum {
+	 MHL_ACK					= 0x33	// Command or Data byte acknowledge
+	,MHL_NACK					= 0x34	// Command or Data byte not acknowledge
+	,MHL_ABORT					= 0x35	// Transaction abort
+	,MHL_WRITE_STAT				= 0x60 | 0x80	// 0xE0 - Write one status register strip top bit
+	,MHL_SET_INT				= 0x60	// Write one interrupt register
+	,MHL_READ_DEVCAP_REG		= 0x61	// Read one register
+	,MHL_GET_STATE				= 0x62	// Read CBUS revision level from follower
+	,MHL_GET_VENDOR_ID			= 0x63	// Read vendor ID value from follower.
+	,MHL_SET_HPD				= 0x64	// Set Hot Plug Detect in follower
+	,MHL_CLR_HPD				= 0x65	// Clear Hot Plug Detect in follower
+	,MHL_SET_CAP_ID				= 0x66	// Set Capture ID for downstream device.
+	,MHL_GET_CAP_ID				= 0x67	// Get Capture ID from downstream device.
+	,MHL_MSC_MSG				= 0x68	// VS command to send RCP sub-commands
+	,MHL_GET_SC1_ERRORCODE		= 0x69	// Get Vendor-Specific command error code.
+	,MHL_GET_DDC_ERRORCODE		= 0x6A	// Get DDC channel command error code.
+	,MHL_GET_MSC_ERRORCODE		= 0x6B	// Get MSC command error code.
+	,MHL_WRITE_BURST			= 0x6C	// Write 1-16 bytes to responder's scratchpad.
+	,MHL_GET_SC3_ERRORCODE		= 0x6D	// Get channel 3 command error code.
+	,MHL_WRITE_XSTAT			= 0x70 /* Write one extended status register. */
+	,MHL_READ_XDEVCAP_REG		= 0x71 /* Read one extended devcap register. */
+
+	,MHL_READ_EDID_BLOCK				/* let the rest of these float, they are software specific */
+	,MHL_SEND_3D_REQ_OR_FEAT_REQ
+	,MHL_READ_DEVCAP
+	,MHL_READ_XDEVCAP
+};
+
+/* RAP action codes */
+#define MHL_RAP_POLL				0x00	// Just do an ack
+#define MHL_RAP_CONTENT_ON			0x10	// Turn content streaming ON.
+#define MHL_RAP_CONTENT_OFF			0x11	// Turn content streaming OFF.
+#define MHL_RAP_CBUS_MODE_DOWN		0x20
+#define MHL_RAP_CBUS_MODE_UP		0x21
+
+/* RAPK status codes */
+#define MHL_RAPK_NO_ERR				0x00	/* RAP action recognized & supported */
+#define MHL_RAPK_UNRECOGNIZED		0x01	/* Unknown RAP action code received */
+#define MHL_RAPK_UNSUPPORTED		0x02	/* Received RAP action code is not supported */
+#define MHL_RAPK_BUSY				0x03	/* Responder too busy to respond */
+
+/*
+ * Error status codes for RCPE messages
+ */
+/* No error. (Not allowed in RCPE messages) */
+#define MHL_RCPE_STATUS_NO_ERROR		0x00
+/* Unsupported/unrecognized key code */
+#define MHL_RCPE_STATUS_INEFFECTIVE_KEY_CODE	0x01
+/* Responder busy. Initiator may retry message */
+#define MHL_RCPE_STATUS_BUSY			0x02
+
+
+/* Extended Device Capability Registers 7.12.1 */
+enum {
+	XDEVCAP_ADDR_ECBUS_SPEEDS			= 0x80
+	,XDEVCAP_ADDR_TMDS_SPEEDS			= 0x81
+	,XDEVCAP_ADDR_ECBUS_DEV_ROLES	                = 0x82
+	,XDEVCAP_ADDR_ECBUS_DEV_MAPX		        = 0x83
+	,XDEVCAP_LIMIT  /* don't hard-code this one */
+	,XDEVCAP_ADDR_RESERVED_4			= 0x84
+	,XDEVCAP_ADDR_RESERVED_5			= 0x85
+	,XDEVCAP_ADDR_RESERVED_6			= 0x86
+	,XDEVCAP_ADDR_RESERVED_7			= 0x87
+	,XDEVCAP_ADDR_RESERVED_8			= 0x88
+	,XDEVCAP_ADDR_RESERVED_9			= 0x89
+	,XDEVCAP_ADDR_RESERVED_A			= 0x8A
+	,XDEVCAP_ADDR_RESERVED_B			= 0x8B
+	,XDEVCAP_ADDR_RESERVED_C			= 0x8C
+	,XDEVCAP_ADDR_RESERVED_D			= 0x8D
+	,XDEVCAP_ADDR_RESERVED_E			= 0x8E
+	,XDEVCAP_ADDR_RESERVED_F			= 0x8F
+	/* this one must be last */
+	,XDEVCAP_ADDR_LAST
+	,XDEVCAP_START	= XDEVCAP_ADDR_ECBUS_SPEEDS
+};
+
+#define XDEVCAP_OFFSET(reg) (reg - XDEVCAP_ADDR_ECBUS_SPEEDS)
+SI_PUSH_STRUCT_PACKING //(
+typedef struct SI_PACK_THIS_STRUCT _MHLXDevCap_t {
+	uint8_t ecbus_speeds;
+	uint8_t tmds_speeds;
+	uint8_t ecbus_dev_roles;
+	uint8_t log_dev_mapx;
+	uint8_t reserved_4;
+	uint8_t reserved_5;
+	uint8_t reserved_6;
+	uint8_t reserved_7;
+	uint8_t reserved_8;
+	uint8_t reserved_9;
+	uint8_t reserved_a;
+	uint8_t reserved_b;
+	uint8_t reserved_c;
+	uint8_t reserved_d;
+	uint8_t reserved_e;
+	uint8_t reserved_f;
+} MHLXDevCap_t,*PMHLXDevCap_t;
+
+typedef union {
+	MHLXDevCap_t mxdc;
+	uint8_t xdevcap_cache[XDEVCAP_ADDR_LAST];
+} MHLXDevCap_u, *PMHLXDevCap_u;
+SI_POP_STRUCT_PACKING //)
+
+/* XDEVCAP - eCBUS Speeds 7.12.1.1 */
+#define MHL_XDC_ECBUS_S_075				0x01
+#define MHL_XDC_ECBUS_S_8BIT			0x02
+#define MHL_XDC_ECBUS_S_12BIT			0x04
+#define MHL_XDC_ECBUS_D_150				0x10
+#define MHL_XDC_ECBUS_D_8BIT			0x20
+
+/* XDEVCAP - TMDS Speeds 7.12.1.2 */
+#define MHL_XDC_TMDS_000				0x00
+#define MHL_XDC_TMDS_150				0x01
+#define MHL_XDC_TMDS_300				0x02
+#define MHL_XDC_TMDS_600				0x04
+
+/* XDEVCAP - Device Roles 7.12.1.3?       */
+#define MHL_XDC_DEV_HOST				0x01
+#define MHL_XDC_DEV_DEVICE				0x02
+#define MHL_XDC_DEV_CHARGER				0x04
+#define MHL_XDC_HID_HOST				0x08
+#define MHL_XDC_HID_DEVICE				0x10
+
+/* XDEVCAP - Extended Logical Device Map 7.12.1.4 */
+#define MHL_XDC_LD_PHONE				0x01
+
+/* Extended Device Status Registers 18.2.2 */
+enum {
+	XDEVSTAT_OFFSET_CURR_ECBUS_MODE		= 0x00,
+	XDEVSTAT_OFFSET_AVLINK_MODE_STATUS	= 0x01,
+	XDEVSTAT_OFFSET_AVLINK_MODE_CONTROL	= 0x02,
+	XDEVSTAT_OFFSET_MULTI_SINK_STATUS	= 0x03,
+	XDEVSTAT_OFFSET_RESERVED_04			= 0x04,
+	XDEVSTAT_OFFSET_RESERVED_05			= 0x05,
+	XDEVSTAT_OFFSET_RESERVED_06			= 0x06,
+	XDEVSTAT_OFFSET_RESERVED_07			= 0x07,
+	XDEVSTAT_OFFSET_RESERVED_08			= 0x08,
+	XDEVSTAT_OFFSET_RESERVED_09			= 0x09,
+	XDEVSTAT_OFFSET_RESERVED_0A			= 0x0A,
+	XDEVSTAT_OFFSET_RESERVED_0B			= 0x0B,
+	XDEVSTAT_OFFSET_RESERVED_0C			= 0x0C,
+	XDEVSTAT_OFFSET_RESERVED_0D			= 0x0D,
+	XDEVSTAT_OFFSET_RESERVED_0E			= 0x0E,
+	XDEVSTAT_OFFSET_RESERVED_0F			= 0x0F,
+	XDEVSTAT_OFFSET_RESERVED_10			= 0x10,
+	XDEVSTAT_OFFSET_RESERVED_11			= 0x11,
+	XDEVSTAT_OFFSET_RESERVED_12			= 0x12,
+	XDEVSTAT_OFFSET_RESERVED_13			= 0x13,
+	XDEVSTAT_OFFSET_RESERVED_14			= 0x14,
+	XDEVSTAT_OFFSET_RESERVED_15			= 0x15,
+	XDEVSTAT_OFFSET_RESERVED_16			= 0x16,
+	XDEVSTAT_OFFSET_RESERVED_17			= 0x17,
+	XDEVSTAT_OFFSET_RESERVED_18			= 0x18,
+	XDEVSTAT_OFFSET_RESERVED_19			= 0x19,
+	XDEVSTAT_OFFSET_RESERVED_1A			= 0x1A,
+	XDEVSTAT_OFFSET_RESERVED_1B			= 0x1B,
+	XDEVSTAT_OFFSET_RESERVED_1C			= 0x1C,
+	XDEVSTAT_OFFSET_RESERVED_1D			= 0x1D,
+	XDEVSTAT_OFFSET_RESERVED_1E			= 0x1E,
+	XDEVSTAT_OFFSET_RESERVED_1F			= 0x1F,
+	/* this one must be last */
+	XDEVSTAT_SIZE
+};
+
+/* XDEVSTAT - Current eCBUS Mode 18.2.2.1 */
+#define MHL_XDS_SLOT_MODE_8BIT				0x00
+#define MHL_XDS_SLOT_MODE_6BIT				0x01
+
+#define MHL_XDS_LINK_CLOCK_75MHZ			0x00
+#define MHL_XDS_LINK_CLOCK_150MHZ			0x10
+#define MHL_XDS_LINK_CLOCK_300MHZ			0x20
+#define MHL_XDS_LINK_CLOCK_600MHZ			0x30
+
+/* XDEVSTAT - AV Link Mode Status 18.2.2.2 */
+#define MHL_XDS_LINK_STATUS_NO_SIGNAL		0x00
+#define MHL_XDS_LINK_STATUS_CRU_LOCKED		0x01
+#define MHL_XDS_LINK_STATUS_TMDS_NORMAL		0x02
+#define MHL_XDS_LINK_STATUS_TMDS_RESERVED	0x03
+
+/* XDEVSTAT - AV Link Mode Control 18.2.2.3 */
+#define MHL_XDS_LINK_RATE_1_5_GBPS			0x00
+#define MHL_XDS_LINK_RATE_3_0_GBPS			0x01
+#define MHL_XDS_LINK_RATE_6_0_GBPS			0x02
+
+/* XDEVSTAT - Multi-Sink Status 18.2.2.4 */
+#define MHL_XDS_SINK_STATUS_1_HPD_LOW		0x00
+#define MHL_XDS_SINK_STATUS_1_HPD_HIGH		0x01
+#define MHL_XDS_SINK_STATUS_2_HPD_LOW		0x00
+#define MHL_XDS_SINK_STATUS_2_HPD_HIGH		0x04
+#define MHL_XDS_SINK_STATUS_3_HPD_LOW		0x00
+#define MHL_XDS_SINK_STATUS_3_HPD_HIGH		0x10
+#define MHL_XDS_SINK_STATUS_4_HPD_LOW		0x00
+#define MHL_XDS_SINK_STATUS_4_HPD_HIGH		0x40
+
+
+/*
+ * Define format of Write Burst used in MHL 3
+ * to assign TDM slots to virtual channels.
+ */
+struct SI_PACK_THIS_STRUCT virt_chan_info {
+	uint8_t vc_num;
+	uint8_t feature_id;
+#define FEATURE_ID_E_MSC					0x00
+#define FEATURE_ID_USB						0x01
+#define FEATURE_ID_AUDIO					0x02
+#define FEATURE_ID_IP						0x03
+#define FEATURE_ID_COMP_VIDEO				0x04
+	union {
+		uint8_t channel_size;
+		uint8_t response;
+#define VC_RESPONSE_ACCEPT					0x00
+#define VC_RESPONSE_BAD_VC_NUM				0x01
+#define VC_RESPONSE_BAD_FEATURE_ID			0x02
+#define VC_RESPONSE_BAD_CHANNEL_SIZE		0x03
+	} req_resp;
+};
+
+#define MAX_VC_ENTRIES 3
+struct SI_PACK_THIS_STRUCT tdm_alloc_burst {
+	uint8_t burst_id_h;
+	uint8_t burst_id_l;
+	uint8_t checksum;
+	uint8_t tot_ent;
+	uint8_t seq;
+	uint8_t num_ent;
+	struct virt_chan_info vc_info[MAX_VC_ENTRIES];
+	uint8_t reserved;
+};
+
+struct __attribute__((__packed__)) bist_setup_burst {
+	uint8_t	burst_id_h;
+	uint8_t	burst_id_l;
+	uint8_t	checksum;
+	uint8_t	e_cbus_duration;
+	uint8_t	e_cbus_pattern;
+#define BS_PATTERN_UNSPECIFIED	0x00
+#define BS_PATTERN_PRBS			0x01
+#define BS_PATTERN_FIXED_8		0x02
+#define BS_PATTERN_FIXED_10		0x03
+#define BS_PATTERN_MAX			BS_PATTERN_FIXED_10
+	uint8_t	e_cbus_fixed_h;
+	uint8_t	e_cbus_fixed_l;
+	uint8_t	reserved;
+	uint8_t	avlink_data_rate;
+	uint8_t	avlink_pattern;
+#define BS_AV_PATTERN_UNSPECIFIED	0x00
+#define BS_AV_PATTERN_PRBS			0x01
+#define BS_AV_PATTERN_FIXED_8		0x02
+#define BS_AV_PATTERN_FIXED_10		0x03
+#define BS_AV_PATTERN_MAX			BS_AV_PATTERN_FIXED_10
+	uint8_t	avlink_video_mode;
+	uint8_t	avlink_duration;
+	uint8_t	avlink_fixed_h;
+	uint8_t	avlink_fixed_l;
+	uint8_t	avlink_randomizer;
+	uint8_t	impedance_mode;
+#define IMP_MODE_AV_LINK_TX_LOW		0x00
+#define IMP_MODE_AV_LINK_TX_HIGH	0x01
+#define IMP_MODE_AV_LINK_RX			0x02
+#define IMP_MODE_E_CBUS_D_TX_LOW	0x04
+#define IMP_MODE_E_CBUS_D_TX_HIGH	0x05
+#define IMP_MODE_E_CBUS_D_RX		0x06
+#define IMP_MODE_E_CBUS_S_TX_LOW	0x08
+#define IMP_MODE_E_CBUS_S_TX_HIGH	0x09
+#define IMP_MODE_E_CBUS_S_RX		0x0A
+};
+
+struct __attribute__((__packed__)) bist_return_status_burst {
+	uint8_t	burst_id_h;
+	uint8_t	burst_id_l;
+	uint8_t	checksum;
+	uint8_t reserved[9];
+	uint8_t	e_cbus_stat_h;
+	uint8_t	e_cbus_stat_l;
+	uint8_t	avlink_stat_h;
+	uint8_t	avlink_stat_l;
+};
+
+#endif

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.c
@@ -1,0 +1,1378 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawasaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+#include "linux/kernel.h"
+#include "linux/types.h"
+#include "mhl_lib_edid.h"
+#include <linux/string.h>
+#include <linux/errno.h>
+
+/* Block 0 */
+#define EDID_OFFSET_HEADER_FIRST_00	0x00
+#define EDID_OFFSET_HEADER_FIRST_FF	0x01
+#define EDID_OFFSET_HEADER_LAST_FF	0x06
+#define EDID_OFFSET_HEADER_LAST_00	0x07
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+/* svd (short video descriptor) native bit mask */
+#define NATIVE_BIT_MASK 0x7F
+
+/* Start of data block collection */
+#define DBC_START_OFFSET 4
+
+#define VIC_16 MHL_VIC_16_1920x1080p60_16_19
+
+#define MAX_DATA_BLOCK_SIZE 31
+
+const struct hdmi_edid_video_mode_property_type vga_preferred_disp_info
+= {HDMI_VFRMT_640x480p60_4_3, 640, 480, false, 800, 160, 525, 45,
+		31500, 60000, 25200, 60000, true};
+
+/* CEA Data Block Tag Codes */
+enum {
+	RESERVED_1 = 0,
+	AUDIO_DATA_BLOCK,
+	VIDEO_DATA_BLOCK,
+	VENDOR_SPECIFIC_DATA_BLOCK,
+	SPEAKER_ALLOCATION_DATA_BLOCK,
+	VESA_DTC_DATA_BLOCK,
+	RESERVED_2,
+	USE_EXTENDED_TAG
+};
+
+#ifdef DEBUG_PRINT
+#define PRINT_DATA(_data, _count, _string) \
+	{ \
+		int i; \
+		pr_debug("-----%s(): %s-----\n", __func__, _string);\
+		for(i = 0; i<_count; i++){ \
+			pr_debug("0x%02x ", _data[i]); \
+			if ((i+1) %16 == 0) \
+				pr_debug("\n"); \
+			if (i == _count - 1) \
+				pr_debug("\n"); \
+		} \
+		pr_debug("-----\n"); \
+	}
+#else
+#define PRINT_DATA(_data, _count, _string)
+#endif
+
+#define OFFSET_MOVE(_offset, _number, _max_offset) \
+_offset += _number;\
+pr_debug("moving... offset = %d\n", _offset);\
+if (_offset >= _max_offset) {\
+	pr_warn("LINE : %d. Illegal offset. max offset is %d\n", __LINE__, _max_offset);\
+	return _max_offset;\
+}
+
+#define IS_LATENCY_FIELDS_PRESENT(_vsd) \
+	pr_debug("Latency Fields Present = 0x%x (offset = 8)\n", *(_vsd + 8));\
+	pr_info("0x%02x\n",*(_vsd + 8) & 0x80);\
+	if (*(_vsd + 8) & 0x80) {
+
+#define IS_I_LATENCY_FIELDS_PRESENT(_vsd) \
+	pr_debug("I Latency Fields Present = 0x%x (offset = 8)\n", *(_vsd + 8));\
+	if (*(_vsd + 8) & 0x40) {
+
+#define FILL_WITH_0_EXCEPT_FOR_IMAGE_SIZE(_vsd, _offset)\
+	pr_debug("Keep Image_Size, other is 0 (offset = %d)\n", _offset);\
+	pr_debug("current : 0x%02x\n", *(_vsd + _offset));\
+	*(_vsd + _offset) &= 0x18;\
+	pr_debug("change to : 0x%02x\n", *(_vsd + _offset))
+
+#define GET_HDMI_VIC_LEN(_hdmi_vic_len, _vsd, _offset)\
+	_hdmi_vic_len = (*(_vsd + _offset)) >> 5;\
+	pr_debug("hdmi_vic_len = %d\n", _hdmi_vic_len)
+
+#define GET_HDMI_3D_LEN(_hdmi_3d_len, _vsd, _offset)\
+	_hdmi_3d_len = *(_vsd + _offset) & 0x1F;\
+	pr_debug("hdmi_3d_len = %d\n", _hdmi_3d_len)
+
+static int mhl_lib_edid_remove_vic(uint8_t *svd, uint8_t svd_size,
+	uint8_t *filter, uint8_t filter_size);
+static int mhl_lib_edid_pull_up_and_padding(uint8_t *head,
+	int data_size, int pull_up_size);
+static void mhl_lib_edid_remake_ext_blocK(
+	PCEA_extension_t extension,
+	int pull_up_size,
+	uint8_t *last_svd_address,
+	int new_svd_size);
+static const uint8_t *hdmi_edid_find_block_v2(
+	const uint8_t *in_buf,
+	const uint8_t db_num,
+	 u32 start_offset,
+	 u8 type, u8 *len);
+
+static void hdmi_edid_detail_desc(
+		const u8 *data_buf,
+		u32 *disp_mode,
+		const struct hdmi_edid_video_mode_property_type *hdmi_edid_disp_mode_lut,
+		u32 mode_lut_len,
+		u32 *most_hi_quality_disp_mode_index);
+
+
+bool mhl_edid_check_edid_header(uint8_t *pSingleEdidBlock)
+{
+	uint8_t i = 0;
+	uint8_t first_00 = EDID_OFFSET_HEADER_FIRST_00;
+	uint8_t first_ff = EDID_OFFSET_HEADER_FIRST_FF;
+	uint8_t last_ff = EDID_OFFSET_HEADER_LAST_FF;
+	uint8_t last_00 = EDID_OFFSET_HEADER_LAST_00;
+
+	if (0x00 != pSingleEdidBlock[first_00]) {
+		pr_debug("%s: no offset header first\n", __func__);
+		return false;
+	}
+
+	for (i = first_ff; i <= last_ff; i++)
+		if (0xFF != pSingleEdidBlock[i]) {
+			pr_debug("%s: no ff\n", __func__);
+			return false;
+		}
+
+	if (0x00 != pSingleEdidBlock[last_00]) {
+		pr_debug("%s: no offset header last\n", __func__);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+ * Calculte checksum of the 128 byte block pointed to by the
+ * pointer passed as parameter
+ *
+ * p_EDID_block_data : Pointer to a 128 byte block whose checksum
+ * needs to be calculated
+ *
+ * RETURNS : true if chcksum is 0. false if not.
+ */
+
+bool mhl_lib_edid_is_valid_checksum(uint8_t *p_EDID_block_data)
+{
+	uint8_t i;
+	uint8_t checksum = 0;
+
+	for (i = 0; i < EDID_BLOCK_SIZE; i++)
+		checksum += p_EDID_block_data[i];
+
+	if (checksum) {
+		pr_warn("%s: false\n", __func__);
+		return false;
+	}
+
+	return true;
+}
+
+int mhl_edid_parser_get_num_cea_861_extensions(uint8_t *pSingleEdidBlock)
+{
+	PEDID_block0_t p_EDID_block_0 = (PEDID_block0_t)pSingleEdidBlock;
+	/* check edid header format exists or not */
+
+	if (!mhl_edid_check_edid_header(pSingleEdidBlock)) {
+		pr_warn("%s:invalid edid header\n", __func__);
+		return MHL_FAIL;
+	}
+
+	if (!mhl_lib_edid_is_valid_checksum(pSingleEdidBlock)) {
+		pr_warn("%s:checksum error\n", __func__);
+		return MHL_FAIL;
+	}
+
+	return p_EDID_block_0->extension_flag;
+}
+
+/*
+ * ext_edid : one extension edid block (128 byte)
+ */
+static uint8_t get_data_block_tag_code(uint8_t data_block_collection);
+static uint8_t get_data_block_length(uint8_t data_block_collection);
+static void remove_head_from_data(uint8_t *data, int data_length);
+static void set_data_block_length(uint8_t *data_block, uint8_t length);
+static uint8_t calculate_generic_checksum(
+	uint8_t *info_frame_data,
+	uint8_t checksum,
+	uint8_t length);
+
+int squash_data_with_prune_0(uint8_t *data, int length)
+{
+	int i;
+	int hit_cnt = 0;
+	uint8_t *head = data;
+	uint8_t *last = head + length - 1;
+	int orig_len = length;
+
+	/* squash hdmi vic */
+	for (;  0 < length; length--) {
+		if (*data == 0x00) {
+			memcpy((void *)data, (const void *)(data + 1), (size_t)(length - 1));
+			*(data + length - 1) = 0x00;
+
+			if ((data + length - 1) > last) {
+				pr_warn("exceeds max mem. length = %d\n", length);
+				return -EPERM;
+			}
+		} else
+			data++;
+	}
+
+	/* count 0 in the entire data */
+	for (i = 0; i < orig_len; i++)
+		if (*(head + i) == 0x00)
+			hit_cnt++;
+
+	return hit_cnt;
+}
+
+int mhl_edid_parser_remove_vic16_1080p60fps(uint8_t *ext_edid)
+{
+	PCEA_extension_t extension = (PCEA_extension_t)ext_edid;
+	uint8_t db_len;		/*data block length*/
+	uint8_t *db_header;	/* video data block header */
+	uint8_t *svd;		/* short video descriptor */
+	int new_svd_size = 0;
+	int i;
+	int pull_up_size = 0;
+	uint8_t *last_svd_address = NULL;
+
+	/* search video tag code */
+	db_header = (uint8_t *)hdmi_edid_find_block_v2(
+		(const uint8_t *)ext_edid,
+		1,
+		 DBC_START_OFFSET,
+		 VIDEO_DATA_BLOCK,
+		 &db_len);
+
+    new_svd_size = db_len;
+
+	if (db_header == NULL) {
+		pr_debug("%s: no video data block\n", __func__);
+		return MHL_SUCCESS;
+	}
+
+	svd = db_header + 1;
+	for (i = 0; i < db_len; i++) {
+		/* search vic 16 */
+		if ((NATIVE_BIT_MASK & *svd) == VIC_16) {
+			/*
+			 *remove vic 16 from the data block
+			 */
+			pull_up_size++;
+			pr_debug("%s:vic16 1080p60fps is removed : 0x%02x\n", __func__, *svd);
+			*svd = 0x00;
+			/* set last svd address with
+			 * vic 16 pointing address
+			 */
+			new_svd_size--;
+		}
+		svd++;
+	}
+
+	last_svd_address = db_header + db_len - squash_data_with_prune_0(db_header + 1, db_len) + 1;
+
+	/* the vic 16 address is
+	 * overwritten by the followng address
+	 */
+	mhl_lib_edid_remake_ext_blocK(
+		extension,
+		pull_up_size,
+		last_svd_address,
+		new_svd_size);
+
+	/* change the length of the data block */
+	set_data_block_length(
+		db_header,
+		new_svd_size);
+
+	/* checksum */
+	extension->checksum = 0x00;
+	extension->checksum = calculate_generic_checksum(
+		(uint8_t *)extension,
+		 0x00,
+		 sizeof(*extension));
+
+
+
+	return MHL_SUCCESS;
+}
+
+/*
+ * svd : short video descriptor
+ */
+void mhl_lib_edid_remove_vic_from_svd(uint8_t *ext_edid,
+		 uint8_t *not_removed_vic_array,
+		 uint8_t not_removed_vic_array_size)
+{
+	PCEA_extension_t extension = (PCEA_extension_t)ext_edid;
+	uint8_t db_len;		/*data block length*/
+	uint8_t *db_header;	/* video data block header */
+
+	/* search video tag code */
+	db_header = (uint8_t *)hdmi_edid_find_block_v2(
+		(const uint8_t *)ext_edid,
+		1,
+		 DBC_START_OFFSET,
+		 VIDEO_DATA_BLOCK,
+		 &db_len);
+
+	if (db_header != NULL) {
+		/* svd : short video descriptor */
+		uint8_t *svd = db_header + 1;
+		int svd_size = db_len;
+		int new_svd_size = mhl_lib_edid_remove_vic(
+				svd, svd_size,
+				not_removed_vic_array,
+				not_removed_vic_array_size);
+
+		/* change the length of the data block */
+		set_data_block_length(db_header, new_svd_size);
+
+		{/* re-making the ext_edid data */
+			int pull_up_size = svd_size - new_svd_size;
+			uint8_t *last_svd_address = svd + new_svd_size;
+
+			mhl_lib_edid_remake_ext_blocK(
+					extension,
+					pull_up_size,
+					last_svd_address,
+					new_svd_size);
+		}
+	}
+}
+
+
+
+
+/*
+ * make edid with new svd size.
+ * (svd : short video descriptor)
+ */
+static void mhl_lib_edid_remake_ext_blocK(
+					PCEA_extension_t extension,
+					 int pull_up_size,
+					 uint8_t *last_svd_address,
+					 int new_svd_size)
+{
+	int check_sum_1_byte = 1;
+
+	/* renew svd size. check sum is not included */
+	/*int pull_up_target_size =
+		 block_size_128_byte -
+		 cea_ext_1st_4_byte -
+		 data_block_header_size_1_byte -
+		 new_svd_size -
+		 check_sum_1_byte;*/
+
+	int pull_up_target_size = (uint8_t *)extension +
+				 EDID_BLOCK_SIZE -
+				 last_svd_address -
+				 check_sum_1_byte;
+
+
+	pr_debug("%s:pull up size = %d\n", __func__, pull_up_size);
+	pr_debug("%s:new svd size = %d\n", __func__, new_svd_size);
+	pr_debug("%s:last svd = 0x%02x, 0x%02x, 0x%02x\n", __func__, *(last_svd_address-1), *(last_svd_address), *(last_svd_address+1));
+	pr_debug("%s:pull up target size = %d\n", __func__, pull_up_target_size);
+
+
+	/* pull up the data after svd */
+	mhl_lib_edid_pull_up_and_padding(
+		last_svd_address,
+		pull_up_target_size,
+		pull_up_size);
+
+	/* offset for 18 byte descriptors */
+	if (*((uint8_t *)extension + 2) != 0)
+		*((uint8_t *)extension + 2) = *((uint8_t *)extension + 2) - pull_up_size;
+
+	/* check sum */
+	extension->checksum = 0x00;
+	extension->checksum = calculate_generic_checksum(
+		(uint8_t *)extension,
+		 0x00,
+		 sizeof(*extension));
+}
+
+void mhl_lib_edid_set_checksum(uint8_t *one_edid_blk)
+{
+	PEDID_block0_t one_edid_blk_ = (PEDID_block0_t)one_edid_blk;
+
+	/* check sum */
+	one_edid_blk_->checksum = 0x00;
+	one_edid_blk_->checksum = calculate_generic_checksum(
+		(uint8_t *)one_edid_blk_,
+		 0x00,
+		 sizeof(*one_edid_blk_));
+}
+
+
+
+/* Add hdmi vic to vsd (vendor specific data). this API must be called
+ * after remove all hdmi vic and 3d info in vsd. */
+static int mhl_lib_edid_add_hdmi_vic(uint8_t *vsd, uint8_t vsd_size, int hdmi_vic_flag)
+{
+	uint8_t vic_num = 0;
+	int tmp_vic_flag = hdmi_vic_flag;
+
+	if (vsd_size < MHL_MAX_HDMI_BIC_NUM + 14)
+		return -EINVAL;
+
+	if (!vsd)
+		return -EINVAL;
+
+	/* get number of hdmi vic */
+	for ( ; tmp_vic_flag != 0 ; tmp_vic_flag &= tmp_vic_flag - 1 )
+        vic_num++;
+
+	/* hdmi video present */
+	*(vsd + 7) |= 0x20;
+
+	/* hdmi vic number */
+	*(vsd + 13) |= (vic_num << 5);
+
+	{
+		int i;
+		int vsd_cnt = 0;
+
+		for (i = 0; (hdmi_vic_flag != 0); i++) {
+
+			if (hdmi_vic_flag & 0x01)
+				*(vsd + 14 + vsd_cnt++) = i + 1;
+
+			hdmi_vic_flag = hdmi_vic_flag >> 1;
+		}
+	}
+
+	return 14 + vic_num;
+}
+
+static int get_converted_hdmi_vic(uint8_t vic)
+{
+	switch (vic) {
+	case 95:
+		return 1;
+	case 94:
+		return 2;
+	case 93:
+		return 3;
+	case 98:
+		return 4;
+	default:
+		return -EINVAL;
+	}
+}
+
+static bool is_supp_hdmi_vic(uint8_t hdmi_vic, uint8_t *supp_vic, uint8_t supp_vic_size)
+{
+	int i;
+
+	for (i = 0; i < supp_vic_size; i++) {
+		int supp_hdmi_vic = get_converted_hdmi_vic(supp_vic[i]);
+		if (hdmi_vic == supp_hdmi_vic)
+			return true;
+	}
+
+	return false;
+}
+
+
+
+static int mhl_lib_edid_remove_hdmi_vic_and_3d(
+				uint8_t *vsd, uint8_t vsd_size)
+{
+	uint8_t offset = 0;
+	uint8_t new_vsd_size = 0;
+
+	PRINT_DATA(vsd, vsd_size + 1, "[in] vsd")
+
+	if ((uint8_t)vsd_size != (uint8_t)(*vsd & 0x1F)) {
+		pr_warn("%s:Illegal vsd size, [in] = %d, db_len = %d\n",
+		 __func__,
+		 vsd_size,
+		 *vsd & 0x1F);
+		return (*vsd) & 0x1F;
+	}
+
+	if (vsd_size < 9)
+		return vsd_size;
+
+	/* fill HDMI_Video_present with 0 */
+	*(vsd + 8) = *(vsd + 8) & 0xDF;
+
+	offset = 9;
+	IS_LATENCY_FIELDS_PRESENT(vsd)
+		OFFSET_MOVE(offset, 2, vsd_size);
+	}
+	IS_I_LATENCY_FIELDS_PRESENT(vsd)
+		OFFSET_MOVE(offset, 2, vsd_size);
+	}
+
+	FILL_WITH_0_EXCEPT_FOR_IMAGE_SIZE(vsd, offset);
+	OFFSET_MOVE(offset, 1, vsd_size);
+
+	/* remaining fields are filled up with 0 */
+
+	memset((void *)(vsd + offset), 0x00, (size_t)(vsd_size + 1 - offset));
+
+	pr_debug("%s:0 fill size = %d\n", __func__, vsd_size +1 - offset);
+	pr_debug("%s: return = %d\n", __func__, offset);
+	new_vsd_size = offset - 1;
+
+	set_data_block_length(vsd, new_vsd_size);
+	PRINT_DATA(vsd, vsd_size + 1, "[out] vsd")
+
+	return new_vsd_size;
+}
+
+
+/* this API does not change the vsd size info
+ * even some data is removed. Keep original length data. */
+int mhl_lib_edid_replace_hdmi_vic_and_remove_3d(
+	uint8_t *vsd,
+	int vsd_size,
+	uint8_t *supp_vic,
+	uint8_t supp_vic_size)
+{
+	int hdmi_vic_len;
+	int hdmi_3d_len;
+	int i;
+	int new_hdmi_vic_len = 0;
+	uint8_t offset = 0;
+	uint8_t new_vsd_size = 0;
+
+	PRINT_DATA(vsd, vsd_size + 1, "[in] vsd")
+
+	if ((uint8_t)vsd_size != (uint8_t)(*vsd & 0x1F)) {
+		pr_warn("%s:Illegal vsd size, vsd size = %d, db_len = %d\n",
+		 __func__,
+		 vsd_size,
+		 *vsd & 0x1F);
+		return (*vsd) & 0x1F;
+	}
+
+	if (vsd_size < 9)
+		return vsd_size;
+
+	/* check HDMI Video Present */
+	if (!(*(vsd + 8) & 0x20)) {
+		pr_debug("%s:no HDMI Video Present\n", __func__);
+		return vsd_size;
+	}
+
+	offset = 9;
+
+	IS_LATENCY_FIELDS_PRESENT(vsd)
+		OFFSET_MOVE(offset, 2, vsd_size);
+	}
+
+	IS_I_LATENCY_FIELDS_PRESENT(vsd)
+		OFFSET_MOVE(offset, 2, vsd_size);
+	}
+
+	FILL_WITH_0_EXCEPT_FOR_IMAGE_SIZE(vsd, offset);
+	OFFSET_MOVE(offset, 1, vsd_size);
+
+	GET_HDMI_VIC_LEN(hdmi_vic_len/*out*/, vsd/*in*/, offset/*in*/);
+	GET_HDMI_3D_LEN (hdmi_3d_len/*out*/,  vsd/*in*/, offset/*in*/);
+	OFFSET_MOVE(offset, 1, vsd_size);
+
+	/* fill unsupported vic with 0 */
+	for (i = 0; i < hdmi_vic_len; i++) {
+		uint8_t *hdmi_vic = (vsd + offset + i);
+		if (!is_supp_hdmi_vic(*hdmi_vic, supp_vic, supp_vic_size))
+			*hdmi_vic = 0x00;
+		else
+			new_hdmi_vic_len++;
+	}
+
+	/* renew HDMI_VIC_LEN and HDMI_3D_LEN(intentionally 0) */
+	OFFSET_MOVE(offset, -1, vsd_size);
+	*(vsd + offset) =  new_hdmi_vic_len << 5;
+	OFFSET_MOVE(offset, 1, vsd_size);
+
+	/* squash hdmi vic */
+	squash_data_with_prune_0((vsd + offset), hdmi_vic_len);
+
+	/* remove 3d */
+	{
+		uint8_t *vsd_3d_data = vsd + offset + hdmi_vic_len;
+		memset((void *)(vsd_3d_data), 0x00, (size_t)(hdmi_3d_len));
+	}
+
+	new_vsd_size = offset + new_hdmi_vic_len -1;
+
+	set_data_block_length(vsd, new_vsd_size);
+
+	pr_debug("new size = %d\n", new_vsd_size);
+	PRINT_DATA(vsd, vsd_size + 1, "[out] vsd")
+
+	return new_vsd_size;
+}
+
+/*
+ * NOTE : "not_removed_vic_array" and "not_removed_vic_array_size"
+ * don't work. Entire hdmi vic and 3d info are removed.
+ */
+void mhl_lib_edid_remove_hdmi_vic_and_3d_from_vsd(
+	uint8_t *ext_edid,
+	uint8_t *not_removed_vic_array,
+	uint8_t not_removed_vic_array_size)
+{
+	PCEA_extension_t extension = (PCEA_extension_t)ext_edid;
+	uint8_t db_len;
+	uint8_t *vsd = NULL;
+	uint8_t *data_block_header = NULL;
+
+	PRINT_DATA(ext_edid, EDID_BLOCK_SIZE, "[in] ext_edid")
+
+	/* search vendor specific tag code */
+	data_block_header = (uint8_t *)hdmi_edid_find_block_v2(
+		(const uint8_t *)ext_edid,
+		1,
+		 DBC_START_OFFSET,
+		 VENDOR_SPECIFIC_DATA_BLOCK,
+		 &db_len);
+
+	if (data_block_header != NULL) {
+		int vsd_size = db_len;
+		int new_vsd_size = -1;
+		/* vsd : vendor specific data */
+		vsd = data_block_header;
+
+		if (not_removed_vic_array != NULL) {
+			new_vsd_size = mhl_lib_edid_replace_hdmi_vic_and_remove_3d(
+				vsd, vsd_size,
+				not_removed_vic_array, not_removed_vic_array_size);
+		} else {
+			new_vsd_size = mhl_lib_edid_remove_hdmi_vic_and_3d(vsd, vsd_size);
+
+			pr_debug("%s:vsd_size=%d\n", __func__, vsd_size);
+			pr_debug("%s:new_vsd_size=%d\n", __func__, new_vsd_size);
+		}
+
+		/* change the length of the data block */
+		set_data_block_length(data_block_header, new_vsd_size);
+
+
+		{/* re-making the ext_edid data */
+			int pull_up_size = vsd_size - new_vsd_size;
+			uint8_t *last_vsd_address = vsd + new_vsd_size + 1;
+			int check_sum_1_byte = 1;
+			int pull_up_target_size = ext_edid +
+				 EDID_BLOCK_SIZE -
+				 last_vsd_address -
+				 check_sum_1_byte;
+
+			pr_debug("%s:pull_up_size=%d\n",
+			 __func__, pull_up_size);
+			pr_debug("%s:*last_vsd_address=0x%x\n",
+			 __func__, *last_vsd_address);
+			pr_debug("%s:pull_up_target_size=%d\n",
+			 __func__, pull_up_target_size);
+
+			/* pull up the data after vsd */
+			mhl_lib_edid_pull_up_and_padding(last_vsd_address,
+				 pull_up_target_size,/* check sum must not be counted */
+				 pull_up_size);
+
+			/* offset for 18 byte descriptors */
+			if ( *(ext_edid + 2) != 0)
+				*(ext_edid + 2) = *(ext_edid + 2) - pull_up_size;
+
+			/* check sum */
+			extension->checksum = 0x00;
+			extension->checksum = calculate_generic_checksum(
+				(uint8_t *)extension,
+				 0x00,
+				 sizeof(*extension));
+		}
+	}
+
+	PRINT_DATA(ext_edid, EDID_BLOCK_SIZE, "[out] ext_edid")
+}
+
+/*
+ * It removes vic from 1)svd with using 2)filter and returns
+ * its remained vic data size in the svd. Any vic in svd
+ * which is not specified in filter is removed from svd.
+ *
+ * 1)svd : short video descriptor
+ * 2)filter : it is used for remove vic from short video descriptor.
+ */
+static int mhl_lib_edid_remove_vic(
+	uint8_t *svd, uint8_t svd_size,
+	uint8_t *filter, uint8_t filter_size)
+{
+	int i;
+	int j;
+	int removed_size = 0;
+	uint8_t *work_filter = filter;
+
+	for (i = 0; i < svd_size; i++) {
+		bool remove = true;
+		for (j = 0; j < filter_size; j++) {
+
+			if ((NATIVE_BIT_MASK & *svd) == *work_filter++) {
+				remove = false;
+				break;
+			}
+		}
+		work_filter = filter;
+
+		if (remove) {
+			remove_head_from_data(svd, svd_size - (i + 1));
+			removed_size++;
+		} else {
+			svd++;
+		}
+	}
+
+	return svd_size - removed_size;
+}
+
+static void set_data_block_length(uint8_t *data_block, uint8_t length)
+{
+	*data_block &= 0xE0;
+	*data_block |= (length & 0x1F);
+}
+
+static uint8_t get_data_block_tag_code(uint8_t data_block_collection)
+{
+	return (data_block_collection & 0xE0) >> 5;
+}
+
+static uint8_t get_data_block_length(uint8_t data_block_collection)
+{
+	return data_block_collection & 0x1F;
+}
+
+/*
+ * pull up data of array (head) with pull_up_size
+ * and padding 0 to the last by the pull up size.
+ *
+ * e.g.
+ *  scnenario : pull_up_size is 2, head is pointing 1st element (1)
+ *
+ *  API execution :
+ *    uint8_t data[10] = {1,2,3,4,5,6,7,8,9,10};
+ *    mhl_lib_edid_pull_up_and_padding(data, 10, 2);
+ *    result : data[10] = {1,2,3,4,5,6,7,8,9,10}; -->
+ *             data[10] = {3,4,5,6,7,8,9,10,0,0};
+ */
+/* #define DEBUG_PRINT_EDID_LIB */
+static int mhl_lib_edid_pull_up_and_padding(
+	uint8_t *head,
+	 int data_size,
+	 int pull_up_size)
+{
+	int i;
+	int loop_cnt;
+	int remainder;
+	uint8_t *org_head = head;
+	uint8_t *last_address = org_head + data_size;
+
+	if (pull_up_size == 0)
+		return MHL_SUCCESS;
+
+	loop_cnt = data_size / pull_up_size;
+	remainder = data_size % pull_up_size;
+
+#ifdef DEBUG_PRINT_EDID_LIB
+	pr_info("loop_cnt : %d\n", loop_cnt);
+	pr_info("remainder : %d\n", remainder);
+#endif
+
+	for (i = 0; i < loop_cnt; i++) {
+		if (head + pull_up_size < last_address)
+			memcpy((void *)head,
+			 (const void *)(head + pull_up_size),
+			 (size_t)pull_up_size);
+
+		head += pull_up_size;
+#ifdef DEBUG_PRINT_EDID_LIB
+		{
+			int j;
+			pr_debug(" ---- pull up ----\n");
+			for (j = 0; j < data_size; j++)
+				pr_debug("0x%02x, ", *(org_head + j));
+			pr_debug("\n");
+		}
+#endif
+	}
+	/* padding */
+	head -= pull_up_size - remainder;
+	for (i = 0; i < pull_up_size; i++) {
+
+		if (head <= last_address) {
+			*head++ = 0x00;
+		} else {
+			pr_warn("%s:illegal padding\n", __func__);
+			return MHL_FAIL;
+		}
+#ifdef DEBUG_PRINT_EDID_LIB
+		{
+			int j;
+			pr_info(" ---- padding ----\n");
+			for (j = 0; j < data_size; j++)
+				pr_info("0x%02x, ", *(org_head + j));
+			pr_info("\n");
+		}
+#endif
+	}
+
+	return MHL_SUCCESS;
+}
+
+static int mhl_lib_edid_pull_up(
+	uint8_t *head,
+	 int data_size,
+	 int pull_up_size)
+{
+	/* will be inplemented in future */
+	return 0;
+}
+
+
+/* data_length : length from next pointer of *data  */
+static void remove_head_from_data(uint8_t *data, int data_length)
+{
+	int i;
+	for (i = 0; i < data_length; i++) {
+		*data = *(data + 1);
+		data++;
+	}
+	pr_debug("\n");
+	*data = 0;
+}
+
+static uint8_t calculate_generic_checksum(
+	uint8_t *info_frame_data,
+	 uint8_t checksum,
+	 uint8_t length)
+{
+	uint8_t i;
+
+	for (i = 0; i < length; i++)
+		checksum += info_frame_data[i];
+
+	checksum = 0x100 - checksum;
+
+	return checksum;
+}
+
+/*
+ * A caller's edid pointer is stored in.
+ * The caller must not free or change the
+ * pointer until other callers finish using it.
+ */
+static const uint8_t *edid_data;
+
+void mhl_lib_edid_set_edid(const uint8_t *edid)
+{
+	edid_data = edid;
+}
+
+
+static const uint8_t *hdmi_edid_find_block_v2(
+	const uint8_t *in_buf,
+	const uint8_t db_num,
+	 u32 start_offset,
+	 u8 type, u8 *len)
+{
+	/* the start of data block collection, start of Video Data Block */
+	u32 offset = start_offset;
+	u32 end_dbc_offset = in_buf[2];
+	uint8_t target_db_num = db_num;
+
+	*len = 0;
+
+	/*
+	 * * edid buffer 1, byte 2 being 4 means no non-DTD/Data block
+	 *   collection present.
+	 * * edid buffer 1, byte 2 being 0 menas no non-DTD/DATA block
+	 *   collection present and no DTD data present.
+	 */
+	if ((end_dbc_offset == 0) || (end_dbc_offset == 4)) {
+		pr_warn("EDID: no DTD or non-DTD data present\n");
+		return NULL;
+	}
+
+	while (offset < end_dbc_offset) {
+		u8 block_len = in_buf[offset] & 0x1F;
+		if ((in_buf[offset] >> 5) == type) {
+			*len = block_len;
+			pr_debug("%s: EDID: type=%d found @ 0x%x w/ len=%d\n",
+				__func__, type, offset, block_len);
+
+			if (--target_db_num <= 0)
+				return in_buf + offset;
+		}
+		offset += (uint8_t)(1 + block_len);
+	}
+	pr_debug("%s: EDID: type=%d block not found in EDID block\n",
+		__func__, type);
+
+	return NULL;
+} /* hdmi_edid_find_block */
+
+
+static bool mhl_lib_is_ieee_reg_id(const uint8_t *ext_edid)
+{
+	u8 len;
+	const u8 *vsd = NULL;
+	uint8_t cnt = 1;
+
+	while ((vsd = hdmi_edid_find_block_v2((const uint8_t *)ext_edid, cnt++, DBC_START_OFFSET,
+				   VENDOR_SPECIFIC_DATA_BLOCK, &len))) {
+
+		if (vsd == NULL || len < 3 || len > MAX_DATA_BLOCK_SIZE) {
+			pr_warn("%s: No/Invalid Vendor Specific Data Block. count = %d\n",
+			  __func__, cnt - 1);
+			return false;
+		}
+
+		/* check ieee oui code */
+		if (0x0c03 == (((u32)vsd[3] << 16) + ((u32)vsd[2] << 8) + (u32)vsd[1]))
+			return true;
+	}
+
+	return false;
+} /* mhl_lib_is_ieee_reg_id */
+
+
+/*
+ * If no data is set with mhl_lib_edid_set_edid(),
+ * then always false is returned. Otherwise if the
+ * set edid data is HDMI, then return true.
+ */
+bool mhl_lib_edid_is_hdmi(void)
+{
+	int cea_861_ext_num;
+	int i;
+
+	if (edid_data == NULL) {
+		pr_debug("%s:arg is null\n", __func__);
+		return false;
+	}
+
+	/* check the number of extention block */
+	cea_861_ext_num =
+		mhl_edid_parser_get_num_cea_861_extensions((uint8_t *)edid_data);
+
+	if (cea_861_ext_num < 0) {
+		pr_warn("%s:illegal ext num\n", __func__);
+		return false;
+	}
+
+	switch (cea_861_ext_num) {
+	case 0:
+		pr_debug("%s:DVI\n", __func__);
+		return false;
+	case 1:
+		i = 1;
+		break;
+	default:
+		i = 2;
+	}
+
+	for (; i <= cea_861_ext_num; i++)
+		if ((edid_data[i * 0x80]) == 2)
+			if (mhl_lib_is_ieee_reg_id(edid_data + (i * 0x80))) {
+				pr_debug("%s:HDMI\n", __func__);
+				return true;
+			}
+
+	pr_debug("%s:DVI\n", __func__);
+	return false;
+
+}
+
+struct std_timing {
+	uint8_t first_byte;
+	uint8_t second_byte;
+};
+
+/*
+ * supported std_timings are returned.
+ *
+ * true : supported
+ * false : not supported
+ */
+static bool is_supported_std_timing(
+	uint8_t first_byte,
+	uint8_t second_byte,
+	const struct mhl_video_timing_info *video_timing_info,
+	uint8_t length)
+{
+	int i = 0;
+
+	for (i = 0; i < length; i++)
+		if ((first_byte == (video_timing_info + i)->h_pixcel) &&
+			second_byte == (video_timing_info + i)->aspect_refresh)
+			return true;
+
+	return false;
+}
+/*
+ * remove unsupported resolution data from
+ * standard timing (std_timing).
+ */
+void mhl_lib_edid_remove_standard_timing(
+	const struct mhl_video_timing_info *support_video,
+	uint8_t length,
+	uint8_t *std_timing)
+{
+	uint8_t offset = 0;
+	uint8_t std_timing_cnt = 0;
+	bool is_support = false;
+
+	for (std_timing_cnt = 0; std_timing_cnt < 8; std_timing_cnt++) {
+		is_support = is_supported_std_timing(
+			*(std_timing + offset),
+			*(std_timing + offset + 1),
+			 support_video,
+			 length);
+
+		/* if the sdt timing is not supported,
+		 * blank is set. */
+		if (!is_support) {
+			if (*(std_timing + offset) != 0x01 &&
+				 *(std_timing + offset + 1) != 0x01)
+				pr_debug("%s:removed 0x%2x, 0x%2x\n",
+				 __func__,
+				 *(std_timing + offset),
+				 *(std_timing + offset + 1));
+
+			/* set blank */
+			*(std_timing + offset) = 0x01;
+			*(std_timing + offset + 1) = 0x01;
+		}
+
+		offset += 2;
+	}
+}
+
+void mhl_lib_edid_remove_established_timing(
+	const struct mhl_video_timing_info *support_video,
+	uint8_t length,
+	uint8_t *est_timing)
+{
+	int i = 0;
+	uint8_t est_timing_1_result = 0;
+	uint8_t est_timing_2_result = 0;
+	uint8_t est_timing_3_result = 0;
+
+	for (i = 0; i < length; i++) {
+		est_timing_1_result |= *est_timing & (support_video + i)->est_timing_1;
+		est_timing_2_result |= *(est_timing + 1) & (support_video + i)->est_timing_2;
+		est_timing_3_result |= *(est_timing + 2) & (support_video + i)->est_timing_3;
+	}
+	*est_timing = est_timing_1_result;
+	*(est_timing + 1) = est_timing_2_result;
+	*(est_timing + 2) = est_timing_3_result;
+
+	return;
+}
+
+
+/*
+ * Replace the preferred display data in blk0 with edid.
+ *
+ * blk0 : pointer to the head of the block 0
+ * edid : the data will replace the current preferred display info
+ *  in block 0 (18 byte from 0x36 byte in blk0).
+ */
+void mhl_lib_edid_replace_dtd_preferred_disp_info(
+		uint8_t *blk0,
+		const struct hdmi_edid_video_mode_property_type *video_mode_param)
+{
+	uint8_t *disp_info = &blk0[0x36];
+	uint32_t h_image_size = 0;
+	uint32_t v_image_size = 0;
+	uint32_t tmp_4_3_v_image_size = 0;
+
+	pr_debug("%s()\n", __func__);
+
+	disp_info[0x0] = (uint8_t)(video_mode_param->pixel_freq & 0x000000FF);
+	disp_info[0x1] = (uint8_t)((video_mode_param->pixel_freq & 0x0000FF00)>>8);
+	disp_info[0x2] = (uint8_t)(video_mode_param->active_h & 0x000000FF);
+	disp_info[0x3] = (uint8_t)(video_mode_param->total_blank_h & 0x000000FF);
+	disp_info[0x4] = (uint8_t)((video_mode_param->active_h & 0x00000F00) >> 4) |
+			(uint8_t)((video_mode_param->total_blank_h & 0x0000FF00) >> 4);
+	disp_info[0x5] = (uint8_t)(video_mode_param->active_v & 0x000000FF);
+	disp_info[0x6] = (uint8_t)(video_mode_param->total_blank_v & 0x000000FF);
+	disp_info[0x7] = (uint8_t)((video_mode_param->active_v & 0x00000F00) >> 4) |
+			(uint8_t)((video_mode_param->total_blank_v & 0x0000FF00) >> 4);
+
+	/*
+	 * aspect ratio in original disp info is changed to video_mode_param's one.
+	 * e.g.
+	 * 	if original is 16:9 and video_mode_param is 4:3, then the original
+	 * 	data will be replaced with 4:3 parameter.
+	 */
+
+	/* set original image size of disp info in blk0 */
+	h_image_size = (uint32_t)(((disp_info[0xE] & 0xF0) << 4) | disp_info[0xC]);
+	v_image_size = (uint32_t)(((disp_info[0xE] & 0x0F) << 8) | disp_info[0xD]);
+	tmp_4_3_v_image_size = h_image_size * 3/4;
+
+	if (video_mode_param->aspect_ratio_4_3) {
+		/* 4:3 v size is calculated */
+		if (tmp_4_3_v_image_size < v_image_size)
+			/* original does not indicate 4:3,
+			 * so the v size is replaced with 4:3 */
+			v_image_size = tmp_4_3_v_image_size;
+	} else {
+		/* 16:9 v size is calculated */
+		if (!(tmp_4_3_v_image_size > v_image_size))
+			/* v_image_size is probably 4:3, so replace it with 16:19 */
+			v_image_size = h_image_size * 9/16;
+	}
+
+	disp_info[0xC] = (uint8_t)(h_image_size & 0x00000FF);
+	disp_info[0xD] = (uint8_t)(v_image_size & 0x00000FF);
+	disp_info[0xE] = (uint8_t)(((h_image_size & 0x00000F00) >> 4) | ((v_image_size & 0x00000F00) >> 8));
+
+	return;
+}
+
+/*
+ *
+ */
+bool mhl_lib_edid_is_supp_disp_info_in_one_dtd_blk(
+		const uint8_t *one_descriptor,
+		const struct hdmi_edid_video_mode_property_type *edid,
+		uint32_t mode_lut_len,
+		uint32_t *preferd_disp_index)
+{
+	u32 disp_mode = 0;
+	hdmi_edid_detail_desc(one_descriptor, &disp_mode, edid, mode_lut_len, preferd_disp_index);
+
+	pr_debug("%s:disp_mode = %d (0x%x)\n", __func__, disp_mode, disp_mode);
+
+	if (disp_mode != HDMI_VFRMT_FORCE_32BIT)
+		return true;
+
+	return false;
+
+}
+
+/*
+ * blk0 : pointer to the head of the block 0
+ * edid : support display info
+ * mode_lut_len : length of edid (how many instance of the struct are contained.)
+ */
+void mhl_lib_edid_replace_unsupport_descriptor_with_dummy(
+		uint8_t *blk0,
+		const struct hdmi_edid_video_mode_property_type *edid,
+		uint32_t mode_lut_len)
+{
+	u32 desc_offset = 0;
+	int i = 0;
+
+	pr_debug("%s()\n", __func__);
+
+	while (4 > i && 0 != blk0[0x36 + desc_offset]) {
+		u32 preferred_disp_mode = 0;
+		bool is_support = false;
+
+		pr_debug("%s: blk0[0x%2x] = 0x%2x\n",
+				__func__,
+				0x36 + desc_offset,
+				blk0[0x36 + desc_offset]);
+
+		is_support = mhl_lib_edid_is_supp_disp_info_in_one_dtd_blk(
+				&blk0[0x36 + desc_offset],
+				edid,
+				mode_lut_len,
+				&preferred_disp_mode);
+
+		if (i == 0) {
+			if (!is_support) {
+				/* VGA is set forcibly since it is mandatory disp */
+				pr_debug("%s: replace with vga preferred disp info \n", __func__);
+				mhl_lib_edid_replace_dtd_preferred_disp_info(
+										blk0,
+										&vga_preferred_disp_info);
+			}
+		} else {
+			if (!is_support) {
+				/* set dummy data here */
+				/* might not need the pull up procedure. comment out.
+				if (i < 3) {
+					pr_debug("%s: 18 * (4 - (i + 1) = %d \n",
+							__func__,
+							18 * (4 - (i + 1)));
+					mhl_lib_edid_pull_up_and_padding(
+							&blk0[0x36 + desc_offset],
+							18 * (4 - (i + 1)),
+							18);
+				}
+
+				memset(&blk0[0x6C], 0x00, 18);
+				blk0[0x6C + 3] = 0x10;
+				*/
+				memset(&blk0[0x36 + desc_offset], 0x00, 18);
+				blk0[0x36 + desc_offset + 0x03] = 0x10;
+
+			} else {
+				pr_debug("%s: supported, cont i : %d\n",
+					__func__, i);
+			}
+		}
+		desc_offset += 0x12;
+		++i;
+	}
+
+	return;
+}
+
+/*
+ * hdmi_edid_disp_mode_lut must contain each list with high quality order.
+ * (Hi quality if the index is large)
+ *
+ * data_buf : pointer to the one dtd block
+ * disp_mode : display mode (VIC id defined in mhl_lib_edid.h).
+ * 				 If no disp info in data_buf is not found
+ * 				 in hdmi_edid_disp_mode_lut, then
+ * 				 HDMI_VFRMT_FORCE_32BIT is returned.
+ * hdmi_edid_disp_mode_lut : support display info.
+ * mode_lut_len : length of edid (how many instance of the struct are contained.)
+ * most_hi_quality_disp_mode_index : NULL, then nothing to be done.
+ * 				 otherwise most high quality disp info of hdmi_edid_disp_mode_lut is returned.
+ */
+static void hdmi_edid_detail_desc(
+		const u8 *data_buf,
+		u32 *disp_mode,
+		const struct hdmi_edid_video_mode_property_type *hdmi_edid_disp_mode_lut,
+		u32 mode_lut_len,
+		u32 *most_hi_quality_disp_mode_index)
+{
+	u32	aspect_ratio_4_3    = false;
+	u32	interlaced          = false;
+	u32	active_h            = 0;
+	u32	active_v            = 0;
+	u32	blank_h             = 0;
+	u32	blank_v             = 0;
+	u32	ndx                 = 0;
+	u32	max_num_of_elements = 0;
+	u32	img_size_h          = 0;
+	u32	img_size_v          = 0;
+
+	pr_debug("%s()\n", __func__);
+	PRINT_DATA(data_buf, 18, "data buf")
+
+	/*
+	 * * See VESA Spec
+	 * * EDID_TIMING_DESC_UPPER_H_NIBBLE[0x4]: Relative Offset to the
+	 *   EDID detailed timing descriptors - Upper 4 bit for each H
+	 *   active/blank field
+	 * * EDID_TIMING_DESC_H_ACTIVE[0x2]: Relative Offset to the EDID
+	 *   detailed timing descriptors - H active
+	 */
+	active_h = ((((u32)data_buf[0x4] >> 0x4) & 0xF) << 8)
+		| data_buf[0x2];
+
+	/*
+	 * EDID_TIMING_DESC_H_BLANK[0x3]: Relative Offset to the EDID detailed
+	 *   timing descriptors - H blank
+	 */
+	blank_h = (((u32)data_buf[0x4] & 0xF) << 8)
+		| data_buf[0x3];
+
+	/*
+	 * * EDID_TIMING_DESC_UPPER_V_NIBBLE[0x7]: Relative Offset to the
+	 *   EDID detailed timing descriptors - Upper 4 bit for each V
+	 *   active/blank field
+	 * * EDID_TIMING_DESC_V_ACTIVE[0x5]: Relative Offset to the EDID
+	 *   detailed timing descriptors - V active
+	 */
+	active_v = ((((u32)data_buf[0x7] >> 0x4) & 0xF) << 8)
+		| data_buf[0x5];
+
+	/*
+	 * EDID_TIMING_DESC_V_BLANK[0x6]: Relative Offset to the EDID
+	 * detailed timing descriptors - V blank
+	 */
+	blank_v = (((u32)data_buf[0x7] & 0xF) << 8)
+		| data_buf[0x6];
+
+	/*
+	 * * EDID_TIMING_DESC_IMAGE_SIZE_UPPER_NIBBLE[0xE]: Relative Offset
+	 *   to the EDID detailed timing descriptors - Image Size upper
+	 *   nibble V and H
+	 * * EDID_TIMING_DESC_H_IMAGE_SIZE[0xC]: Relative Offset to the EDID
+	 *   detailed timing descriptors - H image size
+	 * * EDID_TIMING_DESC_V_IMAGE_SIZE[0xD]: Relative Offset to the EDID
+	 *   detailed timing descriptors - V image size
+	 */
+	img_size_h = ((((u32)data_buf[0xE] >> 0x4) & 0xF) << 8)
+		| data_buf[0xC];
+	img_size_v = (((u32)data_buf[0xE] & 0xF) << 8)
+		| data_buf[0xD];
+
+	/*
+	 * aspect ratio as 4:3 if within specificed range , rathaer than being
+	 * absolute value
+	 */
+	aspect_ratio_4_3 = (abs((int)(img_size_h * 3 - img_size_v * 4)) < 5) ? 1 : 0;
+
+	max_num_of_elements = mode_lut_len;
+
+	/*
+	 * EDID_TIMING_DESC_INTERLACE[0x11:7]: Relative Offset to the EDID
+	 * detailed timing descriptors - Interlace flag
+	 */
+	pr_debug("%s: Interlaced mode byte data_buf[0x11]=[%x]\n", __func__,
+		data_buf[0x11]);
+
+	/*
+	 * CEA 861-D: interlaced bit is bit[7] of byte[0x11]
+	 */
+	interlaced = (data_buf[0x11] & 0x80) >> 7;
+
+	pr_debug("%s: A[%ux%u] B[%ux%u] V[%ux%u] %s\n", __func__,
+		active_h, active_v, blank_h, blank_v, img_size_h, img_size_v,
+		interlaced ? "i" : "p");
+
+	*disp_mode = HDMI_VFRMT_FORCE_32BIT;
+	while (ndx < max_num_of_elements) {
+		const struct hdmi_edid_video_mode_property_type *edid =
+			hdmi_edid_disp_mode_lut + ndx;
+
+		if ((interlaced    == edid->interlaced)    &&
+			(active_h  == edid->active_h)      &&
+			(blank_h   == edid->total_blank_h) &&
+			(blank_v   == edid->total_blank_v) &&
+			((active_v == edid->active_v) ||
+			(active_v  == (edid->active_v + 1)))) {
+			if (edid->aspect_ratio_4_3 && !aspect_ratio_4_3)
+				/* Aspect ratio 16:9 */
+				*disp_mode = edid->video_code + 1;
+			else
+				/* Aspect ratio 4:3 */
+				*disp_mode = edid->video_code;
+
+			pr_debug("%s: mode found:%d\n", __func__, *disp_mode);
+
+			if (most_hi_quality_disp_mode_index != NULL)
+				*most_hi_quality_disp_mode_index = ndx;
+			else
+				break;
+		}
+		++ndx;
+	}
+	if (ndx == max_num_of_elements)
+		pr_debug("%s: *no mode* found\n", __func__);
+} /* hdmi_edid_detail_desc */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.h
@@ -1,0 +1,919 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_edid.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawasaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+#ifndef __MHL_EDID_PARSER_H__
+#define __MHL_EDID_PARSER_H__
+
+#include <linux/types.h>
+#include "si_infoframe.h"
+#include "mhl_defs.h"
+#include "mhl_common.h"
+
+
+
+#define MHL_BLOCK_SIZE			128
+/* EDID BLOCK SIZE */
+#define EDID_BLOCK_SIZE			MHL_BLOCK_SIZE
+
+typedef struct SI_PACK_THIS_STRUCT _TwoBytes_t {
+	unsigned char low;
+	unsigned char high;
+} TwoBytes_t, *PTwoBytes_t;
+
+#define EDID_EXTENSION_TAG			0x02
+#define EDID_EXTENSION_BLOCK_MAP	0xF0
+#define EDID_REV_THREE				0x03
+#define EDID_BLOCK_0				0x00
+#define EDID_BLOCK_2_3				0x01
+
+/*
+ * The order must not be changed!!
+ *
+ */
+typedef enum {
+	DBTC_TERMINATOR,
+	DBTC_AUDIO_DATA_BLOCK,
+	DBTC_VIDEO_DATA_BLOCK,
+	DBTC_VENDOR_SPECIFIC_DATA_BLOCK,
+	DBTC_SPEAKER_ALLOCATION_DATA_BLOCK,
+	DBTC_VESA_DTC_DATA_BLOCK,
+	/* reserved				= 6 */
+	DBTC_USE_EXTENDED_TAG	= 7
+} data_block_tag_code_e;
+
+typedef struct SI_PACK_THIS_STRUCT _data_block_header_fields_t {
+	uint8_t length_following_header	: 5;
+	data_block_tag_code_e tag_code	: 3;
+} data_block_header_fields_t, *Pdata_block_header_fields_t;
+
+typedef union SI_PACK_THIS_STRUCT _data_block_header_byte_t {
+	data_block_header_fields_t	fields;
+	uint8_t						as_byte;
+} data_block_header_byte_t, *Pdata_block_header_byte_t;
+
+typedef enum {
+	ETC_VIDEO_CAPABILITY_DATA_BLOCK,
+	ETC_VENDOR_SPECIFIC_VIDEO_DATA_BLOCK,
+	ETC_VESA_VIDEO_DISPLAY_DEVICE_INFORMATION_DATA_BLOCK,
+	ETC_VESA_VIDEO_DATA_BLOCK,
+	ETC_HDMI_VIDEO_DATA_BLOCK,
+	ETC_COLORIMETRY_DATA_BLOCK,
+	ETC_VIDEO_RELATED,
+
+	ETC_CEA_MISC_AUDIO_FIELDS				= 16,
+	ETC_VENDOR_SPECIFIC_AUDIO_DATA_BLOCK,
+	ETC_HDMI_AUDIO_DATA_BLOCK,
+	ETC_AUDIO_RELATED,
+
+	ETC_GENERAL								= 32
+} extended_tag_code_e;
+
+typedef struct SI_PACK_THIS_STRUCT _extended_tag_code_t {
+	extended_tag_code_e etc : 8;
+} extended_tag_code_t, *Pextended_tag_code_t;
+
+typedef struct SI_PACK_THIS_STRUCT _cea_short_descriptor_t {
+	unsigned char VIC		: 7;
+	unsigned char native	: 1;
+} cea_short_descriptor_t, *Pcea_short_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _MHL_short_desc_t {
+	cea_short_descriptor_t cea_short_desc;
+	MHL2_video_descriptor_t mhl_vid_desc;
+} MHL_short_desc_t, *PMHL_short_desc_t;
+
+typedef struct SI_PACK_THIS_STRUCT _video_data_block_t
+{
+	data_block_header_byte_t header;
+	cea_short_descriptor_t short_descriptors[1]; /* open ended */
+} video_data_block_t, *p_video_data_block_t;
+
+typedef enum {
+	/* reserved = 0 */
+	afd_linear_PCM_IEC60958 = 1,
+	afd_AC3,
+	afd_MPEG1_layers_1_2,
+	afd_MPEG1_layer_3,
+	afdMPEG2_MultiChannel,
+	afd_AAC,
+	afd_DTS,
+	afd_ATRAC,
+	afd_one_bit_audio,
+	afd_dolby_digital,
+	afd_DTS_HD,
+	afd_MAT_MLP,
+	afd_DST,
+	afd_WMA_Pro
+	/* reserved = 15 */
+} AudioFormatCodes_e;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_short_audio_descriptor_t {
+	unsigned char		max_channels_minus_one	: 3;
+	AudioFormatCodes_e	audio_format_code		: 4;
+	unsigned char		F17						: 1;
+
+	unsigned char freq_32_Khz		: 1;
+	unsigned char freq_44_1_KHz		: 1;
+	unsigned char freq_48_KHz		: 1;
+	unsigned char freq_88_2_KHz		: 1;
+	unsigned char freq_96_KHz		: 1;
+	unsigned char freq_176_4_KHz	: 1;
+	unsigned char freq_192_KHz		: 1;
+	unsigned char F27				: 1;
+
+	union {
+		struct SI_PACK_THIS_STRUCT {
+			unsigned res_16_bit	: 1;
+			unsigned res_20_bit	: 1;
+			unsigned res_24_bit	: 1;
+			unsigned F33_37		: 5;
+		} audio_code_1_LPCM;
+		struct SI_PACK_THIS_STRUCT {
+			uint8_t max_bit_rate_div_by_8_KHz;
+		} audio_codes_2_8;
+		struct SI_PACK_THIS_STRUCT {
+			uint8_t default_zero;
+		} audio_codes_9_15;
+	} byte3;
+} CEA_short_audio_descriptor_t, *PCEA_short_audio_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _audio_data_block_t {
+	data_block_header_byte_t header;
+	CEA_short_audio_descriptor_t short_audio_descriptors[1]; /* open ended */
+} audio_data_block_t, *Paudio_data_block_t;
+
+typedef struct SI_PACK_THIS_STRUCT _speaker_allocation_flags_t
+{
+	unsigned char spk_front_left_front_right				: 1;
+	unsigned char spk_LFE									: 1;
+	unsigned char spk_front_center							: 1;
+	unsigned char spk_rear_left_rear_right					: 1;
+	unsigned char spk_rear_center							: 1;
+	unsigned char spk_front_left_center_front_right_center	: 1;
+	unsigned char spk_rear_left_center_rear_right_center	: 1;
+	unsigned char spk_reserved								: 1;
+} speaker_allocation_flags_t, *Pspeaker_allocation_flags_t;
+
+typedef struct SI_PACK_THIS_STRUCT _speaker_allocation_data_block_payload_t {
+	speaker_allocation_flags_t speaker_alloc_flags;
+	uint8_t reserved[2];
+} speaker_allocation_data_block_payload_t, *Pspeaker_allocation_data_block_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT _speaker_allocation_data_block_t {
+	data_block_header_byte_t header;
+	speaker_allocation_data_block_payload_t payload;
+} speaker_allocation_data_block_t, *Pspeaker_allocation_data_block_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_BA_t {
+	unsigned char B : 4;
+	unsigned char A : 4;
+} HDMI_LLC_BA_t, *PHDMI_LLC_BA_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_DC_t {
+	unsigned char D : 4;
+	unsigned char C : 4;
+} HDMI_LLC_DC_t, *PHDMI_LLC_DC_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_Byte6_t {
+	unsigned char DVI_dual		:1;
+	unsigned char reserved		:2;
+	unsigned char DC_Y444		:1;
+	unsigned char DC_30bit		:1;
+	unsigned char DC_36bit		:1;
+	unsigned char DC_48bit		:1;
+	unsigned char supports_AI	:1;
+} HDMI_LLC_Byte6_t, *PHDMI_LLC_Byte6_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_byte8_t {
+	unsigned char CNC0_adjacent_pixels_independent			: 1;
+	unsigned char CNC1_specific_processing_still_pictures	: 1;
+	unsigned char CNC2_specific_processing_cinema_content	: 1;
+	unsigned char CNC3_specific_processing_low_AV_latency	: 1;
+	unsigned char reserved									: 1;
+	unsigned char HDMI_video_present						: 1;
+	unsigned char I_latency_fields_present					: 1;
+	unsigned char latency_fields_present					: 1;
+} HDMI_LLC_byte8_t, *PHDMI_LLC_byte8_t;
+
+typedef enum {
+	imsz_NO_ADDITIONAL,
+	imsz_ASPECT_RATIO_CORRECT_BUT_NO_GUARRANTEE_OF_CORRECT_SIZE,
+	imsz_CORRECT_SIZES_ROUNDED_TO_NEAREST_1_CM,
+	imsz_CORRECT_SIZES_DIVIDED_BY_5_ROUNDED_TO_NEAREST_5_CM
+} image_size_e;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_Byte13_t {
+	unsigned char reserved			: 3;
+	image_size_e image_size			: 2;
+	unsigned char _3D_multi_present	: 2;
+	unsigned char _3D_present		: 1;
+} HDMI_LLC_Byte13_t, *PHDMI_LLC_Byte13_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_Byte14_t {
+	unsigned char HDMI_3D_len	: 5;
+	unsigned char HDMI_VIC_len	: 3;
+} HDMI_LLC_Byte14_t, *PHDMI_LLC_Byte14_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VSDB_byte_13_through_byte_15_t {
+	HDMI_LLC_Byte13_t byte13;
+	HDMI_LLC_Byte14_t byte14;
+	uint8_t vicList[1]; /* variable length list base on HDMI_VIC_len */
+} VSDB_byte_13_through_byte_15_t, *PVSDB_byte_13_through_byte_15_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VSDB_all_fields_byte_9_through_byte15_t {
+	uint8_t video_latency;
+	uint8_t audio_latency;
+	uint8_t interlaced_video_latency;
+	uint8_t interlaced_audio_latency;
+	VSDB_byte_13_through_byte_15_t byte_13_through_byte_15;
+	/* There must be no fields after here */
+} VSDB_all_fields_byte_9_through_byte15_t, *PVSDB_all_fields_byte_9_through_byte15_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VSDB_all_fields_byte_9_through_byte_15_sans_progressive_latency_t {
+	uint8_t interlaced_video_latency;
+	uint8_t interlaced_audio_latency;
+	VSDB_byte_13_through_byte_15_t byte_13_through_byte_15;
+	/* There must be no fields after here */
+} VSDB_all_fields_byte_9_through_byte_15_sans_progressive_latency_t, *PVSDB_all_fields_byte_9_through_byte_15_sans_progressive_latency_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VSDB_all_fields_byte_9_through_byte_15_sans_interlaced_latency_t {
+	uint8_t video_latency;
+	uint8_t audio_latency;
+	VSDB_byte_13_through_byte_15_t byte_13_through_byte_15;
+	/* There must be no fields after here */
+} VSDB_all_fields_byte_9_through_byte_15_sans_interlaced_latency_t, *PVSDB_all_fields_byte_9_through_byte_15_sans_interlaced_latency_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VSDB_all_fields_byte_9_through_byte_15_sans_all_latency_t {
+	VSDB_byte_13_through_byte_15_t byte_13_through_byte_15;
+	/* There must be no fields after here */
+} VSDB_all_fields_byte_9_through_byte_15_sans_all_latency_t, *PVSDB_all_fields_byte_9_through_byte_15_sans_all_latency_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_LLC_vsdb_payload_t {
+	HDMI_LLC_BA_t B_A;
+	HDMI_LLC_DC_t D_C;
+	HDMI_LLC_Byte6_t byte6;
+	uint8_t maxTMDSclock;
+	HDMI_LLC_byte8_t byte8;
+	union {
+		VSDB_all_fields_byte_9_through_byte_15_sans_all_latency_t			vsdb_all_fields_byte_9_through_byte_15_sans_all_latency;
+		VSDB_all_fields_byte_9_through_byte_15_sans_progressive_latency_t	vsdb_all_fields_byte_9_through_byte_15_sans_progressive_latency;
+		VSDB_all_fields_byte_9_through_byte_15_sans_interlaced_latency_t	vsdb_all_fields_byte_9_through_byte_15_sans_interlaced_latency;
+		VSDB_all_fields_byte_9_through_byte15_t								vsdb_all_fields_byte_9_through_byte_15;
+	} vsdb_fields_byte_9_through_byte_15;
+	/* There must be no fields after here */
+} HDMI_LLC_vsdb_payload_t, *PHDMI_LLC_vsdb_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT st_3D_structure_all_15_8_t {
+	uint8_t frame_packing	: 1;
+	uint8_t reserved1		: 5;
+	uint8_t top_bottom		: 1;
+	uint8_t reserved2		: 1;
+} _3D_structure_all_15_8_t, *P_3D_structure_all_15_8_t;
+
+typedef struct SI_PACK_THIS_STRUCT st_3D_structure_all_7_0_t {
+	uint8_t side_by_side	: 1;
+	uint8_t reserved		: 7;
+} _3D_structure_all_7_0_t, *P_3D_structure_all_7_0_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_3D_structure_all_t {
+	_3D_structure_all_15_8_t _3D_structure_all_15_8;
+	_3D_structure_all_7_0_t _3D_structure_all_7_0;
+} _3D_structure_all_t, *P_3D_structure_all_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_3D_mask_t {
+	uint8_t _3D_mask_15_8;
+	uint8_t _3D_mask_7_0;
+} _3D_mask_t, *P_3D_mask_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_2D_VIC_order_3D_structure_t {
+	_3D_structure_e _3D_structure	: 4;	/* definition from info frame */
+	unsigned _2D_VIC_order			: 4;
+} _2D_VIC_order_3D_structure_t, *P_2D_VIC_order_3D_structure_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_3D_detail_t {
+	unsigned char reserved		: 4;
+	unsigned char _3D_detail	: 4;
+} _3D_detail_t, *P_3D_detail_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_3D_structure_and_detail_entry_sans_byte1_t {
+	_2D_VIC_order_3D_structure_t byte0;
+	/*see HDMI 1.4 spec w.r.t. contents of 3D_structure_X */
+} _3D_structure_and_detail_entry_sans_byte1_t, *P_3D_structure_and_detail_entry_sans_byte1_t;
+
+typedef struct SI_PACK_THIS_STRUCT tag_3D_structure_and_detail_entry_with_byte1_t {
+	_2D_VIC_order_3D_structure_t byte0;
+	_3D_detail_t byte1;
+} _3D_structure_and_detail_entry_with_byte1_t, *P_3D_structure_and_detail_entry_with_byte1_t;
+
+typedef union tag_3D_structure_and_detail_entry_u {
+	_3D_structure_and_detail_entry_sans_byte1_t sans_byte1;
+	_3D_structure_and_detail_entry_with_byte1_t with_byte1;
+} _3D_structure_and_detail_entry_u, *P_3D_structure_and_detail_entry_u;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_3D_sub_block_sans_all_AND_mask_t {
+	_3D_structure_and_detail_entry_u _3D_structure_and_detail_list[1];
+} HDMI_3D_sub_block_sans_all_AND_mask_t,*PHDMI_3D_sub_block_sans_all_AND_mask_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_3D_sub_block_sans_mask_t {
+	_3D_structure_all_t _3D_structure_all;
+	_3D_structure_and_detail_entry_u _3D_structure_and_detail_list[1];
+} HDMI_3D_sub_block_sans_mask_t, *PHDMI_3D_sub_block_sans_mask_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_3D_sub_block_with_all_AND_mask_t {
+	_3D_structure_all_t _3D_structure_all;
+	_3D_mask_t _3D_mask;
+	_3D_structure_and_detail_entry_u _3D_structure_and_detail_list[1];
+} HDMI_3D_sub_block_with_all_AND_mask_t, *PHDMI_3D_sub_block_with_all_AND_mask_t;
+
+typedef union {
+	HDMI_3D_sub_block_sans_all_AND_mask_t	HDMI_3D_sub_block_sans_all_AND_mask;
+	HDMI_3D_sub_block_sans_mask_t			HDMI_3D_sub_block_sans_mask;
+	HDMI_3D_sub_block_with_all_AND_mask_t	HDMI_3D_sub_block_with_all_AND_mask;
+} HDMI_3D_sub_block_t, *PHDMI_3D_sub_block_t;
+
+typedef struct SI_PACK_THIS_STRUCT _vsdb_t {
+	data_block_header_byte_t header;
+	uint8_t IEEE_OUI[3];
+	union {
+		HDMI_LLC_vsdb_payload_t HDMI_LLC;
+		uint8_t payload[1]; /* open ended */
+	} payload_u;
+} vsdb_t, *P_vsdb_t;
+
+typedef enum {
+	xvYCC_601 = 1,
+	xvYCC_709 = 2
+} colorimetry_xvYCC_e;
+
+typedef struct SI_PACK_THIS_STRUCT _colorimetry_xvYCC_t {
+	colorimetry_xvYCC_e	xvYCC		:2;
+	unsigned char		reserved1	:6;
+} colorimetry_xvYCC_t, *Pcolorimetry_xvYCC_t;
+
+typedef struct SI_PACK_THIS_STRUCT _colorimetry_meta_data_t {
+	unsigned char meta_data : 3;
+	unsigned char reserved2 : 5;
+} colorimetry_meta_data_t, *Pcolorimetry_meta_data_t;
+
+typedef struct SI_PACK_THIS_STRUCT _colorimetry_data_payload_t {
+	colorimetry_xvYCC_t ci_data;
+	colorimetry_meta_data_t cm_meta_data;
+} colorimetry_data_payload_t, *Pcolorimetry_data_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT _colorimetry_data_block_t {
+	data_block_header_byte_t header;
+	extended_tag_code_t extended_tag;
+	colorimetry_data_payload_t payload;
+} colorimetry_data_block_t, *Pcolorimetry_data_block_t;
+
+typedef enum {
+	ceou_NEITHER,
+	ceou_ALWAYS_OVERSCANNED,
+	ceou_ALWAYS_UNDERSCANNED,
+	ceou_BOTH
+} CE_overscan_underscan_behavior_e;
+
+typedef enum {
+	itou_NEITHER,
+	itou_ALWAYS_OVERSCANNED,
+	itou_ALWAYS_UNDERSCANNED,
+	itou_BOTH
+} IT_overscan_underscan_behavior_e;
+
+typedef enum {
+	ptou_NEITHER,
+	ptou_ALWAYS_OVERSCANNED,
+	ptou_ALWAYS_UNDERSCANNED,
+	ptou_BOTH,
+} PT_overscan_underscan_behavior_e;
+
+typedef struct SI_PACK_THIS_STRUCT _video_capability_data_payload_t {
+	CE_overscan_underscan_behavior_e S_CE	: 2;
+	IT_overscan_underscan_behavior_e S_IT	: 2;
+	PT_overscan_underscan_behavior_e S_PT	: 2;
+	unsigned QS								: 1;
+	unsigned quantization_range_selectable	: 1;
+} video_capability_data_payload_t, *Pvideo_capability_data_payload_t;
+
+typedef struct SI_PACK_THIS_STRUCT _video_capability_data_block_t {
+	data_block_header_byte_t header;
+	extended_tag_code_t extended_tag;
+	video_capability_data_payload_t payload;
+} video_capability_data_block_t, *Pvideo_capability_data_block_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_data_block_collection_t {
+	data_block_header_byte_t header;
+	union {
+		extended_tag_code_t extended_tag;
+		cea_short_descriptor_t short_descriptor;
+	} payload_u;
+	/* open ended array of cea_short_descriptor_t starts here */
+} CEA_data_block_collection_t, *PCEA_data_block_collection_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_extension_version_1_t {
+	uint8_t reservedMustBeZero;
+	uint8_t reserved[123];
+} CEA_extension_version_1_t, *PCEA_extension_version_1_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_extension_2_3_misc_support_t {
+	uint8_t total_number_detailed_timing_descriptors_in_entire_EDID	: 4;
+	uint8_t YCrCb422_support										: 1;
+	uint8_t YCrCb444_support										: 1;
+	uint8_t basic_audio_support										: 1;
+	uint8_t underscan_IT_formats_by_default							: 1;
+} CEA_extension_2_3_misc_support_t, *PCEA_extension_2_3_misc_support_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_extension_version_2_t {
+	CEA_extension_2_3_misc_support_t misc_support;
+	uint8_t reserved[123];
+} CEA_extension_version_2_t,*PCEA_extension_version_2_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_extension_version_3_t {
+	CEA_extension_2_3_misc_support_t misc_support;
+	union {
+		uint8_t data_block_collection[123];
+		uint8_t reserved[123];
+	} Offset4_u;
+} CEA_extension_version_3_t, *PCEA_extension_version_3_t;
+
+typedef struct SI_PACK_THIS_STRUCT _block_map_t {
+	uint8_t tag;
+	uint8_t block_tags[126];
+	uint8_t checksum;
+} block_map_t, *Pblock_map_t;
+
+typedef struct SI_PACK_THIS_STRUCT _CEA_extension_t {
+	uint8_t tag;
+	uint8_t revision;
+	uint8_t byte_offset_to_18_byte_descriptors;
+	union
+	{
+		CEA_extension_version_1_t version1;
+		CEA_extension_version_2_t version2;
+		CEA_extension_version_3_t version3;
+	} version_u;
+	uint8_t checksum;
+} CEA_extension_t, *PCEA_extension_t;
+
+typedef struct SI_PACK_THIS_STRUCT _detailed_timing_descriptor_t {
+	uint8_t pixel_clock_low;
+	uint8_t pixel_clock_high;
+	uint8_t horz_active_7_0;
+	uint8_t horz_blanking_7_0;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char horz_blanking_11_8	: 4;
+		unsigned char horz_active_11_8		: 4;
+	} horz_active_blanking_high;
+	uint8_t vert_active_7_0;
+	uint8_t vert_blanking_7_0;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char vert_blanking_11_8	: 4;
+		unsigned char vert_active_11_8		: 4;
+	} vert_active_blanking_high;
+	uint8_t horz_sync_offset_7_0;
+	uint8_t horz_sync_pulse_width7_0;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char vert_sync_pulse_width_3_0	: 4;
+		unsigned char vert_sync_offset_3_0		: 4;
+	} vert_sync_offset_width;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char vert_sync_pulse_width_5_4	: 2;
+		unsigned char vert_sync_offset_5_4		: 2;
+		unsigned char horz_sync_pulse_width_9_8	: 2;
+		unsigned char horzSyncOffset9_8			: 2;
+	} hs_offset_hs_pulse_width_vs_offset_vs_pulse_width;
+	uint8_t horz_image_size_in_mm_7_0;
+	uint8_t vert_image_size_in_mm_7_0;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char vert_image_size_in_mm_11_8 : 4;
+		unsigned char horz_image_size_in_mm_11_8 : 4;
+	} image_size_high;
+	uint8_t horz_border_in_lines;
+	uint8_t vert_border_in_pixels;
+	struct SI_PACK_THIS_STRUCT {
+		unsigned char stereo_bit_0			: 1;
+		unsigned char sync_signal_options	: 2;
+		unsigned char sync_signal_type		: 2;
+		unsigned char stereo_bits_2_1		: 2;
+		unsigned char interlaced			: 1;
+	} flags;
+} detailed_timing_descriptor_t, *Pdetailed_timing_descriptor_t;
+
+typedef struct SI_PACK_THIS_STRUCT _red_green_bits_1_0_t {
+	unsigned char green_y	: 2;
+	unsigned char green_x	: 2;
+	unsigned char red_y		: 2;
+	unsigned char red_x		: 2;
+} red_green_bits_1_0_t, *Pred_green_bits_1_0_t;
+
+typedef struct SI_PACK_THIS_STRUCT _blue_white_bits_1_0_t {
+	unsigned char white_y	: 2;
+	unsigned char white_x	: 2;
+	unsigned char blue_y	: 2;
+	unsigned char blue_x	: 2;
+} blue_white_bits_1_0_t, *Pblue_white_bits_1_0_t;
+
+typedef struct SI_PACK_THIS_STRUCT _established_timings_I_t {
+	unsigned char et800x600_60Hz : 1;
+	unsigned char et800x600_56Hz : 1;
+	unsigned char et640x480_75Hz : 1;
+	unsigned char et640x480_72Hz : 1;
+	unsigned char et640x480_67Hz : 1;
+	unsigned char et640x480_60Hz : 1;
+	unsigned char et720x400_88Hz : 1;
+	unsigned char et720x400_70Hz : 1;
+} established_timings_I_t, *Pestablished_timings_I_t;
+
+typedef struct SI_PACK_THIS_STRUCT _established_timings_II_t {
+	unsigned char et1280x1024_75Hz	: 1;
+	unsigned char et1024x768_75Hz	: 1;
+	unsigned char et1024x768_70Hz	: 1;
+	unsigned char et1024x768_60Hz	: 1;
+	unsigned char et1024x768_87HzI	: 1;
+	unsigned char et832x624_75Hz	: 1;
+	unsigned char et800x600_75Hz	: 1;
+	unsigned char et800x600_72Hz	: 1;
+} established_timings_II_t, *Pestablished_timings_II_t;
+
+typedef struct SI_PACK_THIS_STRUCT _manufacturers_timings_t {
+	unsigned char reserved			: 7;
+	unsigned char et1152x870_75Hz	: 1;
+} manufacturers_timings_t, *Pmanufacturers_timings_t;
+
+typedef enum {
+	iar_16_to_10,
+	iar_4_to_3,
+	iar_5_to_4,
+	iar_16_to_9
+} image_aspect_ratio_e;
+
+typedef struct SI_PACK_THIS_STRUCT _standard_timing_t {
+	unsigned char horz_pix_div_8_minus_31;
+	unsigned char field_refresh_rate_minus_60	: 6;
+	image_aspect_ratio_e image_aspect_ratio		: 2;
+} standard_timing_t, *Pstandard_timing_t;
+
+typedef struct SI_PACK_THIS_STRUCT _EDID_block0_t {
+	unsigned char header_data[8];
+	TwoBytes_t id_manufacturer_name;
+	TwoBytes_t id_product_code;
+	unsigned char serial_number[4];
+	unsigned char week_of_manufacture;
+	unsigned char year_of_manufacture;
+	unsigned char EDID_version;
+	unsigned char EDID_revision;
+	unsigned char video_input_definition;
+	unsigned char horz_screen_size_or_aspect_ratio;
+	unsigned char vert_screen_size_or_aspect_ratio;
+	unsigned char display_transfer_characteristic;
+	unsigned char feature_support;
+	red_green_bits_1_0_t red_green_bits_1_0;
+	blue_white_bits_1_0_t blue_white_bits_1_0;
+	unsigned char red_x;
+	unsigned char red_y;
+	unsigned char green_x;
+	unsigned char green_y;
+	unsigned char blue_x;
+	unsigned char blue_y;
+	unsigned char white_x;
+	unsigned char white_y;
+	established_timings_I_t established_timings_I;
+	established_timings_II_t established_timings_II;
+	manufacturers_timings_t manufacturers_timings;
+	standard_timing_t standard_timings[8];
+	detailed_timing_descriptor_t detailed_timing_descriptors[4];
+	unsigned char extension_flag;
+	unsigned char checksum;
+} EDID_block0_t, *PEDID_block0_t;
+
+typedef struct SI_PACK_THIS_STRUCT _monitor_name_t {
+	uint8_t flag_required[2];
+	uint8_t flag_reserved;
+	uint8_t data_type_tag;
+	uint8_t flag;
+	uint8_t ascii_name[13];
+} monitor_name_t, *Pmonitor_name_t;
+
+typedef struct SI_PACK_THIS_STRUCT _monitor_range_limits_t {
+	uint8_t flag_required[2];
+	uint8_t flag_reserved;
+	uint8_t data_type_tag;
+	uint8_t flag;
+	uint8_t min_vertical_rate_in_Hz;
+	uint8_t max_vertical_rate_in_Hz;
+	uint8_t min_horizontal_rate_in_KHz;
+	uint8_t max_horizontal_rate_in_KHz;
+	uint8_t max_pixel_clock_in_MHz_div_10;
+	uint8_t tag_secondary_formula;
+	uint8_t filler[7];
+} monitor_range_limits_t, *Pmonitor_range_limits_t;
+
+typedef union tag_18_byte_descriptor_u {
+	detailed_timing_descriptor_t dtd;
+	monitor_name_t name;
+	monitor_range_limits_t range_limits;
+} _18_byte_descriptor_u, *P_18_byte_descriptor_u;
+
+typedef struct SI_PACK_THIS_STRUCT _display_mode_3D_info_t {
+	unsigned char dmi_3D_supported			: 1;
+	unsigned char dmi_sufficient_bandwidth	: 1;
+} display_mode_3D_info_t, *Pdisplay_mode_3D_info_t;
+
+typedef enum {
+	vif_single_frame_rate,
+	vif_dual_frame_rate
+} VIC_info_flags_e;
+
+typedef enum {
+	vsm_progressive,
+	vsm_interlaced
+} VIC_scan_mode_e;
+
+typedef enum {
+	par_1_to_1,
+	par_16_to_15,
+	par_16_to_27,
+	par_16_to_45,
+	par_16_to_45_160_to_45,
+	par_1_to_15_10_to_15,
+	par_1_to_9_10_to_9,
+	par_2_to_15_20_to_15,
+	par_2_to_9,
+	par_2_to_9_20_to_9,
+	par_32_to_27,
+	par_32_to_45,
+	par_4_to_27_40_to_27,
+	par_4_to_9,
+	par_4_to_15,
+	par_64_to_45,
+	par_8_to_15,
+	par_8_to_27,
+	par_8_to_27_80_to_27,
+	par_8_to_45_80_to_45,
+	par_8_to_9,
+	par_4_to_3,
+	par_64_to_63
+} pixel_aspect_ratio_e;
+
+typedef struct SI_PACK_THIS_STRUCT _VIC_info_fields_t {
+	image_aspect_ratio_e	image_aspect_ratio	:2;
+	VIC_scan_mode_e			interlaced			:1;
+	pixel_aspect_ratio_e	pixel_aspect_ratio	:5;
+
+	VIC_info_flags_e	frame_rate_info		:1;
+	uint8_t				clocks_per_pixel_shift_count:2;
+	uint8_t				field2_v_blank		:2;
+	uint8_t				reserved			:3;
+} VIC_info_fields_t, *PVIC_info_fields_t;
+
+typedef struct SI_PACK_THIS_STRUCT _VIC_info_t {
+	uint16_t columns;
+	uint16_t rows;
+	uint16_t h_blank_in_pixels;
+	uint16_t v_blank_in_pixels;
+	uint32_t field_rate_in_milliHz;
+	VIC_info_fields_t fields;
+} VIC_info_t, *PVIC_info_t;
+
+typedef struct SI_PACK_THIS_STRUCT _HDMI_VIC_info_t {
+	uint16_t columns;
+	uint16_t rows;
+	uint32_t field_rate_0_in_milliHz;
+	uint32_t field_rate_1_in_milliHz;
+	uint32_t pixel_clock_0;
+	uint32_t pixel_clock_1;
+	uint8_t corresponding_MHL3_VIC;
+} HDMI_VIC_info_t, *PHDMI_VIC_info_t;
+
+#ifdef ENABLE_EDID_DEBUG_PRINT /* //( */
+void dump_EDID_block_impl(const char *pszFunction, int iLineNum,uint8_t override,uint8_t *pData,uint16_t length);
+void clear_EDID_block_impl(uint8_t *pData);
+/* #define DUMP_EDID_BLOCK(override,pData,length) dump_EDID_block_impl(__FUNCTION__,__LINE__,override,(uint8_t *)pData,length); */
+#define CLEAR_EDID_BLOCK(pData) clear_EDID_block_impl(pData);
+#else /* //)( */
+/* #define DUMP_EDID_BLOCK(override,pData,length)*/ /* nothing to do */
+#define CLEAR_EDID_BLOCK(pData) /* nothing to do */
+#endif /* //) */
+
+enum EDID_error_codes {
+	EDID_OK,
+	EDID_INCORRECT_HEADER,
+	EDID_CHECKSUM_ERROR,
+	EDID_NO_861_EXTENSIONS,
+	EDID_SHORT_DESCRIPTORS_OK,
+	EDID_LONG_DESCRIPTORS_OK,
+	EDID_EXT_TAG_ERROR,
+	EDID_REV_ADDR_ERROR,
+	EDID_V_DESCR_OVERFLOW,
+	EDID_UNKNOWN_TAG_CODE,
+	EDID_NO_DETAILED_DESCRIPTORS,
+	EDID_DDC_BUS_REQ_FAILURE,
+	EDID_DDC_BUS_RELEASE_FAILURE,
+	EDID_READ_TIMEOUT
+};
+
+
+#define MHL_VIC_16_1920x1080p60_16_19 16
+
+#define EDID_EXTENSION_TAG			0x02
+#define EDID_REV_THREE				0x03
+
+int mhl_edid_parser_get_num_cea_861_extensions(uint8_t *pEdid);
+int mhl_edid_parser_remove_vic16_1080p60fps(uint8_t *ext_edid);
+void mhl_lib_edid_set_edid(const uint8_t *edid);
+bool mhl_lib_edid_is_hdmi(void);
+void mhl_lib_edid_remove_vic_from_svd(uint8_t *ext_edid,
+		uint8_t *not_removed_vic_array,
+		uint8_t not_removed_vic_array_size);
+void mhl_lib_edid_remove_hdmi_vic_and_3d_from_vsd(uint8_t *ext_edid,
+							 uint8_t *not_removed_vic_array,
+							 uint8_t not_removed_vic_array_size);
+
+bool mhl_lib_edid_is_valid_checksum(uint8_t *p_EDID_block_data);
+
+bool mhl_edid_check_edid_header(uint8_t *pSingleEdidBlock);
+
+/*[vic], [H.Pixel], [Aspect ratio | Refresh Rate]*/
+struct mhl_video_timing_info {
+	uint32_t vic;
+	uint32_t h_pixcel;
+	uint32_t aspect_refresh;
+	uint32_t est_timing_1;
+	uint32_t est_timing_2;
+	uint32_t est_timing_3;
+};
+
+void mhl_lib_edid_remove_standard_timing(
+	const struct mhl_video_timing_info *support_video,
+	uint8_t length,
+	uint8_t *std_timing);
+
+void mhl_lib_edid_remove_established_timing(
+	const struct mhl_video_timing_info *support_video,
+	uint8_t length,
+	uint8_t *est_timing);
+
+void mhl_lib_edid_set_checksum(uint8_t *one_edid_blk);
+
+void mhl_lib_edid_add_hdmi_vic_to_vsd(uint8_t *ext_edid, int hdmi_vic_flag);
+
+int mhl_lib_edid_replace_hdmi_vic_and_remove_3d(
+	uint8_t *vsd,
+	int vsd_size,
+	uint8_t *supp_vic,
+	uint8_t supp_vic_size);
+
+#define MHL_MAX_HDMI_BIC_NUM 0x04
+#define MHL_BIT_HDMI_VIC_1  (0x01 << 0)
+#define MHL_BIT_HDMI_VIC_2  (0x01 << 1)
+#define MHL_BIT_HDMI_VIC_3  (0x01 << 2)
+#define MHL_BIT_HDMI_VIC_4  (0x01 << 3)
+
+
+#define HDMI_VFRMT_UNKNOWN		0
+#define HDMI_VFRMT_640x480p60_4_3	1
+#define HDMI_VFRMT_720x480p60_4_3	2
+#define HDMI_VFRMT_720x480p60_16_9	3
+#define HDMI_VFRMT_1280x720p60_16_9	4
+#define HDMI_VFRMT_1920x1080i60_16_9	5
+#define HDMI_VFRMT_720x480i60_4_3	6
+#define HDMI_VFRMT_1440x480i60_4_3	HDMI_VFRMT_720x480i60_4_3
+#define HDMI_VFRMT_720x480i60_16_9	7
+#define HDMI_VFRMT_1440x480i60_16_9	HDMI_VFRMT_720x480i60_16_9
+#define HDMI_VFRMT_720x240p60_4_3	8
+#define HDMI_VFRMT_1440x240p60_4_3	HDMI_VFRMT_720x240p60_4_3
+#define HDMI_VFRMT_720x240p60_16_9	9
+#define HDMI_VFRMT_1440x240p60_16_9	HDMI_VFRMT_720x240p60_16_9
+#define HDMI_VFRMT_2880x480i60_4_3	10
+#define HDMI_VFRMT_2880x480i60_16_9	11
+#define HDMI_VFRMT_2880x240p60_4_3	12
+#define HDMI_VFRMT_2880x240p60_16_9	13
+#define HDMI_VFRMT_1440x480p60_4_3	14
+#define HDMI_VFRMT_1440x480p60_16_9	15
+#define HDMI_VFRMT_1920x1080p60_16_9	16
+#define HDMI_VFRMT_720x576p50_4_3	17
+#define HDMI_VFRMT_720x576p50_16_9	18
+#define HDMI_VFRMT_1280x720p50_16_9	19
+#define HDMI_VFRMT_1920x1080i50_16_9	20
+#define HDMI_VFRMT_720x576i50_4_3	21
+#define HDMI_VFRMT_1440x576i50_4_3	HDMI_VFRMT_720x576i50_4_3
+#define HDMI_VFRMT_720x576i50_16_9	22
+#define HDMI_VFRMT_1440x576i50_16_9	HDMI_VFRMT_720x576i50_16_9
+#define HDMI_VFRMT_720x288p50_4_3	23
+#define HDMI_VFRMT_1440x288p50_4_3	HDMI_VFRMT_720x288p50_4_3
+#define HDMI_VFRMT_720x288p50_16_9	24
+#define HDMI_VFRMT_1440x288p50_16_9	HDMI_VFRMT_720x288p50_16_9
+#define HDMI_VFRMT_2880x576i50_4_3	25
+#define HDMI_VFRMT_2880x576i50_16_9	26
+#define HDMI_VFRMT_2880x288p50_4_3	27
+#define HDMI_VFRMT_2880x288p50_16_9	28
+#define HDMI_VFRMT_1440x576p50_4_3	29
+#define HDMI_VFRMT_1440x576p50_16_9	30
+#define HDMI_VFRMT_1920x1080p50_16_9	31
+#define HDMI_VFRMT_1920x1080p24_16_9	32
+#define HDMI_VFRMT_1920x1080p25_16_9	33
+#define HDMI_VFRMT_1920x1080p30_16_9	34
+#define HDMI_VFRMT_2880x480p60_4_3	35
+#define HDMI_VFRMT_2880x480p60_16_9	36
+#define HDMI_VFRMT_2880x576p50_4_3	37
+#define HDMI_VFRMT_2880x576p50_16_9	38
+#define HDMI_VFRMT_1920x1250i50_16_9	39
+#define HDMI_VFRMT_1920x1080i100_16_9	40
+#define HDMI_VFRMT_1280x720p100_16_9	41
+#define HDMI_VFRMT_720x576p100_4_3	42
+#define HDMI_VFRMT_720x576p100_16_9	43
+#define HDMI_VFRMT_720x576i100_4_3	44
+#define HDMI_VFRMT_1440x576i100_4_3	HDMI_VFRMT_720x576i100_4_3
+#define HDMI_VFRMT_720x576i100_16_9	45
+#define HDMI_VFRMT_1440x576i100_16_9	HDMI_VFRMT_720x576i100_16_9
+#define HDMI_VFRMT_1920x1080i120_16_9	46
+#define HDMI_VFRMT_1280x720p120_16_9	47
+#define HDMI_VFRMT_720x480p120_4_3	48
+#define HDMI_VFRMT_720x480p120_16_9	49
+#define HDMI_VFRMT_720x480i120_4_3	50
+#define HDMI_VFRMT_1440x480i120_4_3	HDMI_VFRMT_720x480i120_4_3
+#define HDMI_VFRMT_720x480i120_16_9	51
+#define HDMI_VFRMT_1440x480i120_16_9	HDMI_VFRMT_720x480i120_16_9
+#define HDMI_VFRMT_720x576p200_4_3	52
+#define HDMI_VFRMT_720x576p200_16_9	53
+#define HDMI_VFRMT_720x576i200_4_3	54
+#define HDMI_VFRMT_1440x576i200_4_3	HDMI_VFRMT_720x576i200_4_3
+#define HDMI_VFRMT_720x576i200_16_9	55
+#define HDMI_VFRMT_1440x576i200_16_9	HDMI_VFRMT_720x576i200_16_9
+#define HDMI_VFRMT_720x480p240_4_3	56
+#define HDMI_VFRMT_720x480p240_16_9	57
+#define HDMI_VFRMT_720x480i240_4_3	58
+#define HDMI_VFRMT_1440x480i240_4_3	HDMI_VFRMT_720x480i240_4_3
+#define HDMI_VFRMT_720x480i240_16_9	59
+#define HDMI_VFRMT_1440x480i240_16_9	HDMI_VFRMT_720x480i240_16_9
+#define HDMI_VFRMT_1280x720p24_16_9	60
+#define HDMI_VFRMT_1280x720p25_16_9	61
+#define HDMI_VFRMT_1280x720p30_16_9	62
+#define HDMI_VFRMT_1920x1080p120_16_9	63
+#define HDMI_VFRMT_1920x1080p100_16_9	64
+/* Video Identification Codes from 65-127 are reserved for the future */
+#define HDMI_VFRMT_END			127
+
+/* extended video formats */
+#define HDMI_VFRMT_3840x2160p30_16_9	(HDMI_VFRMT_END + 1)
+#define HDMI_VFRMT_3840x2160p25_16_9	(HDMI_VFRMT_END + 2)
+#define HDMI_VFRMT_3840x2160p24_16_9	(HDMI_VFRMT_END + 3)
+#define HDMI_VFRMT_4096x2160p24_16_9	(HDMI_VFRMT_END + 4)
+#define HDMI_EVFRMT_END			HDMI_VFRMT_4096x2160p24_16_9
+
+/* VESA DMT TIMINGS */
+#define HDMI_VFRMT_1024x768p60_4_3	(HDMI_EVFRMT_END + 1)
+#define HDMI_VFRMT_1280x1024p60_5_4	(HDMI_EVFRMT_END + 2)
+#define HDMI_VFRMT_2560x1600p60_16_9	(HDMI_EVFRMT_END + 3)
+#define VESA_DMT_VFRMT_END		HDMI_VFRMT_2560x1600p60_16_9
+#define HDMI_VFRMT_MAX			(VESA_DMT_VFRMT_END + 1)
+#define HDMI_VFRMT_FORCE_32BIT		0x7FFFFFFF
+
+struct hdmi_edid_video_mode_property_type {
+	u32	video_code;
+	u32	active_h;
+	u32	active_v;
+	u32	interlaced;
+	u32	total_h;
+	u32	total_blank_h;
+	u32	total_v;
+	u32	total_blank_v;
+	/* Must divide by 1000 to get the frequency */
+	u32	freq_h;
+	/* Must divide by 1000 to get the frequency */
+	u32	freq_v;
+	/* Must divide by 1000 to get the frequency */
+	u32	pixel_freq;
+	/* Must divide by 1000 to get the frequency */
+	u32	refresh_rate;
+	u32	aspect_ratio_4_3;
+};
+
+
+void mhl_lib_edid_replace_dtd_preferred_disp_info(
+		uint8_t *blk0,
+		const struct hdmi_edid_video_mode_property_type *edid);
+
+bool mhl_lib_edid_is_supp_disp_info_in_one_dtd_blk(
+		const uint8_t *one_descriptor,
+		const struct hdmi_edid_video_mode_property_type *edid,
+		uint32_t mode_lut_len,
+		uint32_t *preferd_disp_index);
+
+void mhl_lib_edid_replace_unsupport_descriptor_with_dummy(
+		uint8_t *blk0,
+		const struct hdmi_edid_video_mode_property_type *edid,
+		uint32_t mode_lut_len);
+
+extern const struct hdmi_edid_video_mode_property_type vga_preferred_disp_info;
+
+#endif /* __MHL_EDID_PARSER__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.c
@@ -1,0 +1,527 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Yasuyuki Kino <yasuyuki.kino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "mhl_lib_infoframe.h"
+#include "mhl_sii8620_8061_device.h"
+#include "mhl_common.h"
+#include "mhl_platform.h"
+
+#define SIZE_AVI_INFOFRAME				14
+
+#define CEA_861_F_VIC_info_entry(VIC,columns,rows,HBlank,VBLank,FieldRate,image_aspect_ratio,scanmode,PixelAspectRatio,flags,clocksPerPelShift,AdditionalVBlank) \
+									{columns,rows,HBlank,VBLank,FieldRate,{image_aspect_ratio,scanmode,PixelAspectRatio,flags,clocksPerPelShift,AdditionalVBlank}}
+
+static uint32_t calculate_pixel_clock(uint16_t columns, uint16_t rows,
+			       uint32_t vertical_sync_frequency_in_milliHz,
+			       uint8_t VIC);
+typedef enum {
+	cea_iar_4_to_3,
+	cea_iar_16_to_9,
+	cea_iar_64_to_27,
+	cea_iar_256_to_135
+} cea_image_aspect_ratio_e;
+
+#define hdmi_vic_infoEntry(HDMI_VIC,columns,rows,FieldRate0,FieldRate1,pixel_clock_0,pixel_clock_1,mhl_vic) \
+							{columns,rows,FieldRate0,FieldRate1,pixel_clock_0,pixel_clock_1,mhl_vic}
+
+HDMI_VIC_info_t hdmi_vic_info[]=
+{
+	 hdmi_vic_infoEntry( 0,   0,   0,    0,    0,         0,        0,0)
+	,hdmi_vic_infoEntry( 1,3840,2160,30000,29970, 297000000,296703000,95)
+	,hdmi_vic_infoEntry( 2,3840,2160,25000,25000, 297000000,297000000,94)
+	,hdmi_vic_infoEntry( 3,3840,2160,24000,23976, 297000000,296703000,93)
+	,hdmi_vic_infoEntry( 4,4096,2160,24000,24000, 297000000,297000000,98)
+};
+
+static VIC_info_t VIC_info[]=
+{
+	 CEA_861_F_VIC_info_entry(  0,   0,   0,  0, 0,  0000 ,cea_iar_4_to_3   ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry(  1, 640, 480,160,45, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry(  2, 720, 480,138,45, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_8_to_9             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry(  3, 720, 480,138,45, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_32_to_27           ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry(  4,1280, 720,370,30, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry(  5,1920,1080,280,22, 60000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_1_to_1             ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry(  6, 720, 480,276,22, 60000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_8_to_9             ,vif_dual_frame_rate  ,1,1)
+	,CEA_861_F_VIC_info_entry(  7, 720, 480,276,22, 60000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_32_to_27           ,vif_dual_frame_rate  ,1,1)
+	,CEA_861_F_VIC_info_entry(  8, 720, 240,276,22, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_4_to_9             ,vif_dual_frame_rate  ,1,1)
+	,CEA_861_F_VIC_info_entry(  9, 720, 428,276,22, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_16_to_27           ,vif_dual_frame_rate  ,1,1)
+	,CEA_861_F_VIC_info_entry( 10,2880, 480,552,22, 60000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_2_to_9_20_to_9     ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry( 11,2880, 480,552,22, 60000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_8_to_27_80_to_27   ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry( 12,2880, 240,552,22, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_1_to_9_10_to_9     ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry( 13,2880, 240,552,22, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_4_to_27_40_to_27   ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry( 14,1440, 480,276,45, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_4_to_9             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 15,1440, 480,276,45, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_16_to_27           ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 16,1920,1080,280,45, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 17, 720, 576,144,49, 50000 ,cea_iar_4_to_3   ,vsm_progressive,par_16_to_15           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 18, 720, 576,144,49, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_64_to_45           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 19,1280, 720,700,30, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 20,1920,1080,720,22, 50000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_1_to_1             ,vif_single_frame_rate,0,1)
+	,CEA_861_F_VIC_info_entry( 21, 720, 576,288,24, 50000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_16_to_15           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 22, 720, 576,288,24, 50000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_64_to_45           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 23, 720, 288,288,24, 50000 ,cea_iar_4_to_3   ,vsm_progressive,par_8_to_15            ,vif_single_frame_rate,1,2) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 24, 720, 288,288,24, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_32_to_45           ,vif_single_frame_rate,1,2) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 25,2880, 576,576,24, 50000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_2_to_15_20_to_15   ,vif_single_frame_rate,0,1)
+	,CEA_861_F_VIC_info_entry( 26,2880, 576,576,24, 50000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_16_to_45_160_to_45 ,vif_single_frame_rate,0,1)
+	,CEA_861_F_VIC_info_entry( 27,2880, 288,576,24, 50000 ,cea_iar_4_to_3   ,vsm_progressive,par_1_to_15_10_to_15   ,vif_single_frame_rate,0,2)
+	,CEA_861_F_VIC_info_entry( 28,2880, 288,576,24, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_8_to_45_80_to_45   ,vif_single_frame_rate,0,2)
+	,CEA_861_F_VIC_info_entry( 29,1440, 576,288,49, 50000 ,cea_iar_4_to_3   ,vsm_progressive,par_8_to_15            ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 30,1440, 576,288,49, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_32_to_45           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 31,1920,1080,720,45, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 32,1920,1080,830,45, 24000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 33,1920,1080,720,45, 25000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 34,1920,1080,280,45, 30000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 35,2880, 480,552,45, 60000 ,cea_iar_4_to_3   ,vsm_progressive,par_2_to_9             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 36,2880, 480,552,45, 60000 ,cea_iar_16_to_9  ,vsm_progressive,par_8_to_27            ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 37,2880, 576,576,49, 50000 ,cea_iar_4_to_3   ,vsm_progressive,par_4_to_15            ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 38,2880, 576,576,49, 50000 ,cea_iar_16_to_9  ,vsm_progressive,par_16_to_45           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 39,1920,1080,384,85, 50000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_1_to_1             ,vif_single_frame_rate,0,0) /*1250,total*/
+	,CEA_861_F_VIC_info_entry( 40,1920,1080,720,22,100000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_1_to_1             ,vif_single_frame_rate,0,1)
+	,CEA_861_F_VIC_info_entry( 41,1280, 720,700,30,100000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 42, 720, 576,144,49,100000 ,cea_iar_4_to_3   ,vsm_progressive,par_16_to_15           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 43, 720, 576,144,49,100000 ,cea_iar_16_to_9  ,vsm_progressive,par_64_to_45           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 44, 720, 576,288,24,100000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_16_to_15           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 45, 720, 576,288,24,100000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_64_to_45           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 46,1920,1080,280,22,120000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_1_to_1             ,vif_dual_frame_rate  ,0,1)
+	,CEA_861_F_VIC_info_entry( 47,1280, 720,370,30,120000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 48, 720, 480,138,45,120000 ,cea_iar_4_to_3   ,vsm_progressive,par_8_to_9             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 49, 720, 480,138,45,120000 ,cea_iar_16_to_9  ,vsm_progressive,par_32_to_27           ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 50, 720, 480,276,22,120000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_8_to_9             ,vif_dual_frame_rate  ,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 51, 720, 480,276,22,120000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_32_to_27           ,vif_dual_frame_rate  ,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 52, 720, 576,144,49,200000 ,cea_iar_4_to_3   ,vsm_progressive,par_16_to_15           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 53, 720, 576,144,49,200000 ,cea_iar_16_to_9  ,vsm_progressive,par_64_to_45           ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 54, 720, 576,288,24,200000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_16_to_15           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 55, 720, 576,288,24,200000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_64_to_45           ,vif_single_frame_rate,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 56, 720, 480,138,45,240000 ,cea_iar_4_to_3   ,vsm_progressive,par_8_to_9             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 57, 720, 480,138,45,240000 ,cea_iar_16_to_9  ,vsm_progressive,par_32_to_27           ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 58, 720, 480,276,22,240000 ,cea_iar_4_to_3   ,vsm_interlaced ,par_8_to_9             ,vif_dual_frame_rate  ,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 59, 720, 480,276,22,240000 ,cea_iar_16_to_9  ,vsm_interlaced ,par_32_to_27           ,vif_dual_frame_rate  ,1,1) /* (1440) */
+	,CEA_861_F_VIC_info_entry( 60,1280, 720,370,30, 24000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 61,1280, 720,370,30, 25000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 62,1280, 720,370,30, 30000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 63,1920,1080,280,45,120000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_dual_frame_rate  ,0,0)
+	,CEA_861_F_VIC_info_entry( 64,1920,1080,280,45,100000 ,cea_iar_16_to_9  ,vsm_progressive,par_1_to_1             ,vif_single_frame_rate,0,0)
+
+	,CEA_861_F_VIC_info_entry( 65,1280, 720,2020, 30, 24000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 66,1280, 720,2680, 30, 25000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 67,1280, 720,2020, 30, 30000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 68,1280, 720, 700, 30, 50000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 69,1280, 720, 370, 30, 60000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 70,1280, 720, 700, 30,100000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 71,1280, 720, 370, 30,120000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 72,1920,1080, 830, 45, 24000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 73,1920,1080, 720, 45, 25000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 74,1920,1080, 280, 45, 30000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 75,1920,1080, 720, 45, 50000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 76,1920,1080, 280, 45, 60000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 77,1920,1080, 720, 45,100000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 78,1920,1080, 280, 45,120000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 79,1680, 720,1620, 30, 24000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 80,1680, 720,1488, 30, 25000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 81,1680, 720, 960, 30, 30000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 82,1680, 720, 520, 30, 50000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 83,1680, 720, 520, 30, 60000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 84,1680, 720, 320,105,100000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 85,1680, 720, 320,105,120000, cea_iar_64_to_27,   vsm_progressive,par_64_to_63, vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 86,2560,1080,1190, 20, 24000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 87,2560,1080, 640, 45, 25000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 88,2560,1080, 960, 45, 30000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 89,2560,1080, 740, 45, 50000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 90,2560,1080, 440, 20, 60000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 91,2560,1080, 410,170,100000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 92,2560,1080, 740,170,120000, cea_iar_64_to_27,   vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 93,3840,2160,1660, 90, 24000, cea_iar_16_to_9,    vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 94,3840,2160,1440, 90, 25000, cea_iar_16_to_9,    vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 95,3840,2160, 560, 90, 30000, cea_iar_16_to_9,    vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 96,3840,2160,1440, 90, 50000, cea_iar_16_to_9,    vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry( 97,3840,2160, 560, 90, 60000, cea_iar_16_to_9,    vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 98,4096,2160,1404, 90, 24000, cea_iar_256_to_135, vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry( 99,4096,2160,1184, 90, 25000, cea_iar_256_to_135, vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry(100,4096,2160, 304, 90, 30000, cea_iar_256_to_135, vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry(101,4096,2160,1184, 90, 50000, cea_iar_256_to_135, vsm_progressive,par_1_to_1,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry(102,4096,2160, 304, 90, 60000, cea_iar_256_to_135, vsm_progressive,par_1_to_1,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry(103,3840,2160,1660, 90, 24000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry(104,3840,2160,1440, 90, 25000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry(105,3840,2160, 560, 90, 30000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+	,CEA_861_F_VIC_info_entry(106,3840,2160,1440, 90, 50000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_single_frame_rate,0,0)
+	,CEA_861_F_VIC_info_entry(107,3840,2160, 560, 90, 60000, cea_iar_64_to_27,   vsm_progressive,par_4_to_3,   vif_dual_frame_rate,  0,0)
+};
+
+typedef struct _timing_mode_from_data_sheet_t
+{
+	uint16_t h_total;
+	uint16_t v_total;
+	uint32_t pixel_clock;
+	struct
+	{
+	uint8_t interlaced:1;
+	uint8_t reserved:7;
+	}flags;
+	char	*description;
+}timing_mode_from_data_sheet_t,*Ptiming_mode_from_data_sheet_t;
+
+timing_mode_from_data_sheet_t timing_modes_from_data_sheet[]=
+{
+	 { 800, 525, 25175000,{0,0},"VGA"}
+	,{1088, 517, 33750000,{0,0},"WVGA"}
+	,{1056, 628, 40000000,{0,0},"SVGA"}
+	,{1344, 806, 65000000,{0,0},"XGA"}
+	,{1716, 262, 27000000,{1,0},"480i"}/* DS has VTOTAL for progressive */
+	,{1728, 312, 27000000,{1,0},"576i"}/* DS has VTOTAL for progressive */
+	,{ 858, 525, 27000000,{0,0},"480p"}
+	,{ 864, 625, 27000000,{0,0},"576p"}
+	,{1650, 750, 74250000,{0,0},"720p"}
+	,{2200, 562, 74250000,{1,0},"1080i"}/* DS has VTOTAL for progressive */
+	,{2750,1125, 74250000,{0,0},"1080p,24/30"}
+	,{2640,1125,148500000,{0,0},"1080p50"}
+	,{2200,1125,148500000,{0,0},"1080p60"}
+};
+
+void print_vic_modes(uint8_t vic)
+{
+	int i;
+	struct vic_name {
+		uint8_t vic;
+		char name[10];
+	} vic_name_table[] = {
+				{2, "480P"},
+				{4, "720P60"},
+				{5, "1080i60"},
+				{6, "480i"},
+				{16, "1080P60"},
+				{17, "576P50"},
+				{19, "720P50"},
+				{20, "1080i50"},
+				{21, "576i50"},
+				{31, "1080P50"},
+				{32, "1080P24"},
+				{33, "1080P25"},
+				{34, "1080P30"},
+				{0, ""} /* to handle the case where the VIC is not found in the table */
+	};
+#define	NUM_VIC_NAMES (sizeof(vic_name_table)/sizeof(vic_name_table[0]))
+	/* stop before the terminator */
+	for(i = 0; i < (NUM_VIC_NAMES - 1); i++) {
+		if (vic == vic_name_table[i].vic) {
+			break;
+		}
+	}
+	pr_info("VIC = %d (%s)\n", vic, vic_name_table[i].name);
+}
+
+uint8_t calculate_avi_info_frame_checksum(hw_avi_payload_t *payload)
+{
+	uint8_t checksum;
+
+	pr_debug("%s called\n", __func__);
+
+	checksum = 0x82 + 0x02 + 0x0D;	/* these are set by the hardware */
+	return calculate_generic_checksum(payload->ifData, checksum,
+						SIZE_AVI_INFOFRAME);
+}
+
+uint8_t calculate_generic_checksum(
+	uint8_t *info_frame_data,
+	 uint8_t checksum,
+	 uint8_t length)
+{
+	uint8_t i;
+
+	for (i = 0; i < length; i++)
+		checksum += info_frame_data[i];
+
+	checksum = 0x100 - checksum;
+
+	return checksum;
+}
+
+int is_valid_avif(avi_info_frame_t *avif)
+{
+	uint8_t	checksum;
+
+	checksum = calculate_generic_checksum((uint8_t *)avif, 0, sizeof(*avif));
+	if (0 != checksum) {
+		pr_err("%s: AVI info frame checksum is: 0x%02x "
+		       "should be 0\n", __func__, checksum);
+		return 0;
+
+	} else if (0x82 != avif->header.type_code) {
+		pr_err("%s: Invalid AVI type code: 0x%02x\n",
+		       __func__, avif->header.type_code);
+		return 0;
+
+	} else if (0x02 != avif->header.version_number) {
+		pr_err("%s: Invalid AVI version: 0x%02x\n",
+		       __func__, avif->header.version_number);
+		return 0;
+
+	} else if (0x0D != avif->header.length) {
+		pr_err("%s: Invalid AVI length: 0x%02x\n",
+		       __func__, avif->header.length);
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+int is_valid_vsif(vendor_specific_info_frame_t *vsif)
+{
+	uint8_t	checksum;
+
+	checksum = calculate_generic_checksum((uint8_t *)vsif, 0,
+			sizeof(vsif->header) + vsif->header.length );
+	if (0 != checksum) {
+		pr_err("%s: VSIF info frame checksum is: 0x%02x "
+			"should be 0\n", __func__, checksum);
+		/*
+			Try again, assuming that the header includes the checksum.
+		*/
+		checksum = calculate_generic_checksum((uint8_t *)vsif, 0,
+			sizeof(vsif->header) + vsif->header.length
+			+ sizeof(vsif->payLoad.checksum));
+	if (0 != checksum) {
+		pr_err("%s: VSIF info frame checksum "
+			"(adjusted for checksum itself) is: 0x%02x "
+			"should be 0\n", __func__, checksum);
+		return 0;
+
+		}
+	}
+	if (0x81 != vsif->header.type_code) {
+		pr_err("%s: Invalid VSIF type code: 0x%02x\n",
+			__func__, vsif->header.type_code);
+		return 0;
+
+	} else if (0x01 != vsif->header.version_number) {
+		pr_err("%s: Invalid VSIF version: 0x%02x\n",
+			__func__, vsif->header.version_number);
+		return 0;
+
+	} else {
+		return 1;
+	}
+}
+
+uint32_t find_pixel_clock_from_AVI_VIC(uint8_t vic)
+{
+	if (vic < ARRAY_SIZE(VIC_info)){
+		return calculate_pixel_clock((uint16_t)VIC_info[vic].columns
+					     , (uint16_t)VIC_info[vic].rows
+					     , (uint32_t)VIC_info[vic].field_rate_in_milliHz
+					     , vic
+			);
+	}else{
+		pr_err("%s: vic:%d is out of range\n",
+		       __func__, vic);
+		return 0;
+	}
+}
+
+uint32_t find_pixel_clock_from_HDMI_VIC(uint8_t vic)
+{
+	if (vic < ARRAY_SIZE(hdmi_vic_info)){
+		return hdmi_vic_info[vic].pixel_clock_0;
+	}else{
+		pr_err("%s: vic:%d is out of range\n", __func__, vic);
+		return 0;
+	}
+}
+
+uint32_t find_pixel_clock_from_totals(uint16_t h_total, uint16_t v_total)
+{
+	uint32_t ret_val = 0;
+	uint8_t i;
+
+	/* Measure the HTOTAL and VTOTAL and look them up in a table */
+	for (i = 0 ; i < sizeof(timing_modes_from_data_sheet)/sizeof(timing_modes_from_data_sheet[0]); ++i) {
+		if (timing_modes_from_data_sheet[i].h_total == h_total) {
+			if (timing_modes_from_data_sheet[i].v_total == v_total) {
+				ret_val = timing_modes_from_data_sheet[i].pixel_clock;
+				pr_debug("%s: vic was 0, %s\n",
+					 __func__, timing_modes_from_data_sheet[i].description);
+				return ret_val;
+			}
+		}
+	}
+
+	pr_err("%s: VIC was zero!!! h_total: 0x%04x v_total:0x%04x\n",
+	       __func__, h_total, v_total);
+
+	return ret_val;
+}
+
+static uint32_t calculate_pixel_clock(uint16_t columns, uint16_t rows,
+			       uint32_t vertical_sync_frequency_in_milliHz,
+			       uint8_t VIC)
+{
+	uint32_t pixel_clock_frequency;
+	uint32_t vertical_sync_period_in_microseconds;
+	uint32_t vertical_active_period_in_microseconds;
+	uint32_t vertical_blank_period_in_microseconds;
+	uint32_t horizontal_sync_frequency_in_hundredths_of_KHz;
+	uint32_t horizontal_sync_period_in_nanoseconds;
+	uint32_t horizontal_active_period_in_nanoseconds;
+	uint32_t horizontal_blank_period_in_nanoseconds;
+
+	vertical_sync_period_in_microseconds = 1000000000/vertical_sync_frequency_in_milliHz;
+
+	VIC &= 0x7F;
+	if( VIC >= sizeof(VIC_info)/sizeof(VIC_info[0])){
+		pr_err("%s: VIC out of range\n", __func__);
+		return 0;
+	}
+
+	if (0 == VIC) {
+		/* rule of thumb: */
+		vertical_active_period_in_microseconds = (vertical_sync_period_in_microseconds * 8) / 10;
+
+	} else {
+		uint16_t v_total_in_lines;
+		uint16_t v_blank_in_lines;
+
+		if (vsm_interlaced == VIC_info[VIC].fields.interlaced) {
+			/* fix up these two values */
+			vertical_sync_frequency_in_milliHz /= 2;
+			vertical_sync_period_in_microseconds *= 2;
+
+			/* proceed with calculations */
+			v_blank_in_lines = 2 * VIC_info[VIC].v_blank_in_pixels + VIC_info[VIC].fields.field2_v_blank;
+
+		} else {
+			/*  when multiple vertical blanking values present,
+			    allow for higher clocks by calculating maximum possible
+			*/
+			v_blank_in_lines = VIC_info[VIC].v_blank_in_pixels + VIC_info[VIC].fields.field2_v_blank;
+		}
+		v_total_in_lines = VIC_info[VIC].rows +v_blank_in_lines ;
+		vertical_active_period_in_microseconds = (vertical_sync_period_in_microseconds * VIC_info[VIC].rows) / v_total_in_lines;
+
+	}
+
+	/* rigorous calculation: */
+	vertical_blank_period_in_microseconds  = vertical_sync_period_in_microseconds - vertical_active_period_in_microseconds;
+
+	horizontal_sync_frequency_in_hundredths_of_KHz = rows * 100000;
+	horizontal_sync_frequency_in_hundredths_of_KHz /= vertical_active_period_in_microseconds;
+
+	horizontal_sync_period_in_nanoseconds    = 100000000 / horizontal_sync_frequency_in_hundredths_of_KHz;
+
+
+	if (0 == VIC) {
+		/* rule of thumb: */
+		horizontal_active_period_in_nanoseconds = (horizontal_sync_period_in_nanoseconds * 8) / 10;
+	} else {
+		uint16_t h_total_in_pixels;
+		uint16_t h_clocks;
+		h_clocks = VIC_info[VIC].columns << VIC_info[VIC].fields.clocks_per_pixel_shift_count;
+		h_total_in_pixels = h_clocks + VIC_info[VIC].h_blank_in_pixels;
+		horizontal_active_period_in_nanoseconds = (horizontal_sync_period_in_nanoseconds * h_clocks) / h_total_in_pixels;
+	}
+	/* rigorous calculation: */
+	horizontal_blank_period_in_nanoseconds = horizontal_sync_period_in_nanoseconds - horizontal_active_period_in_nanoseconds;
+
+	pixel_clock_frequency = columns * (1000000000/ horizontal_active_period_in_nanoseconds);
+
+	return pixel_clock_frequency;
+}
+
+uint8_t hdmi_vic_to_mhl3_vic(uint8_t vic)
+{
+	if (vic < ARRAY_SIZE(hdmi_vic_info)){
+		return hdmi_vic_info[vic].corresponding_MHL3_VIC;
+	}else{
+		pr_err("%s: vic:%d is out of range\n", __func__, vic);
+		return 0;
+	}
+}
+
+/*
+  is_MHL_timing_mode
+
+	MHL has a maximum link clock of 75Mhz. // MHLの最大link clockは75Mhz
+	For now, we use a rule of thumb regarding
+		blanking intervals to calculate a pixel clock,
+		then we convert it to a link clock and compare to 75MHz
+
+*/
+
+
+static uint8_t is_MHL_timing_mode(uint16_t columns,
+					uint16_t rows,
+					uint32_t vertical_sync_frequency_in_milliHz,
+					uint8_t VIC)
+{
+	uint32_t pixel_clock_frequency;
+	uint8_t ret_val = 0;
+
+	pixel_clock_frequency = calculate_pixel_clock(
+					columns,
+					rows,
+					vertical_sync_frequency_in_milliHz,
+					VIC);
+
+	if (qualify_pixel_clock_for_mhl(pixel_clock_frequency, 24)) {
+		pr_debug("%s: pixel_clock_frequency: 24\n", __func__);
+		ret_val = 1;
+	}
+	if (qualify_pixel_clock_for_mhl(pixel_clock_frequency, 16)) {
+		pr_debug("%s: pixel_clock_frequency: 16\n", __func__);
+		ret_val = 1;
+	}
+
+	return ret_val;
+}
+
+uint8_t IsQualifiedMhlVIC(uint8_t VIC)
+{
+	uint8_t ret_val=0;
+	if (VIC > 0) {
+		ret_val= is_MHL_timing_mode(VIC_info[VIC].columns
+							, VIC_info[VIC].rows
+							, VIC_info[VIC].field_rate_in_milliHz
+							, VIC);
+		if (vif_dual_frame_rate == VIC_info[VIC].fields.frame_rate_info) {
+			uint32_t field_rate_in_milliHz;
+			switch(VIC_info[VIC].field_rate_in_milliHz)
+			{
+			case 24000: /* 23.97 */
+				field_rate_in_milliHz = 23970;
+				break;
+
+			case 30000: /* 29.97 */
+				field_rate_in_milliHz = 29970;
+				break;
+
+			case 60000: /* 59.94 */
+				field_rate_in_milliHz = 59940;
+				break;
+
+			case 120000: /* 119.88 */
+				field_rate_in_milliHz = 119880;
+				break;
+
+			case 240000: /* 239.76 */
+				field_rate_in_milliHz = 239760;
+				break;
+
+			default: /* error or unknown case */
+				field_rate_in_milliHz=0;
+				break;
+			}
+			ret_val |= is_MHL_timing_mode(VIC_info[VIC].columns
+								, VIC_info[VIC].rows
+								, field_rate_in_milliHz
+								, VIC);
+		}
+	}
+	return ret_val;
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.h
@@ -1,0 +1,44 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_infoframe.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Yasuyuki Kino <yasuyuki.kino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_INFOFRAME_LIB_H__
+#define __MHL_INFOFRAME_LIB_H__
+
+#include <linux/module.h>
+#include <linux/clk.h>
+#include <linux/of_platform.h>
+#include <linux/err.h>
+#include <linux/of_gpio.h>
+#include <linux/delay.h>
+#include <linux/slab.h>
+#include "si_infoframe.h"
+
+void print_vic_modes(uint8_t vic);
+
+int is_valid_vsif(vendor_specific_info_frame_t *vsif);
+int is_valid_avif(avi_info_frame_t *avif);
+
+uint8_t calculate_avi_info_frame_checksum(hw_avi_payload_t *payload);
+uint8_t calculate_generic_checksum(uint8_t *info_frame_data,
+				   uint8_t checksum,
+				   uint8_t length);
+
+uint32_t find_pixel_clock_from_AVI_VIC(uint8_t vic);
+uint32_t find_pixel_clock_from_HDMI_VIC(uint8_t vic);
+uint32_t find_pixel_clock_from_totals(uint16_t h_total, uint16_t v_total);
+
+uint8_t hdmi_vic_to_mhl3_vic(uint8_t vic);
+
+uint8_t IsQualifiedMhlVIC(uint8_t VIC);
+#endif
+

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.c
@@ -1,0 +1,265 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/gpio.h>
+#include <linux/hrtimer.h>
+#include <linux/fs.h>
+#include <linux/semaphore.h>
+#include <linux/i2c.h>
+#include <linux/interrupt.h>
+#include <linux/cdev.h>
+#include <linux/stringify.h>
+#include <asm/uaccess.h>
+
+#include "mhl_lib_timer.h"
+#include "mhl_platform.h"
+
+#define MHL_DRIVER_TIMER_NAME "sii8620_timer"
+#define MSEC_TO_NSEC(x)		(x * 1000000UL)
+
+static struct mhl_dev_context *get_mhl_device_context(void);
+static void mhl_tx_timer_work_handler(struct work_struct *work);
+static enum hrtimer_restart mhl_tx_timer_handler(struct hrtimer *timer);
+static int is_timer_handle_valid(struct mhl_dev_context *dev_context,
+				 void *timer_handle);
+
+struct mhl_dev_context {
+	struct workqueue_struct	*timer_work_queue;
+	struct list_head	timer_list;
+	struct semaphore	isr_lock;
+} timer_context;
+
+struct timer_obj {
+	struct list_head	list_link;
+	struct work_struct	work_item;
+	struct hrtimer		hr_timer;
+	struct mhl_dev_context	*dev_context;
+	uint8_t			flags;
+#define TIMER_OBJ_FLAG_WORK_IP	0x01
+#define TIMER_OBJ_FLAG_DEL_REQ	0x02
+	void			*callback_param;
+	void (*timer_callback_handler)(void *callback_param);
+};
+
+static struct mhl_dev_context *get_mhl_device_context(void)
+{
+	return &timer_context;
+}
+
+static void mhl_tx_timer_work_handler(struct work_struct *work)
+{
+	struct timer_obj	*mhl_timer;
+
+	mhl_timer = container_of(work, struct timer_obj, work_item);
+
+	mhl_timer->flags |= TIMER_OBJ_FLAG_WORK_IP;
+	if (!down_interruptible(&mhl_timer->dev_context->isr_lock)) {
+
+		mhl_timer->timer_callback_handler(mhl_timer->callback_param);
+
+		up(&mhl_timer->dev_context->isr_lock);
+	}
+	mhl_timer->flags &= ~TIMER_OBJ_FLAG_WORK_IP;
+
+	if(mhl_timer->flags & TIMER_OBJ_FLAG_DEL_REQ) {
+		/*
+		 * Deletion of this timer was requested during the execution of
+		 * the callback handler so go ahead and delete it now.
+		 */
+		kfree(mhl_timer);
+	}
+}
+
+static enum hrtimer_restart mhl_tx_timer_handler(struct hrtimer *timer)
+{
+	struct timer_obj	*mhl_timer;
+
+	mhl_timer = container_of(timer, struct timer_obj, hr_timer);
+
+	queue_work(mhl_timer->dev_context->timer_work_queue,
+			   &mhl_timer->work_item);
+
+	return HRTIMER_NORESTART;
+}
+
+static int is_timer_handle_valid(struct mhl_dev_context *dev_context,
+				 void *timer_handle)
+{
+	struct timer_obj	*timer;
+
+	list_for_each_entry(timer, &dev_context->timer_list, list_link) {
+		if (timer == timer_handle)
+			break;
+	}
+
+	if(timer != timer_handle) {
+		pr_err("%s: Invalid timer handle %p received\n",
+			 __func__, timer_handle);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int mhl_lib_timer_create(void (*callback_handler)(void *callback_param),
+			 void *callback_param,
+			 void **timer_handle)
+{
+	struct mhl_dev_context	*dev_context;
+	struct timer_obj		*new_timer;
+
+	dev_context = get_mhl_device_context();
+
+	if (callback_handler == NULL)
+		return -EINVAL;
+
+	if (dev_context->timer_work_queue == NULL)
+		return -ENOMEM;
+
+	new_timer = kmalloc(sizeof(*new_timer), GFP_KERNEL);
+	if (new_timer == NULL)
+		return -ENOMEM;
+
+	new_timer->timer_callback_handler = callback_handler;
+	new_timer->callback_param = callback_param;
+	new_timer->flags = 0;
+
+	new_timer->dev_context = dev_context;
+	INIT_WORK(&new_timer->work_item, mhl_tx_timer_work_handler);
+
+	list_add(&new_timer->list_link, &dev_context->timer_list);
+
+	hrtimer_init(&new_timer->hr_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	new_timer->hr_timer.function = mhl_tx_timer_handler;
+	*timer_handle = new_timer;
+	return 0;
+}
+
+int mhl_lib_timer_delete(void **timer_handle)
+{
+	struct mhl_dev_context	*dev_context;
+	struct timer_obj		*timer;
+	int						status;
+
+	dev_context = get_mhl_device_context();
+
+	status = is_timer_handle_valid(dev_context, *timer_handle);
+	if (status == 0) {
+		timer = *timer_handle;
+
+		list_del(&timer->list_link);
+
+		hrtimer_cancel(&timer->hr_timer);
+
+		if(timer->flags & TIMER_OBJ_FLAG_WORK_IP) {
+			/*
+			 * Request to delete timer object came from within the timer's
+			 * callback handler.  If we were to proceed with the timer deletion
+			 * we would deadlock at cancel_work_sync().  So instead just flag
+			 * that the user wants the timer deleted.  Later when the timer
+			 * callback completes the timer's work handler will complete the
+			 * process of deleting this timer.
+			 */
+			timer->flags |= TIMER_OBJ_FLAG_DEL_REQ;
+		} else {
+			cancel_work_sync(&timer->work_item);
+			*timer_handle = NULL;
+			kfree(timer);
+		}
+	}
+
+	return status;
+}
+
+int mhl_lib_timer_start(void *timer_handle, uint32_t time_msec)
+{
+	struct mhl_dev_context	*dev_context;
+	struct timer_obj	*timer;
+	ktime_t			timer_period;
+	int			status;
+
+	dev_context = get_mhl_device_context();
+
+	status = is_timer_handle_valid(dev_context, timer_handle);
+	if (status == 0) {
+		long secs=0;
+		timer = timer_handle;
+
+		secs=time_msec/1000;
+		time_msec %= 1000;
+		timer_period = ktime_set(secs, MSEC_TO_NSEC(time_msec));
+		hrtimer_start(&timer->hr_timer, timer_period, HRTIMER_MODE_REL);
+	}
+
+	return status;
+}
+
+int mhl_lib_timer_stop(void *timer_handle)
+{
+	struct mhl_dev_context	*dev_context;
+	struct timer_obj	*timer;
+	int			status;
+
+	dev_context = get_mhl_device_context();
+
+	status = is_timer_handle_valid(dev_context, timer_handle);
+	if (status == 0) {
+		timer = timer_handle;
+
+		hrtimer_cancel(&timer->hr_timer);
+	}
+	return status;
+}
+
+int mhl_lib_timer_init(void)
+{
+	int ret = 0;
+
+	struct mhl_dev_context *dev_context;
+
+	dev_context = &timer_context;
+
+	sema_init(&dev_context->isr_lock, 1);
+	INIT_LIST_HEAD(&timer_context.timer_list);
+	timer_context.timer_work_queue = create_workqueue(MHL_DRIVER_TIMER_NAME);
+
+	if (timer_context.timer_work_queue == NULL) {
+		ret = -ENOMEM;
+	}
+
+	return ret;
+}
+
+void mhl_lib_timer_release(void)
+{
+	struct timer_obj	*mhl_timer;
+	struct mhl_dev_context	*dev_context;
+
+	dev_context = get_mhl_device_context();
+
+	/*
+	 * Make sure all outstanding timer objects are canceled and the
+	 * memory allocated for them is freed.
+	 */
+
+	while(!list_empty(&dev_context->timer_list)) {
+		mhl_timer = list_first_entry(&dev_context->timer_list,
+									 struct timer_obj, list_link);
+		hrtimer_cancel(&mhl_timer->hr_timer);
+		list_del(&mhl_timer->list_link);
+		kfree(mhl_timer);
+	}
+
+	destroy_workqueue(dev_context->timer_work_queue);
+	dev_context->timer_work_queue = NULL;
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.h
@@ -1,0 +1,25 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_lib_timer.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_LIB_TIMER_H__
+#define __MHL_LIB_TIMER_H_
+
+
+int mhl_lib_timer_init(void);
+int mhl_lib_timer_create(void (*callback_handler)(void *callback_param),
+			void *callback_param,
+			void **timer_handle);
+int mhl_lib_timer_delete(void **timer_handle);
+int mhl_lib_timer_start(void *timer_handle, uint32_t time_msec);
+int mhl_lib_timer_stop(void *timer_handle);
+void mhl_lib_timer_release(void);
+
+#endif

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform.h
@@ -1,6 +1,7 @@
 /* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform.h
  *
- * Copyright (c) 2014 Sony Mobile Communications Inc.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
  *
  * Author: [Hirokuni Kawasaki <hirokuni.kawaaki@sonymobile.com>]
  *
@@ -13,30 +14,89 @@
 #ifndef __MHL_PLATFORM_H__
 #define __MHL_PLATFORM_H__
 
+
+#define MHL_USB_INUSE 0
+#define MHL_USB_NON_INUSE 1
+
+#include <linux/types.h>
 #include <linux/i2c.h>
+#include <linux/power_supply.h>
 
-#include <linux/mhl/mhl.h>
-#include <linux/mhl/si_8620_regs.h>
+#include "si_8620_regs.h"
+/*
+ * Following are public to other files
+ */
+struct mhl_tx_ctrl {
+	struct i2c_client *i2c_handle;
+};
 
-/* PMIC VMIN SETTING [FIXME] */
-#define MHL_PMIC_VMIN_SET
+typedef enum {
+	HPD_CTRL_MODE_ERROR = -1,
+	HPD_CTRL_OPEN_DRAIN,
+	HPD_CTRL_PUSH_PULL
+} hpd_control_mode;
 
-/***** mhl_platform.c *****/
-int mhl_pf_init(void);
-void mhl_pf_exit(void);
+int is_interrupt_asserted(void);
 
-/***** mhl_platform_power.c *****/
-int mhl_platform_power_init(void);
-void mhl_platform_power_exit(void);
+/*
+ * usb/mhl switch control
+ */
+int mhl_pf_switch_to_usb(void);
+void mhl_pf_switch_register_cb(int (*device_discovery)(void *context_cb),
+								void *context);
+void mhl_pf_switch_unregister_cb(void);
 
-/***** mhl_platform_base.c *****/
-struct clk *mhl_pf_get_mhl_clk(void);
+/* charger I/F */
+void  mhl_platform_power_stop_charge(void);
+int   mhl_platform_power_start_charge(char *devcap);
+
+/* get gpio_num I/F */
 int mhl_pf_get_gpio_num_int(void);
 int mhl_pf_get_gpio_num_pwr(void);
 int mhl_pf_get_gpio_num_rst(void);
 int mhl_pf_get_gpio_num_fw_wake(void);
 
-/***** mhl_platform_i2c.c *****/
-void mhl_pf_i2c_init(struct i2c_adapter *adapter);
+/* get i2c_client I/F */
+struct i2c_client *mhl_pf_get_i2c_client(void);
 
+/* get clk */
+extern struct clk *mhl_pf_get_mhl_clk(void);
+
+/*
+ * chip power control
+ */
+void mhl_pf_chip_power_on(void);
+void mhl_pf_chip_power_off(void);
+bool mhl_pf_is_chip_power_on(void);
+
+hpd_control_mode platform_get_hpd_control_mode(void);
+
+int mhl_pf_get_irq_number(void);
+const char *mhl_pf_get_device_name(void);
+
+
+/*
+ * i2c
+ */
+/* when chip pwr is down, the error code is returned. -MHL_I2C_NOT_AVAILABLE */
+#define MHL_I2C_NOT_AVAILABLE 0xC100
+/* Following must be accessed by only mhl_platform.c */
+void mhl_pf_i2c_init(struct i2c_adapter *adapter);
+int mhl_pf_read_reg_block(u8 page, u8 offset, u8 count, u8 *values);
+int mhl_pf_read_reg(u8 page, u8 offset);
+int mhl_pf_write_reg(u8 page, u8 offset, u8 value);
+int mhl_pf_write_reg_block(u8 page, u8 offset, u16 count, u8 *values);
+int mhl_pf_modify_reg(u8 page, u8 offset, u8 mask, u8 value);
+
+/*
+ *Following is for unit test config
+ */
+#ifndef UNIT_TEST
+/*todo : must be changed to use dts file*/
+#define GPIO_MHL_SWITCH_SEL_1 10
+#define GPIO_MHL_SWITCH_SEL_2 11
+#else
+#define GPIO_MHL_SWITCH_SEL_1 10
+#define GPIO_MHL_SWITCH_SEL_2 11
+#endif
 #endif /* __MHL_PLATFORM_H__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_base.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_base.c
@@ -1,6 +1,7 @@
 /* [kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_base.c]
  *
- * Copyright (c) 2014 Sony Mobile Communications Inc.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
  *
  * Author: [Hirokuni Kawasaki <hirokuni.kawaaki@sonymobile.com>]
  *
@@ -12,30 +13,18 @@
 
 #include <linux/module.h>
 #include <linux/clk.h>
+#include <linux/platform_device.h>
 #include <linux/usb/msm_hsusb.h>
 #include <linux/gpio.h>
 #include <linux/of_gpio.h>
 #include <linux/of_platform.h>
 #include <linux/delay.h>
 
-#include <mdss_hdmi_mhl.h>
-
+#include "mhl_common.h"
 #include "mhl_platform.h"
 
 #define MHL_DRIVER_NAME "sii8620"
 #define COMPATIBLE_NAME "qcom,mhl-sii8620"
-
-/*
- *Following is for unit test config
- */
-#ifndef UNIT_TEST
-/*todo : must be changed to use dts file*/
-#define GPIO_MHL_SWITCH_SEL_1 10
-#define GPIO_MHL_SWITCH_SEL_2 11
-#else
-#define GPIO_MHL_SWITCH_SEL_1 10
-#define GPIO_MHL_SWITCH_SEL_2 11
-#endif
 
 /*gpio*/
 static int int_gpio;
@@ -55,32 +44,14 @@ static void *context_cb;
 static int (*device_discovery_cb)(void *context_cb);
 static void *usb_ctx;
 static struct i2c_client *mhl_i2c_client;
-struct clk *mhl_clk_base;
-struct platform_device *hdmi_pdev;
-struct msm_hdmi_mhl_ops hdmi_mhl_ops;
+static struct clk *mhl_clk;
 
 enum gpio_direction_types {
 	GPIO_OUTPUT,
 	GPIO_INPUT
 };
 
-/* It should be removed later */
-#ifdef MHL_PMIC_VMIN_SET
 extern int qpnp_chg_notify_mhl_state(int state);
-#endif
-
-static void mhl_pf_external_notify(int data)
-{
-	/* noitfy charger of mhl status */
-#ifdef MHL_PMIC_VMIN_SET
-	qpnp_chg_notify_mhl_state(data);
-#endif
-
-	notify_usb_online(usb_ctx, data);
-
-	/* notify HDMI Driver of change of HDMI Clock. */
-	hdmi_mhl_ops.set_upstream_hpd(hdmi_pdev, (uint8_t)data);
-}
 
 static bool mhl_pf_is_switch_to_usb(void)
 {
@@ -95,21 +66,25 @@ int mhl_pf_get_gpio_num_int(void)
 {
 	return int_gpio;
 }
+EXPORT_SYMBOL(mhl_pf_get_gpio_num_int);
 
 int mhl_pf_get_gpio_num_pwr(void)
 {
 	return pwr_gpio;
 }
+EXPORT_SYMBOL(mhl_pf_get_gpio_num_pwr);
 
 int mhl_pf_get_gpio_num_rst(void)
 {
 	return rst_gpio;
 }
+EXPORT_SYMBOL(mhl_pf_get_gpio_num_rst);
 
 int mhl_pf_get_gpio_num_fw_wake(void)
 {
 	return fw_wake_gpio;
 }
+EXPORT_SYMBOL(mhl_pf_get_gpio_num_fw_wake);
 
 int mhl_pf_get_irq_number(void)
 {
@@ -126,8 +101,9 @@ EXPORT_SYMBOL(mhl_pf_get_i2c_client);
 
 struct clk *mhl_pf_get_mhl_clk(void)
 {
-	return mhl_clk_base;
+	return mhl_clk;
 }
+EXPORT_SYMBOL(mhl_pf_get_mhl_clk);
 
 
 /**
@@ -167,7 +143,7 @@ int mhl_pf_switch_to_usb(void)
 		 */
 		/*return MHL_FAIL;*/
 	} else {
-		mhl_pf_external_notify(0);
+		notify_usb_online(usb_ctx, 0);
 	}
 
 	return MHL_SUCCESS;
@@ -200,7 +176,9 @@ void mhl_pf_switch_register_cb(int (*device_discovery)(void *context),
 		rc = device_discovery_cb(context_cb);
 		if (rc == MHL_USB_INUSE) {
 			if (notify_usb_online) {
-				mhl_pf_external_notify(1);
+				/* Found MHL device */
+				qpnp_chg_notify_mhl_state(1);
+				notify_usb_online(usb_ctx, 1);
 			}
 		}
 	}
@@ -265,7 +243,9 @@ static int mhl_pf_switch_device_discovery(void *data,
 		rc = device_discovery_cb(context_cb);
 		if (rc == MHL_USB_INUSE) {
 			if (notify_usb_online) {
-				mhl_pf_external_notify(1);
+				/* Found MHL device */
+				qpnp_chg_notify_mhl_state(1);
+				notify_usb_online(usb_ctx, 1);
 			}
 		}
 	} else {
@@ -455,7 +435,6 @@ static int mhl_tx_get_dt_data(struct device *dev_)
 	int rc = 0;
 	struct device_node *of_node = NULL;
 	struct platform_device *op = NULL;
-	struct device_node *hdmi_tx_node = NULL;
 
 	of_node = dev_->of_node;
 	if (!of_node) {
@@ -469,8 +448,8 @@ static int mhl_tx_get_dt_data(struct device *dev_)
 		goto error;
 	}
 
-	mhl_clk_base = clk_get(&op->dev, "");
-	if (!mhl_clk_base) {
+	mhl_clk = clk_get(&op->dev, "");
+	if (!mhl_clk) {
 		pr_err("%s: invalid clk\n", __func__);
 		goto error;
 	}
@@ -481,25 +460,9 @@ static int mhl_tx_get_dt_data(struct device *dev_)
 		goto error;
 	}
 
-	/* parse phandle for hdmi tx */
-	hdmi_tx_node = of_parse_phandle(of_node, "qcom,hdmi-tx-map", 0);
-	if (!hdmi_tx_node) {
-		pr_err("%s: can't find hdmi phandle\n", __func__);
-		goto error;
-	}
-
-	hdmi_pdev = of_find_device_by_node(hdmi_tx_node);
-	if (!hdmi_pdev) {
-		pr_err("%s: can't find the device by hdmi_tx_node\n", __func__);
-		goto error;
-	}
-	pr_debug("%s: hdmi_pdev [0X%x]\n",
-	       __func__, (unsigned int)hdmi_pdev);
-
 	return 0;
 error:
 	pr_err("%s: ret due to err\n", __func__);
-	hdmi_pdev = NULL;
 	return rc;
 } /* mhl_tx_get_dt_data */
 
@@ -548,39 +511,17 @@ static int mhl_i2c_probe(struct i2c_client *client,
 		goto failed_probe;
 	}
 
-	rc = mhl_pf_init();
-	if (rc < 0) {
-		pr_err("%s:failed mhl_pf_init\n", __func__);
-		return rc;
-	}
-
-	rc = mhl_platform_power_init();
-	if (rc < 0) {
-		pr_err("%s:failed mhl_platform_power_init\n", __func__);
-		return rc;
-	}
-
-	rc = msm_hdmi_register_mhl(hdmi_pdev,
-				   &hdmi_mhl_ops, NULL);
-	if (rc) {
-		pr_err("%s: register with hdmi failed\n", __func__);
-		return rc;
-	}
-
 	return 0;
 
 failed_probe:
 	mhl_pf_swtich_resource_free();
-	hdmi_pdev = NULL;
+
 	return rc;
 }
 
 static int mhl_i2c_remove(struct i2c_client *client)
 {
 	pr_debug("%s:\n", __func__);
-
-	mhl_platform_power_exit();
-	mhl_pf_exit();
 
 	/*
 	 * All gpio will be released. All release needing gpio
@@ -589,8 +530,6 @@ static int mhl_i2c_remove(struct i2c_client *client)
 	mhl_pf_gpio_config_release();
 
 	mhl_pf_swtich_resource_free();
-
-	hdmi_pdev = NULL;
 
 	return 0;
 }

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_power.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_power.c
@@ -1,6 +1,7 @@
 /* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_platform_power.c
  *
- * Copyright (c) 2014 Sony Mobile Communications Inc.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
  *
  * Author: [Ryousuke Satou <Ryousuke.X.Satou@sonymobile.com>]
  *
@@ -10,12 +11,28 @@
  * of the License, or (at your option) any later version.
  */
 
+#include <linux/module.h>
+#include <linux/input.h>
+#include <linux/string.h>
 #include <linux/power_supply.h>
 #include <linux/slab.h>
 #include <linux/delay.h>
-
 #include "mhl_platform.h"
+#include "mhl_defs.h"
 
+/* sysfs debug on */
+/* #define MHL_PWR_DEBUG_ON */
+
+/* Current */
+#define CURRENT_100MA			100000
+#define CURRENT_500MA			500000
+#define CURRENT_700MA			700000
+#define CURRENT_900MA			900000
+#define CURRENT_1500MA			1500000
+#define CURRENT_2000MA			2000000
+
+/* VMIN */
+#define VMIN_MHL				4300000
 
 static	bool vbus_active;
 static	int	 mhl_mode;
@@ -24,9 +41,163 @@ static	int	 max_current_val;
 static	int	 max_current;
 static	struct	power_supply	mhl_psy;
 static	struct device *mhl_dev;
-#ifdef MHL_PMIC_VMIN_SET
 static	struct	power_supply	*batt_psy;
+
+/***** debug function start *****/
+#ifdef MHL_PWR_DEBUG_ON
+static	uint8_t			devcap_sysfs[DEVCAP_SIZE];
+
+/* MHL_VERSION */
+static ssize_t mhl_platform_power_mhlver_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, sizeof(buf), "%x\n",
+		devcap_sysfs[DEVCAP_OFFSET_MHL_VERSION]);
+}
+
+static ssize_t mhl_platform_power_mhlver_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int		get_data;
+
+	sscanf(buf, "%x", &get_data);
+	devcap_sysfs[DEVCAP_OFFSET_MHL_VERSION] = (uint8_t)get_data;
+	pr_debug("set to MHL_VERSION < 0x%x\n",
+		devcap_sysfs[DEVCAP_OFFSET_MHL_VERSION]);
+
+	return count;
+}
+
+/* DEV_CAT */
+static ssize_t mhl_platform_power_devcap_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, sizeof(buf), "%x\n",
+		devcap_sysfs[DEVCAP_OFFSET_DEV_CAT]);
+}
+
+static ssize_t mhl_platform_power_devcap_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int		get_data;
+
+	sscanf(buf, "%x", &get_data);
+	devcap_sysfs[DEVCAP_OFFSET_DEV_CAT] = (uint8_t)get_data;
+	pr_debug("%x\n", devcap_sysfs[DEVCAP_OFFSET_DEV_CAT]);
+
+	return count;
+}
+
+/* current_val */
+static ssize_t mhl_platform_power_current_max_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, sizeof(int), "%x\n", current_val);
+}
+
+static ssize_t mhl_platform_power_current_max_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int get_data;
+	int ret;
+
+	sscanf(buf, "%x", &get_data);
+
+	if (get_data == 0) {
+		/* set to 0mA */
+		mhl_platform_power_stop_charge();
+	} else if (get_data == 1) {
+		/* set to 500mA */
+		ret = mhl_platform_power_start_charge(NULL);
+		if (ret < 0)
+			pr_debug("failed. set to max_current.\n ");
+	} else if (get_data == 2) {
+		/* set to XXXmA */
+		ret = mhl_platform_power_start_charge(devcap_sysfs);
+		if (ret < 0)
+			pr_debug("failed. set to max_current.\n ");
+	} else
+		pr_debug("not set to max_current.\n ");
+
+	return count;
+}
+
+static DEVICE_ATTR(charge_mhlver,
+			0660,
+			mhl_platform_power_mhlver_show,
+			mhl_platform_power_mhlver_store);
+
+static DEVICE_ATTR(charge_devcap,
+			0660,
+			mhl_platform_power_devcap_show,
+			mhl_platform_power_devcap_store);
+
+static DEVICE_ATTR(charge_max_current,
+			0660,
+			mhl_platform_power_current_max_show,
+			mhl_platform_power_current_max_store);
+
+static int mhl_platform_power_debug_init(struct device *dev)
+{
+	int rc = -1;
+
+	pr_debug("%s: called\n", __func__);
+
+	dev->class = class_create(THIS_MODULE, "mhl_power");
+	if (IS_ERR(dev->class)) {
+		pr_err("%s:failed class creation\n", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(dev,
+				&dev_attr_charge_mhlver);
+	if (rc) {
+		pr_err("%s: failed to create file for charge_mhlver\n",
+			__func__);
+		return rc;
+	}
+
+	rc = device_create_file(dev,
+				&dev_attr_charge_devcap);
+	if (rc) {
+		pr_err("%s: failed to create file for charge_devcap\n",
+			__func__);
+		return rc;
+	}
+
+	rc = device_create_file(dev,
+		&dev_attr_charge_max_current);
+	if (rc) {
+		pr_err("%s: failed to create file for charge_max_current\n",
+			__func__);
+		return rc;
+	}
+
+	return 0;
+}
+
+static void mhl_platform_power_debug_release(struct device *dev)
+{
+	pr_debug("%s: called\n", __func__);
+
+	device_remove_file(dev, &dev_attr_charge_mhlver);
+	device_remove_file(dev, &dev_attr_charge_devcap);
+	device_remove_file(dev, &dev_attr_charge_max_current);
+	class_destroy(dev->class);
+}
+
+#else
+
+static int mhl_platform_power_debug_init(struct device *parent)
+{
+	return 0;
+}
+
+static void mhl_platform_power_debug_release(struct device *dev)
+{
+}
 #endif
+/***** debug function end *****/
 
 static char *mhl_pm_power_supplied_to[] = {
 	"usb",
@@ -133,7 +304,7 @@ static int mhl_power_property_is_writeable(struct power_supply *psy,
 	return 0;
 }
 
-int mhl_platform_power_init(void)
+static int __init mhl_platform_power_init(void)
 {
 	int ret = 0;
 
@@ -141,8 +312,8 @@ int mhl_platform_power_init(void)
 
 	current_val = 0;
 	vbus_active = false;
-	max_current_val	 = 0;
-	max_current  = 0;
+	max_current_val	 = CURRENT_500MA;
+	max_current  = CURRENT_500MA;
 	mhl_mode = 0;
 
 	/* create device */
@@ -174,6 +345,13 @@ int mhl_platform_power_init(void)
 		goto failed_error;
 	}
 
+	/* debug function */
+	ret = mhl_platform_power_debug_init(mhl_dev);
+	if (ret < 0) {
+		pr_err("%s:failed mhl_platform_power_debug_init\n", __func__);
+		goto failed_error;
+	}
+
 	return ret;
 
 failed_error:
@@ -181,7 +359,7 @@ failed_error:
 	return ret;
 }
 
-void mhl_platform_power_exit(void)
+static void __exit mhl_platform_power_exit(void)
 {
 	pr_debug("%s: called\n", __func__);
 
@@ -190,9 +368,10 @@ void mhl_platform_power_exit(void)
 	max_current_val = 0;
 	max_current = 0;
 	mhl_mode = 0;
-#ifdef MHL_PMIC_VMIN_SET
 	batt_psy = NULL;
-#endif
+
+	/* debug function */
+	mhl_platform_power_debug_release(mhl_dev);
 
 	/* unregist power_supply */
 	power_supply_unregister(&mhl_psy);
@@ -213,41 +392,130 @@ void mhl_platform_power_stop_charge(void)
 }
 EXPORT_SYMBOL(mhl_platform_power_stop_charge);
 
-/*
- * set set_current to max_current.
- */
-void mhl_platform_power_start_charge(int set_current)
+int mhl_platform_power_start_charge(char *devcap)
 {
+	int mhl_version;
+	int dev_type;
+	int pow;
+	int plim;
 	union power_supply_propval current_temp;
+	int rty_cnt;
 
 	pr_debug("%s: called\n", __func__);
 
-#ifdef MHL_PMIC_VMIN_SET
-	/* acquire "the chager driver's power_supply" to change VMIN */
-	if (!batt_psy) {
-		/* maximum 1 seconds retry. The time could be enough. */
-		/* fail safe for getting the battery instance. */
-		/* As far as usng ko object install way,  */
-		/* probably, the battery object of kernel */
-		/* could exist. */
-		int rty_cnt;
-		for (rty_cnt = 0; rty_cnt < 10; rty_cnt++) {
-			batt_psy = power_supply_get_by_name("battery");
-			if (batt_psy)
-				break;
-			pr_warn("%s:try to get battery instance again %x",
-				__func__, rty_cnt);
-			msleep(100);
+	/* pre discovery */
+	if (!devcap) {
+		/* acquire "the chager driver's power_supply" to change VMIN */
+		if (!batt_psy) {
+			/* maximum 1 seconds retry. The time could be enough. */
+			/* fail safe for getting the battery instance. */
+			/* As far as usng ko object install way,  */
+			/* probably, the battery object of kernel */
+			/* could exist. */
+			for (rty_cnt = 0; rty_cnt < 10; rty_cnt++) {
+				batt_psy = power_supply_get_by_name("battery");
+				if (batt_psy)
+					break;
+				pr_warn("%s:try to get battery instance again %x",
+					__func__, rty_cnt);
+				msleep(100);
+			}
 		}
-	}
-#endif
 
-	max_current = set_current;
-	mhl_mode = 1;
-	pr_info("%s: current=%dmA\n", __func__, max_current/1000);
+		max_current_val = CURRENT_500MA;
+		max_current = CURRENT_500MA;
+		mhl_mode = 1;
+		pr_info("%s: max_current=%d\n", __func__, max_current);
+		current_temp.intval = max_current;
+		mhl_power_set_property(&mhl_psy,
+			POWER_SUPPLY_PROP_CURRENT_MAX,
+			&current_temp);
+		return 0;
+	}
+
+	/* after discovery */
+	mhl_version = devcap[DEVCAP_OFFSET_MHL_VERSION] &
+		MHL_VER_MASK_MAJOR;
+	dev_type = devcap[DEVCAP_OFFSET_DEV_CAT] &
+		MHL_DEV_CATEGORY_MASK_DEV_TYPE;
+	pow = devcap[DEVCAP_OFFSET_DEV_CAT] &
+		MHL_DEV_CATEGORY_MASK_POW;
+	plim = devcap[DEVCAP_OFFSET_DEV_CAT] &
+		MHL_DEV_CATEGORY_MASK_PLIM;
+
+	pr_debug("%s: MHL_VERSION=0x%x DEV_CAT=0x%x\n",
+				__func__, devcap[DEVCAP_OFFSET_MHL_VERSION],
+				devcap[DEVCAP_OFFSET_DEV_CAT]);
+	pr_debug("%s: mhl_version=0x%x dev_type=0x%x pow=0x%x plim=0x%x\n",
+				__func__, mhl_version, dev_type, pow, plim);
+
+	/* check POW */
+	if (pow == MHL_DEV_CATEGORY_POW_BIT) {
+		/* check MHL ver */
+		if (mhl_version == MHL_DEV_MHL_VER_10) {
+			pr_debug("%s: mhl ver=1.0\n", __func__);
+			/* check device type */
+			if ((dev_type == MHL_DEV_CAT_DONGLE) ||
+				(dev_type == MHL_DEV_CAT_SINK)) {
+
+				max_current = CURRENT_500MA;
+				pr_info("%s: max_current=500mA\n", __func__);
+			} else
+				return -EINVAL;
+		} else {
+			pr_debug("%s: mhl ver >= 2\n", __func__);
+
+			/* check PLIM */
+			if (plim == MHL_DEV_CAT_PLIM_500) {
+				max_current = CURRENT_500MA;
+				pr_info("%s: max_current=500mA\n", __func__);
+			} else if (plim == MHL_DEV_CAT_PLIM_900) {
+				max_current = CURRENT_900MA;
+				pr_info("%s: max_current=900mA\n", __func__);
+			} else if (plim == MHL_DEV_CAT_PLIM_1500) {
+				max_current = CURRENT_1500MA;
+				pr_info("%s: max_current=1500mA\n", __func__);
+			} else if (plim == MHL_DEV_CAT_PLIM_100) {
+				max_current = CURRENT_100MA;
+				pr_info("%s: max_current=100mA\n", __func__);
+			} else if (plim == MHL_DEV_CAT_PLIM_2000) {
+
+				/* check device type(Direct Attach) */
+				if (dev_type == MHL_DEV_CAT_DIRECT_SINK) {
+					pr_debug("%s:dev type =Direct Attach\n",
+								__func__);
+					/* Though MHL spec says
+					that the device can offer 2000 mA
+					at least,
+					the current max is set to 1500 mA
+					due to hw limitation. */
+					max_current = CURRENT_1500MA;
+					pr_info("%s: max_current=1500mA\n",
+								__func__);
+				} else {
+					pr_debug("%s:dev type =other\n",
+								__func__);
+					max_current = CURRENT_1500MA;
+					pr_info("%s: max_current=1500mA\n",
+								__func__);
+				}
+			} else
+				return -EINVAL;
+		}
+	} else
+		max_current = 0;
+
 	current_temp.intval = max_current;
 	mhl_power_set_property(&mhl_psy,
 		POWER_SUPPLY_PROP_CURRENT_MAX,
 		&current_temp);
+
+	pr_debug("%s: max_current=%d\n", __func__, max_current);
+
+	return 0;
 }
 EXPORT_SYMBOL(mhl_platform_power_start_charge);
+
+module_init(mhl_platform_power_init);
+module_exit(mhl_platform_power_exit);
+MODULE_LICENSE("GPL");

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_devcap.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_devcap.h
@@ -1,0 +1,67 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_devcap.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Yasuyuki Kino <yasuyuki.kino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_SII8620_8061_DEVCAP_H__
+#define __MHL_SII8620_8061_DEVCAP_H__
+
+#include "mhl_defs.h"
+
+enum tdm_vc_assignments {
+	TDM_VC_CBUS1	= 0,
+	TDM_VC_E_MSC	= 1,
+	TDM_VC_T_CBUS	= 2,
+	TDM_VC_MAX		= TDM_VC_T_CBUS + 1
+};
+
+/* Device Capability Registers */
+
+#define DEVCAP_VAL_DEV_STATE		0
+#define DEVCAP_VAL_MHL_VERSION		MHL_VERSION
+#define DEVCAP_VAL_DEV_CAT			MHL_DEV_CAT_SOURCE
+#define DEVCAP_VAL_ADOPTER_ID_H		0x03
+#define DEVCAP_VAL_ADOPTER_ID_L		0xA7
+#define DEVCAP_VAL_VID_LINK_MODE	(MHL_DEV_VID_LINK_SUPP_16BPP \
+					| MHL_DEV_VID_LINK_SUPP_VGA\
+					| MHL_DEV_VID_LINK_SUPP_ISLANDS \
+					| MHL_DEV_VID_LINK_SUPPYCBCR422 \
+					| MHL_DEV_VID_LINK_SUPPRGB444)
+#define DEVCAP_VAL_AUD_LINK_MODE	(MHL_DEV_AUD_LINK_2CH \
+					| MHL_DEV_AUD_LINK_8CH)
+#define DEVCAP_VAL_VIDEO_TYPE		0
+#define DEVCAP_VAL_LOG_DEV_MAP		MHL_DEV_LD_GUI
+#define DEVCAP_VAL_BANDWIDTH		0x00
+#define DEVCAP_VAL_FEATURE_FLAG		(MHL_FEATURE_RCP_SUPPORT \
+					| MHL_FEATURE_RAP_SUPPORT	\
+					| MHL_FEATURE_SP_SUPPORT)
+#define DEVCAP_VAL_DEVICE_ID_H		0x04
+#define DEVCAP_VAL_DEVICE_ID_L		0x05
+#define DEVCAP_VAL_SCRATCHPAD_SIZE	MHL_SCRATCHPAD_SIZE
+#define DEVCAP_VAL_INT_STAT_SIZE	MHL_INT_AND_STATUS_SIZE
+#define DEVCAP_VAL_RESERVED		0
+
+/* Extended Device Capability Registers */
+
+#define XDEVCAP_VAL_ECBUS_SPEEDS	(MHL_XDC_ECBUS_S_075 \
+					| MHL_XDC_ECBUS_S_8BIT \
+					)
+
+#define XDEVCAP_VAL_TMDS_SPEEDS		(MHL_XDC_TMDS_150 \
+					| MHL_XDC_TMDS_300 \
+					| MHL_XDC_TMDS_600 \
+					)
+
+#define XDEVCAP_VAL_DEV_ROLES		MHL_XDC_DEV_HOST
+#define XDEVCAP_VAL_LOG_DEV_MAPX	0
+#define XDEVCAP_VAL_RESERVE			0
+
+#endif /*__MHL_SII8620_8061_DEVCAP_H__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.c
@@ -1,0 +1,2896 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <linux/delay.h>
+#include <linux/platform_device.h>
+#include <linux/clk.h>
+#include <linux/module.h>
+
+#include "mhl_platform.h"
+#include "si_8620_regs.h"
+#include "mhl_sii8620_8061_device.h"
+#include "mhl_cbus_control.h"
+#include "mhl_lib_infoframe.h"
+#include "mhl_lib_edid.h"
+#include "mhl_common.h"
+#include "mhl_tx.h"
+#include "mhl_lib_timer.h"
+
+/* zero imp */
+#define MAX_ZERO_IMP_DISC	8
+
+/* HPD */
+#define BITS_GPIO_01_HPD_LOW	0
+#define BITS_HPD_CTRL_PUSH_PULL_LOW  (BITS_GPIO_01_HPD_LOW  | 0x10)
+
+#define BIT_GPIO_0_DISABLED	0x01
+#define BIT_GPIO_0_HIGH	0x02
+#define BIT_GPIO_1_DISABLED	0x04
+#define BIT_GPIO_1_HIGH	0x08
+#define BITS_GPIO_01_HPD_HIGH	(BIT_GPIO_0_HIGH | BIT_GPIO_1_HIGH)
+#define BITS_HPD_CTRL_PUSH_PULL_HIGH	(BITS_GPIO_01_HPD_HIGH | 0x30)
+#define BITS_HPD_CTRL_OPEN_DRAIN_HIGH (BITS_GPIO_01_HPD_HIGH | 0x70)
+
+/* Discovery Interrupt Register */
+#define REG_DISC_INTR              REG_PAGE_5_CBUS_DISC_INTR0
+#define BIT_RGND_READY_INT         BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT6
+#define BIT_CBUS_MHL12_DISCON_INT  BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT5
+#define BIT_CBUS_MHL3_DISCON_INT   BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT4
+#define BIT_NOT_MHL_EST_INT        BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT3
+#define BIT_MHL_EST_INT            BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT2
+#define BIT_MHL3_EST_INT           BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT1
+
+/* Discovery Interrupt Mask Register */
+#define REG_DISC_INTR_MASK              REG_PAGE_5_CBUS_DISC_INTR0_MASK
+#define BIT_RGND_READY_INT_MASK         BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK6
+#define BIT_CBUS_MHL12_DISCON_INT_MASK	BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK5
+#define BIT_CBUS_MHL3_DISCON_INT_MASK	BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK4
+#define BIT_NOT_MHL_EST_INT_MASK		BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK3
+#define BIT_MHL_EST_INT_MASK			BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK2
+#define BIT_MHL3_EST_INT_MASK			BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK1
+
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_ENABLE_XDEVCAP	0x80
+#define BIT_PAGE_2_TMDS_CSTAT_P3_DISABLE_AUTO_AVIF_CLEAR	0x04
+#define BIT_PAGE_2_TMDS_CSTAT_P3_AVIF_MANUAL_CLEAR_STROBE	0x08
+
+/* CoC Interrupt */
+#define REG_PAGE_3_MHL_COC_CTL3					TX_PAGE_3,0x45
+#define BIT_PAGE_3_MHL_COC_CTL3_ECHO_CANCEL	0x01
+
+/* TDM Interrupt Register */
+#define BIT_TDM_INTR_SYNC_DATA BIT_PAGE_1_TRXINTH_TRX_INTR8
+#define BIT_TDM_INTR_SYNC_WAIT BIT_PAGE_1_TRXINTH_TRX_INTR9
+#define BIT_TDM_INTR_SYNC_UNSYNC BIT_PAGE_1_TRXINTH_TRX_INTR10
+
+/* TDM Interrupt Mask Register */
+#define BIT_TDM_INTR_SYNC_DATA_MASK	BIT_PAGE_1_TRXINTMH_TRX_INTRMASK8
+#define BIT_TDM_INTR_SYNC_WAIT_MASK	BIT_PAGE_1_TRXINTMH_TRX_INTRMASK9
+#define BIT_TDM_INTR_SYNC_UNSYNC_MASK BIT_PAGE_1_TRXINTMH_TRX_INTRMASK10
+
+#define BIT_COC_PLL_LOCK_STATUS_CHANGE			0x01
+#define BIT_COC_CALIBRATION_DONE				0x02
+#define BIT_COC_8b_10b_ERROR					0x04
+#define BIT_COC_CALIBRATION_COMMA1				0x08
+#define BIT_COC_CALIBRATION_COMMA2				0x10
+
+/* CoC Calibration state */
+#define BIT_COC_STAT_6_CALIBRATION_DONE			0x80
+#define BITS_ES0_0_COC_STAT_F_CALIBRATION_STATE_2		0x02
+#define BITS_ES1_0_COC_STAT_0_CALIBRATION_MASK			0x8F
+#define BITS_ES1_0_COC_STAT_0_CALIBRATION_STATE_2		0x02
+#define BITS_ES1_0_COC_STAT_0_PLL_LOCKED				0x80
+
+/* TDM status */
+#define MSK_TDM_SYNCHRONIZED					0xC0
+#define VAL_TDM_SYNCHRONIZED					0x80
+
+/* HDCP interrupt Register */
+#define BIT_HDCP2_INTR_AUTH_DONE				BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT0
+#define BIT_HDCP2_INTR_AUTH_FAIL				BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT1
+#define BIT_HDCP2_INTR_RPTR_RCVID_CHANGE		BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT4
+#define BIT_HDCP2_INTR_RPTR_SMNG_XFER_DONE		BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT5
+#define BIT_HDCP2_INTR_SEND_REAUTH_REQ			BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT6
+#define BIT_HDCP2_INTR_SEND_RPTR_READY			BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT7
+
+/* EMSC */
+#define REG_EMSC_INTR_0_STAT	TX_PAGE_3,0x2C
+#define REG_EMSC_INTR_0_MASK	TX_PAGE_3,0x2D
+
+#define VAL_PAGE_3_M3_CTRL_MHL1_2_VALUE (BIT_PAGE_3_M3_CTRL_SW_MHL3_SEL \
+			| BIT_PAGE_3_M3_CTRL_ENC_TMDS)
+
+/* 400msec is enough to wait the RGND interruption. */
+#define DISCOVERY_TIME 900
+static void *discovery_timer;
+
+enum {
+	ENCODE_FORMAT_NONE,
+	ENCODE_FORMAT_RGB444,
+	ENCODE_FORMAT_PPIXEL,
+};
+
+static uint8_t colorSpaceTranslateInfoFrameToHw[] = {
+	VAL_PAGE_6_INPUT_FORMAT_RGB,
+	VAL_PAGE_6_INPUT_FORMAT_YCBCR422,
+	VAL_PAGE_6_INPUT_FORMAT_YCBCR444,
+	VAL_PAGE_6_INPUT_FORMAT_INTERNAL_RGB	/* reserved for future */
+};
+
+static struct completion rgnd_done;
+static CBUS_MODE_TYPE cbus_mode;
+static int cbusp_processing_cond;
+static bool is_hdcp_support;
+static int imp_zero_cnt;
+static bool hdcp_authentication;
+
+/* infoframe parameter */
+avi_info_frame_t		current_avi_info_frame;
+vendor_specific_info_frame_t	current_vs_info_frame;
+uint8_t		valid_vsif;
+uint8_t		valid_avif;
+hw_avi_payload_t		outgoingAviPayLoad;
+mhl3_vsif_t			outgoing_mhl3_vsif;
+uint8_t		rx_hdmi_ctrl2_defval;
+
+/* Local functions */
+static void params_init_for_ready_to_mhl_connection(void);
+static void regs_init_for_ready_to_mhl_connection(void);
+static void regs_init_for_ready_to_tmds_connection(void);
+static void mhl_reset_states(void);
+static void mhl_sii8620_clear_and_mask_interrupts(bool is_exclude_rgnd);
+
+/* hdcp uevent */
+enum mhl_hdcp_state {
+	HDCP_STATE_INACTIVE,
+	HDCP_STATE_AUTHENTICATING,
+	HDCP_STATE_AUTHENTICATED,
+	HDCP_STATE_AUTH_FAIL
+};
+static void mhl_tx_send_hdcp_state(enum mhl_hdcp_state hdcp_state);
+static struct device *pdev;
+/* test code */
+
+/* sysfs */
+static struct device dev;
+static int mhl_device_sysfs_init(struct device *dev);
+static void mhl_device_sysfs_release(void);
+static void mhl_discovery_timer_stop(void);
+
+static int int_disc_isr(uint8_t int_disc_status);
+static int g2wb_err_isr(uint8_t intr_stat);
+static int g2wb_isr(uint8_t intr_stat);
+static int mhl_cbus_isr(uint8_t cbus_int);
+static int mhl_cbus_err_isr(uint8_t cbus_err_int);
+static int int_info_frame_isr(uint8_t int_info_frame_isr_status);
+static int hdcp_isr(uint8_t tpi_int_status);
+static int hdcp2_isr(uint8_t intr_status);
+static int int_edid_devcap_isr(uint8_t int_edid_devcap_status);
+static int mhl3_block_isr(uint8_t status);
+static int coc_isr(uint8_t coc_int_status);
+static int tdm_isr(uint8_t intr_status);
+
+/* video control */
+static void unmute_video(void);
+static int set_hdmi_params(void);
+static uint16_t get_incoming_horizontal_total(void);
+static uint16_t get_incoming_vertical_total(void);
+static void process_info_frame_change(vendor_specific_info_frame_t *vsif
+			       , avi_info_frame_t *avif);
+
+struct intr_tbl {
+	uint8_t mask_page;
+	uint8_t mask_offset;
+	uint8_t stat_page;
+	uint8_t stat_offset;
+	int (*isr)(uint8_t status);
+	char *name;
+};
+
+struct intr_tbl g_intr_tbl[] = {
+	{ REG_PAGE_5_CBUS_DISC_INTR0_MASK,	REG_PAGE_5_CBUS_DISC_INTR0,
+		int_disc_isr,		"DISC"	},
+	{ REG_PAGE_5_MDT_INT_1_MASK,		REG_PAGE_5_MDT_INT_1,
+		g2wb_err_isr,		"G2WB"	},
+	{ REG_PAGE_5_MDT_INT_0_MASK,		REG_PAGE_5_MDT_INT_0,
+		g2wb_isr,		"G2WB"	},
+	{ REG_PAGE_5_CBUS_INT_0_MASK,	REG_PAGE_5_CBUS_INT_0,
+		mhl_cbus_isr,		"MSC"	},
+	{ REG_PAGE_5_CBUS_INT_1_MASK,	REG_PAGE_5_CBUS_INT_1,
+		mhl_cbus_err_isr,	"MERR"	},
+	{ REG_PAGE_3_EMSCINTRMASK,		REG_PAGE_3_EMSCINTR,
+		mhl3_block_isr,		"BLOCK" },
+	{ REG_PAGE_0_INTR8_MASK,		REG_PAGE_0_INTR8,
+		int_info_frame_isr,	"INFR"	},
+	{ REG_PAGE_6_TPI_INTR_EN,		REG_PAGE_6_TPI_INTR_ST0,
+		hdcp_isr,		"HDCP"	},
+	{ REG_PAGE_3_HDCP2X_INTR0_MASK,	REG_PAGE_3_HDCP2X_INTR0,
+		hdcp2_isr,		"HDCP2"	},
+	{ REG_PAGE_2_INTR9_MASK,		REG_PAGE_2_INTR9,
+		int_edid_devcap_isr,	"EDID"	},
+	{ REG_PAGE_0_INTR5_MASK,		REG_PAGE_0_INTR5,
+		int_scdt_isr,		"SCDT"	},
+	{ REG_PAGE_7_COC_INTR_MASK,		REG_PAGE_7_COC_INTR,
+		coc_isr,		"COC"	},
+	{ REG_PAGE_1_TRXINTMH,		REG_PAGE_1_TRXINTH,
+		tdm_isr,		"TDM"	},
+};
+
+enum {
+	INTR_DISC,
+	INTR_G2WB_ERR,
+	INTR_G2WB,
+	INTR_MSC,
+	INTR_MERR,
+	INTR_BLOCK,
+	INTR_INFR,
+	INTR_HDCP,
+	INTR_HDCP2,
+	INTR_EDID,
+	INTR_SCDT,
+	INTR_COC,
+	INTR_TDM,
+	MAX_INTR
+};
+
+bool mhl_device_get_hdcp_status(void)
+{
+	if (is_hdcp_support)
+		pr_debug("%s: HDCP ON\n", __func__);
+	else
+		pr_debug("%s: HDCP OFF\n", __func__);
+
+	return is_hdcp_support;
+}
+
+static void mhl_tx_send_hdcp_state(enum mhl_hdcp_state hdcp_state)
+{
+	char *envp[2];
+
+	switch (hdcp_state) {
+	case HDCP_STATE_AUTHENTICATED:
+		envp[0] = "HDCP_STATE=PASS";
+		envp[1] = NULL;
+		break;
+	case HDCP_STATE_AUTH_FAIL:
+		envp[0] = "HDCP_STATE=FAIL";
+		envp[1] = NULL;
+		break;
+	case HDCP_STATE_INACTIVE:
+	case HDCP_STATE_AUTHENTICATING:
+	default:
+		return;
+	}
+
+	pr_debug("%s: Sending %s uevent\n", __func__, envp[0]);
+
+	if (&pdev->kobj != NULL) {
+		kobject_uevent_env(&pdev->kobj, KOBJ_CHANGE, envp);
+	}
+} /* mhl_tx_send_hdcp_state */
+
+bool mhl_device_is_peer_device_mhl3(void)
+{
+	bool ret = false;
+
+	switch (cbus_mode) {
+	case CBUS_oCBUS_PEER_IS_MHL3:
+	case CBUS_bCBUS:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D_CALIBRATED:
+	case CBUS_eCBUS_S:
+	case CBUS_eCBUS_D:
+		ret = true;
+		break;
+	case CBUS_NO_CONNECTION:
+	case CBUS_oCBUS_PEER_VERSION_PENDING:
+	case CBUS_oCBUS_PEER_IS_MHL1_2:
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+bool mhl_device_is_peer_device_mhl1_2(void)
+{
+	bool ret = false;
+
+	switch (cbus_mode) {
+	case CBUS_oCBUS_PEER_IS_MHL1_2:
+		ret = true;
+		break;
+	case CBUS_NO_CONNECTION:
+	case CBUS_oCBUS_PEER_VERSION_PENDING:
+	case CBUS_oCBUS_PEER_IS_MHL3:
+	case CBUS_bCBUS:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D_CALIBRATED:
+	case CBUS_eCBUS_S:
+	case CBUS_eCBUS_D:
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+/*
+  Per MHL specs heartbeat is required but
+  disconnection may be handled using rxsense only.
+*/
+void enable_heartbeat(void)
+{
+	/* Turn on heartbeat polling unconditionally to meet the specs */
+#ifdef HEARTBEAT
+	pr_debug("%s: Heartbeat polling is enabled\n",
+		__func__);
+	mhl_pf_write_reg(REG_PAGE_5_MSC_HEARTBEAT_CONTROL, 0xA7);
+#endif
+}
+
+/*
+ For MHL 3 the auto_zone bits must be cleared.
+ TODO: Check with characterization team if anything new shows up in their testing.
+ */
+static void clear_auto_zone_for_mhl_3(void)
+{
+	/* Clear auto zone */
+	mhl_pf_write_reg(REG_PAGE_3_TX_ZONE_CTL1, 0x0);
+
+	/* Program PLL for 1X and clock from HSIC */
+	mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL0,
+			(BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_1X |
+			BIT_PAGE_3_MHL_PLL_CTL0_CRYSTAL_CLK_SEL |
+			BIT_PAGE_3_MHL_PLL_CTL0_ZONE_MASK_OE));
+			/* 0x0337 <= 0x07 */
+}
+
+/*
+ For MHL 1/2 we should use auto_zone.
+ */
+static void set_auto_zone_for_mhl_1_2(void)
+{
+	/* Enable AUTO ZONE for MHL1/2 */
+	mhl_pf_write_reg(REG_PAGE_3_TX_ZONE_CTL1,
+			MSK_PAGE_3_TX_ZONE_CTL1_TX_ZONE_CTRL_MODE);
+
+	/* Program PLL for 1X and clock from HDMI */
+	mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL0,
+			(BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_1X |
+			BIT_PAGE_3_MHL_PLL_CTL0_ZONE_MASK_OE));
+			/* 0x0337 <= 0x05 */
+}
+
+int mhl_drv_connection_is_mhl3(void)
+{
+	return IS_MODE_MHL3 ? 1 : 0;
+}
+
+bool mhl_device_is_connected(void)
+{
+	if (BIT_PAGE_5_CBUS_STATUS_CBUS_HPD & mhl_pf_read_reg(REG_PAGE_5_CBUS_STATUS))
+		return true;
+	else
+		return false;
+}
+
+static void chip_power_on(void)
+{
+	mhl_tx_rcp_start();
+
+	mhl_pf_chip_power_on();
+
+	params_init_for_ready_to_mhl_connection();
+}
+
+static void mhl_device_release_resource(void)
+{
+	mhl_discovery_timer_stop();
+
+	/* charge(off/0mA) */
+	mhl_platform_power_stop_charge();
+
+	drive_hpd_low();
+
+	mhl_sii8620_clear_and_mask_interrupts(false);
+
+	mhl_pf_chip_power_off();
+
+	mhl_tx_rcp_stop();
+
+	cbus_mode = CBUS_NO_CONNECTION;
+
+	cbusp_processing_cond = 0;
+}
+
+static void chip_power_off(void)
+{
+	mhl_device_release_resource();
+	mhl_pf_switch_to_usb();
+}
+
+void mhl_device_chip_reset(void)
+{
+	mhl_device_release_resource();
+	chip_power_on();
+}
+
+static void mhl_discovery_timer_func(void *callback_param)
+{
+	pr_info("%s:\n", __func__);
+
+	chip_power_off();
+}
+
+static void params_init_for_ready_to_mhl_connection(void)
+{
+	/* chage(pre discovery) */
+	mhl_platform_power_start_charge(NULL);
+	cbus_mode = CBUS_NO_CONNECTION;
+	cbusp_processing_cond = 0;
+	regs_init_for_ready_to_mhl_connection();
+
+	/* Set Disconnect HDCP Authentication. */
+	hdcp_authentication = false;
+
+	mhl_device_edid_init_edid_done_resource();
+}
+
+static void mhl_discovery_timer_start(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_start(discovery_timer, DISCOVERY_TIME);
+	if (ret != 0)
+		pr_err("%s: Failed to start discovery timer!\n", __func__);
+}
+
+static void mhl_discovery_timer_stop(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_stop(discovery_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to stop discovery timer!\n", __func__);
+}
+
+static void mhl_discovery_timer_create(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_create(mhl_discovery_timer_func,
+					NULL,
+					&discovery_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to create discovery timer!\n", __func__);
+}
+
+static void mhl_discovery_timer_delete(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_delete(&discovery_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to delete discovery timer!\n", __func__);
+}
+
+int drive_hpd_low(void)
+{
+	hpd_control_mode mode;
+	int ret_val = -1;
+
+	pr_debug("%s()\n",  __func__);
+
+	mode = platform_get_hpd_control_mode();
+
+	mhl_pf_modify_reg(REG_PAGE_2_EDID_CTRL
+			  , BIT_PAGE_2_EDID_CTRL_EDID_PRIME_VALID
+			  , VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE);
+
+	if (HPD_CTRL_OPEN_DRAIN == mode)
+		ret_val = mhl_pf_write_reg(REG_PAGE_0_HPD_CTRL, 0x55);
+	else if (HPD_CTRL_PUSH_PULL == mode)
+		ret_val = mhl_pf_write_reg(
+			REG_PAGE_0_HPD_CTRL,
+			 BITS_HPD_CTRL_PUSH_PULL_LOW);
+
+	mhl_pf_write_reg(REG_PAGE_0_INTR8_MASK, 0x00);
+
+	/* FIXME CallBack function */
+
+	return ret_val;
+}
+
+bool mhl_dev_is_set_hpd(void)
+{
+	int ret_val;
+
+	ret_val = mhl_pf_read_reg(REG_PAGE_5_CBUS_STATUS);
+
+	if (BIT_PAGE_5_CBUS_STATUS_CBUS_HPD & ret_val) {
+		pr_debug("%s:set hpd :0x%02x \n", __func__, ret_val);
+		return true;
+	} else {
+		pr_warn("%s:No HPD :0x%02x\n", __func__, ret_val);
+		return false;
+	}
+}
+
+int drive_hpd_high(void)
+{
+	hpd_control_mode mode;
+	int ret_val = -1;
+	int cstat_p3;
+
+	mode = platform_get_hpd_control_mode();
+
+	/* sample REG_PAGE_2_TMDS_CSTAT_P3 __BEFORE__ driving upstream HDP high */
+	cstat_p3 = mhl_pf_read_reg(REG_PAGE_2_TMDS_CSTAT_P3);
+
+
+	/* disable auto-clear */
+	cstat_p3 |= BIT_PAGE_2_TMDS_CSTAT_P3_DISABLE_AUTO_AVIF_CLEAR;
+	mhl_pf_write_reg(REG_PAGE_2_TMDS_CSTAT_P3, cstat_p3);
+
+	if (HPD_CTRL_OPEN_DRAIN == mode)
+		ret_val = mhl_pf_write_reg(REG_PAGE_0_HPD_CTRL,
+			 BITS_HPD_CTRL_OPEN_DRAIN_HIGH);
+	else if (HPD_CTRL_PUSH_PULL == mode)
+		ret_val = mhl_pf_write_reg(REG_PAGE_0_HPD_CTRL,
+			 BITS_HPD_CTRL_PUSH_PULL_HIGH);
+
+/* TODO ask SIMG why this need. In EDID upsteram API also contains the question.
+	if (ret_val >= 0)
+		return cstat_p3;
+*/
+	return ret_val;
+}
+
+static int int_disc_isr(uint8_t int_disc_status)
+{
+	pr_debug("%s:\n", __func__);
+
+	if ((BIT_CBUS_MHL12_DISCON_INT & int_disc_status) ||
+		(BIT_CBUS_MHL3_DISCON_INT & int_disc_status) ||
+		(BIT_NOT_MHL_EST_INT & int_disc_status)) {
+		pr_info("%s: got CBUS_DIS. MHL disconnection\n", __func__);
+
+		mhl_discovery_timer_start();
+		params_init_for_ready_to_mhl_connection();
+
+	} else if (int_disc_status & BIT_RGND_READY_INT) {
+		int disc_stat2;
+		pr_info("%s:RGND_READY INT\n", __func__);
+
+		disc_stat2 = mhl_pf_read_reg(REG_PAGE_5_DISC_STAT2);
+		pr_debug("%s:RGND impedance register spec:", __func__);
+		pr_debug("0x00 open, 0x01 2k, 0x10 1k, 0x11 Shorted\n");
+		pr_info("%s:measured impedance : %#x\n", __func__,
+			(disc_stat2 & 0x03));
+
+		mhl_reset_states();
+
+		if (0x02 == (disc_stat2 & 0x03)) {
+			pr_debug("%s: Cable impedance = 1k (MHL Device)\n",
+								__func__);
+			imp_zero_cnt = 0;
+
+			/* Cancel UnpoweredDongle Discovery Timer */
+			mhl_discovery_timer_stop();
+
+			mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL9,
+					 BIT_PAGE_5_DISC_CTRL9_WAKE_DRVFLT
+					 | BIT_PAGE_5_DISC_CTRL9_DISC_PULSE_PROCEED);
+
+			mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL4, 0x90);
+
+			complete(&rgnd_done);
+
+			pr_debug("%s:enable int\n", __func__);
+			mhl_pf_write_reg(REG_DISC_INTR_MASK,
+					 BIT_MHL3_EST_INT_MASK
+					 |BIT_CBUS_MHL3_DISCON_INT_MASK
+					 |BIT_CBUS_MHL12_DISCON_INT_MASK
+					 |BIT_NOT_MHL_EST_INT_MASK
+					 |BIT_MHL_EST_INT_MASK
+					 |BIT_RGND_READY_INT_MASK);
+
+			mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL0,
+				(BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_1X |
+				BIT_PAGE_3_MHL_PLL_CTL0_CRYSTAL_CLK_SEL |
+				BIT_PAGE_3_MHL_PLL_CTL0_ZONE_MASK_OE));
+
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL0, 0xC0);
+			mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+				VAL_PAGE_3_M3_CTRL_PEER_VERSION_PENDING_VALUE);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL1, 0xA2);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL2, 0x03);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL3, 0x35);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL5, 0x01);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL6, 0x02);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL7, 0x08);
+			/*
+			 * 0x071C. Def=0x0F.
+			 * Changed to 0xFF on 1/24 as per char team
+			 */
+			mhl_pf_write_reg(REG_PAGE_7_COC_CTLC, 0xFF);
+
+			/* enable HSIC earlier to enhance stability */
+			mhl_pf_write_reg(REG_PAGE_0_DPD
+					, BIT_PAGE_0_DPD_PWRON_PLL
+					| BIT_PAGE_0_DPD_PDNTX12
+					| BIT_PAGE_0_DPD_OSC_EN
+					| BIT_PAGE_0_DPD_PWRON_HSIC
+					);
+
+			mhl_pf_write_reg(REG_PAGE_7_COC_INTR_MASK,
+					 BIT_COC_PLL_LOCK_STATUS_CHANGE
+					 | BIT_COC_CALIBRATION_DONE);
+
+			mhl_pf_write_reg(REG_PAGE_5_CBUS_INT_1_MASK,
+					 BIT_CBUS_MSC_ABORT_RCVD
+					 | BIT_CBUS_CMD_ABORT);
+
+			mhl_pf_write_reg(REG_MSC_INTR_MASK,
+					 BIT_CBUS_MSC_MT_DONE
+					 | BIT_CBUS_HPD_CHG
+					 | BIT_CBUS_MSC_MR_WRITE_STAT
+					 | BIT_CBUS_MSC_MR_MSC_MSG
+					 | BIT_CBUS_MSC_MR_WRITE_BURST
+					 | BIT_CBUS_MSC_MR_SET_INT
+					 | BIT_CBUS_MSC_MT_DONE_NACK);
+		} else if (0x00 == (disc_stat2 & 0x03)) {
+			pr_debug("%s: impedance count=%x\n",
+				__func__, imp_zero_cnt);
+			msleep(50);
+			imp_zero_cnt++;
+			if(imp_zero_cnt > MAX_ZERO_IMP_DISC){
+				chip_power_off();
+			} else {
+				mhl_discovery_timer_start();
+				params_init_for_ready_to_mhl_connection();
+				return BIT_RGND_READY_INT;
+			}
+		} else {
+			pr_debug("%s: Cable impedance != 1k (Not MHL Device)\n",
+								__func__);
+			chip_power_off();
+		}
+	} else if (BIT_MHL_EST_INT &  int_disc_status) {
+		uint8_t	msc_compat = BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_ENABLE_XDEVCAP;
+
+		pr_info("%s: oCBUS Connection Established\n", __func__);
+
+		/* Cancel UnpoweredDongle Discovery Timer */
+		mhl_discovery_timer_stop();
+
+		cbus_mode = CBUS_oCBUS_PEER_VERSION_PENDING;
+		mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL4, 0x10);	/* Default 0x8C */
+
+		mhl_pf_write_reg(REG_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL,
+				 msc_compat);
+
+		regs_init_for_ready_to_tmds_connection();
+		mhl_msc_cbus_communication_start();
+	}
+
+	return 0;
+}
+
+static int mhl_cbus_isr(uint8_t cbus_int)
+{
+	int ret_val = -1;
+	pr_debug("%s: 0xC8,0x92: %X\n", __func__, cbus_int);
+
+	/* some times a sink will send a CBUS1 message before we get
+		the TDM_SYNC interrupt.  If we were in the calibrated
+		state, then ignore this interrupt until we are calibrated.
+	*/
+	switch(cbus_mode){
+	case CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D_CALIBRATED:
+		pr_warn("%s CBUS1 message received cbus_int:0x%02x\n",
+			 __func__, cbus_int);
+		return -1;
+		break;
+	case CBUS_NO_CONNECTION:
+	case CBUS_oCBUS_PEER_VERSION_PENDING:
+	case CBUS_oCBUS_PEER_IS_MHL1_2:
+	case CBUS_oCBUS_PEER_IS_MHL3:
+	case CBUS_bCBUS:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D:
+	case CBUS_eCBUS_S:
+	case CBUS_eCBUS_D:
+	default:
+		break;
+	}
+
+	/* Clear Interrupt Register*/
+	if (cbus_int & ~BIT_CBUS_HPD_CHG) {
+		/* bugzilla 27396
+		 * Logic to detect missed HPD interrupt.
+		 * Do not clear BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT2 yet.
+		 */
+		mhl_pf_write_reg(REG_PAGE_5_CBUS_INT_0,
+					cbus_int & ~BIT_CBUS_HPD_CHG);
+	}
+
+	if (BIT_CBUS_HPD_CHG & cbus_int) {
+		pr_debug("\n------------------------------------\n");
+		pr_info("[CBUS] got HPD\n");
+		mhl_msc_hpd_receive();
+	}
+
+	if (BIT_CBUS_MSC_MT_DONE & cbus_int) {
+		pr_debug("\n------------------------------------\n");
+		pr_info("[CBUS] got ACK for MSC Cmd\n");
+		mhl_msc_command_done(true);
+	}
+
+	if (BIT_CBUS_MSC_MT_DONE_NACK & cbus_int) {
+		pr_debug("\n------------------------------------\n");
+		pr_warn("[CBUS] got NACK for MSC Cmd\n");
+		mhl_msc_command_done(false);
+	}
+
+	if (BIT_CBUS_MSC_MR_WRITE_STAT & cbus_int) {
+		pr_debug("\n------------------------------------\n");
+		pr_info("[CBUS] got WRITE_STAT\n");
+		mhl_msc_write_stat_receive();
+	}
+
+	if ((BIT_CBUS_MSC_MR_MSC_MSG & cbus_int)) {
+		pr_debug("\n------------------------------------\n");
+		pr_info("[CBUS] got MSC_MSG\n");
+		mhl_msc_msg_receive();
+		mhl_msc_command_done(true);
+	}
+
+	if (BIT_CBUS_MSC_MR_SET_INT & cbus_int) {
+		pr_debug("\n------------------------------------\n");
+		pr_info("[CBUS] got SET_INT\n");
+		mhl_msc_set_int_receive();
+	}
+
+	return ret_val;
+}
+
+static int mhl_cbus_err_isr(uint8_t cbus_err_int)
+{
+	if (cbus_err_int & (BIT_CBUS_DDC_ABORT | BIT_CBUS_MSC_ABORT_RCVD |  BIT_CBUS_CMD_ABORT)) {
+		pr_err("[CBUS] Abort.\n");
+		mhl_cbus_abort(cbus_err_int);
+	}
+
+	return 0;
+}
+
+static int int_edid_devcap_isr(uint8_t int_edid_devcap_status)
+{
+	/* Clear Interrupt Register*/
+	mhl_pf_write_reg(REG_PAGE_2_INTR9, int_edid_devcap_status);
+
+	if (BIT_INTR9_DEVCAP_DONE & int_edid_devcap_status) {
+		pr_info("[CBUS] READ_DEVCAP done\n");
+		mhl_msc_command_done(true);
+	}
+	if ((BIT_INTR9_EDID_DONE | BIT_INTR9_EDID_ERROR)
+		& int_edid_devcap_status) {
+		pr_info("[CBUS] EDID done\n");
+		mhl_8620_dev_int_edid_isr(int_edid_devcap_status);
+		mhl_msc_command_done(true);
+	}
+	return int_edid_devcap_status;
+}
+
+int int_scdt_isr(uint8_t int_scdt_status)
+{
+	if (int_scdt_status & BIT_INTR5_SCDT_CHANGE) {
+		uint8_t temp;
+		temp = mhl_pf_read_reg(REG_PAGE_2_TMDS_CSTAT_P3);
+
+		if (BIT_PAGE_2_TMDS_CSTAT_P3_SCDT & temp) {
+			pr_info("got SCDT HIGH\n");
+
+			/* enable infoframe interrupt */
+			mhl_pf_write_reg(REG_PAGE_0_INTR8_MASK,
+					 (BIT_INTR8_CEA_NEW_AVI | BIT_INTR8_CEA_NEW_VSI));
+
+			if (IS_MODE_MHL3 || IS_MODE_HDMI) { /* HDMI or MHL3 mode */
+				mhl_pf_write_reg(REG_PAGE_6_TPI_SC,
+					VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_HDMI);
+
+				/* enable infoframe interrupt */
+				mhl_pf_write_reg(REG_PAGE_0_INTR8_MASK,
+						 (BIT_INTR8_CEA_NEW_AVI | BIT_INTR8_CEA_NEW_VSI));
+			} else { /* DVI mode */
+
+				/* FIXME HPD CALL BACK needs to be supported*/
+
+				set_cond_in_cbus_control(UPSTREAM_VIDEO_READY);
+				start_video();
+			}
+		} else {
+			pr_info("got SCDT LOW\n");
+
+			/* Clear all InfoFrame info which is now stale. */
+			mhl_pf_write_reg(REG_PAGE_2_TMDS_CSTAT_P3,
+					 BIT_PAGE_2_TMDS_CSTAT_P3_AVIF_MANUAL_CLEAR_STROBE |
+					 BIT_PAGE_2_TMDS_CSTAT_P3_DISABLE_AUTO_AVIF_CLEAR);
+
+			valid_vsif = 0;
+			valid_avif = 0;
+			memset(&current_vs_info_frame, 0,
+			       sizeof(current_vs_info_frame));
+
+			memset(&current_avi_info_frame, 0,
+			       sizeof(current_avi_info_frame));
+			stop_video();
+
+			/* disable infoframe interrupt */
+			mhl_pf_write_reg(REG_PAGE_0_INTR8_MASK, 0x00);
+		}
+	}
+
+	return 0;
+}
+
+static int int_info_frame_isr(uint8_t int_info_frame_status)
+{
+	vendor_specific_info_frame_t	vsif;
+	avi_info_frame_t		avif;
+
+	/* Clear Interrupt Register*/
+	mhl_pf_write_reg(REG_PAGE_0_INTR8, int_info_frame_status);
+
+	/* FIXME hpd_high_callback */
+
+	/* Resolution change interrupt (NEW_AVIF or NEW_VSIF) */
+	if (BIT_INTR8_CEA_NEW_VSI & int_info_frame_status) {
+		pr_info("got NEW_VSIF\n");
+
+		/* Select VSIF */
+		mhl_pf_write_reg(REG_PAGE_2_RX_HDMI_CTRL2,
+				 rx_hdmi_ctrl2_defval
+				 | VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_VSI);
+
+		/* Read VSIF packet */
+		mhl_pf_read_reg_block(REG_PAGE_2_RX_HDMI_MON_PKT_HEADER1,
+				      sizeof(vsif),
+				      (uint8_t *)&vsif);
+	}
+
+	if (BIT_INTR8_CEA_NEW_AVI & int_info_frame_status) {
+		pr_info("got NEW_AVIF\n");
+
+		/* Select AVIF */
+		mhl_pf_write_reg(REG_PAGE_2_RX_HDMI_CTRL2,
+				 rx_hdmi_ctrl2_defval
+				 | VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_AVI);
+
+		/* Read AVIF packet */
+		mhl_pf_read_reg_block(REG_PAGE_2_RX_HDMI_MON_PKT_HEADER1,
+				      sizeof(avif),
+				      (uint8_t *)&avif);
+
+		if (0 == avif.header.type_code) {
+			pr_warn("%s: type code is invalid\n", __func__);
+			return int_info_frame_status;
+		} else
+			pr_debug("%s: type code is valid\n", __func__);
+	}
+
+	switch (int_info_frame_status &
+		(BIT_INTR8_CEA_NEW_VSI|BIT_INTR8_CEA_NEW_AVI)) {
+	case BIT_INTR8_CEA_NEW_VSI:
+		process_info_frame_change(&vsif, NULL);
+		break;
+	case BIT_INTR8_CEA_NEW_AVI:
+		process_info_frame_change(NULL, &avif);
+		break;
+	case (BIT_INTR8_CEA_NEW_VSI|BIT_INTR8_CEA_NEW_AVI):
+		process_info_frame_change(&vsif, &avif);
+		break;
+	}
+
+	return int_info_frame_status;
+}
+
+static int hdcp_isr(uint8_t tpi_int_status)
+{
+	uint8_t query_data;
+
+	query_data = mhl_pf_read_reg(REG_PAGE_6_TPI_COPP_DATA1);
+
+	if (BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_BCAPS_DONE_STAT & tpi_int_status) {
+
+		if (BIT_PAGE_6_TPI_COPP_DATA1_COPP_PROTYPE & query_data) {
+
+			/*
+			  If the downstream device is a repeater,
+			  enforce a 5 second delay to pass HDCP CTS 1B-03.
+			  TODO: Describe this in the PR.
+			  2013-12-18 Allow the enforcement to exit early
+			  if the KSV_FIFO_LAST bit gets set, which, in turn,
+			  implies that BCAPS[5] (KSV_FIFO_RDY) is set.
+			  This fixes the occasional "Inactivity Timer Expired
+			  Not Judged" result in 1B-02.
+			*/
+			if (BIT_PAGE_6_TPI_COPP_DATA1_COPP_HDCP_REP ==
+				(BIT_PAGE_6_TPI_COPP_DATA1_COPP_HDCP_REP & query_data)) {
+				struct timeval ksv_poll_start;
+				struct timeval current_time, elapsed_time;
+				do_gettimeofday(&ksv_poll_start);
+				do {
+					uint8_t dbg_regs[7];
+					int cbus_connected_state;
+					if (BIT_PAGE_6_TPI_KSV_FIFO_STAT_KSV_FIFO_LAST
+						& mhl_pf_read_reg(REG_PAGE_6_TPI_KSV_FIFO_STAT))
+						break;
+
+					cbus_connected_state
+						= mhl_pf_read_reg(REG_PAGE_5_CBUS_STATUS);
+					cbus_connected_state
+						&= (BIT_PAGE_5_CBUS_STATUS_CBUS_CONNECTED
+							| BIT_PAGE_5_CBUS_STATUS_CBUS_HPD);
+					if ((BIT_PAGE_5_CBUS_STATUS_CBUS_CONNECTED
+						| BIT_PAGE_5_CBUS_STATUS_CBUS_HPD)
+							!= cbus_connected_state)
+						break;
+
+					mhl_pf_read_reg_block(
+						REG_PAGE_6_TPI_HW_DBG1,
+						sizeof(dbg_regs),
+						dbg_regs);
+
+					msleep(50);
+					do_gettimeofday(&current_time);
+					elapsed_time.tv_usec
+						= current_time.tv_usec
+							- ksv_poll_start.tv_usec;
+					elapsed_time.tv_sec
+						= current_time.tv_sec
+							- ksv_poll_start.tv_sec;
+					if (elapsed_time.tv_usec < 0) {
+						/* handle the borrow case */
+						elapsed_time.tv_usec += 1000000;
+						elapsed_time.tv_sec  -= 1;
+					}
+				} while (elapsed_time.tv_sec < 3);
+			}
+
+			/* Start authentication here */
+			mhl_pf_write_reg(REG_PAGE_6_TPI_COPP_DATA2,
+					VAL_PAGE_6_TPI_COPP_PROTLEVEL_MAX);
+		}
+	} else if (BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_ERR_STAT & tpi_int_status) {
+		/* Set Disconnect HDCP Authentication. */
+		hdcp_authentication = false;
+
+		/* send HDCP FAIL uevent */
+		mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+		start_hdcp();
+	} else if (BIT_PAGE_6_TPI_INTR_ST0_TPI_COPP_CHNGE_STAT & tpi_int_status) {
+		int link_status;
+
+		link_status = query_data & MSK_PAGE_6_TPI_COPP_DATA1_COPP_LINK_STATUS;
+
+		switch (link_status) {
+		case VAL_TPI_COPP_LINK_STATUS_NORMAL:
+			unmute_video();
+			break;
+
+		case VAL_TPI_COPP_LINK_STATUS_LINK_LOST:
+			/* Set Disconnect HDCP Authentication. */
+			hdcp_authentication = false;
+
+			/* send HDCP FAIL uevent */
+			mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+			start_hdcp();
+			break;
+		case VAL_TPI_COPP_LINK_STATUS_RENEGOTIATION_REQ:
+			pr_debug("tpi BSTATUS2: 0x%x\n",
+				 mhl_pf_read_reg(REG_PAGE_6_TPI_BSTATUS2));
+			/* Disabling TMDS output here will disturb the clock */
+			mhl_pf_modify_reg(REG_PAGE_6_TPI_SC,
+					  BIT_PAGE_6_TPI_SC_TPI_AV_MUTE,
+					  VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_MUTED);
+
+			/* send TPI hardware to HDCP_Prep state */
+			mhl_pf_write_reg(REG_PAGE_6_TPI_COPP_DATA2, 0);
+			break;
+		case VAL_TPI_COPP_LINK_STATUS_LINK_SUSPENDED:
+			/* Set Disconnect HDCP Authentication. */
+			hdcp_authentication = false;
+
+			/* send HDCP FAIL uevent */
+			mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+			start_hdcp();
+			break;
+		}
+	}
+	/* Check if HDCP state has changed: */
+	else if (BIT_PAGE_6_TPI_INTR_ST0_TPI_AUTH_CHNGE_STAT & tpi_int_status) {
+		uint8_t new_link_prot_level;
+
+		new_link_prot_level = (uint8_t)
+			(query_data & (BIT_PAGE_6_TPI_COPP_DATA1_COPP_GPROT |
+				       BIT_PAGE_6_TPI_COPP_DATA1_COPP_LPROT));
+
+		switch (new_link_prot_level) {
+		case (VAL_TPI_COPP_GPROT_NONE | VAL_TPI_COPP_LPROT_NONE):
+			/* Set Disconnect HDCP Authentication. */
+			hdcp_authentication = false;
+
+			/* send HDCP FAIL uevent */
+			mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+			start_hdcp();
+			break;
+		case VAL_TPI_COPP_GPROT_SECURE:
+		case VAL_TPI_COPP_LPROT_SECURE:
+		case (VAL_TPI_COPP_GPROT_SECURE | VAL_TPI_COPP_LPROT_SECURE):
+			pr_info("%s: HDCP1.4 Authentication Done.\n", __func__);
+
+			/* send HDCP PASS uevent */
+			mhl_tx_send_hdcp_state(HDCP_STATE_AUTHENTICATED);
+			unmute_video();
+			break;
+		}
+	}
+
+	return 0;
+}
+
+static int g2wb_err_isr(uint8_t intr_stat)
+{
+
+	if (BIT_MDT_RCV_TIMEOUT	& intr_stat)
+		pr_warn("%s: BIT_MDT_RCV_TIMEOUT\n", __func__);
+
+	if (BIT_MDT_RCV_SM_ABORT_PKT_RCVD & intr_stat)
+		pr_warn("%s: BIT_MDT_RCV_SM_ABORT_PKT_RCVD\n", __func__);
+
+	if (BIT_MDT_RCV_SM_ERROR & intr_stat)
+		pr_warn("%s: BIT_MDT_RCV_SM_ERROR\n", __func__);
+
+	if (BIT_MDT_XMIT_TIMEOUT & intr_stat)
+		pr_warn("%s: BIT_MDT_XMIT_TIMEOUT\n", __func__);
+
+	if (BIT_MDT_XMIT_SM_ABORT_PKT_RCVD & intr_stat)
+		pr_warn("%s: BIT_MDT_XMIT_SM_ABORT_PKT_RCVD\n", __func__);
+
+	if (BIT_MDT_XMIT_SM_ERROR & intr_stat)
+		pr_warn("%s: BIT_MDT_XMIT_SM_ERROR\n", __func__);
+
+	return 0;
+}
+
+static int g2wb_isr(uint8_t intr_stat)
+{
+	if (BIT_MDT_XFIFO_EMPTY & intr_stat) {
+		cbus_wb_write_burst_send_done();
+		mhl_msc_command_done(true);
+	}
+
+	/* FIXME Add GEN2 Receive */
+	return 0;
+}
+
+static int hdcp2_isr(uint8_t intr_status)
+{
+	uint8_t rcvr_info[3];
+	uint8_t rcvr_id_list[5];
+
+	pr_debug("Got HDCP2\n");
+	pr_debug("%s: int val: %X\n", __func__, intr_status);
+
+	if (intr_status & BIT_HDCP2_INTR_AUTH_DONE) {
+		pr_info("%s: HDCP2.2 Authentication Done.\n", __func__);
+
+		/* send HDCP PASS uevent */
+		mhl_tx_send_hdcp_state(HDCP_STATE_AUTHENTICATED);
+
+		/* Enable high-value content / disable mute */
+	}
+
+	if (intr_status & BIT_HDCP2_INTR_AUTH_FAIL)	{
+		uint8_t ro_gp0;
+		uint8_t ro_auth[2];
+
+		/* Disable high-value content / enable mute */
+
+		ro_gp0 = mhl_pf_read_reg(REG_PAGE_3_HDCP2X_GP_OUT0);
+		mhl_pf_read_reg_block(REG_PAGE_3_HDCP2X_AUTH_STAT,
+			sizeof(ro_auth), ro_auth);
+
+		pr_warn("%s: HDCP2.2 Authentication Failed\n\tgp0 %02X, status %02X %02X\n",
+			__func__,
+			ro_gp0, ro_auth[0],
+			ro_auth[1]);
+
+		/* Set Not a during HDCP Authentication. */
+		hdcp_authentication = false;
+
+		/* send HDCP FAIL uevent */
+		mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+	}
+
+	if (intr_status & BIT_HDCP2_INTR_RPTR_RCVID_CHANGE)	{
+		int cnt;
+
+		pr_info("%s: HDCP2.2 RCV_ID Changed.\n", __func__);
+
+			/* Read RCVR INFO and RCVR ID LIST */
+			mhl_pf_read_reg_block(REG_PAGE_3_HDCP2X_RPT_RCVID_OUT,
+				sizeof(rcvr_info), rcvr_info);
+			mhl_pf_read_reg_block(REG_PAGE_3_HDCP2X_RPT_RCVR_ID0,
+				sizeof(rcvr_id_list), rcvr_id_list);
+
+		/* print rcvr_info */
+		for (cnt = 0; cnt < sizeof(rcvr_info); cnt++) {
+			pr_debug("%s: rcvr_info[%2x]=%2x\n",
+				__func__,
+				cnt,
+				rcvr_info[cnt]
+			);
+			}
+
+		/* print rcvr_id_list */
+		for (cnt = 0; cnt < sizeof(rcvr_id_list); cnt++) {
+			pr_debug("%s: rcvr_id_list[%2x]=%2x\n",
+				__func__,
+				cnt,
+				rcvr_id_list[cnt]
+			);
+		}
+	}
+
+	mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0, intr_status);
+
+	return intr_status;
+}
+
+static int mhl3_block_isr(uint8_t status)
+{
+	bool payload_encountered = false;
+
+	if (BIT_PAGE_3_EMSCINTR_EMSC_XFIFO_EMPTY & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_EMSC_XFIFO_EMPTY\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_EMSC_XMIT_ACK_TOUT & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_EMSC_XMIT_ACK_TOUT\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_SPI_EMSC_READ_ERR & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_SPI_EMSC_READ_ERR\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_SPI_EMSC_WRITE_ERR & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_SPI_EMSC_WRITE_ERR\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_SPI_COMMA_CHAR_ERR & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_SPI_COMMA_CHAR_ERR\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_EMSC_XMITDONE & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_EMSC_XMITDONE\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_EMSC_XMIT_GNT_TOUT & status)
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_EMSC_XMIT_GNT_TOUT\n",
+			__func__);
+	if (BIT_PAGE_3_EMSCINTR_SPI_DVLD & status) {
+		pr_info("%s: Got isr of BIT_PAGE_3_EMSCINTR_SPI_DVLD\n",
+			__func__);
+		if (block_input_buffer_available()) {
+			int block_index;
+			uint8_t rfifo_byte_count[2];
+	#define EMSC_HEADER_SIZE (1 + STD_TRANSPORT_HDR_SIZE)
+			uint16_t fifo_data_len, block_len;
+			mhl_pf_read_reg_block(REG_PAGE_3_EMSCRFIFOBCNTL,
+					sizeof(rfifo_byte_count),
+					rfifo_byte_count);
+
+			/*
+			  TODO: Lee - should this be validated against
+				our actual FIFO size?
+			*/
+			fifo_data_len = ((uint16_t)rfifo_byte_count[1] << 8)
+					 | (uint16_t)rfifo_byte_count[0];
+			pr_debug("%s: ================= EMSCINTR_SPI_DVLD interrupt, payload length: %d\n",
+				__func__ , fifo_data_len);
+
+			do {
+				uint8_t *buffer = NULL;
+				uint8_t header[EMSC_HEADER_SIZE];
+				struct SI_PACK_THIS_STRUCT
+					standard_transport_header_t *tport_hdr;
+
+				if (fifo_data_len < EMSC_HEADER_SIZE) {
+					pr_debug("%s: eMSC FIFO did not contain enough data for a EMSC_HEADER (%d < %d\n",
+						__func__ , fifo_data_len,
+						EMSC_HEADER_SIZE);
+					break;
+				}
+				mhl_pf_read_reg_block(
+					REG_PAGE_3_EMSC_RCV_READ_PORT,
+					EMSC_HEADER_SIZE,
+					header);
+				pr_debug("%s: ================= EMSCINTR_SPI_DVLD interrupt, payload header: %02X %02X %02X\n",
+						__func__ , header[0],
+						header[1], header[2]);
+				fifo_data_len -= EMSC_HEADER_SIZE;
+				tport_hdr = (struct SI_PACK_THIS_STRUCT
+						standard_transport_header_t *)
+						&header[1];
+
+				pr_debug("%s: ================= EMSCINTR_SPI_DVLD interrupt, tport_hdr->length_remaining: %d\n",
+					__func__ ,
+					tport_hdr->length_remaining);
+
+				/*
+				  FIFO data count MUST be at LEAST enough
+				  for the current transport header
+				  remaining byte count.
+				*/
+				if (fifo_data_len
+					< tport_hdr->length_remaining) {
+					pr_debug("%s: eMSC FIFO data count not enough for STD header remaining byte count: (%d < %d\n",
+						__func__ ,
+						fifo_data_len,
+						tport_hdr->length_remaining);
+					break;
+				}
+
+				block_len = 0;
+				if (tport_hdr->length_remaining > 0) {
+					payload_encountered = true;
+					block_index
+						= alloc_block_input_buffer(&buffer);
+					block_len = tport_hdr->length_remaining;
+
+					mhl_pf_read_reg_block(
+						REG_PAGE_3_EMSC_RCV_READ_PORT,
+						block_len,
+						buffer);
+					set_block_input_buffer_length(
+						block_index, block_len);
+					add_received_byte_count(
+						block_len
+						+ STD_TRANSPORT_HDR_SIZE);
+				}
+
+				add_peer_blk_rx_buffer_avail(
+						tport_hdr->rx_unload_ack);
+				fifo_data_len -= block_len;
+				if (!block_input_buffer_available())
+					break;
+
+			} while (fifo_data_len > 0);
+			if (payload_encountered)
+				mhl_tx_emsc_received();
+		}
+	}
+	return status;
+}
+
+static int coc_isr(uint8_t coc_int_status)
+{
+	int ret_val = 0;
+
+	pr_debug("Got CoC\n");
+	pr_debug("%s: 0xC2,0x26: %X\n", __func__, coc_int_status);
+
+	if (!IS_MODE_MHL3) {
+		pr_warn("%s: illegal coc int", __func__);
+		return ret_val;
+	}
+
+	if (BIT_COC_PLL_LOCK_STATUS_CHANGE & coc_int_status)
+		pr_info("%s: COC PLL lock status change\n", __func__);
+
+	if (BIT_COC_CALIBRATION_DONE & coc_int_status) {
+		int calibration_stat;
+		uint8_t calibrated_value;
+
+		pr_info("%s: Calibration Done\n", __func__);
+
+		calibration_stat =
+			mhl_pf_read_reg(REG_PAGE_7_COC_STAT_0);
+		calibration_stat &= BITS_ES1_0_COC_STAT_0_CALIBRATION_MASK;
+		calibrated_value =
+			BITS_ES1_0_COC_STAT_0_PLL_LOCKED |
+			BITS_ES1_0_COC_STAT_0_CALIBRATION_STATE_2;
+
+		if (calibrated_value == calibration_stat) {
+			/* disable timeout */
+			mhl_pf_write_reg(REG_PAGE_7_COC_CTLB, 0x00);
+			pr_debug("%s: CoC in calibrated state\n", __func__);
+			mhl_pf_write_reg(REG_PAGE_1_TRXINTMH,
+				BIT_TDM_INTR_SYNC_DATA_MASK |
+				BIT_TDM_INTR_SYNC_WAIT_MASK);
+			cbus_mode = CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED;
+		} else
+			pr_warn("%s: calibration state: 0x%02X\n",
+				__func__, calibration_stat);
+	}
+
+	return ret_val;
+}
+
+static int tdm_isr(uint8_t intr_status)
+{
+	int ret_val = 0;
+	uint8_t tdm_status;
+
+	pr_debug("Got TDM\n");
+	pr_debug("%s: 0x7A,0x65: %X\n", __func__, intr_status);
+
+	if (!IS_MODE_MHL3) {
+		pr_warn("%s: illegal tdm int", __func__);
+		return ret_val;
+	}
+
+	if (BIT_TDM_INTR_SYNC_DATA & intr_status) {
+
+		pr_info("%s: TDM in SYNC_DATA state.\n", __func__);
+		tdm_status = mhl_pf_read_reg(REG_PAGE_1_TRXSTA2);
+
+		if ((tdm_status & MSK_TDM_SYNCHRONIZED) ==
+			VAL_TDM_SYNCHRONIZED) {
+
+			pr_debug("%s: TDM is synchronized\n", __func__);
+
+			if (CBUS_eCBUS_S > cbus_mode)
+				cbus_mode = CBUS_eCBUS_S;
+
+			mhl_cbus_communication_eCBUS_start();
+
+			mhl_tx_initialize_block_transport();
+		} else {
+			pr_debug("%s: TDM not synchronized, retrying\n",
+				__func__);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL2, 0x00);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL2, 0x80);
+		}
+	}
+
+	if (BIT_TDM_INTR_SYNC_WAIT & intr_status)
+		pr_warn("%s: TDM in SYNC_WAIT state.\n", __func__);
+
+	return ret_val;
+}
+
+void mhl_device_isr(void)
+{
+	int reg_value;
+	int mask_reg_value;
+	int already_cleared;
+	uint8_t intr_num;
+	uint8_t intr_stat;
+
+	for (intr_num = 0; (intr_num < MAX_INTR) &&
+		(is_interrupt_asserted()); intr_num++) {
+
+		mask_reg_value = mhl_pf_read_reg(g_intr_tbl[intr_num].mask_page,
+					g_intr_tbl[intr_num].mask_offset);
+
+		if (mask_reg_value) {
+			reg_value = mhl_pf_read_reg(
+					g_intr_tbl[intr_num].stat_page,
+					g_intr_tbl[intr_num].stat_offset);
+
+			if (reg_value < 0) {
+				pr_err("%s:Interrupt State Register read failed,  0x%02x:0x%02x\n",
+					__func__,
+					g_intr_tbl[intr_num].stat_page,
+					g_intr_tbl[intr_num].stat_offset);
+				return;
+			}
+
+			intr_stat = (uint8_t)reg_value;
+
+			/*
+			 * Process only specific interrupts we have enabled.
+			 * Ignore others.
+			 */
+			intr_stat = intr_stat & mask_reg_value;
+			if (intr_stat) {
+				pr_info("INTR-%s = %02X\n",
+					g_intr_tbl[intr_num].name, intr_stat);
+
+				already_cleared
+					= g_intr_tbl[intr_num].isr(intr_stat);
+				if (already_cleared >= 0) {
+					/*
+					 * only clear the interrupts that were
+					 * not cleared by the specific ISR.
+					 */
+					intr_stat &= ~already_cleared;
+					if (intr_stat) {
+						/*
+						 * Clear interrupt
+						 * since specific ISR did not.
+						 */
+						mhl_pf_write_reg(
+							g_intr_tbl[intr_num].
+								stat_page,
+							g_intr_tbl[intr_num].
+								stat_offset,
+							intr_stat);
+					}
+				}
+			}
+
+			if (cbus_mode >= CBUS_eCBUS_S)
+				mhl_tx_push_block_transactions();
+
+		}
+	}
+
+	exe_cbus_command();
+}
+
+static void cbus_reset(void)
+{
+	pr_debug("%s: perform CBUS reset to clean MHL STAT values\n", __func__);
+	mhl_pf_write_reg(REG_PAGE_0_PWD_SRST,
+			BIT_PAGE_0_PWD_SRST_CBUS_RST | BIT_PAGE_0_PWD_SRST_CBUS_RST_SW_EN);
+	mhl_pf_write_reg(REG_PAGE_0_PWD_SRST,
+			BIT_PAGE_0_PWD_SRST_CBUS_RST_SW_EN);
+}
+
+/*
+ * disconnect_mhl
+ * This function performs s/w as well as h/w state transitions.
+ */
+static void regs_init_for_ready_to_mhl_connection(void)
+{
+	pr_debug("%s() IN\n", __func__);
+
+	/* only 19MHZ mode is supported */
+	mhl_pf_write_reg(REG_PAGE_3_DIV_CTL_MAIN, 0x04);
+	mhl_pf_write_reg(REG_PAGE_3_HDCP2X_TP1, 0x5E);
+
+	cbus_wb_disable_gen2_write_burst_xmit();
+
+	stop_video();
+	pr_debug("%s: STOP_VIDEO DONE\n", __func__);
+	msleep(50);
+	cbus_reset();
+	clear_auto_zone_for_mhl_3();
+
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL0, 0x40);
+	mhl_pf_write_reg(REG_PAGE_5_CBUS3_CNVT, 0x84);
+
+	mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL5, 0x0D);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL3, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL1, 0x0A);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL2, 0x14);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL17, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL18, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL19, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL1A, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL7, 0x06);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL11, 0x32);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL4, 0x28);
+
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTLF, 0x00);
+
+	/* Enable timeout */
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTLB, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL14, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL15, 0x00);
+
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL0, 0x40);
+
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL14, 0x00);
+	mhl_pf_write_reg(REG_PAGE_7_COC_CTL15, 0x00);
+
+	mhl_pf_write_reg(REG_PAGE_1_HRXCTRL3, 0x07);
+	mhl_pf_write_reg(REG_PAGE_5_CBUS3_CNVT, 0x84);
+
+	mhl_pf_write_reg(REG_PAGE_1_FCCTR13, 0xFC);
+	mhl_pf_write_reg(REG_PAGE_1_FCCTR14, 0xFF);
+	mhl_pf_write_reg(REG_PAGE_1_FCCTR15, 0xFF);
+	mhl_pf_write_reg(REG_PAGE_1_FCCTR50, 0x03);
+
+	mhl_pf_write_reg(REG_PAGE_3_MHL_PLL_CTL0,
+		(BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_1X |
+		BIT_PAGE_3_MHL_PLL_CTL0_CRYSTAL_CLK_SEL |
+		BIT_PAGE_3_MHL_PLL_CTL0_ZONE_MASK_OE));
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL0, 0xC0);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL1, 0xBB);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL3, 0x48);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL5, 0x3F);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL2, 0x2F);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL6, 0x2A);
+	mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL7, 0x08);
+
+	cbus_mode = CBUS_NO_CONNECTION;
+
+	drive_hpd_low();
+
+	mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+			 VAL_PAGE_3_M3_CTRL_PEER_VERSION_PENDING_VALUE);
+
+	mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL1, 0x07);
+	mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL4, 0x10);	 /* Default 0x84 */
+	mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL8, 0x00);	 /* Default 0x83 */
+
+	/* Discovery Control Register */
+	mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL9,
+			 BIT_PAGE_5_DISC_CTRL9_WAKE_DRVFLT
+			 | BIT_PAGE_5_DISC_CTRL9_WAKE_PULSE_BYPASS);
+
+	/* FIXME Workarond for 1k impedance not measured */
+	msleep(20);
+
+	mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL1, 0x25);
+
+	/*
+		Adjust RGND vbias threshold and calibration resistance
+		as per Characterization team's recommendation.
+		CBUS driver strength is maintained at POR default of "Strong".
+	*/
+	mhl_pf_write_reg(REG_PAGE_3_MHL_CBUS_CTL0,
+		(BIT_PAGE_3_MHL_CBUS_CTL0_CBUS_DRV_SEL_STRONG |
+		BIT_PAGE_3_MHL_CBUS_CTL0_CBUS_RGND_VBIAS_734));
+
+	mhl_pf_write_reg(REG_PAGE_3_MHL_CBUS_CTL1,
+		BIT_PAGE_3_MHL_CBUS_CTL1_1115_OHM);
+	/*
+	 * Leave just enough of the transmitter powered up
+	 * to detect connections.
+	 * i.e. disable the following:
+	 *	BIT_PAGE_0_DPD_PDNRX12, BIT_PAGE_0_DPD_PWRON_HSIC,
+	 *	BIT_PAGE_0_DPD_PDIDCK_N, BIT_PAGE_0_DPD_PD_MHL_CLK_N
+	 */
+	mhl_pf_write_reg(REG_PAGE_0_DPD,
+		 BIT_PAGE_0_DPD_PWRON_PLL |
+		BIT_PAGE_0_DPD_PDNTX12 |
+		BIT_PAGE_0_DPD_OSC_EN);
+
+	pr_debug("%s:Clear Interrupt registers and configure MASK settings\n", __func__);
+
+	/* FIXME please check the lastest referene code 
+	   Additional registers need to be cleared 
+	 */
+	mhl_sii8620_clear_and_mask_interrupts(true);
+
+	pr_debug("%s() OUT\n", __func__);
+}
+
+static void regs_init_for_ready_to_tmds_connection(void)
+{
+	int ret_val = 0;
+
+	pr_debug("%s:\n", __func__);
+
+	peer_specific_init();
+
+	rx_hdmi_ctrl2_defval = REG_RX_HDMI_CTRL2_DEFVAL_DVI;
+
+	drive_hpd_low();
+
+	mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+			 VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE);
+
+	mhl_pf_write_reg(REG_PAGE_5_DISC_CTRL9,
+			 BIT_PAGE_5_DISC_CTRL9_WAKE_DRVFLT |
+			 BIT_PAGE_5_DISC_CTRL9_WAKE_PULSE_BYPASS
+	);
+
+	/* TMDS Clock Control Register */
+	mhl_pf_write_reg(REG_PAGE_2_TMDS0_CCTRL1, 0x90);
+
+	/* TMDS Clock Enable Register */
+	mhl_pf_write_reg(REG_PAGE_2_TMDS_CLK_EN, 0x01);
+
+	/* Enable Tx Clock Path & Equalizer */
+	mhl_pf_write_reg(REG_PAGE_2_TMDS_CH_EN, 0x11);
+	mhl_pf_write_reg(REG_PAGE_2_BGR_BIAS, 0x87);
+	mhl_pf_write_reg(REG_PAGE_2_ALICE0_ZONE_CTRL, 0xE8);
+	mhl_pf_write_reg(REG_PAGE_2_ALICE0_MODE_CTRL, 0x04);
+
+	/* Enable TPI */
+	ret_val = mhl_pf_read_reg(REG_PAGE_0_LM_DDC);
+	ret_val &= ~BIT_PAGE_0_LM_DDC_SW_TPI_EN;
+	ret_val |= VAL_PAGE_0_LM_DDC_SW_TPI_EN_ENABLED;
+	mhl_pf_write_reg(REG_PAGE_0_LM_DDC, ret_val);
+
+	mhl_pf_write_reg(REG_PAGE_6_TPI_COPP_DATA2, VAL_PAGE_6_TPI_COPP_PROTLEVEL_MIN);
+	mhl_pf_write_reg(REG_PAGE_6_TPI_HW_OPT3, 0x76);
+	mhl_pf_write_reg(REG_PAGE_0_TMDS_CCTRL, BIT_PAGE_0_TMDS_CCTRL_TMDS_OE);
+	mhl_pf_write_reg(REG_PAGE_6_TPI_DTD_B2, 79);
+
+	/* Initialize DEVCAP*/
+	init_devcap();
+
+	/* 2013-03-01 bugzilla 27180 */
+	mhl_pf_write_reg(REG_PAGE_5_CBUS_LINK_CONTROL_8, 0x1D);
+
+	cbus_wb_start_gen2_write_burst();
+
+	mhl_pf_write_reg(REG_PAGE_0_BIST_CTRL, 0x00);
+
+	/*
+	  hearbeat enable/disable to be done once in run time
+	  not at every hot plug.
+	*/
+	enable_heartbeat();
+}
+
+void peer_specific_init(void)
+{
+	if (IS_MODE_MHL3) {
+		/*
+		  on Titan 1.1 and following, even in MHL3 mode,
+		  TPI:1A[0] controls DVI vs. HDMI
+		*/
+		mhl_pf_write_reg(REG_PAGE_0_SYS_CTRL1,
+			 BIT_PAGE_0_SYS_CTRL1_BLOCK_DDC_VIA_UPSTREAM_HPD_LOW);
+	} else {
+		/* disable and clear uninteresting interrupts for MHL 1/2 */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0_MASK, 0x00);
+		mhl_pf_write_reg(REG_EMSC_INTR_0_MASK, 0x00);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0, 0xFF);
+		mhl_pf_write_reg(REG_PAGE_0_INTR1, 0xFF);
+
+		mhl_pf_write_reg(REG_PAGE_0_SYS_CTRL1,
+				 BIT_PAGE_0_SYS_CTRL1_BLOCK_DDC_VIA_UPSTREAM_HPD_LOW
+				 |BIT_PAGE_0_SYS_CTRL1_TX_CONTROL_HDMI);
+	}
+}
+
+int mhl_sii8620_device_start(void *context)
+{
+	int timeout;
+	pr_debug("%s:\n", __func__);
+
+	/*
+	 * rgnd_done must be initialized before chip_power_on.
+	 * Because rgnd interrupt could occur immediately just after
+	 * calling the chip_power_on() and the wait code in the interrupt
+	 * is called before call INIT_COMPLETION and wait_for_xxx,
+	 * if the INIT_COMPLETION is called after the chip_power_on().
+	 */
+	INIT_COMPLETION(rgnd_done);
+	chip_power_on();
+	pr_debug("%s:RGND measurement wait\n", __func__);
+	timeout = wait_for_completion_interruptible_timeout(&rgnd_done, HZ/2);
+	if (!timeout) {
+		/* timeout happens */
+		pr_warn("%s:time out\n", __func__);
+		chip_power_off();
+		return MHL_USB_NON_INUSE;
+	} else {
+		pr_debug("%s:MHL impedance was found.\n", __func__);
+	}
+
+	return MHL_USB_INUSE;
+}
+
+/*
+ * mhl_device_initialize()
+ */
+int mhl_device_initialize(struct device *dev)
+{
+	int rc = 0;
+
+	pr_debug("%s:\n", __func__);
+
+	init_completion(&rgnd_done);
+
+	cbus_mode = CBUS_NO_CONNECTION;
+
+	mhl_discovery_timer_create();
+
+	is_hdcp_support = true;
+
+	imp_zero_cnt = 0;
+
+	mhl_sii8620_device_edid_init();
+#ifndef UNIT_TEST
+	mhl_device_sysfs_init(dev);
+#endif
+	rc = mhl_cbus_control_initialize();
+	if(rc)
+		return rc;
+
+	cbusp_processing_cond = 0;
+
+	pdev = dev;
+
+	return rc;
+}
+
+void mhl_device_release(struct device *dev)
+{
+	chip_power_off();
+
+	mhl_pf_switch_unregister_cb();
+
+	cbus_mode = CBUS_NO_CONNECTION;
+
+	mhl_discovery_timer_delete();
+
+	mhl_sii8620_device_edid_release();
+#ifndef UNIT_TEST
+	mhl_device_sysfs_release();
+#endif
+	mhl_cbus_control_release();
+}
+
+static void mhl_reset_states()
+{
+	mhl_msc_init();
+
+	cbus_mode = CBUS_NO_CONNECTION;
+}
+
+static void mhl_sii8620_clear_and_mask_interrupts(bool is_exclude_rgnd)
+{
+	uint8_t intr_num;
+	pr_debug("%s()\n", __func__);
+
+	/* clear and mask all interrupts */
+	for(intr_num = 0; intr_num < MAX_INTR; intr_num++) {
+		/* Clear and disable all other interrupts */
+		if (intr_num != INTR_DISC) {
+			mhl_pf_write_reg(g_intr_tbl[intr_num].stat_page,
+				g_intr_tbl[intr_num].stat_offset, 0xff);
+			mhl_pf_write_reg(g_intr_tbl[intr_num].mask_page,
+				g_intr_tbl[intr_num].mask_offset, 0x00);
+		}
+	}
+
+	/*
+	  RGND intterupt needs to be enabled after the above all interrupt
+	  registers are initialized.
+	 */
+	if (is_exclude_rgnd) {
+		/* Keep only RGND interrupt enabled for 8620 */
+		mhl_pf_write_reg(g_intr_tbl[INTR_DISC].stat_page,
+			g_intr_tbl[INTR_DISC].stat_offset,
+			(u8)~BIT_RGND_READY_INT);
+		mhl_pf_write_reg(g_intr_tbl[INTR_DISC].mask_page,
+			g_intr_tbl[INTR_DISC].mask_offset, BIT_RGND_READY_INT);
+	} else {
+		mhl_pf_write_reg(g_intr_tbl[INTR_DISC].stat_page,
+			g_intr_tbl[INTR_DISC].stat_offset,
+			0xff);
+		mhl_pf_write_reg(g_intr_tbl[INTR_DISC].mask_page,
+			g_intr_tbl[INTR_DISC].mask_offset, 0x00);
+	}
+}
+
+int mhl_device_switch_cbus_mode(CBUS_MODE_TYPE mode_sel)
+{
+	int		status = 1;
+	uint8_t	slot_total;
+
+	pr_debug("%s: Switch cbus_mode from %x to %x\n",
+		__func__, cbus_mode, mode_sel);
+
+	if (mhl_device_get_cbus_mode() < CBUS_oCBUS_PEER_VERSION_PENDING)
+		return -1;
+
+	switch (mode_sel) {
+	case CBUS_oCBUS_PEER_IS_MHL1_2:
+		pr_debug("%s: Switch to MHL1/2 oCBUS mode\n", __func__);
+
+		mhl_pf_write_reg(
+			REG_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL,
+			0x02);
+		mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+			VAL_PAGE_3_M3_CTRL_MHL1_2_VALUE);
+
+		/*
+		 * disable BIT_PAGE_0_DPD_PWRON_HSIC
+		 */
+		mhl_pf_write_reg(REG_PAGE_0_DPD,
+			BIT_PAGE_0_DPD_PWRON_PLL |
+			BIT_PAGE_0_DPD_PDNTX12 |
+			BIT_PAGE_0_DPD_OSC_EN
+			);
+
+		mhl_pf_write_reg(REG_PAGE_7_COC_INTR_MASK, 0x00);
+
+		set_auto_zone_for_mhl_1_2();
+
+		/* Video failed with C0 -
+		   when Phalanx->Titan->Jubilee was used for
+		   HDCP CTS 1.x
+		*/
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL0, 0xBC);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL1, 0xBB);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL3, 0x48);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL5, 0x3F);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL2, 0x2F);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL6, 0x2A);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL7, 0x08);
+
+		cbus_mode = CBUS_oCBUS_PEER_IS_MHL1_2;
+
+		break;
+
+	case CBUS_oCBUS_PEER_IS_MHL3:
+		cbus_mode = CBUS_oCBUS_PEER_IS_MHL3;
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL0, 0x40);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL1, 0x07);
+		break;
+
+	case CBUS_eCBUS_S:
+		cbus_wb_disable_gen2_write_burst_xmit();
+
+		cbus_mode = CBUS_TRANSITIONAL_TO_eCBUS_S;
+
+
+		mhl_pf_write_reg(REG_PAGE_1_TTXSPINUMS,
+				 mhl_get_tdm_virt_chan_slot_counts(TDM_VC_E_MSC));
+		slot_total = mhl_get_tdm_virt_chan_slot_counts(TDM_VC_E_MSC);
+		mhl_pf_write_reg(REG_PAGE_1_TTXHSICNUMS,
+				 mhl_get_tdm_virt_chan_slot_counts(TDM_VC_T_CBUS));
+		slot_total += mhl_get_tdm_virt_chan_slot_counts(TDM_VC_T_CBUS);
+		mhl_pf_write_reg(REG_PAGE_1_TTXTOTNUMS, slot_total);
+
+		/* begin reset */
+		mhl_pf_write_reg(REG_PAGE_0_PWD_SRST, 0xA0);
+
+		mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL5, 0xF9);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL3,
+				 BIT_PAGE_3_MHL_COC_CTL3_ECHO_CANCEL);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL1, 0x10);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL2, 0x18);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL17, 0x61);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL18, 0x46);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL19, 0x15);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL1A, 0x01);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL7, 0x06);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL11, 0xF8);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL1, 0xBA);
+		mhl_pf_write_reg(REG_PAGE_3_MHL_COC_CTL4, 0x2D);
+
+		/* release sw-reset */
+		mhl_pf_write_reg(REG_PAGE_0_PWD_SRST, 0x20);
+
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTLF, 0x07);
+
+		/* Enable timeout */
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTLB,0x01);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL14, 0x03);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL15, 0x80);
+
+		msleep(50);
+
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL0, 0x5C);
+
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL14, 0x00);
+		mhl_pf_write_reg(REG_PAGE_7_COC_CTL15, 0x80);
+
+		mhl_pf_write_reg(REG_PAGE_1_HRXCTRL3, 0x07);
+		mhl_pf_write_reg(REG_PAGE_5_CBUS3_CNVT, 0x85);
+
+		mhl_pf_write_reg(REG_PAGE_1_FCCTR13, 0xFC);
+		mhl_pf_write_reg(REG_PAGE_1_FCCTR14, 0xFF);
+		mhl_pf_write_reg(REG_PAGE_1_FCCTR15, 0xFF);
+		mhl_pf_write_reg(REG_PAGE_1_FCCTR50, 0x03);
+
+		break;
+
+	case CBUS_eCBUS_D:
+		pr_err("Invalid or unsupported CBUS mode "	\
+						"specified\n");
+		break;
+	case CBUS_NO_CONNECTION:
+	case CBUS_oCBUS_PEER_VERSION_PENDING:
+	case CBUS_bCBUS:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S:
+	case CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D:
+	case CBUS_TRANSITIONAL_TO_eCBUS_D_CALIBRATED:
+	default:
+		pr_err("Invalid or unsupported CBUS mode "	\
+						"specified\n");
+		status = -EINVAL;
+		break;
+	}
+
+	return status;
+}
+
+CBUS_MODE_TYPE mhl_device_get_cbus_mode(void)
+{
+	return cbus_mode;
+}
+
+void mhl_device_set_cbus_mode(CBUS_MODE_TYPE mode)
+{
+	cbus_mode = mode;
+}
+
+static ssize_t mhl_device_sysfs_rda_aksv(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	ssize_t ret, rc;
+	uint8_t aksv[5];
+
+	ret = mhl_pf_read_reg_block(REG_PAGE_0_AKSV_1,
+			ARRAY_SIZE(aksv), aksv);
+
+	if (ret != 0) {
+		mhl_pf_chip_power_on();
+		mhl_pf_read_reg_block(REG_PAGE_0_AKSV_1,
+				      ARRAY_SIZE(aksv), aksv);
+		mhl_pf_chip_power_off();
+	}
+
+	rc = snprintf(buf, PAGE_SIZE, "%02X%02X%02X%02X%02X\n",
+			aksv[4], aksv[3], aksv[2], aksv[1], aksv[0]);
+	pr_info("%s: '%02X%02X%02X%02X%02X'\n", __func__,
+				aksv[4], aksv[3], aksv[2], aksv[1], aksv[0]);
+
+	return rc;
+} /* mhl_device_tx_sysfs_rda_aksv */
+
+static ssize_t mhl_device_sysfs_rda_tmds(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	ssize_t rc, ret;
+	int8_t  tmds_status;
+
+	if (!mhl_pf_is_chip_power_on()) {
+		/* tmds is off. */
+		rc = snprintf(buf, PAGE_SIZE, "OFF\n");
+		pr_info("%s: '%s'\n", __func__, "OFF");
+	} else {
+		ret = mhl_pf_read_reg_block(REG_PAGE_6_TPI_SC,
+			1, &tmds_status);
+		/* read tmds status */
+		if (((tmds_status & 0x10) == 0) && (ret == 0)) {
+			rc = snprintf(buf, PAGE_SIZE, "ON\n");
+			pr_info("%s: '%s'\n", __func__, "ON");
+		} else {
+			rc = snprintf(buf, PAGE_SIZE, "OFF\n");
+			pr_info("%s: '%s'\n", __func__, "OFF");
+		}
+	}
+
+	return rc;
+} /* mhl_device_sysfs_rda_tmds */
+
+static ssize_t mhl_device_hdcp_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, sizeof(bool), "%x\n",
+		is_hdcp_support);
+}
+
+static ssize_t mhl_device_hdcp_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int		get_data;
+
+	sscanf(buf, "%x", &get_data);
+
+	if(!get_data)
+		is_hdcp_support = false;
+	else
+		is_hdcp_support = true;
+
+	pr_debug("set is_hdcp_support < 0x%x\n",
+		is_hdcp_support);
+
+	return (ssize_t)count;
+}
+
+static char *mhl_dev_print_cbusp(MHL_DEV_CBUS_P cbusp)
+{
+	switch (cbusp) {
+	case DEV_EDID_READ:
+		return "DEV_EDID_READ";
+	case DEV_RESERVE_P_1:
+		return "DEV_RESERVE_P1";
+	case DEV_RESERVE_P_2:
+		return "DEV_RESERVE_P2";
+	case DEV_RESERVE_P_3:
+		return "DEV_RESERVE_P3";
+	case DEV_WRITE_BURST_SEND:
+		return "DEV_WRITE_BURST_SEND";
+	case DEV_RAP_SEND:
+		return "DEV_RAP_SEND";
+	case TERMINATE:/* nothing to do */
+		break;
+	default:/* nothing to do */
+		break;
+	}
+
+	return "unknown";
+}
+
+#define MHL_DEV_IS_BIT_ACTIVE(_val, _bit) (_val & (0x01 << _bit))
+
+static void mhl_dev_print_cbusp_cond(void)
+{
+	if (MHL_DEV_IS_BIT_ACTIVE(cbusp_processing_cond, 1))
+		pr_debug("%s: DEV_EDID_READ = 1\n", __func__);
+	else
+		pr_debug("%s: DEV_EDID_READ = 0\n", __func__);
+
+	if (MHL_DEV_IS_BIT_ACTIVE(cbusp_processing_cond, 4))
+		pr_debug("%s: DEV_WRITE_BURST_SEND = 1\n", __func__);
+	else
+		pr_debug("%s: DEV_WRITE_BURST_SEND = 0\n", __func__);
+}
+
+void mhl_dev_set_cbusp_cond_processing(MHL_DEV_CBUS_P cbusp)
+{
+	pr_debug("%s: %s\n", __func__, mhl_dev_print_cbusp(cbusp));
+
+	cbusp_processing_cond |= (int)cbusp;
+
+	mhl_dev_print_cbusp_cond();
+}
+
+void mhl_dev_clear_cbusp_cond_processing(MHL_DEV_CBUS_P cbusp)
+{
+	pr_debug("%s: %s\n", __func__, mhl_dev_print_cbusp(cbusp));
+
+	cbusp_processing_cond &= (int)~cbusp;
+
+	mhl_dev_print_cbusp_cond();
+}
+
+int mhl_device_get_cbusp_cond(void)
+{
+	pr_debug("%s: cbus protocol cond: 0x%04x\n",
+	 __func__, cbusp_processing_cond);
+
+	mhl_dev_print_cbusp_cond();
+
+	return cbusp_processing_cond;
+}
+
+bool mhl_device_is_cbusb_executing(void)
+{
+	mhl_dev_print_cbusp_cond();
+
+	if (cbusp_processing_cond) {
+		pr_info("%s: yes. val=0x%2x\n",
+			__func__, cbusp_processing_cond);
+		return true;
+	} else {
+		pr_debug("%s: no\n", __func__);
+		return false;
+	}
+}
+
+#ifndef UNIT_TEST
+static DEVICE_ATTR(aksv, 0664, mhl_device_sysfs_rda_aksv, NULL);
+static DEVICE_ATTR(tmds, 0664, mhl_device_sysfs_rda_tmds, NULL);
+static DEVICE_ATTR(hdcp, 0660, mhl_device_hdcp_show, mhl_device_hdcp_store);
+static int mhl_device_sysfs_init(struct device *parent)
+{
+	int rc;
+	struct class *cls = parent->class;
+
+	if (IS_ERR(cls)) {
+		pr_err("%s: failed to create class", __func__);
+	return -ENOMEM;
+	}
+
+	dev.class = cls;
+	dev.parent = parent;
+	dev_set_name(&dev, "hdcp");
+
+	rc = device_register(&dev);
+	if (rc) {
+		class_destroy(dev.class);
+		pr_err("%s: failed to register device", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&dev, &dev_attr_aksv);
+	if (rc) {
+		pr_err("%s: failed to create file for aksv\n", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&dev, &dev_attr_tmds);
+	if (rc) {
+		pr_err("%s: failed to create file for tmds\n", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&dev, &dev_attr_hdcp);
+	if (rc) {
+		pr_err("%s: failed to create file for hdcp\n", __func__);
+		return rc;
+	}
+	return 0;
+}
+
+static void mhl_device_sysfs_release(void)
+{
+	device_remove_file(&dev, &dev_attr_aksv);
+	device_remove_file(&dev, &dev_attr_tmds);
+	device_remove_file(&dev, &dev_attr_hdcp);
+	device_unregister(&dev);
+}
+#endif
+
+int start_video(void)
+{
+	pr_debug("%s called\n", __func__);
+
+	/* stop hdcp and video */
+	if (! IS_MODE_MHL3) {
+		stop_video();
+	}
+
+	/* check HPD status again */
+	if (mhl_device_is_connected() == false) {
+		return false;
+	}
+
+	/* start video should not be done if no PATH_EN received */
+	if (get_cond_in_cbus_control(SENT_PATH_EN_1) == false) {
+		return false;
+	}
+
+	if (IS_MODE_HDMI) { /* HDMI mode */
+		mhl_pf_write_reg(REG_PAGE_2_RX_HDMI_CTRL2,
+				 rx_hdmi_ctrl2_defval = REG_RX_HDMI_CTRL2_DEFVAL_HDMI
+				 | VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_AVI);
+
+		if (false == set_hdmi_params()) {
+			return false;
+		}
+
+		if (IS_MODE_MHL3) {
+			mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+					  VAL_PAGE_3_M3_CTRL_MHL3_VALUE |
+					  BIT_PAGE_3_M3_CTRL_H2M_SWRST);
+
+			/* Deassert H2M reset */
+			mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+					 VAL_PAGE_3_M3_CTRL_MHL3_VALUE);
+		} else {
+			set_auto_zone_for_mhl_1_2();
+
+			if (mhl_device_get_hdcp_status())
+				start_hdcp();
+			else
+				unmute_video();
+		}
+
+		/* Write AVIF for Outgoing Payload */
+		mhl_pf_write_reg_block(REG_PAGE_6_TPI_AVI_CHSUM,
+				       sizeof(outgoingAviPayLoad.ifData),
+				       (uint8_t *)&outgoingAviPayLoad.ifData);
+
+		/* Change Packet Filter */
+		mhl_pf_write_reg(REG_PAGE_2_PKT_FILTER_0, 0xA5);
+
+		if (IS_MODE_MHL3) {
+			enum info_sel_e{
+				info_sel_avi = 0,
+				info_sel_spd,
+				info_sel_audio,
+				info_sel_mpeg,
+				info_sel_generic,
+				info_sel_generic2,
+				info_sel_vsi,
+				info_sel_reserved
+			};
+			uint8_t vsif_buffer[31];
+			/*
+			 * disable HDMI to MHL VSIF conversion (do it in software) (set bit 7)
+			 * and drop generic infoframes (set bit 1)
+			 */
+			mhl_pf_write_reg(REG_PAGE_2_PKT_FILTER_1,
+					 BIT_PAGE_2_PKT_FILTER_1_VSI_OVERRIDE_DIS
+					 | BIT_PAGE_2_PKT_FILTER_1_DROP_GEN_PKT
+					 | BIT_PAGE_2_PKT_FILTER_1_DROP_VSIF_PKT);
+
+			mhl_pf_write_reg(REG_PAGE_6_TPI_INFO_FSEL,
+					 BIT_PAGE_6_TPI_INFO_FSEL_TPI_INFO_EN
+					 |BIT_PAGE_6_TPI_INFO_FSEL_TPI_INFO_RPT
+					 | info_sel_vsi);
+
+			/* hardware takes effect on the write to TPI_INFO_B30,
+				and checksum is calculated on just the first part,
+				so pad the remainder of the buffer
+			*/
+			memset(vsif_buffer, 0, sizeof(vsif_buffer));
+			memcpy(vsif_buffer, (uint8_t *)&outgoing_mhl3_vsif,
+			       sizeof(outgoing_mhl3_vsif));
+			mhl_pf_write_reg_block(REG_PAGE_6_TPI_INFO_B0,
+					       sizeof(vsif_buffer),
+					       (uint8_t *)vsif_buffer);
+
+			set_cond_in_cbus_control(HDCP_READY);
+			if (get_cond_in_cbus_control(TMDS_READY)) {
+				/*
+				  if the hdcp is started here,
+				  TMDS must be stable before starting hdcp.
+				  100msec wait is enough
+				  for making the stable condition.
+				 */
+				msleep(100);
+				pr_warn("LINK_STATUS is already normal");
+				pr_warn("Start HDCP\n");
+				start_hdcp();
+			}
+		} else {
+			/* enable HDMI to MHL_VSIF conversion */
+			mhl_pf_write_reg(REG_PAGE_2_PKT_FILTER_1,
+					 BIT_PAGE_2_PKT_FILTER_1_DROP_GEN_PKT);
+		}
+	} else {
+		/* DVI mode */
+		mhl_pf_write_reg(REG_PAGE_2_RX_HDMI_CTRL2,
+				 rx_hdmi_ctrl2_defval = REG_RX_HDMI_CTRL2_DEFVAL_DVI
+				 | VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_AVI);
+
+		/* FIXME hdcp needs to be disabled when HDCP_SUPPORT is not defined */
+		if (mhl_device_get_hdcp_status())
+			start_hdcp();
+		else
+			unmute_video();
+	}
+
+	return true;
+}
+
+int stop_video(void)
+{
+	pr_debug("%s called\n", __func__);
+
+	/* Set Not a during HDCP Authentication. */
+	hdcp_authentication = false;
+	/* send HDCP FAIL uevent */
+	mhl_tx_send_hdcp_state(HDCP_STATE_AUTH_FAIL);
+
+	if (IS_MODE_MHL3) {
+		int ddcm_status;
+
+		pr_debug("%s: for >= MHL3.0\n", __func__);
+
+		/* disable TMDS early */
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL0, 0xC0);
+
+		/* Invert Dp and Dn to stop video */
+		mhl_pf_write_reg(REG_PAGE_3_M3_CTRL,
+				 VAL_PAGE_3_M3_CTRL_MHL3_VALUE
+				 | BIT_PAGE_3_M3_CTRL_H2M_SWRST);
+
+		/* Turn off HDCP 2.2 interrupt */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0_MASK, 0x00);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_POLL_CS, 0x71);
+
+		{
+			int count = 0;
+			while (0 <= (ddcm_status
+					= mhl_pf_read_reg(
+						REG_PAGE_3_HDCP2X_DDCM_STS))) {
+				if (0 == (MSK_PAGE_3_HDCP2X_DDCM_STS_HDCP2X_DDCM_CTL_CS_3_0
+						& ddcm_status))
+					break;
+
+				if (++count > 256)
+					break;
+				pr_debug("%s: shutting down HDCP\n", __func__);
+			}
+		}
+
+		/* disable encryption */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_CTRL_0, 0x82);
+
+		mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+			 BIT_PAGE_3_M3_P0CTRL_MHL3_P0_HDCP_EN,
+			 0x00);
+
+		pr_debug("%s: HDCP2 Off; Last HDCP2X_DDCM Status %02X;\n",
+			 __func__, ddcm_status);
+
+		/* clear any leftover hdcp2 interrupts */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0, 0xff);
+
+	} else {
+
+		pr_debug("%s: for MHL1/2.x\n", __func__);
+
+		/* Turn off HDCP interrupt */
+		mhl_pf_write_reg(REG_PAGE_6_TPI_INTR_EN , 0x00);
+
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0_MASK, 0x00);
+
+		/* stop hdcp engine */
+		mhl_pf_write_reg(REG_PAGE_6_TPI_COPP_DATA2, 0);
+
+		/* clear any leftover hdcp interrupt */
+		mhl_pf_write_reg(REG_PAGE_6_TPI_INTR_ST0, 0xff);
+
+		/* We must maintain the output bit (bit 0) to allow just one bit change
+		 * later when BKSV read is triggered. This programming is required for HDCP CTS 1.x to pass */
+		if (IS_MODE_HDMI) {
+			mhl_pf_write_reg(REG_PAGE_6_TPI_SC, 
+					 VAL_PAGE_6_TPI_SC_REG_TMDS_OE_POWER_DOWN
+					 | VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_MUTED
+					 | VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_HDMI);
+		} else {
+			mhl_pf_write_reg(REG_PAGE_6_TPI_SC, 
+					 VAL_PAGE_6_TPI_SC_REG_TMDS_OE_POWER_DOWN
+					 | VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_MUTED
+					 | VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_DVI);
+		}
+	}
+
+	return 0;
+}
+
+static void unmute_video(void)
+{
+	pr_info("%s called\n", __func__);
+
+	if (IS_MODE_MHL3) {
+	} else {
+		if (IS_MODE_HDMI) {
+			mhl_pf_write_reg(REG_PAGE_6_TPI_SC, VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_HDMI);
+		} else {
+			mhl_pf_write_reg(REG_PAGE_6_TPI_SC, VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_DVI);
+		}
+	}
+
+	set_cond_in_cbus_control(UPSTREAM_VIDEO_READY);
+}
+
+static void start_hdcp_content_type(void)
+{
+	uint8_t misc_ctrl;
+	uint8_t index;
+	uint8_t msg[2] = { 0x01, 0x00 }; /* One Stream */
+
+	pr_debug("%s: HDCP Content Type = %d\n", __func__,  msg[1]);
+
+	misc_ctrl = mhl_pf_read_reg(REG_PAGE_3_HDCP2X_MISC_CTRL);
+
+	/*
+	* Toggle SMNG_WR_START
+	*/
+	mhl_pf_write_reg(REG_PAGE_3_HDCP2X_MISC_CTRL, misc_ctrl |
+			BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_SMNG_WR_START);
+	mhl_pf_write_reg(REG_PAGE_3_HDCP2X_MISC_CTRL, misc_ctrl);
+
+	/* Write message */
+	for (index = 0; index < 2; index++) {
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_RPT_SMNG_IN, msg[index]);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_MISC_CTRL, misc_ctrl |
+			BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_SMNG_WR);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_MISC_CTRL, misc_ctrl);
+	}
+}
+
+void start_hdcp(void)
+{
+	pr_info("%s called\n", __func__);
+
+	/* Already during HDCP Authentication. */
+	if (hdcp_authentication) {
+		pr_warn("%s Already Authenticated.\n", __func__);
+		return;
+	}
+
+	/* Set During HDCP Authentication. */
+	hdcp_authentication = true;
+
+	if (IS_MODE_MHL3) {
+
+		start_hdcp_content_type();
+
+		/* Unmask HDCP2 INTs */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_INTR0_MASK,
+				 BIT_HDCP2_INTR_AUTH_DONE |
+				 BIT_HDCP2_INTR_AUTH_FAIL |
+				 BIT_HDCP2_INTR_RPTR_RCVID_CHANGE);
+
+		/* Enable HDCP 2.2 */
+		mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_HDCP_EN,
+			BIT_PAGE_3_M3_P0CTRL_MHL3_P0_HDCP_EN);
+
+		/* enable encryption */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_CTRL_0, 0x83);
+
+		/* Enable HDCP2 DDC polling */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_POLL_CS, 0x70);
+
+		/* hdcp2_apply_reauthentication */
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_RPT_SMNG_K, 1);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_CTRL_1, 0x01);
+		mhl_pf_write_reg(REG_PAGE_3_HDCP2X_CTRL_1, 0x00);
+
+	} else {
+		stop_video();
+		
+		/* Ensure we get HDCP interrupts now onwards. Clear interrupt first. */
+		mhl_pf_write_reg(REG_PAGE_6_TPI_INTR_ST0, 0xff);
+
+		if (mhl_device_is_connected()) {
+
+			/* Turn on HDCP interrupt */
+			mhl_pf_write_reg(REG_PAGE_6_TPI_INTR_EN,
+					 (BIT_PAGE_6_TPI_INTR_ST0_TPI_AUTH_CHNGE_STAT
+					  | BIT_PAGE_6_TPI_INTR_ST0_TPI_COPP_CHNGE_STAT
+					  | BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_BCAPS_DONE_STAT
+					  | BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_ERR_STAT
+						 ));
+			
+			msleep(250);
+			/*
+			 * Chip requires only bit 4 to change for BKSV read
+			 * No other bit should change.
+			 */
+
+			mhl_pf_modify_reg(REG_PAGE_6_TPI_SC,
+					  BIT_PAGE_6_TPI_SC_REG_TMDS_OE,
+					  VAL_PAGE_6_TPI_SC_REG_TMDS_OE_ACTIVE);
+		}
+	}
+}
+
+static void process_info_frame_change(vendor_specific_info_frame_t *vsif,
+				      avi_info_frame_t *avif)
+{
+	bool mode_change = false;
+	pr_debug("%s called\n", __func__);
+
+	if (NULL != vsif) {
+		if (is_valid_vsif(vsif)) {
+			pr_debug("VSIF is valid\n");
+			current_vs_info_frame = *vsif;
+			valid_vsif = 1;
+			mode_change = true;
+		}
+	}
+	if (NULL != avif) {
+		if (is_valid_avif(avif)) {
+			pr_debug("AVIF is valid\n");
+			current_avi_info_frame = *avif;
+			valid_avif = 1;
+			mode_change = true;
+		}
+	}
+	if (mode_change) {
+		int cstat_p3;
+		int bits_of_interest;
+		cstat_p3 = mhl_pf_read_reg(REG_PAGE_2_TMDS_CSTAT_P3);
+		bits_of_interest = cstat_p3 & (BIT_PAGE_2_TMDS_CSTAT_P3_SCDT | BIT_PAGE_2_TMDS_CSTAT_P3_CKDT);
+
+		if ((BIT_PAGE_2_TMDS_CSTAT_P3_SCDT | VAL_PAGE_2_TMDS_CSTAT_P3_CKDT_DETECTED)
+			== bits_of_interest) {
+
+			set_cond_in_cbus_control(UPSTREAM_VIDEO_READY);
+			start_video();
+		} else{
+			pr_debug("info frame changed. But SCDT or CKDT is gone\n");
+		}
+	}
+}
+
+uint8_t qualify_pixel_clock_for_mhl(uint32_t pixel_clock_frequency,
+					   uint8_t bits_per_pixel)
+{
+	uint32_t link_clock_frequency;
+	uint32_t max_link_clock_frequency = 0;
+	uint8_t ret_val;
+
+	link_clock_frequency = pixel_clock_frequency * ((uint32_t)(bits_per_pixel >> 3));
+
+	if (IS_MODE_MHL3)
+	{
+		/* FIXME 16bpp mode and TMDS speed have impact on the max value */
+		switch (mhl_cbus_get_highest_tmds_link_speed()) {
+			case MHL_XDC_TMDS_600:
+				max_link_clock_frequency = 600000000;
+				break;
+			case MHL_XDC_TMDS_300:
+				max_link_clock_frequency = 300000000;
+				break;
+			case MHL_XDC_TMDS_150:
+				max_link_clock_frequency = 150000000;
+				break;
+			case MHL_XDC_TMDS_000:
+				max_link_clock_frequency = 000000000;
+				break;
+		}
+	} else {
+		if (mhl_cbus_is_sink_support_ppixel()) {
+			max_link_clock_frequency = 300000000;
+		} else {
+			max_link_clock_frequency = 225000000;
+		}
+	}
+
+	if (link_clock_frequency <  max_link_clock_frequency) {
+		ret_val = 1;
+	} else {
+		ret_val = 0;
+	}
+	pr_debug("%s: Link clock:%u Hz %12s for MHL at %d bpp (max: %u Hz)\n",
+		__func__,
+		link_clock_frequency,
+		ret_val?"valid":"unattainable",
+		(uint16_t)bits_per_pixel,
+		max_link_clock_frequency);
+
+	return ret_val;
+}
+
+#define BIT_EDID_FIELD_FORMAT_HDMI_TO_RGB	0x00
+#define BIT_EDID_FIELD_FORMAT_YCbCr422		0x01
+#define BIT_EDID_FIELD_FORMAT_YCbCr444		0x02
+#define BIT_EDID_FIELD_FORMAT_DVI_TO_RGB	0x03
+
+/* FIXME */
+/* dummy function*/
+static bool is_support_YCbCr422(void){
+	return true;
+}
+
+/* FIXME PENDING. CallBack Function.  */
+static int set_hdmi_params()
+{
+	uint32_t			pixel_clock_frequency;
+	uint8_t				is_compress_mode = 0;
+	AviColorSpace_e			input_clr_spc =acsRGB;
+	uint8_t				output_clr_spc =acsRGB;
+	avi_info_frame_data_byte_4_t	input_video_code;
+	avi_info_frame_data_byte_4_t	output_video_code;
+	enum {
+		use_avi_vic,
+		use_hdmi_vic,
+		use_hardware_totals
+	} timing_info_basis = use_avi_vic;
+	/* default values for MHL3 VSIF, which we will always send */
+	enum mhl_vid_fmt_e vid_fmt 			= mhl_vid_fmt_no_additional;
+	enum mhl_3d_fmt_type_e _3d_fmt_type = mhl_3d_fmt_type_frame_sequential;
+	enum mhl_sep_audio_e sep_aud 		= mhl_sep_audio_not_available;
+	enum mhl_hev_fmt_e hev_fmt			= mhl_hev_fmt_no_additional;
+	uint16_t hev_fmt_type				= 0;
+	uint32_t delay_sync					= 0;
+	enum mhl_av_delay_dir_e	delay_dir	= mhl_av_delay_dir_audio_earlier;
+
+	/* Extract VIC from incoming AVIF */
+	input_video_code = current_avi_info_frame.payLoad.hwPayLoad.namedIfData.
+							ifData_u.bitFields.VIC;
+
+	if (valid_vsif) {
+		pr_debug("%s: valid HDMI VSIF\n", __func__);
+		if (hvfExtendedResolutionFormatPresent == current_vs_info_frame.
+				payLoad.pb4.HDMI_Video_Format) {
+			uint8_t vic = current_vs_info_frame.payLoad.pb5.HDMI_VIC;
+			/* HDMI_VIC should contain one of 0x01 through 0x04 */
+			pr_debug("%s: HDMI extended resolution %d\n", __func__, vic);
+			timing_info_basis = use_hdmi_vic;
+		}else{
+
+			print_vic_modes((uint8_t)input_video_code.VIC);
+			if (0 == input_video_code.VIC) {
+				pr_err("%s: AVI VIC is zero!!!\n", __func__);
+				/*
+				 * Instead of no video, let us attempt HDCP and if possible show video
+				 * If hdcp fails due to clock difference on input (which we don't know
+				 * about clearly), after 5 attempts it will anyways stabilize and use
+				 * an infoframe interrupt if that arrives with a good vic.
+				 *
+				 * TODO: Maybe we should flag arrival of an infoframe from the time
+				 * this path was executed and abort HDCP a bit earlier.
+				 */
+				return	false;
+			}
+		}
+	}else{ /* no incoming HDMI VSIF */
+		if (0 == input_video_code.VIC) {
+			/*
+				This routine will not be called until we positively know (from the downstream EDID)
+					that the sink is HDMI.
+				We do not support DVI only sources.  The upstream source is expected to choose between
+					HDMI and DVI based upon the EDID that we present upstream.
+				The other information in the infoframe, even if it is non-zero, is not helpful for
+					determining the pixel clock frequency.
+				So we try as best we can to infer the pixel clock from the HTOTAL and VTOTAL registers.
+			*/
+			timing_info_basis = use_hardware_totals;
+
+			pr_warn("%s: AVI VIC is zero!!!\n", __func__);
+
+			return false;
+		} else {
+			print_vic_modes((uint8_t)input_video_code.VIC);
+		}
+	}
+
+	mhl_pf_write_reg(REG_PAGE_0_VID_OVRRD, REG_PAGE_0_VID_OVRRD_DEFVAL | BIT_PAGE_0_VID_OVRRD_M1080P_OVRRD);
+
+	/* Do not remember previous VSIF */
+	valid_vsif = 0;
+	valid_avif = 0;
+
+	/* make a copy of avif */
+	outgoingAviPayLoad = current_avi_info_frame.payLoad.hwPayLoad;
+	switch(timing_info_basis){
+	case use_avi_vic:
+
+		/* compute pixel frequency */
+		pixel_clock_frequency = find_pixel_clock_from_AVI_VIC(input_video_code.VIC);
+		output_video_code = input_video_code;
+		break;
+	case use_hdmi_vic:
+		output_video_code.VIC = current_vs_info_frame.payLoad.pb5.HDMI_VIC;
+		pixel_clock_frequency = find_pixel_clock_from_HDMI_VIC(output_video_code.VIC);
+		output_video_code.VIC = hdmi_vic_to_mhl3_vic(output_video_code.VIC);
+		break;
+	case use_hardware_totals:
+		output_video_code = input_video_code;
+		pixel_clock_frequency = find_pixel_clock_from_totals(
+			get_incoming_horizontal_total(),
+			get_incoming_vertical_total());
+		if (0 == pixel_clock_frequency){
+		  pr_debug("%s: VIC was zero and totals not supported\n", __func__);
+			return false;
+		}
+		break;
+	default:
+		pr_err("%s: shouldn't get here, the following assignment"
+			" statement exists to avoid a compiler warning\n",
+			__func__
+		);
+		break;
+	}
+
+	outgoingAviPayLoad.namedIfData.ifData_u.bitFields.VIC =
+		output_video_code;
+
+	/* extract input color space */
+	input_clr_spc = current_avi_info_frame.payLoad.hwPayLoad.namedIfData.
+		ifData_u.bitFields.pb1.colorSpace;
+
+	pr_debug("%s: input_clr_spc = %02X infoData[0]:%02X\n",
+		 __func__,
+		 input_clr_spc,
+		 current_avi_info_frame.payLoad.hwPayLoad.namedIfData.ifData_u.
+		 infoFrameData[0]);
+
+	/*
+	 * decide about packed pixel mode
+	 */
+	pr_debug("%s: pixel clock:%u\n", __func__, pixel_clock_frequency);
+
+	if (qualify_pixel_clock_for_mhl(pixel_clock_frequency,
+					24)) {
+		pr_debug("%s: OK for 24 bit pixels\n", __func__);
+	} else {
+		/* not enough bandwidth for uncompressed video */
+		if (is_support_YCbCr422()) {
+			pr_debug("%s: Sink supports YCbCr422\n", __func__);
+
+			if (qualify_pixel_clock_for_mhl(pixel_clock_frequency,
+							16)) {
+				/* enough for packed pixel */
+				is_compress_mode = 1;
+			} else {
+				pr_warn("%s: unsupported video mode", __func__);
+				return	false;
+			}
+		} else {
+			pr_warn("unsupported video mode. Sink doesn't support 4:2:2.\n");
+			return	false;
+		}
+	}
+
+	/*
+	 * Determine output color space if it needs to be 4:2:2 or same as input
+	 */
+	output_clr_spc = input_clr_spc;
+
+	if (is_compress_mode) {
+		if (IS_MODE_MHL3 && !mhl_cbus_16bpp_available()) {
+			pr_warn("%s: unsupported video mode. 16bpp not available\n",
+				 __func__);
+			return false;
+		} else if (!IS_MODE_MHL3 && !mhl_cbus_packed_pixel_available()) {
+			pr_warn("%s: unsupported video mode. Packed Pixel not available\n",
+				 __func__);
+			return false;
+		} else {
+			pr_debug("%s: setting packed pixel mode\n", __func__);
+
+			set_link_mode(MHL_STATUS_PATH_ENABLED |
+				MHL_STATUS_CLK_MODE_PACKED_PIXEL);
+
+			/* enforcing 4:2:2 if packed pixel. */
+			output_clr_spc = BIT_EDID_FIELD_FORMAT_YCbCr422;
+
+			/* 16BPP mode */
+			if (IS_MODE_MHL3) {
+				mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+					BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE,
+					VAL_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE_PACKED);
+			/* Packed pxcel mode */
+			} else {
+				mhl_pf_write_reg(REG_PAGE_0_VID_MODE,
+						 VAL_PAGE_0_VID_MODE_M1080P_ENABLE);
+				mhl_pf_write_reg(REG_PAGE_3_MHL_TOP_CTL, 0x41);
+				mhl_pf_write_reg(REG_PAGE_2_MHLTX_CTL6, 0x60);
+			}
+		}
+	} else {
+		pr_debug("%s: not complessed. RGB mode.\n", __func__);
+
+		set_link_mode(MHL_STATUS_PATH_ENABLED |
+			MHL_STATUS_CLK_MODE_NORMAL);
+
+		if (IS_MODE_MHL3) {
+			mhl_pf_modify_reg(REG_PAGE_3_M3_P0CTRL,
+				BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE,
+				VAL_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE_NORMAL);
+		} else {
+			mhl_pf_write_reg(REG_PAGE_0_VID_MODE,
+				 VAL_PAGE_0_VID_MODE_M1080P_DISABLE);
+			mhl_pf_write_reg(REG_PAGE_3_MHL_TOP_CTL, 0x01);
+			mhl_pf_write_reg(REG_PAGE_2_MHLTX_CTL6, 0xA0);
+		}
+	}
+
+	/* Set input color space */
+	mhl_pf_write_reg(REG_PAGE_6_TPI_INPUT,
+		(2<<2) | colorSpaceTranslateInfoFrameToHw[input_clr_spc]);
+
+	/* Set output color space */
+	mhl_pf_write_reg(REG_PAGE_6_TPI_OUTPUT,
+		(1<<2) | colorSpaceTranslateInfoFrameToHw[output_clr_spc]);
+
+	if (IS_MODE_MHL3) {
+		MHL_bits_per_pixel_fmt_data_t bpp_fmt;
+		PMHL_bits_per_pixel_fmt_data_t p_buffer;
+		size_t xfer_size;
+		/* only one descriptor to send */
+		xfer_size = sizeof(bpp_fmt)
+			- sizeof(p_buffer->descriptors)
+			+ sizeof(p_buffer->descriptors[0]);
+		p_buffer = mhl_tx_get_sub_payload_buffer(xfer_size);
+
+		if (p_buffer){
+			p_buffer->header.burst_id.low
+				= LOW_BYTE_16(burst_id_BITS_PER_PIXEL_FMT);
+			p_buffer->header.burst_id.high
+				= HIGH_BYTE_16(burst_id_BITS_PER_PIXEL_FMT);
+			p_buffer->header.checksum = 0;
+			p_buffer->header.total_entries = 1;
+			p_buffer->header.sequence_index = 1;
+			p_buffer->num_entries_this_burst = 1;
+			p_buffer->descriptors[0].stream_id = 0;
+			switch (get_link_mode() & MHL_STATUS_CLK_MODE_MASK) {
+			case MHL_STATUS_CLK_MODE_PACKED_PIXEL:
+				p_buffer->descriptors[0].stream_pixel_format
+					= VIEW_PIX_FMT_16BPP;
+				break;
+			case MHL_STATUS_CLK_MODE_NORMAL:
+				p_buffer->descriptors[0].stream_pixel_format
+					= VIEW_PIX_FMT_24BPP;
+				break;
+			}
+			p_buffer->header.checksum=
+				calculate_generic_checksum(
+					(uint8_t *)p_buffer, 0, xfer_size);
+			mhl_tx_push_block_transactions();
+		}
+		mhl_pf_write_reg(REG_PAGE_3_MHL_DP_CTL0, 0xF0);
+
+		/* fill in values for MHL3 VSIF */
+		outgoing_mhl3_vsif.header.type_code = MHL3_VSIF_TYPE;
+		outgoing_mhl3_vsif.header.version_number = MHL3_VSIF_VERSION;
+		outgoing_mhl3_vsif.header.length = sizeof(outgoing_mhl3_vsif);
+		outgoing_mhl3_vsif.checksum = 0;
+		outgoing_mhl3_vsif.iee_oui[0]= (uint8_t)(IEEE_OUI_MHL3 & 0xFF);
+		outgoing_mhl3_vsif.iee_oui[1]= (uint8_t)((IEEE_OUI_MHL3>> 8)& 0xFF);
+		outgoing_mhl3_vsif.iee_oui[2]= (uint8_t)((IEEE_OUI_MHL3 >>16) & 0xFF);
+		outgoing_mhl3_vsif.pb4	= MHL3_VSIF_PB4(vid_fmt,_3d_fmt_type,sep_aud);
+		outgoing_mhl3_vsif.pb5_reserved = 0;
+		outgoing_mhl3_vsif.pb6  = MHL3_VSIF_PB6(hev_fmt);
+		outgoing_mhl3_vsif.mhl_hev_fmt_type.high = HIGH_BYTE_16(hev_fmt_type);
+		outgoing_mhl3_vsif.mhl_hev_fmt_type.low  = LOW_BYTE_16(hev_fmt_type);
+		outgoing_mhl3_vsif.pb9  = MHL3_VSIF_PB9(delay_sync,delay_dir);
+		outgoing_mhl3_vsif.av_delay_sync.high    = HIGH_BYTE_16(delay_sync);
+		outgoing_mhl3_vsif.av_delay_sync.low     = LOW_BYTE_16(delay_sync);
+
+		outgoing_mhl3_vsif.checksum =
+			calculate_generic_checksum((uint8_t *)&outgoing_mhl3_vsif,
+						   0, outgoing_mhl3_vsif.header.length);
+
+		/*
+		 * Program TMDS link speeds
+		*/
+		switch(get_link_mode() & MHL_STATUS_CLK_MODE_MASK) {
+		case MHL_STATUS_CLK_MODE_PACKED_PIXEL:
+			mhl_cbus_set_lowest_tmds_link_speed(
+				pixel_clock_frequency, 16);
+			break;
+		case MHL_STATUS_CLK_MODE_NORMAL:
+			mhl_cbus_set_lowest_tmds_link_speed(
+				pixel_clock_frequency, 24);
+			break;
+		}
+	} else
+		send_link_mode_to_sink();
+
+	outgoingAviPayLoad.namedIfData.checksum = 0;
+	outgoingAviPayLoad.namedIfData.ifData_u.bitFields.pb1.colorSpace
+		= output_clr_spc;
+	outgoingAviPayLoad.ifData[1] &= 0x7F;
+	outgoingAviPayLoad.ifData[4] &= 0x7F;
+	outgoingAviPayLoad.namedIfData.checksum =
+		calculate_avi_info_frame_checksum(&outgoingAviPayLoad);
+
+	return true;
+}
+
+static uint16_t get_incoming_horizontal_total()
+{
+	uint16_t ret_val;
+
+	ret_val = (((uint16_t)mhl_pf_read_reg(REG_PAGE_0_H_RESH)) << 8) |
+		(uint16_t)mhl_pf_read_reg(REG_PAGE_0_H_RESL);
+	return ret_val;
+}
+
+static uint16_t get_incoming_vertical_total()
+{
+	uint16_t ret_val;
+
+	ret_val = (((uint16_t)mhl_pf_read_reg(REG_PAGE_0_V_RESH)) << 8) |
+		(uint16_t)mhl_pf_read_reg(REG_PAGE_0_V_RESL);
+	return ret_val;
+}
+
+bool is_video_muted(void)
+{
+	bool flag;
+	uint8_t	reg;
+
+	reg = mhl_pf_read_reg(REG_PAGE_6_TPI_SC);
+	if (VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_MUTED & reg)
+		flag = true;
+	else
+		flag = false;
+
+	return flag;
+}
+
+bool is_tmds_active(void)
+{
+	bool flag;
+	uint8_t	reg;
+
+	reg = mhl_pf_read_reg(REG_PAGE_6_TPI_SC);
+	if (BIT_PAGE_6_TPI_SC_REG_TMDS_OE & reg)
+		flag = false;
+	else
+		flag = true;
+
+	return flag;
+}
+
+

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.h
@@ -1,0 +1,175 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_8061_device.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawaaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_MHL_SII8620_8061_DEVICE_H__
+#define __MHL_MHL_SII8620_8061_DEVICE_H__
+#include <linux/platform_device.h>
+#include "mhl_lib_edid.h"
+
+#define VAL_PAGE_3_M3_CTRL_MHL3_VALUE (BIT_PAGE_3_M3_CTRL_SW_MHL3_SEL \
+						|BIT_PAGE_3_M3_CTRL_M3AV_EN \
+						|BIT_PAGE_3_M3_CTRL_ENC_TMDS \
+						|BIT_PAGE_3_M3_CTRL_MHL3_MASTER_EN)
+#define VAL_PAGE_3_M3_CTRL_PEER_VERSION_PENDING_VALUE VAL_PAGE_3_M3_CTRL_MHL3_VALUE
+
+#define IS_MODE_MHL3 (cbus_mode > CBUS_oCBUS_PEER_IS_MHL1_2)
+#define IS_MODE_HDMI mhl_lib_edid_is_hdmi()
+
+#define REG_PAGE_3_MHL_DP_CTL6                             TX_PAGE_3,0x50
+#define REG_PAGE_3_MHL_DP_CTL7                             TX_PAGE_3,0x51
+
+#define REG_PAGE_7_COC_CTL17                               TX_PAGE_7,0x2A
+#define REG_PAGE_7_COC_CTL18                               TX_PAGE_7,0x2B
+#define REG_PAGE_7_COC_CTL19                               TX_PAGE_7,0x2C
+#define REG_PAGE_7_COC_CTL1A                               TX_PAGE_7,0x2D
+
+#define REG_080C_HDCP1X_LB_BIST				TX_PAGE_8, 0x0C
+#define BIT_080C_HDCP1X_LB_BIST				0x01
+/*
+ * core : public. Normally, Outside of device module uses them.
+ */
+/* device cbus protocol type bit assignment */
+typedef enum {
+	DEV_EDID_READ   = 0x01,
+
+	DEV_RESERVE_P_1 = 0x02,/*DCAP READ?*/
+	DEV_RESERVE_P_2 = 0x04,/*HDCP?*/
+	DEV_RESERVE_P_3 = 0x08,/*FEAT?*/
+	DEV_WRITE_BURST_SEND = 0x10,
+	DEV_RAP_SEND = 0x20,/*RAP Command*/
+
+	TERMINATE
+} MHL_DEV_CBUS_P;
+
+int  mhl_device_initialize(struct device *dev);
+void mhl_device_release(struct device *dev);
+void mhl_device_isr (void);
+int mhl_sii8620_device_start(void *context);
+
+/* some cbus protocol is executing, return true, otherwise false. The
+ * detail can be detected with calling mhl_device_get_cbusp_cond(). */
+bool mhl_device_is_cbusb_executing(void);
+
+/* return cbus protocol execution condition.
+ * each bit assignement is according to MHL_DEV_CBUS_P. */
+int mhl_device_get_cbusp_cond(void);
+
+
+/*
+ * core : private. only for mhl device sub modules.
+ * e.g. mhl_xxx_device_xxx.c
+ */
+/* set or clear cbusp (cbus protocol) condition */
+void mhl_dev_set_cbusp_cond_processing(MHL_DEV_CBUS_P cbusp);
+void mhl_dev_clear_cbusp_cond_processing(MHL_DEV_CBUS_P cbusp);
+
+
+/*
+ * isr
+ * The API is for mhl edid function. Other external
+ * module normally shouldn't use it.
+ */
+int int_scdt_isr(uint8_t int_scdt_status);
+
+
+/*
+ * EDID
+ */
+int mhl_sii8620_device_edid_read_request(uint8_t block_number);
+
+/* this define must not be used directory since test code is referring  */
+#define EDID_BLOCK_MAX_NUM		4
+
+void mhl_sii8620_device_edid_init(void);
+void mhl_sii8620_device_edid_release(void);
+int mhl_sii8620_device_get_edid_fifo_partial_block(
+	uint8_t start,
+	uint8_t length,
+	uint8_t *edid_buf);
+int mhl_sii8620_device_edid_get_block_number(void);
+int mhl_8620_dev_int_edid_isr(uint8_t int_edid_devcap_status);
+void mhl_device_start_edid_read(void);
+void mhl_sii8620_device_edid_reset_ddc_fifo(void);
+bool mhl_device_edid_is_command_executing(void);
+void mhl_device_edid_set_upstream_edid(void);
+const uint8_t *mhl_device_edid_get_mhlsink_sprt_hev(uint8_t *length);
+void mhl_device_edid_setup_sink_support_hev_vic(uint8_t *vics, uint8_t length);
+void mhl_device_edid_init_edid_done_resource(void);
+void hdcp2_apply_reauthentication(void);
+bool mhl_device_get_hdcp_status(void);
+
+#define SUPPORT_MHL_1_2_VIDEO_NUM 6
+#define SUPPORT_MHL_3_VIDEO_NUM   SUPPORT_MHL_1_2_VIDEO_NUM + 2
+
+
+
+
+/*
+ * VIDEO Control
+ */
+int start_video(void);
+int stop_video(void);
+bool is_video_muted(void);
+bool is_tmds_active(void);
+void start_hdcp(void);
+
+/*
+ * hpd
+ */
+int drive_hpd_high(void);
+int drive_hpd_low(void);
+bool mhl_dev_is_set_hpd(void);
+
+
+/*
+ * cbus control
+ */
+typedef enum {
+	CBUS_NO_CONNECTION = 0,
+	CBUS_oCBUS_PEER_VERSION_PENDING,
+	CBUS_oCBUS_PEER_IS_MHL1_2,
+	CBUS_oCBUS_PEER_IS_MHL3,
+	CBUS_bCBUS,
+	CBUS_TRANSITIONAL_TO_eCBUS_S,
+	CBUS_TRANSITIONAL_TO_eCBUS_S_CALIBRATED,
+	CBUS_TRANSITIONAL_TO_eCBUS_D,
+	CBUS_TRANSITIONAL_TO_eCBUS_D_CALIBRATED,
+	CBUS_eCBUS_S,
+	CBUS_eCBUS_D
+} CBUS_MODE_TYPE;
+
+CBUS_MODE_TYPE mhl_device_get_cbus_mode(void);
+void mhl_device_set_cbus_mode(CBUS_MODE_TYPE mode);
+
+bool mhl_cbus_is_sink_support_ppixel(void);
+bool mhl_cbus_is_source_support_ppixel(void);
+bool mhl_cbus_packed_pixel_available(void);
+
+bool mhl_cbus_is_sink_support_16bpp(void);
+bool mhl_cbus_is_source_support_16bpp(void);
+bool mhl_cbus_16bpp_available(void);
+
+bool mhl_device_is_peer_device_mhl3(void);
+bool mhl_device_is_peer_device_mhl1_2(void);
+int mhl_drv_connection_is_mhl3(void);
+int mhl_device_switch_cbus_mode(CBUS_MODE_TYPE mode_sel);
+bool mhl_device_is_connected(void);
+void peer_specific_init(void);
+void enable_heartbeat(void);
+
+uint8_t qualify_pixel_clock_for_mhl(uint32_t pixel_clock_frequency,
+					   uint8_t bits_per_pixel);
+
+void mhl_device_chip_reset(void);
+
+#endif /* __MHL_MHL_SII8620_8061_DEVICE_H__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_device_edid.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_device_edid.c
@@ -1,0 +1,1043 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_sii8620_device_edid.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawasaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "linux/string.h"
+
+#include "mhl_sii8620_8061_device.h"
+#include "si_8620_regs.h"
+#include "mhl_platform.h"
+#include "mhl_common.h"
+#include <linux/delay.h>
+#include <linux/errno.h>
+#include "mhl_lib_timer.h"
+#include "mhl_cbus_control.h"
+
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+/* SCDT */
+#define BIT_INTR_SCDT_CHANGE	BIT_PAGE_0_INTR5_INTR5_STAT0
+
+/* EDID */
+#define REG_EDID_FIFO_INT_MASK	REG_PAGE_2_INTR9_MASK /*TX_PAGE_2, 0xE1*/
+#define BIT_INTR9_EDID_ERROR_MASK	BIT_PAGE_2_INTR9_MASK_INTR9_MASK6
+#define BIT_INTR9_EDID_DONE_MASK	BIT_PAGE_2_INTR9_MASK_INTR9_MASK5
+#define BIT_INTR9_DEVCAP_DONE_MASK	BIT_PAGE_2_INTR9_MASK_INTR9_MASK4
+#define VAL_INTR9_EDID_ERROR_MASK	VAL_PAGE_2_INTR9_MASK_INTR9_MASK6_ENABLE
+#define VAL_INTR9_EDID_DONE_MASK	VAL_PAGE_2_INTR9_MASK_INTR9_MASK5_ENABLE
+
+#define BIT_INTR9_EDID_ERROR	BIT_PAGE_2_INTR9_INTR9_STAT6
+#define BIT_INTR9_EDID_DONE	BIT_PAGE_2_INTR9_INTR9_STAT5
+#define BIT_INTR9_DEVCAP_DONE	BIT_PAGE_2_INTR9_INTR9_STAT4
+
+/* 6s is enough to clear edid done */
+#define MHL_CRL_EDID_DONE_TIME 6000
+
+typedef enum {
+	block_0 = 0,
+	block_1 = 128,
+} EDID_FIFO_BLOCK_OFFSET;
+
+static bool edid_is_ext_block(uint8_t *edid);
+
+#define IS_BLOCK_0(_edid)   mhl_edid_check_edid_header(_edid)
+#define IS_EXT_BLOCK(_edid) edid_is_ext_block(_edid)
+
+
+
+/*[vic], [H.Pixel], [Aspect ratio | Refresh Rate], est timing1, 2, 3 */
+/* todo separate standard timing info */
+#define HDMI_VFRMT_640x480p60_4_3_TIMING    {1,  (uint32_t)0x31, (uint32_t)0x40, (uint32_t)0x20, 0, 0}
+#define HDMI_VFRMT_720x480p60_16_9_TIMING   {3,  (uint32_t)0x3B, (uint32_t)0xC0, 0, 0, 0}
+#define HDMI_VFRMT_1280x720p60_16_9_TIMING  {4,  (uint32_t)0x81, (uint32_t)0xC0, 0, 0, 0}
+#define HDMI_VFRMT_1920x1080p60_16_9_TIMING	{16, (uint32_t)0xD1, (uint32_t)0xC0, 0, 0, 0}
+#define HDMI_VFRMT_1920x1080p24_16_9_TIMING {32, (uint32_t)0xD1, (uint32_t)0xE0, 0, 0, 0}
+#define HDMI_VFRMT_1920x1080p30_16_9_TIMING {34, (uint32_t)0xD1, (uint32_t)0xE0, 0, 0, 0}
+#define HDMI_VFRMT_3840x2160p24_16_9_TIMING {93, (uint32_t)0xC1, (uint32_t)0xE0, 0, 0, 0}
+#define HDMI_VFRMT_3840x2160p30_16_9_TIMING {95, (uint32_t)0xC1, (uint32_t)0xE0, 0, 0, 0}
+
+#define RX_DPD_BITS (BIT_PAGE_0_DPD_PDNRX12 \
+			  | BIT_PAGE_0_DPD_PDIDCK_N \
+			  | BIT_PAGE_0_DPD_PD_MHL_CLK_N)
+
+static const struct mhl_video_timing_info mhl_1_2_support_video[SUPPORT_MHL_1_2_VIDEO_NUM] = {
+	HDMI_VFRMT_640x480p60_4_3_TIMING,
+	HDMI_VFRMT_720x480p60_16_9_TIMING,
+	HDMI_VFRMT_1280x720p60_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p60_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p24_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p30_16_9_TIMING
+};
+
+static const struct mhl_video_timing_info mhl_3_support_video[SUPPORT_MHL_3_VIDEO_NUM] = {
+	/* same as MHL 1/2*/
+	HDMI_VFRMT_640x480p60_4_3_TIMING,
+	HDMI_VFRMT_720x480p60_16_9_TIMING,
+	HDMI_VFRMT_1280x720p60_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p60_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p24_16_9_TIMING,
+	HDMI_VFRMT_1920x1080p30_16_9_TIMING,
+	/* newly 4k vic is added to MHL 1/2 in MHL3 */
+	HDMI_VFRMT_3840x2160p24_16_9_TIMING,
+	HDMI_VFRMT_3840x2160p30_16_9_TIMING
+};
+
+/*
+ * supported display info. high quality display info must be aligned in the low quality order.
+ * (index 0 is low quality)
+ *
+ * NOTE : "quality" is currently based on resolution size.
+ * High resolution is currently high quality.
+ *
+ * TODO : it must be meged with MHL1/2 and MHL3 support display information!!
+ */
+const struct hdmi_edid_video_mode_property_type
+	preferred_disp_info[] = {
+
+		/* All 640 H Active */
+		{HDMI_VFRMT_640x480p60_4_3, 640, 480, false, 800, 160, 525, 45,
+		31465, 59940, 25175, 59940, true},
+
+		{HDMI_VFRMT_640x480p60_4_3, 640, 480, false, 800, 160, 525, 45,
+		31500, 60000, 25200, 60000, true},
+
+		/* All 720 H Active */
+		{HDMI_VFRMT_720x480p60_4_3,  720, 480, false, 858, 138, 525, 45,
+		31465, 59940, 27000, 59940, true},
+
+		{HDMI_VFRMT_1280x720p60_16_9,  1280, 720, false, 1650, 370, 750, 30,
+		44955, 59940, 74176, 59940, false},
+
+		{HDMI_VFRMT_1920x1080p24_16_9, 1920, 1080, false, 2750, 830, 1125,
+		45, 27000, 24000, 74250, 24000, false},
+
+		{HDMI_VFRMT_1920x1080p30_16_9, 1920, 1080, false, 2200, 280, 1125,
+		45, 33716, 29970, 74176, 30000, false}
+};
+
+/* EDID retry */
+#define EDID_RETRY_MAX 3
+static int edid_retry_cnt;
+
+static uint8_t mhl_sink_sprt_hev_vic[20];
+
+/* support vic for mhl 1/2 */
+static uint8_t mhl_1_2_support_vic_array[SUPPORT_MHL_1_2_VIDEO_NUM];
+
+/* support vic for mhl 3 */
+static uint8_t mhl_3_support_vic_array[SUPPORT_MHL_3_VIDEO_NUM];
+
+static void mhl_dev_edid_setup_support_video(void)
+{
+	int i = 0;
+
+	pr_debug("%s:mhl1/2 vic setup\n", __func__);
+	for (i = 0; i < SUPPORT_MHL_1_2_VIDEO_NUM; i++) {
+		mhl_1_2_support_vic_array[i] = mhl_1_2_support_video[i].vic;
+		pr_debug("set support vic=%d\n", mhl_1_2_support_vic_array[i]);
+	}
+
+	pr_debug("%s:mhl3 vic setup\n", __func__);
+	for (i = 0; i < SUPPORT_MHL_3_VIDEO_NUM; i++) {
+		mhl_3_support_vic_array[i] = mhl_3_support_video[i].vic;
+		pr_debug("set support vic=%d\n", mhl_3_support_vic_array[i]);
+	}
+}
+
+static bool isMhlSuptFilter;
+static void mhl_dev_edid_mhlsink_hev_init(void);
+
+
+static void edid_filter_prune_ext_blk(uint8_t *edid);
+static void mhl_sii8620_device_set_edid_block_size(uint8_t size);
+static void edid_filter_prune_block_0(uint8_t *blk0);
+
+/* DEBUG */
+#ifdef EDID_DATA_DEBUG_PRINT
+#define DUMP_EDID_BLOCK(override, pData, length) dump_EDID_block_impl(__func__, __LINE__, override, (uint8_t *)pData, length);
+static void dump_EDID_block_impl(const char *pszFunction, int iLineNum, uint8_t override, uint8_t *pData, uint16_t length)
+{
+	uint16_t i;
+	pr_debug("%s:%d EDID DATA:\n", pszFunction, iLineNum);
+
+	for (i = 0; i < length; ) {
+		uint16_t j;
+		uint16_t temp = i;
+
+		for (j = 0; (j < 16) && (i < length); ++j, ++i)
+			printk("%02X ", pData[i]);
+
+		printk(" | ");
+
+		for (j = 0; (j < 16) && (temp < length); ++j, ++temp)
+			printk("%c", ((pData[temp] >= ' ') && (pData[temp] <= 'z')) ? pData[temp] : '.');
+
+		printk("\n");
+	}
+}
+#else
+#define DUMP_EDID_BLOCK(override, pData, length) /* nothing to do */
+#endif
+
+static uint8_t edid_block_size;
+
+struct mhl_sii8620_device_edid_context {
+	bool isReleased;
+	uint8_t edid_fifo_block_number;
+	int current_edid_request_block;
+	uint8_t edid_block_data[EDID_BLOCK_MAX_NUM*EDID_BLOCK_SIZE];
+	void *edid_done_timer;
+	bool is_request_queued;
+	bool is_Receive_EDID_DONE;
+};
+
+static struct mhl_sii8620_device_edid_context edid_context;
+
+/* edid fifo control */
+static void set_current_edid_request_block(int block_num)
+{
+	pr_debug("%s():block_num=%d\n", __func__, block_num);
+	edid_context.current_edid_request_block = block_num;
+}
+
+static uint8_t increment_current_edid_request_block(void)
+{
+	return ++edid_context.current_edid_request_block;
+}
+
+static uint8_t get_current_edid_request_block(void)
+{
+	pr_debug("%s():%d\n",
+		__func__,
+		edid_context.current_edid_request_block);
+
+	return edid_context.current_edid_request_block;
+}
+
+static uint8_t *get_stored_edid_block(void)
+{
+	return edid_context.edid_block_data;
+}
+
+int mhl_sii8620_device_edid_get_block_number(void)
+{
+	return edid_context.edid_fifo_block_number;
+}
+
+int mhl_sii8620_device_get_edid_fifo_partial_block(
+	uint8_t start,
+	uint8_t length,
+	uint8_t *edid_buf)
+{
+	int ret_val;
+	int offset;
+
+	if (edid_context.edid_fifo_block_number & 0x01)
+		offset = edid_block_size; /*128 byte*/
+	else
+		offset = 0;
+
+	pr_debug("%s: initial offset=%d\n", __func__, offset);
+
+	offset += start;
+	if (edid_block_size == (offset + length))
+		edid_context.edid_fifo_block_number++;
+
+	pr_debug("%s: block_num=%d, offset=%d, length = %d, start=%d\n",
+		 __func__,
+		 edid_context.edid_fifo_block_number,
+		 offset, length, start);
+
+	mhl_pf_modify_reg(REG_PAGE_2_EDID_CTRL,
+				BIT_PAGE_2_EDID_CTRL_DEVCAP_SEL,
+				VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID);
+
+	mhl_pf_write_reg(REG_PAGE_2_EDID_FIFO_ADDR, (uint8_t)offset);
+
+	ret_val = mhl_pf_read_reg_block(REG_PAGE_2_EDID_FIFO_RD_DATA
+								, length
+								, edid_buf);
+
+	if (mhl_dev_is_set_hpd()) {
+		return MHL_SUCCESS;
+	} else {
+		pr_err("%s:No HPD ret_val:0x%02x\n", __func__, ret_val);
+		return MHL_FAIL;
+	}
+}
+
+void mhl_sii8620_device_edid_reset_ddc_fifo(void)
+{
+#ifndef MHL_DDC_RESET
+	uint8_t	ddc_status;
+
+	ddc_status = (uint8_t)mhl_pf_read_reg(REG_PAGE_0_DDC_STATUS);/*0,f2*/
+
+	mhl_pf_modify_reg(REG_PAGE_0_LM_DDC,
+					BIT_PAGE_0_LM_DDC_SW_TPI_EN,
+					VAL_PAGE_0_LM_DDC_SW_TPI_EN_ENABLED);
+
+	if (BIT_PAGE_0_DDC_STATUS_DDC_NO_ACK & ddc_status) {
+		pr_warn("Clearing DDC ack status\n");
+		mhl_pf_write_reg(REG_PAGE_0_DDC_STATUS,
+			(uint8_t)(ddc_status & ~BIT_PAGE_0_DDC_STATUS_DDC_NO_ACK));
+	}
+
+	mhl_pf_modify_reg(REG_PAGE_0_DDC_CMD,
+					MSK_PAGE_0_DDC_CMD_DDC_CMD,
+					VAL_PAGE_0_DDC_CMD_DDC_CMD_CLEAR_FIFO);
+
+	mhl_pf_modify_reg(REG_PAGE_0_LM_DDC,
+					BIT_PAGE_0_LM_DDC_SW_TPI_EN,
+					VAL_PAGE_0_LM_DDC_SW_TPI_EN_DISABLED);
+#endif
+}
+
+/* block_number limits is 3 (0 - 3). 4 will be failed. */
+int mhl_sii8620_device_edid_read_request(uint8_t block_number)
+{
+	pr_info("%s():request block number=%d\n", __func__, block_number);
+
+	if (block_number >= EDID_BLOCK_MAX_NUM) {
+		pr_err("%s:invalid blk number=%d\n", __func__, block_number);
+		return MHL_FAIL;
+	}
+
+	if (mhl_dev_is_set_hpd()) {
+		mhl_pf_write_reg(REG_PAGE_0_DDC_MANUAL, 0x00);
+		mhl_pf_write_reg(REG_080C_HDCP1X_LB_BIST, 0x00);
+
+		mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+			VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE
+			| VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID
+			| VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE
+			| ((block_number & 0x01) << 2)
+			| VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE);
+
+		mhl_sii8620_device_edid_reset_ddc_fifo();
+
+		mhl_pf_write_reg(REG_PAGE_5_DISC_STAT1, 0x08);
+		mhl_pf_modify_reg(REG_PAGE_5_DISC_CTRL5,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE);
+
+		if (block_number == 0) {
+			pr_debug("%s()-block 0\n", __func__);
+			mhl_pf_modify_reg(REG_EDID_FIFO_INT_MASK,
+				BIT_INTR9_EDID_ERROR_MASK | BIT_INTR9_EDID_DONE_MASK,
+				VAL_INTR9_EDID_ERROR_MASK | VAL_INTR9_EDID_DONE_MASK);
+
+			mhl_pf_write_reg(REG_PAGE_2_TPI_CBUS_START,
+					 BIT_PAGE_2_TPI_CBUS_START_GET_EDID_START_0);
+		} else {
+			uint8_t param = (uint8_t)(1 << (block_number-1));
+			pr_debug("%s:EDID HW Assist:Reg %02X:%02x to %02X\n",
+				 __func__, REG_PAGE_2_EDID_START_EXT, param);
+			mhl_pf_write_reg(REG_PAGE_2_EDID_START_EXT, param);
+		}
+		set_current_edid_request_block(block_number);
+	} else {
+		pr_warn("%s: sink does not set HPD\n", __func__);
+		return MHL_FAIL;
+	}
+	return MHL_SUCCESS;
+}
+
+static void mhl_device_edid_init_edid_block_info(void)
+{
+	edid_context.edid_fifo_block_number = 0;
+	set_current_edid_request_block(-1);
+	memset((void *)edid_context.edid_block_data, 0, sizeof(edid_context.edid_block_data));
+}
+
+
+void mhl_device_edid_init_edid_done_resource(void)
+{
+	/*
+	 * TODO : This implementation must be replaced with
+	 * mhl_sii8620_device_edid_init() later.
+	 * Currently, call mhl_sii8620_device_edid_release() and
+	 * that xxx_edid_init() continuously has some risk of leaking
+	 * timer resource. that's why temporary this API was created
+	 * to reset only EDID_DONE resource.
+	 */
+	if (mhl_lib_timer_stop(edid_context.edid_done_timer) != 0)
+		pr_warn("%s:timer stop fail\n", __func__);
+
+	edid_context.is_Receive_EDID_DONE = true;
+}
+
+static int mhl_edid_start_edid_request(void)
+{
+	uint8_t req_block;
+
+	if (mhl_lib_timer_start(edid_context.edid_done_timer,
+				MHL_CRL_EDID_DONE_TIME) != 0)
+		pr_err("%s: Failed to start EDID timer!.\n",
+						__func__);
+
+	req_block = get_current_edid_request_block();
+	return mhl_sii8620_device_edid_read_request(req_block);
+}
+
+void mhl_device_start_edid_read(void)
+{
+	pr_debug("%s()\n", __func__);
+
+	/* edid read must not be executed in hdcp engine activating,
+	   otherwise the edid data could be broken.
+	   Stop_video()  internally disables hdcp function.
+	*/
+	stop_video();
+	drive_hpd_low();
+
+	mhl_device_edid_init_edid_block_info();
+	mhl_dev_set_cbusp_cond_processing(DEV_EDID_READ);
+
+	mhl_dev_edid_mhlsink_hev_init();
+
+	if (edid_context.is_Receive_EDID_DONE == false) {
+		pr_debug("%s:queued blk 0 req\n", __func__);
+		edid_context.is_request_queued = true;
+		return;
+	}
+	edid_context.is_request_queued = false;
+	edid_context.is_Receive_EDID_DONE = false;
+
+	set_current_edid_request_block(0);
+	mhl_edid_start_edid_request();
+}
+
+static void mhl_device_clear_edid_done_timer(void *callback_param)
+{
+	pr_warn("%s:expired\n", __func__);
+	edid_context.is_Receive_EDID_DONE = true;
+
+	mhl_dev_clear_cbusp_cond_processing(DEV_EDID_READ);
+
+	mhl_device_chip_reset();
+}
+
+void mhl_sii8620_device_edid_init(void)
+{
+	int ret;
+
+	pr_debug("%s()\n", __func__);
+	mhl_sii8620_device_set_edid_block_size(EDID_BLOCK_SIZE);
+	mhl_lib_edid_set_edid((const uint8_t *)get_stored_edid_block());
+	mhl_device_edid_init_edid_block_info();
+
+	edid_context.is_request_queued = false;
+	edid_context.is_Receive_EDID_DONE = true;
+
+	ret = mhl_lib_timer_create(mhl_device_clear_edid_done_timer,
+					NULL,
+					&edid_context.edid_done_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to allocate EDID timer!\n", __func__);
+
+	mhl_dev_edid_setup_support_video();
+
+	mhl_dev_edid_mhlsink_hev_init();
+
+	edid_retry_cnt = 0;
+}
+
+void mhl_sii8620_device_edid_release(void)
+{
+	int ret;
+
+	ret = mhl_lib_timer_delete(&edid_context.edid_done_timer);
+	if (ret != 0)
+		pr_err("%s: Failed to release EDID timer!\n", __func__);
+}
+
+static void mhl_sii8620_device_set_edid_block_size(uint8_t size)
+{
+	pr_debug("%s()\n", __func__);
+	edid_block_size = size;
+	pr_debug("%s:edid_block_size:%d\n", __func__, edid_block_size);
+}
+
+static bool mhl_dev_edid_is_fifo_hw_good_cond(uint8_t *edid_buf)
+{
+	int i;
+	for (i = 0; i < EDID_BLOCK_SIZE - 1; i++)
+		if (*(edid_buf + i) != *(edid_buf + i + 1))
+			return true;
+
+	pr_warn("%s:edid fifo is in strange condition\n", __func__);
+	return false;
+}
+
+static int read_edid_data_from_edid_fifo(uint8_t *edid_buf, EDID_FIFO_BLOCK_OFFSET block_offset)
+{
+	int ret_val;
+	uint8_t offset;
+
+	offset = block_offset;
+
+	pr_warn("%s.%d:block offset :%d,fifo block number : %d ,block size:%d\n",
+		 __func__, __LINE__,
+		 offset, edid_context.edid_fifo_block_number, edid_block_size);
+
+	edid_context.edid_fifo_block_number++;
+	mhl_pf_write_reg(REG_PAGE_2_EDID_FIFO_ADDR, offset);
+
+	ret_val = mhl_pf_read_reg_block(REG_PAGE_2_EDID_FIFO_RD_DATA
+		, EDID_BLOCK_SIZE
+		, edid_buf);
+
+	DUMP_EDID_BLOCK(0, edid_buf, EDID_BLOCK_SIZE);
+
+	if (!mhl_lib_edid_is_valid_checksum(edid_buf))
+		return MHL_FAIL;
+
+	if (!mhl_dev_edid_is_fifo_hw_good_cond(edid_buf))
+		return MHL_FAIL;
+
+	if (mhl_dev_is_set_hpd())
+		return MHL_SUCCESS;
+	else
+		return MHL_FAIL;
+}
+
+static int mhl_sii8620_device_get_edid_fifo_next_block(uint8_t *edid_buf)
+{
+	int ret_val;
+	uint8_t offset;
+
+	offset = (uint8_t) (edid_block_size * (edid_context.edid_fifo_block_number & 0x01));
+	pr_debug("offset :%d, edid_context.edid_fifo_block_number : %d, edid_block_size:%d\n", offset, edid_context.edid_fifo_block_number, edid_block_size);
+
+	edid_context.edid_fifo_block_number++;
+
+	mhl_pf_modify_reg(REG_PAGE_2_EDID_CTRL,
+				BIT_PAGE_2_EDID_CTRL_DEVCAP_SEL,
+				VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID);
+
+	mhl_pf_write_reg(REG_PAGE_2_EDID_FIFO_ADDR, offset);
+
+	ret_val = mhl_pf_read_reg_block(REG_PAGE_2_EDID_FIFO_RD_DATA
+		, EDID_BLOCK_SIZE
+		, edid_buf);
+
+	if (mhl_dev_is_set_hpd()) {
+		pr_debug("Done reading EDID from FIFO using HW_ASSIST ret_val:0x%02x\n", ret_val);
+		return MHL_SUCCESS;
+	} else {
+		pr_err("No HPD ret_val:0x%02x\n", ret_val);
+		return MHL_FAIL;
+	}
+}
+
+static void mhl_sii8620_device_init_rx_regs(void)
+{
+	/* power up the RX */
+	mhl_pf_modify_reg(REG_PAGE_0_DPD,
+				RX_DPD_BITS, RX_DPD_BITS);
+
+	/* TODO: add to PR. Default for 2A4 is 0x0f */
+	mhl_pf_write_reg(REG_PAGE_2_RX_HDMI_CTRL3, 0x00);
+
+	/*
+	 * Before exposing the EDID to upstream device,setup to drop all
+	 * packets. This ensures we do not get Packet Overflow interrupt.
+	 * Dropping all packets means we still get the AVIF interrupts which is
+	 * crucial. Packet filters must be disabled until after TMDS is enabled.
+	 */
+	mhl_pf_write_reg(REG_PAGE_2_PKT_FILTER_0, 0xFF);
+	mhl_pf_write_reg(REG_PAGE_2_PKT_FILTER_1, 0xFF);
+
+	/* 0x231 def=0A. changed on 1/24/2014 per char team */
+	mhl_pf_write_reg(REG_PAGE_2_ALICE0_BW_I2C, 0x06);
+
+	mhl_pf_modify_reg(REG_PAGE_2_RX_HDMI_CLR_BUFFER,
+				BIT_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_EN,
+				VAL_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_EN_CLEAR);
+
+}
+
+/* we are done with the EDID for now.
+   We now expect to start doing HDCP, which can
+   destroy the contents of our EDID buffer,
+   so do another EDID read, which we know will fail,
+   but that will reset the DDC fifo
+   in such a way as to leave the buffer contents alone
+*/
+void edid_hw_sm_clean_up(void)
+{
+	uint8_t	ddc_status, cbus_status;
+	mhl_pf_write_reg(REG_080C_HDCP1X_LB_BIST, BIT_080C_HDCP1X_LB_BIST);
+	mhl_pf_write_reg(REG_PAGE_0_DDC_MANUAL,
+		BIT_PAGE_0_DDC_MANUAL_MAN_DDC);
+	mhl_pf_write_reg(REG_PAGE_2_INTR9, 0xFF);
+
+	/* Disable EDID interrupt */
+	mhl_pf_write_reg(REG_PAGE_2_INTR9_MASK, 0x00);
+
+	cbus_status = mhl_pf_read_reg(REG_PAGE_5_CBUS_STATUS);
+	if (!(BIT_PAGE_5_CBUS_STATUS_CBUS_CONNECTED & cbus_status)) {
+		mhl_pf_write_reg(REG_PAGE_5_DISC_STAT1, 0x08);
+		mhl_pf_modify_reg(REG_PAGE_5_DISC_CTRL5,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE);
+	}
+
+	mhl_pf_write_reg(REG_PAGE_2_TPI_CBUS_START,
+		BIT_PAGE_2_TPI_CBUS_START_GET_EDID_START_0);
+	ddc_status = mhl_pf_read_reg(REG_PAGE_0_DDC_STATUS);
+
+	if (!(BIT_PAGE_5_CBUS_STATUS_CBUS_CONNECTED & cbus_status)) {
+		mhl_pf_modify_reg(REG_PAGE_5_DISC_CTRL5,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE,
+			0);
+	}
+
+	mhl_pf_write_reg(REG_PAGE_2_INTR9, 0xFF);
+	mhl_pf_write_reg(REG_PAGE_0_DDC_MANUAL, 0x00);
+	mhl_pf_write_reg(REG_080C_HDCP1X_LB_BIST, 0x00);
+
+	ddc_status = mhl_pf_read_reg(REG_PAGE_0_DDC_STATUS);
+
+	mhl_pf_modify_reg(REG_PAGE_0_LM_DDC,
+		BIT_PAGE_0_LM_DDC_SW_TPI_EN,
+		VAL_PAGE_0_LM_DDC_SW_TPI_EN_DISABLED);
+
+	if (BIT_PAGE_0_DDC_STATUS_DDC_BUS_LOW & ddc_status) {
+		pr_debug("%s: Clearing DDC ack status\n", __func__);
+		mhl_pf_write_reg(REG_PAGE_0_DDC_STATUS,
+			ddc_status &
+			~BIT_PAGE_0_DDC_STATUS_DDC_BUS_LOW);
+	}
+
+	mhl_pf_modify_reg(REG_PAGE_0_LM_DDC,
+		BIT_PAGE_0_LM_DDC_SW_TPI_EN,
+		VAL_PAGE_0_LM_DDC_SW_TPI_EN_ENABLED);
+
+}
+
+static int set_upstream_edid(uint8_t *edid_buf, uint16_t length)
+{
+	int reg_val = -1;
+
+	pr_debug("%s:edid write length=%d\n", __func__, length);
+
+	drive_hpd_low();
+
+	/* hdmi spec. 120 msec is enough. */
+	msleep(120);
+
+	mhl_sii8620_device_init_rx_regs();
+
+	edid_hw_sm_clean_up();
+
+	/* choose EDID instead of devcap to appear at the FIFO */
+	mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+		 VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE
+		| VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID
+		| VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE
+		| VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE);
+
+	/* clear the address toward the FIFO and write edid data into the FIFO */
+	mhl_pf_write_reg(REG_PAGE_2_EDID_FIFO_ADDR, 0);
+	mhl_pf_write_reg_block(REG_PAGE_2_EDID_FIFO_WR_DATA, length, edid_buf);
+
+	DUMP_EDID_BLOCK(0, edid_buf, length)
+
+	mhl_pf_write_reg(REG_PAGE_2_EDID_CTRL,
+		 VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_ENABLE
+		| VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID
+		| VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE
+		| VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE);
+
+	/* Turn on heartbeat polling unconditionally to meet the specs */
+	enable_heartbeat();
+
+	/* Enable SCDT interrupt to detect stable incoming clock */
+	mhl_pf_write_reg(REG_PAGE_0_INTR5_MASK, BIT_PAGE_0_INTR5_MASK_INTR5_MASK0);
+
+	/* Disable EDID interrupt */
+	mhl_pf_modify_reg(REG_EDID_FIFO_INT_MASK,
+					BIT_INTR9_EDID_ERROR_MASK | BIT_INTR9_EDID_DONE_MASK,
+					0x00);
+
+	/* HPD was held low all this time. Now we send an HPD high */
+	reg_val = drive_hpd_high();
+
+	/* If SCDT is already high, then we will not get an interrupt */
+	if (BIT_PAGE_2_TMDS_CSTAT_P3_SCDT & reg_val) {
+#if 0 /* SIMG code has this impl. But, SOMC disable . TODO qusetion to SIMG */
+		pr_warn("%s:tmds clock. hpd is just actived\n", __func__);
+		/* todo : the int must be executed in int handler by manually. queue? */
+		int_scdt_isr(BIT_INTR_SCDT_CHANGE);
+#endif
+	}
+
+	/* upstream hdmi device might not be able to respond the hpd low
+	 * just after high. Experimentally,the 300 msec is enough.
+	 */
+	msleep(300);
+
+	return MHL_SUCCESS;
+
+}
+
+/* return false : invalid data, otherwise true */
+static bool mhl_dev_edid_do_edid_filter(uint8_t *edid_buf_read_ptr)
+{
+	pr_debug("%s()", __func__);
+
+	if (IS_BLOCK_0(edid_buf_read_ptr)) {
+		edid_filter_prune_block_0(edid_buf_read_ptr);
+	} else if (IS_EXT_BLOCK(edid_buf_read_ptr)) {
+		pr_debug("%s:ext blk is arrived\n", __func__);
+		edid_filter_prune_ext_blk(edid_buf_read_ptr);
+	} else
+		/* nothing to do*/
+		pr_debug("%s:no blk0, no ext blk.\n", __func__);
+
+	return true;
+}
+
+int  mhl_8620_dev_int_edid_isr(uint8_t int_edid_devcap_status)
+{
+	int edid_complete_size = 0;
+
+	if (!int_edid_devcap_status)
+		/* not edid interrupt */
+		return int_edid_devcap_status;
+
+	/* stop edid done timer */
+	if (mhl_lib_timer_stop(edid_context.edid_done_timer) != 0)
+		pr_warn("%s:timer stop fail\n", __func__);
+
+	/* when interrupt happens, the flag must be
+	 * cleared immediately!! */
+	edid_context.is_Receive_EDID_DONE = true;
+
+	if (!mhl_dev_is_set_hpd())
+		goto edid_read_stop;
+
+	if (edid_context.is_request_queued == true) {
+		/*
+		 * New edid request was already issued.
+		 * skip all edid receiving procedure
+		 * and starts the new request.
+		 */
+		pr_debug("%s:queue has new req. skip\n", __func__);
+		goto retry_edid_read;
+	}
+
+	if (BIT_INTR9_EDID_DONE & int_edid_devcap_status) {
+		int ddcStatus;
+		int num_extensions;
+		uint8_t edid_offset = 0;
+		uint8_t *edid_buf_read_ptr;
+		EDID_FIFO_BLOCK_OFFSET block_num;
+
+		pr_debug("%s: EDID_DONE. available in fifo\n", __func__);
+
+		ddcStatus = mhl_pf_read_reg(REG_PAGE_0_DDC_STATUS);
+		mhl_pf_modify_reg(REG_PAGE_5_DISC_CTRL5,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE,
+			0);
+
+		if (BIT_PAGE_0_DDC_STATUS_DDC_NO_ACK & ddcStatus) {
+			pr_warn("%s,ddc no ack\n", __func__);
+			goto retry_edid_read;
+		}
+
+		/* calculate edid fifo read offset point
+		 * (0 or 128 byte is set to block_num)
+		 */
+		block_num = block_0;
+		edid_offset = edid_block_size * (get_current_edid_request_block() & 0x01);
+
+		if (edid_offset != 0)
+			block_num = block_1;
+		else
+			block_num = block_0;
+
+		pr_debug("%s: fifo offset=%d, reqest block=%d\n",
+			__func__ , edid_offset,
+			get_current_edid_request_block());
+
+		/* Set edid_buf_read_ptr which is somewhere address
+		 * of local edid save area. The ptr is write position
+		 * of the arrived edid block.
+		 */
+		{
+			int write_offset = edid_block_size * get_current_edid_request_block();
+			pr_debug("%s:write offset = %d\n",
+				__func__, write_offset);
+			edid_buf_read_ptr = get_stored_edid_block() + write_offset;
+		}
+
+		/* read 128 byte edid data from FIFO and
+		 * write the data to "edid_block_data" */
+		if (MHL_SUCCESS != read_edid_data_from_edid_fifo(
+			edid_buf_read_ptr, block_num))
+			goto retry_edid_read;
+
+		/* try to read next block or finish */
+		num_extensions = mhl_edid_parser_get_num_cea_861_extensions(get_stored_edid_block());
+		if (num_extensions < 0) {
+			pr_warn("%s: error num_extensions---\n", __func__);
+			goto retry_edid_read;
+		} else if (get_current_edid_request_block() < num_extensions) {
+			/* EDID read next block */
+			increment_current_edid_request_block();
+			if (MHL_SUCCESS != mhl_edid_start_edid_request())
+				goto retry_edid_read;
+
+			goto read_next_block;
+		} else {
+			edid_complete_size = (1 + get_current_edid_request_block()) * edid_block_size;
+			pr_debug("%s: edid read complete\n", __func__);
+			goto edid_read_complete;
+		}
+	}
+
+	if (BIT_INTR9_EDID_ERROR & int_edid_devcap_status) {
+		pr_warn("%s:err int=0x%02x\n", __func__,
+			int_edid_devcap_status);
+		mhl_pf_modify_reg(REG_PAGE_5_DISC_CTRL5,
+			BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE,
+			0);
+
+		goto retry_edid_read;
+	}
+
+	if (edid_context.is_request_queued == true) {
+		pr_debug("%s:queued read request exists", __func__);
+		goto retry_edid_read;
+	}
+
+/* keep edid read */
+read_next_block:
+	return int_edid_devcap_status;
+
+/* edid read will stop */
+edid_read_complete:
+	/*set_upstream_edid(get_stored_edid_block(), edid_complete_size);*/
+edid_read_stop:
+	edid_retry_cnt = 0;
+	mhl_dev_clear_cbusp_cond_processing(DEV_EDID_READ);
+	return int_edid_devcap_status;
+
+/* retry edid read from block 0 */
+retry_edid_read:
+	if (edid_retry_cnt < EDID_RETRY_MAX) {
+		pr_warn("%s: retry edid read. cnt=0x2%x\n",
+			__func__, edid_retry_cnt);
+		mhl_device_start_edid_read();
+		edid_retry_cnt++;
+	} else {
+		pr_warn("%s: retry end!! (%d retry)\n",
+			__func__, edid_retry_cnt);
+		goto edid_read_stop;
+	}
+
+	return int_edid_devcap_status;
+}
+
+void mhl_device_edid_set_upstream_edid(void)
+{
+	int total_size = (1 + get_current_edid_request_block()) * edid_block_size;
+	int i;
+
+	for (i = 0; i < 1 + get_current_edid_request_block(); i++)
+		mhl_dev_edid_do_edid_filter(get_stored_edid_block() + (i * edid_block_size));
+
+	set_upstream_edid(get_stored_edid_block(), total_size);
+}
+
+static void edid_filter_prune_block_0(uint8_t *blk0)
+{
+	if (!mhl_edid_check_edid_header(blk0)) {
+		pr_debug("%s:not blk 0. ignore\n", __func__);
+		return;
+	}
+
+	mhl_lib_edid_remove_established_timing(
+		mhl_1_2_support_video,
+		SUPPORT_MHL_1_2_VIDEO_NUM,
+		(blk0 + 0x23));
+
+	mhl_lib_edid_remove_standard_timing(
+		mhl_1_2_support_video,
+		SUPPORT_MHL_1_2_VIDEO_NUM,
+		(blk0 + 0x26));
+
+	mhl_lib_edid_replace_unsupport_descriptor_with_dummy(
+		blk0,
+		preferred_disp_info,
+		sizeof(preferred_disp_info)/sizeof(*preferred_disp_info));
+
+	mhl_lib_edid_set_checksum(blk0);
+}
+
+static bool edid_is_ext_block(uint8_t *edid)
+{
+	PCEA_extension_t p_CEA_extension = (PCEA_extension_t)edid;
+	if (EDID_EXTENSION_TAG != p_CEA_extension->tag) {
+		pr_info("%s:not ext block. tag=0x%02x\n",
+			 __func__, p_CEA_extension->tag);
+		return false;
+	}
+	return true;
+}
+
+/*
+ * edid : 128 byte edid data
+ */
+static void edid_filter_prune_ext_blk(uint8_t *edid)
+{
+	PCEA_extension_t p_CEA_extension = (PCEA_extension_t)edid;
+
+	if (!edid_is_ext_block(edid))
+		return;
+
+	if (EDID_REV_THREE != p_CEA_extension->revision) {
+		pr_info("%s:ext rev is not edid rev 3\n" , __func__);
+		return;
+	}
+
+	if (mhl_device_is_peer_device_mhl1_2()) {
+		pr_debug("%s:MHL1/2\n" , __func__);
+
+		/* remove all unsupported vic */
+		mhl_lib_edid_remove_vic_from_svd(
+			edid, mhl_1_2_support_vic_array,
+			 sizeof(mhl_1_2_support_vic_array));
+
+		/* remove all hdmi vic and 3d info from vsd */
+		mhl_lib_edid_remove_hdmi_vic_and_3d_from_vsd(edid, NULL, 0);
+
+		/* if either sink or source does not support pp,
+		 * vic16 is removed
+		 */
+		if (mhl_cbus_packed_pixel_available() == false)
+			mhl_edid_parser_remove_vic16_1080p60fps(edid);
+
+	} else if (mhl_device_is_peer_device_mhl3()) {
+		uint8_t length = 0;
+		uint8_t *mhl_supp_4k_vic = NULL;
+
+		pr_debug("%s:MHL3\n" , __func__);
+
+		/* remove all unsupported vic */
+		mhl_lib_edid_remove_vic_from_svd(
+			edid, mhl_3_support_vic_array,
+			 sizeof(mhl_3_support_vic_array));
+
+		/* make hdmi vic filter with MHL3 4k capability */
+		mhl_supp_4k_vic = (uint8_t *)mhl_device_edid_get_mhlsink_sprt_hev(&length);
+
+		/* remove all unsuported hdmi vic and entier 3d info */
+		mhl_lib_edid_remove_hdmi_vic_and_3d_from_vsd(
+			edid, mhl_supp_4k_vic, length);
+
+		return;
+	} else {
+		pr_warn("%s:illegal cbus status:%d\n",
+			 __func__,
+			 mhl_device_get_cbus_mode());
+		return;
+	}
+
+	return;
+}
+
+/*
+ * edid MHL SINK hev info management.
+ * Those API are supposed to be used in MHL3 mode.
+ */
+static void mhl_dev_edid_mhlsink_hev_init(void)
+{
+	memset(mhl_sink_sprt_hev_vic, 0x00, sizeof(mhl_sink_sprt_hev_vic));
+	isMhlSuptFilter = true;
+}
+
+static int mhl_dev_edid_get_sprt_hev_last_idx(void)
+{
+	int i;
+	for (i = 0; i < sizeof(mhl_sink_sprt_hev_vic); i++)
+		if (0x00 == mhl_sink_sprt_hev_vic[i])
+			return i;
+
+	return sizeof(mhl_sink_sprt_hev_vic);
+}
+
+
+static bool mhl_dev_edid_is_vic_support(const uint8_t hev)
+{
+	int i;
+	int max = ARRAY_SIZE(mhl_3_support_video);
+
+	for (i = 0; i < max; i++)
+		if (hev == mhl_3_support_video[i].vic)
+			return true;
+
+	return false;
+}
+
+const uint8_t *mhl_device_edid_get_mhlsink_sprt_hev(uint8_t *length)
+{
+	if (!length)
+		return NULL;
+
+	*length = mhl_dev_edid_get_sprt_hev_last_idx();
+	return mhl_sink_sprt_hev_vic;
+}
+
+
+static void mhl_device_edid_add_mhlsink_sprt_hev(const uint8_t *hev, int length)
+{
+	int i;
+	int cnt;
+	int last_idx;
+	int max;
+	if (!hev)
+		return;
+
+	last_idx =  mhl_dev_edid_get_sprt_hev_last_idx();
+	cnt = last_idx;
+
+	max = last_idx + length;
+
+	if (max > 20) {
+		max = 20;
+		pr_warn("%s:exceed max", __func__);
+	}
+
+	for (i = last_idx; i < max; i++) {
+		/* the filter is used in unit test */
+		if (isMhlSuptFilter) {
+			if (mhl_dev_edid_is_vic_support(*hev)) {
+				pr_debug("%s:add hdmi vic : %d\n",
+					__func__, *hev);
+				mhl_sink_sprt_hev_vic[cnt++] = *hev;
+			}
+		} else {
+			mhl_sink_sprt_hev_vic[cnt++] = *hev;
+		}
+		hev++;
+	}
+}
+
+
+void mhl_device_edid_setup_sink_support_hev_vic(uint8_t *vics, uint8_t length)
+{
+	mhl_device_edid_add_mhlsink_sprt_hev(vics, length);
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.c
@@ -1,0 +1,58 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawasaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <linux/interrupt.h>
+#include <linux/kernel.h>
+#include <linux/sched.h>
+#include "mhl_common.h"
+#include "mhl_platform.h"
+#include "mhl_sii8620_8061_device.h"
+
+static irqreturn_t mhl_irq_handler(int irq, void *data)
+{
+	pr_info("\n");
+	pr_info("***** Got INTR(irq:%d) *****\n", irq);
+	mhl_device_isr();
+	return  IRQ_HANDLED;
+}
+
+int mhl_tx_initialize(void)
+{
+	int ret = -1;
+	pr_debug("%s()\n", __func__);
+
+	ret = request_threaded_irq(mhl_pf_get_irq_number(), NULL,
+								mhl_irq_handler,
+								IRQF_TRIGGER_LOW | IRQF_ONESHOT,
+								mhl_pf_get_device_name(),
+								NULL);
+	if (ret < 0) {
+		pr_err("%s:request_threaded_irq failed, status: %d\n", __func__, ret);
+	}
+
+	/* mhl_sii8620_device_start() is necessary to carry
+	it out after request_threaded_irq().
+	Because it can't detect the RGND interrupt
+	in the "mhl_irq_handler()"
+	if it is registered before request_thread_irq. */
+	mhl_pf_switch_register_cb(
+		mhl_sii8620_device_start, NULL);
+
+	return ret;
+}
+
+void mhl_tx_release(void)
+{
+	pr_debug("%s()\n", __func__);
+	free_irq(mhl_pf_get_irq_number(), NULL);
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.h
@@ -1,0 +1,27 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx.h
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Hirokuni Kawasaki <hirokuni.kawaaki@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef __MHL_TX_H__
+#define __MHL_TX_H__
+#include "linux/types.h"
+int mhl_tx_initialize(void);
+void mhl_tx_release(void);
+
+extern int mhl_tx_rcp_init(struct device *parent);
+extern void mhl_tx_rcp_release(void);
+extern int mhl_tx_rcp_start(void);
+extern void mhl_tx_rcp_stop(void);
+extern u16 mhl_tx_rcp_IsSupported(u8 key_code);
+extern int mhl_tx_rcp_input(u8 key_code);
+
+#endif /* __SOMC_MHL_TX_H__ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx_rcp.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx_rcp.c
@@ -1,0 +1,545 @@
+/* kernel/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx_rcp.c
+ *
+ * Copyright (C) 2013 Sony Mobile Communications AB.
+ * Copyright (C) 2013 Silicon Image Inc.
+ *
+ * Author: [Karino, Masaharu XA <masaharu.xa.karino@sonymobile.com>]
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/vmalloc.h>
+#include <linux/input.h>
+#include <linux/usb/msm_hsusb.h>
+
+#include "mhl_common.h"
+#include "mhl_tx.h"
+
+#define RCP_KEY_RELEASE_TIME1	450
+#define RCP_KEY_RELEASE_TIME2	200
+#define RCP_KEY_INVALID			-1
+
+static int mouse_mode;
+static int mouse_move_distance_dx;
+static int mouse_move_distance_dy;
+
+/* supported RCP key code */
+u16 support_key_code_tbl[] = {
+	KEY_ENTER,		/* 0x00 Select */
+	KEY_UP,			/* 0x01 Up */
+	KEY_DOWN,		/* 0x02 Down */
+	KEY_LEFT,		/* 0x03 Left */
+	KEY_RIGHT,		/* 0x04 Right */
+	KEY_UNKNOWN,		/* 0x05 Right-up */
+	KEY_UNKNOWN,		/* 0x06 Right-down */
+	KEY_UNKNOWN,		/* 0x07 Left-up */
+	KEY_UNKNOWN,		/* 0x08 Left-down */
+	KEY_MENU,		/* 0x09 Root Menu */
+	KEY_OPTION,		/* 0x0A Setup Menu */
+	KEY_UNKNOWN,		/* 0x0B Contents Menu */
+	KEY_UNKNOWN,		/* 0x0C Favorite Menu */
+	KEY_EXIT,		/* 0x0D Exit */
+	KEY_RESERVED,		/* 0x0E */
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x1F */
+	KEY_NUMERIC_0,		/* 0x20 NUMERIC_0 */
+	KEY_NUMERIC_1,		/* 0x21 NUMERIC_1 */
+	KEY_NUMERIC_2,		/* 0x22 NUMERIC_2 */
+	KEY_NUMERIC_3,		/* 0x23 NUMERIC_3 */
+	KEY_NUMERIC_4,		/* 0x24 NUMERIC_4 */
+	KEY_NUMERIC_5,		/* 0x25 NUMERIC_5 */
+	KEY_NUMERIC_6,		/* 0x26 NUMERIC_6 */
+	KEY_NUMERIC_7,		/* 0x27 NUMERIC_7 */
+	KEY_NUMERIC_8,		/* 0x28 NUMERIC_8 */
+	KEY_NUMERIC_9,		/* 0x29 NUMERIC_9 */
+	KEY_DOT,		/* 0x2A Dot */
+	KEY_ENTER,		/* 0x2B Enter */
+	KEY_ESC,		/* 0x2C Clear */
+	KEY_RESERVED,		/* 0x2D */
+	KEY_RESERVED,		/* 0x2E */
+	KEY_RESERVED,		/* 0x2F */
+	KEY_UNKNOWN,		/* 0x30 Channel Up */
+	KEY_UNKNOWN,		/* 0x31 Channel Down */
+	KEY_UNKNOWN,		/* 0x32 Previous Channel */
+	KEY_UNKNOWN,		/* 0x33 Sound Select */
+	KEY_UNKNOWN,		/* 0x34 Input Select */
+	KEY_UNKNOWN,		/* 0x35 Show Information */
+	KEY_UNKNOWN,		/* 0x36 Help */
+	KEY_UNKNOWN,		/* 0x37 Page Up */
+	KEY_UNKNOWN,		/* 0x38 Page Down */
+	KEY_RESERVED,		/* 0x39 */
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x3F */
+	KEY_RESERVED,		/* 0x40 */
+	KEY_VOLUMEUP,		/* 0x41 Volume Up */
+	KEY_VOLUMEDOWN,		/* 0x42 Volume Down */
+	KEY_MUTE,		/* 0x43 Mute */
+	KEY_PLAY,		/* 0x44 Play */
+	KEY_STOP,		/* 0x45 Stop */
+	KEY_PAUSE,		/* 0x46 Pause */
+	KEY_UNKNOWN,		/* 0x47 Record */
+	KEY_REWIND,		/* 0x48 Rewind */
+	KEY_FASTFORWARD,	/* 0x49 Fast Forward */
+	KEY_UNKNOWN,		/* 0x4A Eject */
+	KEY_FORWARD,		/* 0x4B Forward */
+	KEY_BACK,		/* 0x4C Backward */
+	KEY_RESERVED,		/* 0x4D */
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x4F */
+	KEY_UNKNOWN,		/* 0x50 Angle */
+	KEY_UNKNOWN,		/* 0x51 Subtitle */
+	KEY_RESERVED,		/* 0x52 */
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x5F */
+	KEY_PLAYPAUSE,		/* 0x60 Play Function */
+	KEY_PLAYPAUSE,		/* 0x61 Pause_Play Function */
+	KEY_UNKNOWN,		/* 0x62 Record Function */
+	KEY_PAUSE,		/* 0x63 Pause Record Function */
+	KEY_STOP,		/* 0x64 Stop Function  */
+	KEY_MUTE,		/* 0x65 Mute Function */
+	KEY_UNKNOWN,		/* 0x66 Restore Volume Function */
+	KEY_UNKNOWN,		/* 0x67 Tune Function */
+	KEY_UNKNOWN,		/* 0x68 Select Media Function */
+	KEY_RESERVED,		/* 0x69 */
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x70 */
+	KEY_BLUE,			/* 0x71 F1 */
+	KEY_RED,			/* 0x72 F2 */
+	KEY_GREEN,			/* 0x73 F3 */
+	KEY_YELLOW,			/* 0x74 F4 */
+	KEY_UNKNOWN,		/* 0x75 F5 */
+	KEY_RESERVED,		/* 0x76 */
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,
+	KEY_RESERVED,		/* 0x7D */
+	KEY_VENDOR,		/* Vendor Specific */
+	KEY_RESERVED,		/* 0x7F */
+};
+
+static DEFINE_MUTEX(rcp_key_release_mutex);
+static struct workqueue_struct *rcp_key_release_workqueue;
+static struct timer_list key_release_timer;
+
+struct rcp_info {
+	bool bReady;
+	int key_release;
+	int pre_input_key;
+	u16 *key_code_tbl;
+	size_t key_code_tbl_len;
+
+	struct input_dev *input;
+	struct work_struct key_release_work;
+	struct device dev;
+};
+
+static struct rcp_info s_rcp_info = {0};
+
+static ssize_t mhl_tx_rcp_mouse_mode(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	sscanf(buf, "%d", &mouse_mode);
+	pr_debug("%s: mouse_mode = %d\n", __func__, mouse_mode);
+	return count;
+}
+
+static ssize_t mhl_tx_rcp_mouse_move_distance_dx(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	sscanf(buf, "%d", &mouse_move_distance_dx);
+	pr_debug("%s: mouse_move_distance_dx = %d\n",
+		 __func__, mouse_move_distance_dx);
+	return count;
+}
+
+static ssize_t mhl_tx_rcp_mouse_move_distance_dy(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	sscanf(buf, "%d", &mouse_move_distance_dy);
+	pr_debug("%s: mouse_move_distance_dy = %d\n",
+		 __func__, mouse_move_distance_dy);
+	return count;
+}
+
+static void mhl_tx_rcp_key_release_timer(unsigned long data)
+{
+	struct rcp_info *prcpinfo = (struct rcp_info *)data;
+	if (!prcpinfo)
+		return;
+
+	if (prcpinfo->bReady)
+		queue_work(rcp_key_release_workqueue,
+				&prcpinfo->key_release_work);
+}
+
+static void mhl_tx_rcp_key_release_work(struct work_struct *work)
+{
+	struct rcp_info *prcpinfo;
+	prcpinfo = container_of(work, struct rcp_info, key_release_work);
+
+	if (!prcpinfo)
+		return;
+
+	mutex_lock(&rcp_key_release_mutex);
+	if (prcpinfo->key_release != true) {
+		mutex_unlock(&rcp_key_release_mutex);
+		return;
+	}
+	if (prcpinfo->pre_input_key == RCP_KEY_INVALID) {
+		mutex_unlock(&rcp_key_release_mutex);
+		return;
+	}
+
+	input_report_key(prcpinfo->input, prcpinfo->pre_input_key, 0);
+	input_sync(prcpinfo->input);
+	prcpinfo->key_release = false;
+	prcpinfo->pre_input_key = RCP_KEY_INVALID;
+	mutex_unlock(&rcp_key_release_mutex);
+}
+
+static void mhl_tx_rcp_key_input(u8 key_code, u16 input_key_code)
+{
+	int axis = REL_X, distance = -1;
+	bool mouse_event = false;
+	int key_press = (key_code & 0x80) == 0;
+
+	pr_debug("%s: send key events[%x][%x][%d]\n",
+			__func__, key_code, input_key_code, key_press);
+
+	if (mouse_mode) {
+		switch (input_key_code) {
+		case KEY_UP:
+			axis = REL_Y;
+			distance = -mouse_move_distance_dy;
+			mouse_event = true;
+			break;
+		case KEY_DOWN:
+			axis = REL_Y;
+			distance = mouse_move_distance_dy;
+			mouse_event = true;
+			break;
+		case KEY_LEFT:
+			axis = REL_X;
+			distance = -mouse_move_distance_dx;
+			mouse_event = true;
+			break;
+		case KEY_RIGHT:
+			axis = REL_X;
+			distance = mouse_move_distance_dx;
+			mouse_event = true;
+			break;
+		case KEY_ENTER:
+			axis = -1;
+			distance = 0;
+			mouse_event = true;
+			break;
+		case KEY_BLUE:
+			input_key_code = KEY_EXIT;
+			break;
+		default:
+			break;
+		}
+	}
+
+	if (mouse_event) {
+		if (axis >= 0 && key_press) {
+			input_report_rel(s_rcp_info.input, axis, distance);
+			input_sync(s_rcp_info.input);
+			return;
+		} else {
+			input_key_code = BTN_LEFT;
+		}
+	}
+
+	if (key_press) {
+		mutex_lock(&rcp_key_release_mutex);
+		if (s_rcp_info.pre_input_key != input_key_code &&
+				s_rcp_info.key_release) {
+			/* Release previous press key code if current press key
+			 * differs from previous press key.
+			 */
+			input_report_key(s_rcp_info.input,
+					s_rcp_info.pre_input_key, 0);
+			input_sync(s_rcp_info.input);
+		}
+		s_rcp_info.key_release = true;
+		s_rcp_info.pre_input_key = input_key_code;
+		mutex_unlock(&rcp_key_release_mutex);
+		/* rcp key release timer start */
+		switch (input_key_code) {
+		case KEY_UP:
+		case KEY_DOWN:
+		case KEY_LEFT:
+		case KEY_RIGHT:
+		case BTN_LEFT:
+			mod_timer(&key_release_timer,
+				jiffies +
+				msecs_to_jiffies(RCP_KEY_RELEASE_TIME2));
+			break;
+		default:
+			mod_timer(&key_release_timer,
+				jiffies +
+				msecs_to_jiffies(RCP_KEY_RELEASE_TIME1));
+			break;
+		}
+	} else {
+		mutex_lock(&rcp_key_release_mutex);
+		s_rcp_info.key_release = false;
+		s_rcp_info.pre_input_key = RCP_KEY_INVALID;
+		mutex_unlock(&rcp_key_release_mutex);
+	}
+
+	pr_debug("%s: send key events[%x][%x][%d]\n",
+		 __func__, key_code, input_key_code, key_press);
+	mutex_lock(&rcp_key_release_mutex);
+	input_report_key(s_rcp_info.input, input_key_code, key_press);
+	input_sync(s_rcp_info.input);
+	mutex_unlock(&rcp_key_release_mutex);
+}
+
+static void mhl_tx_rcp_common_resource_free(void)
+{
+	s_rcp_info.bReady = false;
+	del_timer_sync(&key_release_timer);
+	destroy_workqueue(rcp_key_release_workqueue);
+}
+/* ----------------------- global functions -----------------------*/
+static DEVICE_ATTR(mouse_move_distance_dx, 0660,
+				NULL, mhl_tx_rcp_mouse_move_distance_dx);
+static DEVICE_ATTR(mouse_move_distance_dy, 0660,
+				NULL, mhl_tx_rcp_mouse_move_distance_dy);
+static DEVICE_ATTR(mouse_mode, 0660,
+				NULL, mhl_tx_rcp_mouse_mode);
+
+int mhl_tx_rcp_init(struct device *parent)
+{
+	int rc;
+	struct class *cls = parent->class;
+
+	if (IS_ERR(cls)) {
+		pr_debug("%s: failed to create class", __func__);
+		return -ENOMEM;
+	}
+
+	s_rcp_info.dev.class = cls;
+	s_rcp_info.dev.parent = parent;
+	dev_set_name(&s_rcp_info.dev, "rcp");
+
+	rc = device_register(&s_rcp_info.dev);
+	if (rc) {
+		pr_err("%s: failed to register device", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&s_rcp_info.dev,
+				 &dev_attr_mouse_move_distance_dx);
+	if (rc) {
+		pr_err("%s: failed to create file for mouse dx\n", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&s_rcp_info.dev,
+				 &dev_attr_mouse_move_distance_dy);
+	if (rc) {
+		pr_err("%s: failed to create file for mouse dy\n", __func__);
+		return rc;
+	}
+
+	rc = device_create_file(&s_rcp_info.dev,
+				 &dev_attr_mouse_mode);
+	if (rc) {
+		pr_err("%s: failed to create file for mouse mode\n", __func__);
+		return rc;
+	}
+	return 0;
+}
+
+void mhl_tx_rcp_release(void)
+{
+	mhl_tx_rcp_stop();
+
+	device_remove_file(&s_rcp_info.dev, &dev_attr_mouse_move_distance_dx);
+	device_remove_file(&s_rcp_info.dev, &dev_attr_mouse_move_distance_dy);
+	device_remove_file(&s_rcp_info.dev, &dev_attr_mouse_mode);
+	device_unregister(&s_rcp_info.dev);
+}
+
+int mhl_tx_rcp_start(void)
+{
+	if (!s_rcp_info.input) {
+		pr_debug("%s: initial input device for RCP\n", __func__);
+		/* key status */
+		s_rcp_info.key_release = false;
+		s_rcp_info.pre_input_key = RCP_KEY_INVALID;
+
+		/* work queue */
+		rcp_key_release_workqueue =
+			create_singlethread_workqueue("mhl_rcp_key_release");
+		INIT_WORK(&s_rcp_info.key_release_work,
+				mhl_tx_rcp_key_release_work);
+
+		/*--- timer initialize ---*/
+		init_timer(&key_release_timer);
+		key_release_timer.function = mhl_tx_rcp_key_release_timer;
+		key_release_timer.data = (unsigned long)&s_rcp_info;
+		key_release_timer.expires = jiffies - HZ;
+		add_timer(&key_release_timer);
+		s_rcp_info.bReady = true;
+		s_rcp_info.input = input_allocate_device();
+
+		/*--- input structure ---*/
+		if (s_rcp_info.input) {
+			int i;
+			int err = -EINVAL;
+
+			s_rcp_info.key_code_tbl = vmalloc(
+				sizeof(support_key_code_tbl));
+			if (!s_rcp_info.key_code_tbl) {
+				pr_err("%s: no alloc mem for rcp keycode tbl\n",
+					   __func__);
+				mhl_tx_rcp_common_resource_free();
+				input_free_device(s_rcp_info.input);
+				s_rcp_info.input = NULL;
+				return -ENOMEM;
+			}
+
+			s_rcp_info.key_code_tbl_len =
+					sizeof(support_key_code_tbl);
+			memcpy(s_rcp_info.key_code_tbl,
+				   &support_key_code_tbl[0],
+				   s_rcp_info.key_code_tbl_len);
+
+			s_rcp_info.input->phys = "cbus/input0";
+			s_rcp_info.input->id.bustype = BUS_VIRTUAL;
+			s_rcp_info.input->id.vendor  = 0x1095;
+			s_rcp_info.input->id.product = 0x8620;
+			s_rcp_info.input->id.version = 0xA;
+
+			s_rcp_info.input->name = "mhl-rcp";
+
+			s_rcp_info.input->keycode = support_key_code_tbl;
+			s_rcp_info.input->keycodesize = sizeof(u16);
+			s_rcp_info.input->keycodemax =
+					ARRAY_SIZE(support_key_code_tbl);
+
+			s_rcp_info.input->evbit[0] = EV_KEY | EV_REP | EV_REL;
+			input_set_capability(s_rcp_info.input, EV_REL, REL_X);
+			input_set_capability(s_rcp_info.input, EV_REL, REL_Y);
+			input_set_capability(s_rcp_info.input, EV_KEY,
+					BTN_LEFT);
+
+			for (i = 0; i < ARRAY_SIZE(support_key_code_tbl); i++) {
+				if (support_key_code_tbl[i] > 1)
+					input_set_capability(s_rcp_info.input,
+						EV_KEY,
+						support_key_code_tbl[i]);
+			}
+
+			err = input_register_device(s_rcp_info.input);
+			if (err < 0) {
+				pr_err("%s: failed to register input device\n"
+						, __func__);
+				vfree(s_rcp_info.key_code_tbl);
+				mhl_tx_rcp_common_resource_free();
+				input_free_device(s_rcp_info.input);
+				s_rcp_info.input = NULL;
+				return err;
+			}
+		} else {
+			mhl_tx_rcp_common_resource_free();
+			return -ENOMEM;
+		}
+	}
+	return 0;
+}
+
+void mhl_tx_rcp_stop(void)
+{
+	mutex_lock(&rcp_key_release_mutex);
+
+	if (s_rcp_info.input) {
+		vfree(s_rcp_info.key_code_tbl);
+		mhl_tx_rcp_common_resource_free();
+		input_unregister_device(s_rcp_info.input);
+		input_free_device(s_rcp_info.input);
+		s_rcp_info.input = NULL;
+	}
+
+	mutex_unlock(&rcp_key_release_mutex);
+}
+
+u16 mhl_tx_rcp_IsSupported(u8 key_code)
+{
+	u8 index = key_code & 0x7f;
+	u16 input_key_code;
+
+	if (!s_rcp_info.key_code_tbl) {
+		pr_err("%s: RCP Key Code Table not initialized\n", __func__);
+		return 0;
+	}
+
+	input_key_code = s_rcp_info.key_code_tbl[index];
+
+	if ((index < s_rcp_info.key_code_tbl_len) &&
+	    (input_key_code > 0)) {
+		return input_key_code;
+	} else {
+		return 0;
+	}
+}
+
+int mhl_tx_rcp_input(u8 key_code)
+{
+	u16 input_key_code;
+
+	input_key_code = mhl_tx_rcp_IsSupported(key_code);
+	if (input_key_code) {
+		mhl_tx_rcp_key_input(key_code, input_key_code);
+		return 0;
+	} else {
+		return -EINVAL;
+	}
+}
+

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_8620_regs.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_8620_regs.h
@@ -1,0 +1,8471 @@
+/*
+
+SiI8620 Linux Drive
+
+Copyright (C) 2013 Silicon Image, Inc.
+
+This program is free software; you can redistribute it and/o
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation version 2.
+This program is distributed AS-IS WITHOUT ANY WARRANTY of any
+kind, whether express or implied; INCLUDING without the implied warranty
+of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE or NON-INFRINGEMENT.  See
+the GNU General Public License for more details at http://www.gnu.org/licenses/gpl-2.0.html.
+
+*/
+
+/*----------------------------------------------------------------------------*/
+/* File Header                                                                */
+/*----------------------------------------------------------------------------*/
+
+#define TX_PAGE_0		(0x72)
+#define TX_PAGE_1		(0x7A)
+#define TX_PAGE_2		(0x92)
+#define TX_PAGE_3		(0x9A)
+#define TX_PAGE_4		(0xBA)
+#define TX_PAGE_5		(0xC8)
+#define TX_PAGE_6		(0xB2)
+#define TX_PAGE_7		(0xC2)
+#define TX_PAGE_8		(0xD2)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_0                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x00 Vendor ID Low byte Register                        (Default: 0x01)    */
+#define REG_PAGE_0_VND_IDL                                 TX_PAGE_0, 0x00
+
+#define MSK_PAGE_0_VND_IDL_VHDL_IDL                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 Vendor ID High byte Register                       (Default: 0x00)    */
+#define REG_PAGE_0_VND_IDH                                 TX_PAGE_0, 0x01
+
+#define MSK_PAGE_0_VND_IDH_VHDL_IDH                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 Device ID Low byte Register                        (Default: 0x60)    */
+#define REG_PAGE_0_DEV_IDL                                 TX_PAGE_0, 0x02
+
+#define MSK_PAGE_0_DEV_IDL_DEV_IDL                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 Device ID High byte Register                       (Default: 0x86)    */
+#define REG_PAGE_0_DEV_IDH                                 TX_PAGE_0, 0x03
+
+#define MSK_PAGE_0_DEV_IDH_DEV_IDH                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 Device Revision Register                           (Default: 0x00)    */
+#define REG_PAGE_0_DEV_REV                                 TX_PAGE_0, 0x04
+
+#define MSK_PAGE_0_DEV_REV_DEV_REV_ID                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x05 Debug Mode Enable Register                         (Default: 0x60)    */
+#define REG_PAGE_0_DEBUG_MODE_EN                           TX_PAGE_0, 0x05
+
+#define MSK_PAGE_0_DEBUG_MODE_EN_SI2C_FILTER_SEL           (0x03 << 6)
+#define BIT_PAGE_0_DEBUG_MODE_EN_SI2C_SDA_DLY_ON           (0x01 << 5)
+#define BIT_PAGE_0_DEBUG_MODE_EN_SI2C_FILTER_TAP_SEL       (0x01 << 4)
+#define BIT_PAGE_0_DEBUG_MODE_EN_DBGMODE3_EN               (0x01 << 3)
+#define BIT_PAGE_0_DEBUG_MODE_EN_DBGMODE2_EN               (0x01 << 2)
+#define BIT_PAGE_0_DEBUG_MODE_EN_SIMODE                    (0x01 << 1)
+#define BIT_PAGE_0_DEBUG_MODE_EN_DBGMODE0_EN               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x06 OTP                                                (Default: 0x08)    */
+#define REG_PAGE_0_OTP_DBYTE510                            TX_PAGE_0, 0x06
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 System Control #1 Register                         (Default: 0x10)    */
+#define REG_PAGE_0_SYS_CTRL1                               TX_PAGE_0, 0x08
+
+#define BIT_PAGE_0_SYS_CTRL1_CBUS125K_SWOVRIDE             (0x01 << 7)
+#define BIT_PAGE_0_SYS_CTRL1_VSYNCPIN                      (0x01 << 6)
+#define BIT_PAGE_0_SYS_CTRL1_BLOCK_DDC_VIA_UPSTREAM_HPD_LOW              (0x01 << 4)
+#define BIT_PAGE_0_SYS_CTRL1_TX_CONTROL_HDMI               (0x01 << 1)
+#define BIT_PAGE_0_SYS_CTRL1_CBUS125K_EN                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 System Status Register                             (Default: 0x00)    */
+#define REG_PAGE_0_SYS_STAT                                TX_PAGE_0, 0x09
+
+#define BIT_PAGE_0_SYS_STAT_OTP_ID8620                     (0x01 << 7)
+#define MSK_PAGE_0_SYS_STAT_OTP_HDCPADRPMUT                (0x03 << 5)
+#define BIT_PAGE_0_SYS_STAT_OTP_HDCPVMUTE                  (0x01 << 4)
+#define BIT_PAGE_0_SYS_STAT_MHL3_DOC_MODE                  (0x01 << 3)
+#define BIT_PAGE_0_SYS_STAT_RSEN                           (0x01 << 2)
+#define BIT_PAGE_0_SYS_STAT_HPDPIN                         (0x01 << 1)
+#define BIT_PAGE_0_SYS_STAT_P_STABLE                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A System Control #3 Register                         (Default: 0x00)    */
+#define REG_PAGE_0_SYS_CTRL3                               TX_PAGE_0, 0x0A
+
+#define BIT_PAGE_0_SYS_CTRL3_SYS_CNTR                      (0x01 << 5)
+#define MSK_PAGE_0_SYS_CTRL3_IO_SETUP_TEST                 (0x03 << 3)
+#define MSK_PAGE_0_SYS_CTRL3_CTL                           (0x03 << 1)
+#define BIT_PAGE_0_SYS_CTRL3_TDM_LSWRESET                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0B System Control DPD                                 (Default: 0x90)    */
+#define REG_PAGE_0_DPD                                     TX_PAGE_0, 0x0B
+
+#define BIT_PAGE_0_DPD_PWRON_PLL                           (0x01 << 7)
+#define BIT_PAGE_0_DPD_PDNTX12                             (0x01 << 6)
+#define BIT_PAGE_0_DPD_PDNRX12                             (0x01 << 5)
+#define BIT_PAGE_0_DPD_OSC_EN                              (0x01 << 4)
+#define BIT_PAGE_0_DPD_PWRON_HSIC                          (0x01 << 3)
+#define BIT_PAGE_0_DPD_PDIDCK_N                            (0x01 << 2)
+#define BIT_PAGE_0_DPD_PD_MHL_CLK_N                        (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C System Control #4 Register                         (Default: 0x07)    */
+#define REG_PAGE_0_SYS_CTRL4                               TX_PAGE_0, 0x0C
+
+#define BIT_PAGE_0_SYS_CTRL4_CTS_FIFO_OF_UF_FLAG           (0x01 << 6)
+#define BIT_PAGE_0_SYS_CTRL4_TCF_OF_UF_FLAG                (0x01 << 5)
+#define BIT_PAGE_0_SYS_CTRL4_MHL_FIFO_OF_UF_FLAG           (0x01 << 4)
+#define BIT_PAGE_0_SYS_CTRL4_CTS_FIFO_AUTO_RST_EN          (0x01 << 2)
+#define BIT_PAGE_0_SYS_CTRL4_TCF_AUTO_RST_EN               (0x01 << 1)
+#define BIT_PAGE_0_SYS_CTRL4_MHL_FIFO_AUTO_RST_EN          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D Dual link Control Register                         (Default: 0x00)    */
+#define REG_PAGE_0_DCTL                                    TX_PAGE_0, 0x0D
+
+#define BIT_PAGE_0_DCTL_TDM_LCLK_PHASE                     (0x01 << 7)
+#define BIT_PAGE_0_DCTL_HSIC_CLK_PHASE                     (0x01 << 6)
+#define BIT_PAGE_0_DCTL_CTS_TCK_PHASE                      (0x01 << 5)
+#define BIT_PAGE_0_DCTL_EXT_DDC_SEL                        (0x01 << 4)
+#define BIT_PAGE_0_DCTL_TRANSCODE                          (0x01 << 3)
+#define BIT_PAGE_0_DCTL_HSIC_RX_STROBE_PHASE               (0x01 << 2)
+#define BIT_PAGE_0_DCTL_TCLKNX_PHASE                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E PWD Software Reset Register                        (Default: 0x00)    */
+#define REG_PAGE_0_PWD_SRST                                TX_PAGE_0, 0x0E
+
+#define BIT_PAGE_0_PWD_SRST_CBUS_RST_SW                    (0x01 << 6)
+#define BIT_PAGE_0_PWD_SRST_CBUS_RST_SW_EN                 (0x01 << 5)
+#define BIT_PAGE_0_PWD_SRST_MHLFIFO_RST                    (0x01 << 4)
+#define BIT_PAGE_0_PWD_SRST_CBUS_RST                       (0x01 << 3)
+#define BIT_PAGE_0_PWD_SRST_SW_RST_AUTO                    (0x01 << 2)
+#define BIT_PAGE_0_PWD_SRST_HDCP2X_SW_RST                  (0x01 << 1)
+#define BIT_PAGE_0_PWD_SRST_SW_RST                         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F HDCP Control Register                              (Default: 0x00)    */
+#define REG_PAGE_0_HDCP_CTRL                               TX_PAGE_0, 0x0F
+
+#define BIT_PAGE_0_HDCP_CTRL_HDCP_ENC_ON                   (0x01 << 6)
+#define BIT_PAGE_0_HDCP_CTRL_HDCP_BKSV_ERR                 (0x01 << 5)
+#define BIT_PAGE_0_HDCP_CTRL_RX_RPTR                       (0x01 << 4)
+#define BIT_PAGE_0_HDCP_CTRL_AN_STOP                       (0x01 << 3)
+#define BIT_PAGE_0_HDCP_CTRL_CP_RESETN                     (0x01 << 2)
+#define BIT_PAGE_0_HDCP_CTRL_HDCP_RI_RDY                   (0x01 << 1)
+#define BIT_PAGE_0_HDCP_CTRL_ENC_EN                        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 Write BKSV1 Register                               (Default: 0x00)    */
+#define REG_PAGE_0_WR_BKSV_1                               TX_PAGE_0, 0x10
+
+#define MSK_PAGE_0_WR_BKSV_1_BKSV0                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 Write BKSV2 Register                               (Default: 0x00)    */
+#define REG_PAGE_0_WR_BKSV_2                               TX_PAGE_0, 0x11
+
+#define MSK_PAGE_0_WR_BKSV_2_BKSV1                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 Write BKSV3 Register                               (Default: 0x00)    */
+#define REG_PAGE_0_WR_BKSV_3                               TX_PAGE_0, 0x12
+
+#define MSK_PAGE_0_WR_BKSV_3_BKSV2                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 Write BKSV4 Register                               (Default: 0x00)    */
+#define REG_PAGE_0_WR_BKSV_4                               TX_PAGE_0, 0x13
+
+#define MSK_PAGE_0_WR_BKSV_4_BKSV3                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 Write BKSV5 Register                               (Default: 0x00)    */
+#define REG_PAGE_0_WR_BKSV_5                               TX_PAGE_0, 0x14
+
+#define MSK_PAGE_0_WR_BKSV_5_BKSV4                         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 HDCP AN_1 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN1                                     TX_PAGE_0, 0x15
+
+#define MSK_PAGE_0_AN1_HDCP_AN0                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 HDCP AN_2 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN2                                     TX_PAGE_0, 0x16
+
+#define MSK_PAGE_0_AN2_HDCP_AN1                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 HDCP AN_3 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN3                                     TX_PAGE_0, 0x17
+
+#define MSK_PAGE_0_AN3_HDCP_AN2                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 HDCP AN_4 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN4                                     TX_PAGE_0, 0x18
+
+#define MSK_PAGE_0_AN4_HDCP_AN3                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 HDCP AN_5 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN5                                     TX_PAGE_0, 0x19
+
+#define MSK_PAGE_0_AN5_HDCP_AN4                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A HDCP AN_6 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN6                                     TX_PAGE_0, 0x1A
+
+#define MSK_PAGE_0_AN6_HDCP_AN5                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1B HDCP AN_7 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN7                                     TX_PAGE_0, 0x1B
+
+#define MSK_PAGE_0_AN7_HDCP_AN6                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1C HDCP AN_8 Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_AN8                                     TX_PAGE_0, 0x1C
+
+#define MSK_PAGE_0_AN8_HDCP_AN7                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1D AKSV_1 Register                                    (Default: 0x00)    */
+#define REG_PAGE_0_AKSV_1                                  TX_PAGE_0, 0x1D
+
+#define MSK_PAGE_0_AKSV_1_AKSV0                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1E AKSV_2 Register                                    (Default: 0x00)    */
+#define REG_PAGE_0_AKSV_2                                  TX_PAGE_0, 0x1E
+
+#define MSK_PAGE_0_AKSV_2_AKSV1                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1F AKSV_3 Register                                    (Default: 0x00)    */
+#define REG_PAGE_0_AKSV_3                                  TX_PAGE_0, 0x1F
+
+#define MSK_PAGE_0_AKSV_3_AKSV2                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 AKSV_4 Register                                    (Default: 0x00)    */
+#define REG_PAGE_0_AKSV_4                                  TX_PAGE_0, 0x20
+
+#define MSK_PAGE_0_AKSV_4_AKSV3                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 AKSV_5 Register                                    (Default: 0x00)    */
+#define REG_PAGE_0_AKSV_5                                  TX_PAGE_0, 0x21
+
+#define MSK_PAGE_0_AKSV_5_AKSV4                            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 Ri_1 Register                                      (Default: 0x00)    */
+#define REG_PAGE_0_RI_1                                    TX_PAGE_0, 0x22
+
+#define MSK_PAGE_0_RI_1_RI_PRIME0                          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 Ri_2 Register                                      (Default: 0x00)    */
+#define REG_PAGE_0_RI_2                                    TX_PAGE_0, 0x23
+
+#define MSK_PAGE_0_RI_2_RI_PRIME1                          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x24 HDCP Ri 128 Compare Value Register                 (Default: 0x7F)    */
+#define REG_PAGE_0_RI_128_COMP                             TX_PAGE_0, 0x24
+
+#define MSK_PAGE_0_RI_128_COMP_RI_128_COMP                 (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x25 HDCP I counter Register                            (Default: 0x00)    */
+#define REG_PAGE_0_HDCP_I_CNT                              TX_PAGE_0, 0x25
+
+#define MSK_PAGE_0_HDCP_I_CNT_HDCP_I_CNT                   (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x26 Ri Status Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_RI_STAT                                 TX_PAGE_0, 0x26
+
+#define BIT_PAGE_0_RI_STAT_RI_ON                           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x27 Ri Command Register                                (Default: 0x00)    */
+#define REG_PAGE_0_RI_CMD                                  TX_PAGE_0, 0x27
+
+#define BIT_PAGE_0_RI_CMD_BCAP_EN                          (0x01 << 1)
+#define BIT_PAGE_0_RI_CMD_RI_EN                            (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x28 Ri Line Start Register                             (Default: 0x11)    */
+#define REG_PAGE_0_RI_START                                TX_PAGE_0, 0x28
+
+#define MSK_PAGE_0_RI_START_RI_LN_NUM                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x29 Ri from Rx #1 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_RI_RX_1                                 TX_PAGE_0, 0x29
+
+#define MSK_PAGE_0_RI_RX_1_RI_RX1                          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2A Ri from Rx #2 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_RI_RX_2                                 TX_PAGE_0, 0x2A
+
+#define MSK_PAGE_0_RI_RX_2_RI_RX2                          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2B HDCP Debug Register                                (Default: 0x00)    */
+#define REG_PAGE_0_TXHDCP_DEBUG                            TX_PAGE_0, 0x2B
+
+#define BIT_PAGE_0_TXHDCP_DEBUG_RI_TRUSH                   (0x01 << 7)
+#define BIT_PAGE_0_TXHDCP_DEBUG_RI_HOLD                    (0x01 << 6)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A Video H Resolution #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_H_RESL                                  TX_PAGE_0, 0x3A
+
+#define MSK_PAGE_0_H_RESL_HRESOUT_7_0                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3B Video H Resolution #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_H_RESH                                  TX_PAGE_0, 0x3B
+
+#define MSK_PAGE_0_H_RESH_HRESOUT_12_8                     (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C Video V Refresh Low Register                       (Default: 0x00)    */
+#define REG_PAGE_0_V_RESL                                  TX_PAGE_0, 0x3C
+
+#define MSK_PAGE_0_V_RESL_VRESOUT_7_0                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D Video V Refresh High Register                      (Default: 0x00)    */
+#define REG_PAGE_0_V_RESH                                  TX_PAGE_0, 0x3D
+
+#define MSK_PAGE_0_V_RESH_VRESOUT_11_8                     (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3E Video Interlace Adjustment Register                (Default: 0x00)    */
+#define REG_PAGE_0_IADJUST                                 TX_PAGE_0, 0x3E
+
+
+/*----------------------------------------------------------------------------*/
+/* 0x3F Video Sync Polarity Detection Register             (Default: 0x00)    */
+#define REG_PAGE_0_POL_DETECT                              TX_PAGE_0, 0x3F
+
+#define BIT_PAGE_0_POL_DETECT_INTERLACEDOUT                (0x01 << 2)
+#define BIT_PAGE_0_POL_DETECT_VSYNCPOLOUT                  (0x01 << 1)
+#define BIT_PAGE_0_POL_DETECT_HSYNCPOLOUT                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x40 Video H De #1 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_H_DEL                                   TX_PAGE_0, 0x40
+
+#define MSK_PAGE_0_H_DEL_HDEOUT_7_0                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 Video H De #2 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_H_DEH                                   TX_PAGE_0, 0x41
+
+#define MSK_PAGE_0_H_DEH_HDEOUT_12_8                       (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 Video V De #1 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_V_DEL                                   TX_PAGE_0, 0x42
+
+#define MSK_PAGE_0_V_DEL_VDEOUT_7_0                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x43 Video V De #2 Register                             (Default: 0x00)    */
+#define REG_PAGE_0_V_DEH                                   TX_PAGE_0, 0x43
+
+#define MSK_PAGE_0_V_DEH_VDEOUT_11_8                       (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x44 Video Refresh Rate #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_REFRESH_RATEL                           TX_PAGE_0, 0x44
+
+#define MSK_PAGE_0_REFRESH_RATEL_REFRESH_RATE_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x45 Video Refresh Rate #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_REFRESH_RATEH                           TX_PAGE_0, 0x45
+
+#define BIT_PAGE_0_REFRESH_RATEH_REFRESH_RATE_7_0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x48 Video Control Register                             (Default: 0x00)    */
+#define REG_PAGE_0_VID_CTRL                                TX_PAGE_0, 0x48
+
+#define BIT_PAGE_0_VID_CTRL_EXTENDEDBITMODE                (0x01 << 5)
+#define BIT_PAGE_0_VID_CTRL_CSCMODE709                     (0x01 << 4)
+#define MSK_PAGE_0_VID_CTRL_ICLK                           (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x49 Video Action Enable Register                       (Default: 0x00)    */
+#define REG_PAGE_0_VID_ACEN                                TX_PAGE_0, 0x49
+
+#define BIT_PAGE_0_VID_ACEN_CLIPINPUTISYC                  (0x01 << 4)
+#define BIT_PAGE_0_VID_ACEN_ENRANGECLIP                    (0x01 << 3)
+#define BIT_PAGE_0_VID_ACEN_ENRGB2YCBCR                    (0x01 << 2)
+#define BIT_PAGE_0_VID_ACEN_ENRANGECOMPRESS                (0x01 << 1)
+#define BIT_PAGE_0_VID_ACEN_ENDOWNSAMPLE                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4A Video Mode Register                                (Default: 0x00)    */
+#define REG_PAGE_0_VID_MODE                                TX_PAGE_0, 0x4A
+
+#define BIT_PAGE_0_VID_MODE_M1080P                         (0x01 << 6)
+#define VAL_PAGE_0_VID_MODE_M1080P_DISABLE                 (0x00 << 6)
+#define VAL_PAGE_0_VID_MODE_M1080P_ENABLE                  (0x01 << 6)
+
+#define BIT_PAGE_0_VID_MODE_ENDITHER                       (0x01 << 5)
+#define BIT_PAGE_0_VID_MODE_ENRANGEEXPAND                  (0x01 << 4)
+#define BIT_PAGE_0_VID_MODE_ENCSC                          (0x01 << 3)
+#define BIT_PAGE_0_VID_MODE_ENUPSAMPLE                     (0x01 << 2)
+#define BIT_PAGE_0_VID_MODE_ENDEMUX                        (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4B Video Blank Data Low Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_0_VID_BLANK0                              TX_PAGE_0, 0x4B
+
+#define MSK_PAGE_0_VID_BLANK0_BLANK0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D Video Blank Data Mid Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_0_VID_BLANK1                              TX_PAGE_0, 0x4D
+
+#define MSK_PAGE_0_VID_BLANK1_BLANK1                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4F Video Blank Data High Byte Register                (Default: 0x00)    */
+#define REG_PAGE_0_VID_BLANK2                              TX_PAGE_0, 0x4F
+
+#define MSK_PAGE_0_VID_BLANK2_BLANK2                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x51 Video Input Mode Register                          (Default: 0xC0)    */
+#define REG_PAGE_0_VID_OVRRD                               TX_PAGE_0, 0x51
+
+#define	REG_PAGE_0_VID_OVRRD_DEFVAL							0x80
+#define BIT_PAGE_0_VID_OVRRD_PP_AUTO_DISABLE               (0x01 << 7)
+#define BIT_PAGE_0_VID_OVRRD_M1080P_OVRRD                  (0x01 << 6)
+#define BIT_PAGE_0_VID_OVRRD_MINIVSYNC_ON                  (0x01 << 5)
+
+#define BIT_PAGE_0_VID_OVRRD_3DCONV_EN                     (0x01 << 4)
+#define VAL_PAGE_0_VID_OVRRD_3DCONV_EN_NORMAL              (0x00 << 4)
+#define VAL_PAGE_0_VID_OVRRD_3DCONV_EN_FRAME_PACK          (0x01 << 4)
+
+#define BIT_PAGE_0_VID_OVRRD_ENRGB2YCBCR_OVRRD             (0x01 << 2)
+#define BIT_PAGE_0_VID_OVRRD_ENDOWNSAMPLE_OVRRD            (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x52 CEA-861 VSI InfoFrame MHL IEEE No #0 Register      (Default: 0x1D)    */
+#define REG_PAGE_0_VSI_MHL_IEEE_NO_0                       TX_PAGE_0, 0x52
+
+#define MSK_PAGE_0_VSI_MHL_IEEE_NO_0_MHL_IEEE_NO_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x53 CEA-861 VSI InfoFrame MHL IEEE No #1 Register      (Default: 0xA6)    */
+#define REG_PAGE_0_VSI_MHL_IEEE_NO_1                       TX_PAGE_0, 0x53
+
+#define MSK_PAGE_0_VSI_MHL_IEEE_NO_1_MHL_IEEE_NO_15_8      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x54 CEA-861 VSI InfoFrame MHL IEEE No #2 Register      (Default: 0x7C)    */
+#define REG_PAGE_0_VSI_MHL_IEEE_NO_2                       TX_PAGE_0, 0x54
+
+#define MSK_PAGE_0_VSI_MHL_IEEE_NO_2_MHL_IEEE_NO_23_16     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x57 I2C Address for Page MHLSpec                       (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_MHLSPEC_ADDR                       TX_PAGE_0, 0x57
+
+#define MSK_PAGE_0_PAGE_MHLSPEC_ADDR_PAGE_MHLSPEC_ADDR_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x58 I2C Address for Page 7 Register                    (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_7_ADDR                             TX_PAGE_0, 0x58
+
+#define MSK_PAGE_0_PAGE_7_ADDR_PAGE_7_ADDR_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x59 One Second Count #1 Register                       (Default: 0x0E)    */
+#define REG_PAGE_0_ONE_SEC_CNTL                            TX_PAGE_0, 0x59
+
+#define MSK_PAGE_0_ONE_SEC_CNTL_ONE_SEC_CNT_7_0            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5A One Second Count #2 Register                       (Default: 0x27)    */
+#define REG_PAGE_0_ONE_SEC_CNTM                            TX_PAGE_0, 0x5A
+
+#define MSK_PAGE_0_ONE_SEC_CNTM_ONE_SEC_CNT_15_8           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5B One Second Count #3 Register                       (Default: 0x07)    */
+#define REG_PAGE_0_ONE_SEC_CNTH                            TX_PAGE_0, 0x5B
+
+#define MSK_PAGE_0_ONE_SEC_CNTH_ONE_SEC_CNT_19_16          (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5D system counter_0                                   (Default: 0xD5)    */
+#define REG_PAGE_0_SYS_CNTR_0                              TX_PAGE_0, 0x5D
+
+#define MSK_PAGE_0_SYS_CNTR_0_CNTR_VALUE_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5E system counter_1                                   (Default: 0x30)    */
+#define REG_PAGE_0_SYS_CNTR_1                              TX_PAGE_0, 0x5E
+
+#define MSK_PAGE_0_SYS_CNTR_1_CNTR_VALUE_15_8              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5F Fast Interrupt Status Register                     (Default: 0x55)    */
+#define REG_PAGE_0_FAST_INTR_STAT                          TX_PAGE_0, 0x5F
+
+#define BIT_PAGE_0_FAST_INTR_STAT_FAST_INTR_STAT_4         (0x01 << 4)
+#define BIT_PAGE_0_FAST_INTR_STAT_FAST_INTR_STAT_3         (0x01 << 3)
+#define BIT_PAGE_0_FAST_INTR_STAT_FAST_INTR_STAT_2         (0x01 << 2)
+#define BIT_PAGE_0_FAST_INTR_STAT_FAST_INTR_STAT_1         (0x01 << 1)
+#define BIT_PAGE_0_FAST_INTR_STAT_FAST_INTR_STAT_0         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 1st Layer Interrupt Status #1 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_0                          TX_PAGE_0, 0x60
+
+#define MSK_PAGE_0_L1_INTR_STAT_0_                         (0x7F << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_0_L1_INTR_STAT_0           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 1st Layer Interrupt Status #2 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_1                          TX_PAGE_0, 0x61
+
+#define MSK_PAGE_0_L1_INTR_STAT_1_                         (0x7F << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_1_L1_INTR_STAT_8           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x62 1st Layer Interrupt Status #3 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_2                          TX_PAGE_0, 0x62
+
+#define MSK_PAGE_0_L1_INTR_STAT_2_                         (0x7F << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_2_L1_INTR_STAT_16          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x63 1st Layer Interrupt Status #4 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_3                          TX_PAGE_0, 0x63
+
+#define MSK_PAGE_0_L1_INTR_STAT_3_                         (0x7F << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_3_L1_INTR_STAT_24          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x64 1st Layer Interrupt Status #5 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_4                          TX_PAGE_0, 0x64
+
+#define MSK_PAGE_0_L1_INTR_STAT_4_                         (0x7F << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_4_L1_INTR_STAT_32          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x65 1st Layer Interrupt Status #6 Register             (Default: 0x55)    */
+#define REG_PAGE_0_L1_INTR_STAT_5                          TX_PAGE_0, 0x65
+
+#define BIT_PAGE_0_L1_INTR_STAT_5_L1_INTR_STAT_41          (0x01 << 1)
+#define BIT_PAGE_0_L1_INTR_STAT_5_L1_INTR_STAT_40          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6E GPIO Control Register 1                            (Default: 0x15)    */
+#define REG_PAGE_0_GPIO_CTRL1                              TX_PAGE_0, 0x6E
+
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_I_8                     (0x01 << 5)
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_OEN_8                   (0x01 << 4)
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_I_7                     (0x01 << 3)
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_OEN_7                   (0x01 << 2)
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_I_6                     (0x01 << 1)
+#define BIT_PAGE_0_GPIO_CTRL1_GPIO_OEN_6                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6F Interrupt Control Register                         (Default: 0x06)    */
+#define REG_PAGE_0_INT_CTRL                                TX_PAGE_0, 0x6F
+
+#define BIT_PAGE_0_INT_CTRL_SOFT_INTR_EN                   (0x01 << 7)
+#define BIT_PAGE_0_INT_CTRL_INTR_OD                        (0x01 << 2)
+#define BIT_PAGE_0_INT_CTRL_INTR_POLARITY                  (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0x70 Interrupt State Register                           (Default: 0x00)    */
+#define REG_PAGE_0_INTR_STATE                              TX_PAGE_0, 0x70
+
+#define BIT_PAGE_0_INTR_STATE_INTR_STATE                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x71 Interrupt Source #1 Register                       (Default: 0x00)    */
+#define REG_PAGE_0_INTR1                                   TX_PAGE_0, 0x71
+
+#define BIT_PAGE_0_INTR1_INTR1_STAT7                       (0x01 << 7)
+#define BIT_PAGE_0_INTR1_INTR1_STAT6                       (0x01 << 6)
+#define BIT_PAGE_0_INTR1_INTR1_STAT5                       (0x01 << 5)
+#define BIT_PAGE_0_INTR1_INTR1_STAT2                       (0x01 << 2)
+
+/*----------------------------------------------------------------------------*/
+/* 0x72 Interrupt Source #2 Register                       (Default: 0x00)    */
+#define REG_PAGE_0_INTR2                                   TX_PAGE_0, 0x72
+
+#define BIT_PAGE_0_INTR2_INTR2_STAT7                       (0x01 << 7)
+#define BIT_PAGE_0_INTR2_INTR2_STAT5                       (0x01 << 5)
+#define BIT_PAGE_0_INTR2_INTR2_STAT1                       (0x01 << 1)
+#define BIT_PAGE_0_INTR2_INTR2_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x73 Interrupt Source #3 Register                       (Default: 0x01)    */
+#define REG_PAGE_0_INTR3                                   TX_PAGE_0, 0x73
+
+#define BIT_PAGE_0_INTR3_INTR3_STAT7                       (0x01 << 7)
+#define BIT_PAGE_0_INTR3_INTR3_STAT6                       (0x01 << 6)
+#define BIT_PAGE_0_INTR3_INTR3_STAT5                       (0x01 << 5)
+#define BIT_PAGE_0_INTR3_INTR3_STAT4                       (0x01 << 4)
+#define BIT_PAGE_0_INTR3_DDC_CMD_DONE                      (0x01 << 3)
+#define BIT_PAGE_0_INTR3_INTR3_STAT2                       (0x01 << 2)
+#define BIT_PAGE_0_INTR3_INTR3_STAT1                       (0x01 << 1)
+#define BIT_PAGE_0_INTR3_INTR3_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x74 Interrupt Source #5 Register                       (Default: 0x00)    */
+#define REG_PAGE_0_INTR5                                   TX_PAGE_0, 0x74
+
+#define BIT_PAGE_0_INTR5_INTR5_STAT7                       (0x01 << 7)
+#define BIT_PAGE_0_INTR5_INTR5_STAT6                       (0x01 << 6)
+#define BIT_PAGE_0_INTR5_INTR5_STAT5                       (0x01 << 5)
+#define BIT_PAGE_0_INTR5_INTR5_STAT4                       (0x01 << 4)
+#define BIT_PAGE_0_INTR5_INTR5_STAT3                       (0x01 << 3)
+#define BIT_PAGE_0_INTR5_INTR5_STAT2                       (0x01 << 2)
+#define BIT_PAGE_0_INTR5_INTR5_STAT1                       (0x01 << 1)
+#define BIT_PAGE_0_INTR5_INTR5_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x75 Interrupt #1 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR1_MASK                              TX_PAGE_0, 0x75
+
+#define BIT_PAGE_0_INTR1_MASK_INTR1_MASK7                  (0x01 << 7)
+#define BIT_PAGE_0_INTR1_MASK_INTR1_MASK6                  (0x01 << 6)
+#define BIT_PAGE_0_INTR1_MASK_INTR1_MASK5                  (0x01 << 5)
+#define BIT_PAGE_0_INTR1_MASK_INTR1_MASK2                  (0x01 << 2)
+
+/*----------------------------------------------------------------------------*/
+/* 0x76 Interrupt #2 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR2_MASK                              TX_PAGE_0, 0x76
+
+#define BIT_PAGE_0_INTR2_MASK_INTR2_MASK7                  (0x01 << 7)
+#define BIT_PAGE_0_INTR2_MASK_INTR2_MASK5                  (0x01 << 5)
+#define BIT_PAGE_0_INTR2_MASK_INTR2_MASK1                  (0x01 << 1)
+#define BIT_PAGE_0_INTR2_MASK_INTR2_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x77 Interrupt #3 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR3_MASK                              TX_PAGE_0, 0x77
+
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK7                  (0x01 << 7)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK6                  (0x01 << 6)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK5                  (0x01 << 5)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK4                  (0x01 << 4)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK3                  (0x01 << 3)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK2                  (0x01 << 2)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK1                  (0x01 << 1)
+#define BIT_PAGE_0_INTR3_MASK_INTR3_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x78 Interrupt #5 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR5_MASK                              TX_PAGE_0, 0x78
+
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK7                  (0x01 << 7)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK6                  (0x01 << 6)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK5                  (0x01 << 5)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK4                  (0x01 << 4)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK3                  (0x01 << 3)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK2                  (0x01 << 2)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK1                  (0x01 << 1)
+#define BIT_PAGE_0_INTR5_MASK_INTR5_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x79 Hot Plug Connection Control Register               (Default: 0x45)    */
+#define REG_PAGE_0_HPD_CTRL                                TX_PAGE_0, 0x79
+
+#define BIT_PAGE_0_HPD_CTRL_HPD_DS_SIGNAL                  (0x01 << 7)
+#define BIT_PAGE_0_HPD_CTRL_HPD_OUT_OD_EN                  (0x01 << 6)
+
+#define BIT_PAGE_0_HPD_CTRL_HPD_OUT_OVR_VAL                (0x01 << 5)
+#define VAL_PAGE_0_HPD_CTRL_HPD_LOW				           (0x00 << 5)
+#define VAL_PAGE_0_HPD_CTRL_HPD_HIGH			           (0x01 << 5)
+
+#define BIT_PAGE_0_HPD_CTRL_HPD_OUT_OVR_EN                 (0x01 << 4)
+#define VAL_PAGE_0_HPD_CTRL_HPD_OUT_OVR_EN_OFF             (0x00 << 4)
+#define VAL_PAGE_0_HPD_CTRL_HPD_OUT_OVR_EN_ON              (0x01 << 4)
+
+#define BIT_PAGE_0_HPD_CTRL_GPIO_I_1                       (0x01 << 3)
+#define BIT_PAGE_0_HPD_CTRL_GPIO_OEN_1                     (0x01 << 2)
+#define BIT_PAGE_0_HPD_CTRL_GPIO_I_0                       (0x01 << 1)
+#define BIT_PAGE_0_HPD_CTRL_GPIO_OEN_0                     (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7A GPIO Control Register                              (Default: 0x55)    */
+#define REG_PAGE_0_GPIO_CTRL                               TX_PAGE_0, 0x7A
+
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_I_5                      (0x01 << 7)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_OEN_5                    (0x01 << 6)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_I_4                      (0x01 << 5)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_OEN_4                    (0x01 << 4)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_I_3                      (0x01 << 3)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_OEN_3                    (0x01 << 2)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_I_2                      (0x01 << 1)
+#define BIT_PAGE_0_GPIO_CTRL_GPIO_OEN_2                    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7B Interrupt Source 7 Register                        (Default: 0x00)    */
+#define REG_PAGE_0_INTR7                                   TX_PAGE_0, 0x7B
+
+#define BIT_PAGE_0_INTR7_INTR7_STAT7                       (0x01 << 7)
+#define BIT_PAGE_0_INTR7_INTR7_STAT6                       (0x01 << 6)
+#define BIT_PAGE_0_INTR7_INTR7_STAT4                       (0x01 << 4)
+#define BIT_PAGE_0_INTR7_INTR7_STAT3                       (0x01 << 3)
+#define BIT_PAGE_0_INTR7_INTR7_STAT2                       (0x01 << 2)
+#define BIT_PAGE_0_INTR7_INTR7_STAT1                       (0x01 << 1)
+#define BIT_PAGE_0_INTR7_INTR7_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7C Interrupt Source 8 Register                        (Default: 0x00)    */
+#define REG_PAGE_0_INTR8                                   TX_PAGE_0, 0x7C
+
+#define BIT_PAGE_0_INTR8_INTR8_STAT6                       (0x01 << 6)
+#define BIT_PAGE_0_INTR8_INTR8_STAT5                       (0x01 << 5)
+#define BIT_PAGE_0_INTR8_INTR8_STAT4                       (0x01 << 4)
+#define BIT_PAGE_0_INTR8_INTR8_STAT3                       (0x01 << 3)
+#define BIT_PAGE_0_INTR8_INTR8_STAT2                       (0x01 << 2)
+#define BIT_PAGE_0_INTR8_INTR8_STAT1                       (0x01 << 1)
+#define BIT_PAGE_0_INTR8_INTR8_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7D Interrupt #7 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR7_MASK                              TX_PAGE_0, 0x7D
+
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK7                  (0x01 << 7)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK6                  (0x01 << 6)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK4                  (0x01 << 4)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK3                  (0x01 << 3)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK2                  (0x01 << 2)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK1                  (0x01 << 1)
+#define BIT_PAGE_0_INTR7_MASK_INTR7_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7E Interrupt #8 Mask Register                         (Default: 0x00)    */
+#define REG_PAGE_0_INTR8_MASK                              TX_PAGE_0, 0x7E
+
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK6                  (0x01 << 6)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK5                  (0x01 << 5)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK4                  (0x01 << 4)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK3                  (0x01 << 3)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK2                  (0x01 << 2)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK1                  (0x01 << 1)
+#define BIT_PAGE_0_INTR8_MASK_INTR8_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 IEEE                                               (Default: 0x10)    */
+#define REG_PAGE_0_TMDS_CCTRL                              TX_PAGE_0, 0x80
+
+#define BIT_PAGE_0_TMDS_CCTRL_TMDS_OE                      (0x01 << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 TMDS Clock Status Register                         (Default: 0x04)    */
+#define REG_PAGE_0_TMDS_CSTAT                              TX_PAGE_0, 0x81
+
+#define BIT_PAGE_0_TMDS_CSTAT_RPWR5V                       (0x01 << 2)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 TMDS Control Register                              (Default: 0x20)    */
+#define REG_PAGE_0_TMDS_CTRL                               TX_PAGE_0, 0x82
+
+#define MSK_PAGE_0_TMDS_CTRL_TCLK_SEL                      (0x03 << 5)
+
+/*----------------------------------------------------------------------------*/
+/* 0x83 TMDS Control #2 Register                           (Default: 0x10)    */
+#define REG_PAGE_0_TMDS_CTRL2                              TX_PAGE_0, 0x83
+
+#define MSK_PAGE_0_TMDS_CTRL2_CLKMULT_CTL                  (0x03 << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0x85 TMDS Control #4 Register                           (Default: 0x02)    */
+#define REG_PAGE_0_TMDS_CTRL4                              TX_PAGE_0, 0x85
+
+#define BIT_PAGE_0_TMDS_CTRL4_SCDT_CKDT_SEL                (0x01 << 1)
+#define BIT_PAGE_0_TMDS_CTRL4_TX_EN_BY_SCDT                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x86 SCDT Holdoff MSB                                   (Default: 0x39)    */
+#define REG_PAGE_0_SCDT_HOLDOFF_MSB                        TX_PAGE_0, 0x86
+
+#define MSK_PAGE_0_SCDT_HOLDOFF_MSB_SCDT_HOLDOFF_MSB_7_0   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x88 TMDS Control #7 Register                           (Default: 0x00)    */
+#define REG_PAGE_0_TMDS_CTRL7                              TX_PAGE_0, 0x88
+
+#define BIT_PAGE_0_TMDS_CTRL7_TMDS_SWAP_BIT                (0x01 << 7)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB0 MHL TX Multi Zone Control1 Register                (Default: 0x00)    */
+#define REG_PAGE_0_TXMZ_CTRL1                              TX_PAGE_0, 0xB0
+
+
+/*----------------------------------------------------------------------------*/
+/* 0xB1 MHL TX Multi Zone Control2 Register                (Default: 0x00)    */
+#define REG_PAGE_0_TXMZ_CTRL2                              TX_PAGE_0, 0xB1
+
+#define BIT_PAGE_0_TXMZ_CTRL2_KEEPER_CLK_PHASE             (0x01 << 7)
+#define BIT_PAGE_0_TXMZ_CTRL2_FC_CLK_PHASE                 (0x01 << 6)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB2 MHL TX Multi Zone Control3 Register                (Default: 0x00)    */
+#define REG_PAGE_0_TXMZ_CTRL3                              TX_PAGE_0, 0xB2
+
+
+/*----------------------------------------------------------------------------*/
+/* 0xB3 MHL TX Multi Zone Control4 Register                (Default: 0x00)    */
+#define REG_PAGE_0_TXMZ_CTRL4                              TX_PAGE_0, 0xB3
+
+
+/*----------------------------------------------------------------------------*/
+/* 0xB4 MHL3 CTS Control Register                          (Default: 0x0A)    */
+#define REG_PAGE_0_MHL3CTS_CTL                             TX_PAGE_0, 0xB4
+
+#define BIT_PAGE_0_MHL3CTS_CTL_MHL3CTS_EN                  (0x01 << 7)
+#define BIT_PAGE_0_MHL3CTS_CTL_MHL3CTS_1LANE               (0x01 << 4)
+#define MSK_PAGE_0_MHL3CTS_CTL_MHL3CTS_CLKOUT_SEL          (0x03 << 2)
+#define BIT_PAGE_0_MHL3CTS_CTL_MHL3CTS_3LANE               (0x01 << 1)
+#define BIT_PAGE_0_MHL3CTS_CTL_MHL3CTS_RST                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB BIST CNTL Register                                 (Default: 0x00)    */
+#define REG_PAGE_0_BIST_CTRL                               TX_PAGE_0, 0xBB
+
+#define BIT_PAGE_0_BIST_CTRL_BIST_START_SEL                (0x01 << 5)
+#define BIT_PAGE_0_BIST_CTRL_BIST_START_BIT                (0x01 << 4)
+#define BIT_PAGE_0_BIST_CTRL_BIST_ALWAYS_ON                (0x01 << 3)
+#define BIT_PAGE_0_BIST_CTRL_BIST_TRANS                    (0x01 << 2)
+#define BIT_PAGE_0_BIST_CTRL_BIST_RESET                    (0x01 << 1)
+#define BIT_PAGE_0_BIST_CTRL_BIST_EN                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBD BIST DURATION0 Register                            (Default: 0x00)    */
+#define REG_PAGE_0_BIST_TEST_SEL                           TX_PAGE_0, 0xBD
+
+#define MSK_PAGE_0_BIST_TEST_SEL_BIST_PATT_SEL             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBE BIST VIDEO_MODE Register                           (Default: 0x00)    */
+#define REG_PAGE_0_BIST_VIDEO_MODE                         TX_PAGE_0, 0xBE
+
+#define MSK_PAGE_0_BIST_VIDEO_MODE_BIST_VIDEO_MODE_3_0     (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF BIST DURATION0 Register                            (Default: 0x00)    */
+#define REG_PAGE_0_BIST_DURATION_0                         TX_PAGE_0, 0xBF
+
+#define MSK_PAGE_0_BIST_DURATION_0_BIST_DURATION_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 BIST DURATION1 Register                            (Default: 0x00)    */
+#define REG_PAGE_0_BIST_DURATION_1                         TX_PAGE_0, 0xC0
+
+#define MSK_PAGE_0_BIST_DURATION_1_BIST_DURATION_15_8      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 BIST DURATION2 Register                            (Default: 0x00)    */
+#define REG_PAGE_0_BIST_DURATION_2                         TX_PAGE_0, 0xC1
+
+#define MSK_PAGE_0_BIST_DURATION_2_BIST_DURATION_22_16     (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 BIST 8BIT_PATTERN Register                         (Default: 0x00)    */
+#define REG_PAGE_0_BIST_8BIT_PATTERN                       TX_PAGE_0, 0xC2
+
+#define MSK_PAGE_0_BIST_8BIT_PATTERN_BIST_10BIT_PATT28LSB  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 BIST 10BIT_PATTERN_L Register                      (Default: 0x00)    */
+#define REG_PAGE_0_BIST_10BIT_PATTERN_L                    TX_PAGE_0, 0xC3
+
+#define MSK_PAGE_0_BIST_10BIT_PATTERN_L_BIST_10BIT_PATT18LSB (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 BIST 10BIT_PATTERN_H Register                      (Default: 0x00)    */
+#define REG_PAGE_0_BIST_10BIT_PATTERN_H                    TX_PAGE_0, 0xC4
+
+#define MSK_PAGE_0_BIST_10BIT_PATTERN_H_BIST_10BIT_PATT22MSB (0x03 << 2)
+#define MSK_PAGE_0_BIST_10BIT_PATTERN_H_RG_BIST_10BIT_PATT12MSB (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 BIST 10BIT_PATTERN_H Register                      (Default: 0x00)    */
+#define REG_PAGE_0_BIST_STATUS                             TX_PAGE_0, 0xC5
+
+#define MSK_PAGE_0_BIST_STATUS_BIST_STATUS                 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 LM DDC Register                                    (Default: 0x80)    */
+#define REG_PAGE_0_LM_DDC                                  TX_PAGE_0, 0xC7
+
+#define BIT_PAGE_0_LM_DDC_SW_TPI_EN                        (0x01 << 7)
+#define VAL_PAGE_0_LM_DDC_SW_TPI_EN_ENABLED                (0x00 << 7)
+#define VAL_PAGE_0_LM_DDC_SW_TPI_EN_DISABLED               (0x01 << 7)
+
+#define BIT_PAGE_0_LM_DDC_VIDEO_MUTE_EN                    (0x01 << 5)
+#define BIT_PAGE_0_LM_DDC_DDC_TPI_SW                       (0x01 << 2)
+#define BIT_PAGE_0_LM_DDC_DDC_GRANT                        (0x01 << 1)
+#define BIT_PAGE_0_LM_DDC_DDC_GPU_REQUEST                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC TX SHA Control Register                            (Default: 0x01)    */
+#define REG_PAGE_0_TXSHA_CTRL                              TX_PAGE_0, 0xCC
+
+#define BIT_PAGE_0_TXSHA_CTRL_SHACTRL_STAT1                (0x01 << 1)
+#define BIT_PAGE_0_TXSHA_CTRL_SHA_GO_STAT                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCD TX KSV FIFO Register                               (Default: 0x00)    */
+#define REG_PAGE_0_TXKSV_FIFO                              TX_PAGE_0, 0xCD
+
+#define MSK_PAGE_0_TXKSV_FIFO_KSV_FIFO_OUT                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE HDCP Repeater Down Stream BSTATUS #1 Register      (Default: 0x00)    */
+#define REG_PAGE_0_TXDS_BSTATUS1                           TX_PAGE_0, 0xCE
+
+#define BIT_PAGE_0_TXDS_BSTATUS1_DS_DEV_EXCEED             (0x01 << 7)
+#define MSK_PAGE_0_TXDS_BSTATUS1_DS_DEV_CNT                (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF HDCP Repeater Down Stream BSTATUS #2 Register      (Default: 0x10)    */
+#define REG_PAGE_0_TXDS_BSTATUS2                           TX_PAGE_0, 0xCF
+
+#define MSK_PAGE_0_TXDS_BSTATUS2_DS_BSTATUS                (0x07 << 5)
+#define BIT_PAGE_0_TXDS_BSTATUS2_DS_HDMI_MODE              (0x01 << 4)
+#define BIT_PAGE_0_TXDS_BSTATUS2_DS_CASC_EXCEED            (0x01 << 3)
+#define MSK_PAGE_0_TXDS_BSTATUS2_DS_DEPTH                  (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 HDCP Repeater V.H0 #0 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH0_0                                 TX_PAGE_0, 0xD8
+
+#define MSK_PAGE_0_TXVH0_0_VP_H0_7_0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 HDCP Repeater V.H0 #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH0_1                                 TX_PAGE_0, 0xD9
+
+#define MSK_PAGE_0_TXVH0_1_VP_H0_15_8                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDA HDCP Repeater V.H0 #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH0_2                                 TX_PAGE_0, 0xDA
+
+#define MSK_PAGE_0_TXVH0_2_VP_H0_23_16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDB HDCP Repeater V.H0 #3 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH0_3                                 TX_PAGE_0, 0xDB
+
+#define MSK_PAGE_0_TXVH0_3_VP_H0_31_24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDC HDCP Repeater V.H1 #0 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH1_0                                 TX_PAGE_0, 0xDC
+
+#define MSK_PAGE_0_TXVH1_0_VP_H1_7_0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDD HDCP Repeater V.H1 #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH1_1                                 TX_PAGE_0, 0xDD
+
+#define MSK_PAGE_0_TXVH1_1_VP_H1_15_8                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDE HDCP Repeater V.H1 #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH1_2                                 TX_PAGE_0, 0xDE
+
+#define MSK_PAGE_0_TXVH1_2_VP_H1_23_16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDF HDCP Repeater V.H1 #3 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH1_3                                 TX_PAGE_0, 0xDF
+
+#define MSK_PAGE_0_TXVH1_3_VP_H1_31_24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE0 HDCP Repeater V.H2 #0 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH2_0                                 TX_PAGE_0, 0xE0
+
+#define MSK_PAGE_0_TXVH2_0_VP_H2_7_0                       (0xFF << 0)
+
+
+/*----------------------------------------------------------------------------*/
+/* 0xE1 HDCP Repeater V.H2 #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH2_1                                 TX_PAGE_0, 0xE1
+
+#define MSK_PAGE_0_TXVH2_1_VP_H2_15_8                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE2 HDCP Repeater V.H2 #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH2_2                                 TX_PAGE_0, 0xE2
+
+#define MSK_PAGE_0_TXVH2_2_VP_H2_23_16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE3 HDCP Repeater V.H2 #3 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH2_3                                 TX_PAGE_0, 0xE3
+
+#define MSK_PAGE_0_TXVH2_3_VP_H2_31_24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE4 HDCP Repeater V.H3 #0 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH3_0                                 TX_PAGE_0, 0xE4
+
+#define MSK_PAGE_0_TXVH3_0_VP_H3_7_0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE5 HDCP Repeater V.H3 #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH3_1                                 TX_PAGE_0, 0xE5
+
+#define MSK_PAGE_0_TXVH3_1_VP_H3_15_8                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE6 HDCP Repeater V.H3 #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH3_2                                 TX_PAGE_0, 0xE6
+
+#define MSK_PAGE_0_TXVH3_2_VP_H3_23_16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE7 HDCP Repeater V.H3 #3 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH3_3                                 TX_PAGE_0, 0xE7
+
+#define MSK_PAGE_0_TXVH3_3_VP_H3_31_24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE8 HDCP Repeater V.H4 #0 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH4_0                                 TX_PAGE_0, 0xE8
+
+#define MSK_PAGE_0_TXVH4_0_VP_H4_7_0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE9 HDCP Repeater V.H4 #1 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH4_1                                 TX_PAGE_0, 0xE9
+
+#define MSK_PAGE_0_TXVH4_1_VP_H4_15_8                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEA HDCP Repeater V.H4 #2 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH4_2                                 TX_PAGE_0, 0xEA
+
+#define MSK_PAGE_0_TXVH4_2_VP_H4_23_16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEB HDCP Repeater V.H4 #3 Register                     (Default: 0x00)    */
+#define REG_PAGE_0_TXVH4_3                                 TX_PAGE_0, 0xEB
+
+#define MSK_PAGE_0_TXVH4_3_VP_H4_31_24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEC DDC I2C Manual Register                            (Default: 0x03)    */
+#define REG_PAGE_0_DDC_MANUAL                              TX_PAGE_0, 0xEC
+
+#define BIT_PAGE_0_DDC_MANUAL_MAN_DDC                      (0x01 << 7)
+#define BIT_PAGE_0_DDC_MANUAL_VP_SEL                       (0x01 << 6)
+#define BIT_PAGE_0_DDC_MANUAL_DSDA                         (0x01 << 5)
+#define BIT_PAGE_0_DDC_MANUAL_DSCL                         (0x01 << 4)
+#define BIT_PAGE_0_DDC_MANUAL_GCP_HW_CTL_EN                (0x01 << 3)
+#define BIT_PAGE_0_DDC_MANUAL_DDCM_ABORT_WP                (0x01 << 2)
+#define BIT_PAGE_0_DDC_MANUAL_IO_DSDA                      (0x01 << 1)
+#define BIT_PAGE_0_DDC_MANUAL_IO_DSCL                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xED DDC I2C Target Slave Address Register              (Default: 0x00)    */
+#define REG_PAGE_0_DDC_ADDR                                TX_PAGE_0, 0xED
+
+#define MSK_PAGE_0_DDC_ADDR_DDC_ADDR                       (0x7F << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEE DDC I2C Target Segment Address Register            (Default: 0x00)    */
+#define REG_PAGE_0_DDC_SEGM                                TX_PAGE_0, 0xEE
+
+#define MSK_PAGE_0_DDC_SEGM_DDC_SEGMENT                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEF DDC I2C Target Offset Adress Register              (Default: 0x00)    */
+#define REG_PAGE_0_DDC_OFFSET                              TX_PAGE_0, 0xEF
+
+#define MSK_PAGE_0_DDC_OFFSET_DDC_OFFSET                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF0 DDC I2C Data In count #1 Register                  (Default: 0x00)    */
+#define REG_PAGE_0_DDC_DIN_CNT1                            TX_PAGE_0, 0xF0
+
+#define MSK_PAGE_0_DDC_DIN_CNT1_DDC_DIN_CNT_7_0            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF1 DDC I2C Data In count #2 Register                  (Default: 0x00)    */
+#define REG_PAGE_0_DDC_DIN_CNT2                            TX_PAGE_0, 0xF1
+
+#define MSK_PAGE_0_DDC_DIN_CNT2_DDC_DIN_CNT_9_8            (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF2 DDC I2C Status Register                            (Default: 0x04)    */
+#define REG_PAGE_0_DDC_STATUS                              TX_PAGE_0, 0xF2
+
+#define BIT_PAGE_0_DDC_STATUS_DDC_BUS_LOW                  (0x01 << 6)
+#define BIT_PAGE_0_DDC_STATUS_DDC_NO_ACK                   (0x01 << 5)
+#define BIT_PAGE_0_DDC_STATUS_DDC_I2C_IN_PROG              (0x01 << 4)
+#define BIT_PAGE_0_DDC_STATUS_DDC_FIFO_FULL                (0x01 << 3)
+#define BIT_PAGE_0_DDC_STATUS_DDC_FIFO_EMPTY               (0x01 << 2)
+#define BIT_PAGE_0_DDC_STATUS_DDC_FIFO_READ_IN_SUE         (0x01 << 1)
+#define BIT_PAGE_0_DDC_STATUS_DDC_FIFO_WRITE_IN_USE        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF3 DDC I2C Command Register                           (Default: 0x30)    */
+#define REG_PAGE_0_DDC_CMD                                 TX_PAGE_0, 0xF3
+
+#define BIT_PAGE_0_DDC_CMD_SDA_DEL_EN                      (0x01 << 5)
+#define BIT_PAGE_0_DDC_CMD_DDC_FLT_EN                      (0x01 << 4)
+
+#define MSK_PAGE_0_DDC_CMD_DDC_CMD                         (0x0F << 0)
+#define VAL_PAGE_0_DDC_CMD_ENH_DDC_READ_NO_ACK             0x04
+#define VAL_PAGE_0_DDC_CMD_DDC_CMD_CLEAR_FIFO              (0x09 << 0)
+#define VAL_PAGE_0_DDC_CMD_DDC_CMD_ABORT                   (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF4 DDC I2C FIFO Data In/Out Register                  (Default: 0x00)    */
+#define REG_PAGE_0_DDC_DATA                                TX_PAGE_0, 0xF4
+
+#define MSK_PAGE_0_DDC_DATA_DDC_DATA_OUT                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF5 DDC I2C Data Out Counter Register                  (Default: 0x00)    */
+#define REG_PAGE_0_DDC_DOUT_CNT                            TX_PAGE_0, 0xF5
+
+#define BIT_PAGE_0_DDC_DOUT_CNT_DDC_DELAY_CNT_8            (0x01 << 7)
+#define MSK_PAGE_0_DDC_DOUT_CNT_DDC_DATA_OUT_CNT           (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF6 DDC I2C Delay Count Register                       (Default: 0x14)    */
+#define REG_PAGE_0_DDC_DELAY_CNT                           TX_PAGE_0, 0xF6
+
+#define MSK_PAGE_0_DDC_DELAY_CNT_DDC_DELAY_CNT_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF7 Test Control Register                              (Default: 0x80)    */
+#define REG_PAGE_0_TEST_TXCTRL                             TX_PAGE_0, 0xF7
+
+#define BIT_PAGE_0_TEST_TXCTRL_RCLK_REF_SEL                (0x01 << 7)
+#define BIT_PAGE_0_TEST_TXCTRL_PCLK_REF_SEL                (0x01 << 6)
+#define MSK_PAGE_0_TEST_TXCTRL_BYPASS_PLL_CLK              (0x0F << 2)
+#define BIT_PAGE_0_TEST_TXCTRL_HDMI_MODE                   (0x01 << 1)
+#define BIT_PAGE_0_TEST_TXCTRL_TST_PLLCK                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF8 CBUS Address Register                              (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_CBUS_ADDR                          TX_PAGE_0, 0xF8
+
+#define MSK_PAGE_0_PAGE_CBUS_ADDR_PAGE_CBUS_ADDR_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF9 I2C Status Register                                (Default: 0x01)    */
+#define REG_PAGE_0_EPST                                    TX_PAGE_0, 0xF9
+
+#define BIT_PAGE_0_EPST_OTP_UNLOCKED                       (0x01 << 7)
+#define BIT_PAGE_0_EPST_BIST2_ERR_CLR                      (0x01 << 6)
+#define BIT_PAGE_0_EPST_BIST1_ERR_CLR                      (0x01 << 5)
+#define BIT_PAGE_0_EPST_BIST_ERR_CLR                       (0x01 << 1)
+#define BIT_PAGE_0_EPST_CMD_DONE_CLR                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFA I2C Command Register                               (Default: 0x00)    */
+#define REG_PAGE_0_EPCM                                    TX_PAGE_0, 0xFA
+
+#define BIT_PAGE_0_EPCM_LD_KSV                             (0x01 << 5)
+#define MSK_PAGE_0_EPCM_EPCM                               (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFB I2C Command Register                               (Default: 0x20)    */
+#define REG_PAGE_0_OTP_CLK                                 TX_PAGE_0, 0xFB
+
+#define BIT_PAGE_0_OTP_CLK_OTP_PROTECT_EN                  (0x01 << 5)
+#define BIT_PAGE_0_OTP_CLK_BYP_OCLKRING_OPTION             (0x01 << 3)
+#define MSK_PAGE_0_OTP_CLK_OCLKDIV                         (0x03 << 1)
+#define BIT_PAGE_0_OTP_CLK_BYPASS_HISC_CLK                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFC I2C Address for Page 1                             (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_1_ADDR                             TX_PAGE_0, 0xFC
+
+#define MSK_PAGE_0_PAGE_1_ADDR_PAGE_1_ADDR_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFD I2C Address for Page 2                             (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_2_ADDR                             TX_PAGE_0, 0xFD
+
+#define MSK_PAGE_0_PAGE_2_ADDR_PAGE_2_ADDR_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFE I2C Address for Page 3                             (Default: 0x00)    */
+#define REG_PAGE_0_PAGE_3_ADDR                             TX_PAGE_0, 0xFE
+
+#define MSK_PAGE_0_PAGE_3_ADDR_PAGE_3_ADDR_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFF I2C Address for HW TPI                             (Default: 0x00)    */
+#define REG_PAGE_0_HW_TPI_ADDR                             TX_PAGE_0, 0xFF
+
+#define MSK_PAGE_0_HW_TPI_ADDR_HW_TPI_ADDR_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_1                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x00 USBT CTRL0 Register                                (Default: 0x00)    */
+#define REG_PAGE_1_UTSRST                                  TX_PAGE_1, 0x00
+
+#define BIT_PAGE_1_UTSRST_FC_SRST                          (0x01 << 5)
+#define BIT_PAGE_1_UTSRST_KEEPER_SRST                      (0x01 << 4)
+#define BIT_PAGE_1_UTSRST_HTX_SRST                         (0x01 << 3)
+#define BIT_PAGE_1_UTSRST_TRX_SRST                         (0x01 << 2)
+#define BIT_PAGE_1_UTSRST_TTX_SRST                         (0x01 << 1)
+#define BIT_PAGE_1_UTSRST_HRX_SRST                         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 HSIC RX Control0 Register                          (Default: 0x27)    */
+#define REG_PAGE_1_HRXCTRL0                                TX_PAGE_1, 0x01
+
+#define MSK_PAGE_1_HRXCTRL0_HRX_MARGIN_3_0                 (0x0F << 4)
+#define BIT_PAGE_1_HRXCTRL0_HRX_ASSERT_RESET               (0x01 << 3)
+#define BIT_PAGE_1_HRXCTRL0_HRX_EXTEND                     (0x01 << 2)
+#define BIT_PAGE_1_HRXCTRL0_HRX_NULL_STUFFING              (0x01 << 1)
+#define BIT_PAGE_1_HRXCTRL0_HRX_STOP_RESET                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 HSIC RX Control1 Register                          (Default: 0x42)    */
+#define REG_PAGE_1_HRXCTRL1                                TX_PAGE_1, 0x02
+
+#define MSK_PAGE_1_HRXCTRL1_HRX_RESET                      (0x0F << 4)
+#define MSK_PAGE_1_HRXCTRL1_HRX_RESUME                     (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 HSIC RX Control2 Register                          (Default: 0x10)    */
+#define REG_PAGE_1_HRXCTRL2                                TX_PAGE_1, 0x03
+
+#define MSK_PAGE_1_HRXCTRL2_HRX_STAY_THRESH                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 HSIC RX Control3 Register                          (Default: 0x05)    */
+#define REG_PAGE_1_HRXCTRL3                                TX_PAGE_1, 0x04
+
+#define MSK_PAGE_1_HRXCTRL3_HRX_AFFCTRL                    (0x0F << 4)
+#define BIT_PAGE_1_HRXCTRL3_HRX_OUT_EN                     (0x01 << 2)
+#define BIT_PAGE_1_HRXCTRL3_STATUS_EN                      (0x01 << 1)
+#define BIT_PAGE_1_HRXCTRL3_HRX_STAY_RESET                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x05 HSIC RX Control4 Register                          (Default: 0x03)    */
+#define REG_PAGE_1_HRXCTRL4                                TX_PAGE_1, 0x05
+
+#define MSK_PAGE_1_HRXCTRL4_HRX_BUFFER                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x06 HSIC RX Write Backoff Register                     (Default: 0x20)    */
+#define REG_PAGE_1_HRXWRBKOF                               TX_PAGE_1, 0x06
+
+#define MSK_PAGE_1_HRXWRBKOF_HRX_WRBKOF                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x07 HSIC RX Override Low Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HRXOVRL                                 TX_PAGE_1, 0x07
+
+#define MSK_PAGE_1_HRXOVRL_HRX_OVERRIDE_7_0                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 HSIC RX Override High Register                     (Default: 0x00)    */
+#define REG_PAGE_1_HRXOVRH                                 TX_PAGE_1, 0x08
+
+#define MSK_PAGE_1_HRXOVRH_HRX_OVERRIDE_10_8               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 HSIC RX Status 1st Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA1                                 TX_PAGE_1, 0x09
+
+#define MSK_PAGE_1_HRXSTA1_HRX_STATUS_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A HSIC RX Status 2nd Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA2                                 TX_PAGE_1, 0x0A
+
+#define MSK_PAGE_1_HRXSTA2_HRX_STATUS_15_8                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0B HSIC RX Status 3rd Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA3                                 TX_PAGE_1, 0x0B
+
+#define MSK_PAGE_1_HRXSTA3_HRX_STATUS_23_16                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C HSIC RX Status 4th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA4                                 TX_PAGE_1, 0x0C
+
+#define MSK_PAGE_1_HRXSTA4_HRX_STATUS_31_24                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D HSIC RX Status 5th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA5                                 TX_PAGE_1, 0x0D
+
+#define MSK_PAGE_1_HRXSTA5_HRX_STATUS_39_32                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E HSIC RX Status 6th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA6                                 TX_PAGE_1, 0x0E
+
+#define MSK_PAGE_1_HRXSTA6_HRX_STATUS_47_40                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F HSIC RX Status 7th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA7                                 TX_PAGE_1, 0x0F
+
+#define MSK_PAGE_1_HRXSTA7_HRX_STATUS_55_48                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 HSIC RX Status 8th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HRXSTA8                                 TX_PAGE_1, 0x10
+
+#define MSK_PAGE_1_HRXSTA8_HRX_STATUS_63_56                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 HSIC RX INT Low Register                           (Default: 0x00)    */
+#define REG_PAGE_1_HRXINTL                                 TX_PAGE_1, 0x11
+
+#define BIT_PAGE_1_HRXINTL_HRX_INTR7                       (0x01 << 7)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR6                       (0x01 << 6)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR5                       (0x01 << 5)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR4                       (0x01 << 4)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR3                       (0x01 << 3)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR2                       (0x01 << 2)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR1                       (0x01 << 1)
+#define BIT_PAGE_1_HRXINTL_HRX_INTR0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 HSIC RX INT High Register                          (Default: 0x00)    */
+#define REG_PAGE_1_HRXINTH                                 TX_PAGE_1, 0x12
+
+#define BIT_PAGE_1_HRXINTH_HRX_INTR15                      (0x01 << 7)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR14                      (0x01 << 6)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR13                      (0x01 << 5)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR12                      (0x01 << 4)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR11                      (0x01 << 3)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR10                      (0x01 << 2)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR9                       (0x01 << 1)
+#define BIT_PAGE_1_HRXINTH_HRX_INTR8                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 HSIC RX INTMASK Low Register                       (Default: 0x00)    */
+#define REG_PAGE_1_HRXINTML                                TX_PAGE_1, 0x13
+
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK7                  (0x01 << 7)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK6                  (0x01 << 6)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK5                  (0x01 << 5)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK4                  (0x01 << 4)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK3                  (0x01 << 3)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK2                  (0x01 << 2)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK1                  (0x01 << 1)
+#define BIT_PAGE_1_HRXINTML_HRX_INTRMASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 HSIC RX INTMASK High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HRXINTMH                                TX_PAGE_1, 0x14
+
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK15                 (0x01 << 7)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK14                 (0x01 << 6)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK13                 (0x01 << 5)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK12                 (0x01 << 4)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK11                 (0x01 << 3)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK10                 (0x01 << 2)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK9                  (0x01 << 1)
+#define BIT_PAGE_1_HRXINTMH_HRX_INTRMASK8                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 TDM TX Buf Register                                (Default: 0x08)    */
+#define REG_PAGE_1_TTXBUF                                  TX_PAGE_1, 0x15
+
+#define MSK_PAGE_1_TTXBUF_TTX_BUFFER_7_0                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 TDM TX NUMBITS Register                            (Default: 0x04)    */
+#define REG_PAGE_1_TTXNUMB                                 TX_PAGE_1, 0x16
+
+#define MSK_PAGE_1_TTXNUMB_TTX_AFFCTRL_3_0                 (0x0F << 4)
+#define MSK_PAGE_1_TTXNUMB_TTX_NUMBPS_2_0                  (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 TDM TX NUMSPISYM Register                          (Default: 0x04)    */
+#define REG_PAGE_1_TTXSPINUMS                              TX_PAGE_1, 0x17
+
+#define MSK_PAGE_1_TTXSPINUMS_TTX_NUMSPISYM                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 TDM TX NUMHSICSYM Register                         (Default: 0x14)    */
+#define REG_PAGE_1_TTXHSICNUMS                             TX_PAGE_1, 0x18
+
+#define MSK_PAGE_1_TTXHSICNUMS_TTX_NUMHSICSYM              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 TDM TX NUMTOTSYM Register                          (Default: 0x18)    */
+#define REG_PAGE_1_TTXTOTNUMS                              TX_PAGE_1, 0x19
+
+#define MSK_PAGE_1_TTXTOTNUMS_TTX_NUMTOTSYM                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A TDM TX SYMSOP0 Low Register                        (Default: 0x55)    */
+#define REG_PAGE_1_TTXSSOP0L                               TX_PAGE_1, 0x1A
+
+#define MSK_PAGE_1_TTXSSOP0L_TTX_SYMSOP0_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1B TDM TX SYMSOP0 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSSOP0H                               TX_PAGE_1, 0x1B
+
+#define MSK_PAGE_1_TTXSSOP0H_TTX_SYMSOP0_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1C TDM TX SYMSOP1 Low Register                        (Default: 0xAA)    */
+#define REG_PAGE_1_TTXSSOP1L                               TX_PAGE_1, 0x1C
+
+#define MSK_PAGE_1_TTXSSOP1L_TTX_SYMSOP1_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1D TDM TX SYMSOP1 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSSOP1H                               TX_PAGE_1, 0x1D
+
+#define MSK_PAGE_1_TTXSSOP1H_TTX_SYMSOP1_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1E TDM TX SYMEOP0 Low Register                        (Default: 0x00)    */
+#define REG_PAGE_1_TTXSEOP0L                               TX_PAGE_1, 0x1E
+
+#define MSK_PAGE_1_TTXSEOP0L_TTX_SYMEOP0_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1F TDM TX SYMEOP0 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSEOP0H                               TX_PAGE_1, 0x1F
+
+#define MSK_PAGE_1_TTXSEOP0H_TTX_SYMEOP0_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 TDM TX SYMEOP1 Low Register                        (Default: 0xFF)    */
+#define REG_PAGE_1_TTXSEOP1L                               TX_PAGE_1, 0x20
+
+#define MSK_PAGE_1_TTXSEOP1L_TTX_SYMEOP1_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 TDM TX SYMEOP1 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSEOP1H                               TX_PAGE_1, 0x21
+
+#define MSK_PAGE_1_TTXSEOP1H_TTX_SYMEOP1_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 TDM TX SYMCOM1 Low Register                        (Default: 0xA5)    */
+#define REG_PAGE_1_TTXSCOM1L                               TX_PAGE_1, 0x22
+
+#define MSK_PAGE_1_TTXSCOM1L_TTX_SYMCOM1_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 TDM TX SYMCOM1 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCOM1H                               TX_PAGE_1, 0x23
+
+#define MSK_PAGE_1_TTXSCOM1H_TTX_SYMCOM1_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x24 TDM TX SYMCOM2 Low Register                        (Default: 0x5A)    */
+#define REG_PAGE_1_TTXSCOM2L                               TX_PAGE_1, 0x24
+
+#define MSK_PAGE_1_TTXSCOM2L_TTX_SYMCOM2_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x25 TDM TX SYMCOM2 High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCOM2H                               TX_PAGE_1, 0x25
+
+#define MSK_PAGE_1_TTXSCOM2H_TTX_SYMCOM2_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x26 TDM TX SYMIDLE Low Register                        (Default: 0x00)    */
+#define REG_PAGE_1_TTXSIDLEL                               TX_PAGE_1, 0x26
+
+#define MSK_PAGE_1_TTXSIDLEL_TTX_SYMIDLE_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x27 TDM TX SYMIDLE High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSIDLEH                               TX_PAGE_1, 0x27
+
+#define MSK_PAGE_1_TTXSIDLEH_TTX_SYMIDLE_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x28 TDM TX SYMRST Low Register                         (Default: 0x93)    */
+#define REG_PAGE_1_TTXSRSTL                                TX_PAGE_1, 0x28
+
+#define MSK_PAGE_1_TTXSRSTL_TTX_SYMRST_7_0                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x29 TDM TX SYMRST High Register                        (Default: 0x00)    */
+#define REG_PAGE_1_TTXSRSTH                                TX_PAGE_1, 0x29
+
+#define MSK_PAGE_1_TTXSRSTH_TTX_SYMRST_9_8                 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2A TDM TX SYMCONN Low Register                        (Default: 0xC6)    */
+#define REG_PAGE_1_TTXSCONNL                               TX_PAGE_1, 0x2A
+
+#define MSK_PAGE_1_TTXSCONNL_TTX_SYMCONN_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2B TDM TX SYMCONN High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCONNH                               TX_PAGE_1, 0x2B
+
+#define MSK_PAGE_1_TTXSCONNH_TTX_SYMCONN_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2C TDM TX SYMCBUS Low Register                        (Default: 0x39)    */
+#define REG_PAGE_1_TTXSCBUSL                               TX_PAGE_1, 0x2C
+
+#define MSK_PAGE_1_TTXSCBUSL_TTX_SYMCBUS_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2D TDM TX SYMCBUS High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCBUSH                               TX_PAGE_1, 0x2D
+
+#define MSK_PAGE_1_TTXSCBUSH_TTX_SYMCBUS_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2E TDM TX SYMCBUSA Low Register                       (Default: 0x63)    */
+#define REG_PAGE_1_TTXSCBUSAL                              TX_PAGE_1, 0x2E
+
+#define MSK_PAGE_1_TTXSCBUSAL_TTX_SYMCBUSA_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2F TDM TX SYMCBUSA High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCBUSAH                              TX_PAGE_1, 0x2F
+
+#define MSK_PAGE_1_TTXSCBUSAH_TTX_SYMCBUSA_9_8             (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x30 TDM TX SYMCBUSN Low Register                       (Default: 0x6C)    */
+#define REG_PAGE_1_TTXSCBUSNL                              TX_PAGE_1, 0x30
+
+#define MSK_PAGE_1_TTXSCBUSNL_TTX_SYMCBUSN_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x31 TDM TX SYMCBUSN High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_TTXSCBUSNH                              TX_PAGE_1, 0x31
+
+#define MSK_PAGE_1_TTXSCBUSNH_TTX_SYMCBUSN_9_8             (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x32 TDM TX Status 1st Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TTXSTA1                                 TX_PAGE_1, 0x32
+
+#define MSK_PAGE_1_TTXSTA1_TTX_STATUS_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x33 TDM TX Status 2nd Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TTXSTA2                                 TX_PAGE_1, 0x33
+
+#define MSK_PAGE_1_TTXSTA2_TTX_STATUS_15_8                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x34 TDM TX Status 3rd Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TTXSTA3                                 TX_PAGE_1, 0x34
+
+#define MSK_PAGE_1_TTXSTA3_TTX_STATUS_23_16                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x35 TDM TX Status 4th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TTXSTA4                                 TX_PAGE_1, 0x35
+
+#define MSK_PAGE_1_TTXSTA4_TTX_STATUS_31_24                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x36 TDM TX INT Low Register                            (Default: 0x00)    */
+#define REG_PAGE_1_TTXINTL                                 TX_PAGE_1, 0x36
+
+#define BIT_PAGE_1_TTXINTL_TTX_INTR7                       (0x01 << 7)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR6                       (0x01 << 6)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR5                       (0x01 << 5)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR4                       (0x01 << 4)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR3                       (0x01 << 3)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR2                       (0x01 << 2)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR1                       (0x01 << 1)
+#define BIT_PAGE_1_TTXINTL_TTX_INTR0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x37 TDM TX INT High Register                           (Default: 0x00)    */
+#define REG_PAGE_1_TTXINTH                                 TX_PAGE_1, 0x37
+
+#define BIT_PAGE_1_TTXINTH_TTX_INTR15                      (0x01 << 7)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR14                      (0x01 << 6)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR13                      (0x01 << 5)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR12                      (0x01 << 4)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR11                      (0x01 << 3)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR10                      (0x01 << 2)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR9                       (0x01 << 1)
+#define BIT_PAGE_1_TTXINTH_TTX_INTR8                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x38 TDM TX INTMASK Low Register                        (Default: 0x00)    */
+#define REG_PAGE_1_TTXINTML                                TX_PAGE_1, 0x38
+
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK7                  (0x01 << 7)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK6                  (0x01 << 6)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK5                  (0x01 << 5)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK4                  (0x01 << 4)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK3                  (0x01 << 3)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK2                  (0x01 << 2)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK1                  (0x01 << 1)
+#define BIT_PAGE_1_TTXINTML_TTX_INTRMASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x39 TDM TX INTMASK High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TTXINTMH                                TX_PAGE_1, 0x39
+
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK15                 (0x01 << 7)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK14                 (0x01 << 6)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK13                 (0x01 << 5)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK12                 (0x01 << 4)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK11                 (0x01 << 3)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK10                 (0x01 << 2)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK9                  (0x01 << 1)
+#define BIT_PAGE_1_TTXINTMH_TTX_INTRMASK8                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A TDM RX Output Enable Register                      (Default: 0x3F)    */
+#define REG_PAGE_1_TRXOUTEN                                TX_PAGE_1, 0x3A
+
+#define MSK_PAGE_1_TRXOUTEN_TRX_OUT_EN                     (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3B TDM RX Control Register                            (Default: 0x1C)    */
+#define REG_PAGE_1_TRXCTRL                                 TX_PAGE_1, 0x3B
+
+#define BIT_PAGE_1_TRXCTRL_TRX_CLR_WVALLOW                 (0x01 << 4)
+#define BIT_PAGE_1_TRXCTRL_TRX_FROM_SE_COC                 (0x01 << 3)
+#define MSK_PAGE_1_TRXCTRL_TRX_NUMBPS_2_0                  (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C TDM RX NUMSPISYM Register                          (Default: 0x04)    */
+#define REG_PAGE_1_TRXSPINUMS                              TX_PAGE_1, 0x3C
+
+#define MSK_PAGE_1_TRXSPINUMS_TRX_NUMSPISYM                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D TDM RX NUMHSICSYM Register                         (Default: 0x14)    */
+#define REG_PAGE_1_TRXHSICNUMS                             TX_PAGE_1, 0x3D
+
+#define MSK_PAGE_1_TRXHSICNUMS_TRX_NUMHSICSYM              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3E TDM RX NUMTOTSYM Register                          (Default: 0x18)    */
+#define REG_PAGE_1_TRXTOTNUMS                              TX_PAGE_1, 0x3E
+
+#define MSK_PAGE_1_TRXTOTNUMS_TRX_NUMTOTSYM                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3F TDM RX MIN12MCHPRD Register                        (Default: 0x08)    */
+#define REG_PAGE_1_TRXMIN12                                TX_PAGE_1, 0x3F
+
+#define MSK_PAGE_1_TRXMIN12_TRX_MIN12MP                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x40 TDM RX MIN2MCHPRD Register                         (Default: 0x08)    */
+#define REG_PAGE_1_TRXMIN2                                 TX_PAGE_1, 0x40
+
+#define MSK_PAGE_1_TRXMIN2_TRX_MIN2MP                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 TDM RX MAX12MCHPRD Register                        (Default: 0x0A)    */
+#define REG_PAGE_1_TRXMAX12                                TX_PAGE_1, 0x41
+
+#define MSK_PAGE_1_TRXMAX12_TRX_MAX12MP                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 TDM RX MAX2MCHPRD Register                         (Default: 0x0A)    */
+#define REG_PAGE_1_TRXMAX2                                 TX_PAGE_1, 0x42
+
+#define MSK_PAGE_1_TRXMAX2_TRX_MAX2MP                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5B TDM RX Status 1st Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA1                                 TX_PAGE_1, 0x5B
+
+#define MSK_PAGE_1_TRXSTA1_TRX_STATUS_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5C TDM RX Status 2nd Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA2                                 TX_PAGE_1, 0x5C
+
+#define MSK_PAGE_1_TRXSTA2_TRX_STATUS_15_8                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5D TDM RX Status 3rd Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA3                                 TX_PAGE_1, 0x5D
+
+#define MSK_PAGE_1_TRXSTA3_TRX_STATUS_23_16                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5E TDM RX Status 4th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA4                                 TX_PAGE_1, 0x5E
+
+#define MSK_PAGE_1_TRXSTA4_TRX_STATUS_31_24                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x5F TDM RX Status 5th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA5                                 TX_PAGE_1, 0x5F
+
+#define MSK_PAGE_1_TRXSTA5_TRX_STATUS_39_32                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 TDM RX Status 6th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA6                                 TX_PAGE_1, 0x60
+
+#define MSK_PAGE_1_TRXSTA6_TRX_STATUS_47_40                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 TDM RX Status 7th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA7                                 TX_PAGE_1, 0x61
+
+#define MSK_PAGE_1_TRXSTA7_TRX_STATUS_55_48                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x62 TDM RX Status 8th Register                         (Default: 0x00)    */
+#define REG_PAGE_1_TRXSTA8                                 TX_PAGE_1, 0x62
+
+#define MSK_PAGE_1_TRXSTA8_TRX_STATUS_63_56                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x63 TDM RX INT Low Register                            (Default: 0x00)    */
+#define REG_PAGE_1_TRXINTL                                 TX_PAGE_1, 0x63
+
+#define BIT_PAGE_1_TRXINTL_TRX_INTR7                       (0x01 << 7)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR6                       (0x01 << 6)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR5                       (0x01 << 5)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR4                       (0x01 << 4)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR3                       (0x01 << 3)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR2                       (0x01 << 2)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR1                       (0x01 << 1)
+#define BIT_PAGE_1_TRXINTL_TRX_INTR0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x64 TDM RX INT High Register                           (Default: 0x00)    */
+#define REG_PAGE_1_TRXINTH                                 TX_PAGE_1, 0x64
+
+#define BIT_PAGE_1_TRXINTH_TRX_INTR15                      (0x01 << 7)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR14                      (0x01 << 6)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR13                      (0x01 << 5)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR12                      (0x01 << 4)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR11                      (0x01 << 3)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR10                      (0x01 << 2)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR9                       (0x01 << 1)
+#define BIT_PAGE_1_TRXINTH_TRX_INTR8                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x65 TDM RX INTMASK Low Register                        (Default: 0x00)    */
+#define REG_PAGE_1_TRXINTML                                TX_PAGE_1, 0x65
+
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK7                  (0x01 << 7)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK6                  (0x01 << 6)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK5                  (0x01 << 5)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK4                  (0x01 << 4)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK3                  (0x01 << 3)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK2                  (0x01 << 2)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK1                  (0x01 << 1)
+#define BIT_PAGE_1_TRXINTML_TRX_INTRMASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x66 TDM RX INTMASK High Register                       (Default: 0x00)    */
+#define REG_PAGE_1_TRXINTMH                                TX_PAGE_1, 0x66
+
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK15                 (0x01 << 7)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK14                 (0x01 << 6)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK13                 (0x01 << 5)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK12                 (0x01 << 4)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK11                 (0x01 << 3)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK10                 (0x01 << 2)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK9                  (0x01 << 1)
+#define BIT_PAGE_1_TRXINTMH_TRX_INTRMASK8                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x67 HSIC TX Strobet EOP Register                       (Default: 0x38)    */
+#define REG_PAGE_1_HTXSTEOP                                TX_PAGE_1, 0x67
+
+#define MSK_PAGE_1_HTXSTEOP_HTX_ST_AEOP_5_0                (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x68 HSIC TX Datat EOP Register                         (Default: 0x38)    */
+#define REG_PAGE_1_HTXDTEOP                                TX_PAGE_1, 0x68
+
+#define MSK_PAGE_1_HTXDTEOP_HTX_DT_AEOP_5_0                (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x69 HSIC TX CRTL Register                              (Default: 0x00)    */
+#define REG_PAGE_1_HTXCTRL                                 TX_PAGE_1, 0x69
+
+#define BIT_PAGE_1_HTXCTRL_HTX_ALLSBE_SOP                  (0x01 << 4)
+#define BIT_PAGE_1_HTXCTRL_HTX_RGDINV_USB                  (0x01 << 3)
+#define BIT_PAGE_1_HTXCTRL_HTX_RSPTDM_BUSY                 (0x01 << 2)
+#define BIT_PAGE_1_HTXCTRL_HTX_DRVCONN1                    (0x01 << 1)
+#define BIT_PAGE_1_HTXCTRL_HTX_DRVRST1                     (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6A HSIC TX AFIFO Control Register                     (Default: 0x00)    */
+#define REG_PAGE_1_HTXAFFCTRL                              TX_PAGE_1, 0x6A
+
+#define MSK_PAGE_1_HTXAFFCTRL_HTX_AFFCTRL_3_0              (0x0F << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6B HSIC TX BUSIDLEP 1st Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEP0                              TX_PAGE_1, 0x6B
+
+#define MSK_PAGE_1_HTXBIDLEP0_HTX_BUSIDPRD_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6C HSIC TX BUSIDLEP 2nd Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEP1                              TX_PAGE_1, 0x6C
+
+#define MSK_PAGE_1_HTXBIDLEP1_HTX_BUSIDPRD_15_8            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6D HSIC TX BUSIDLEP 3rd Register                      (Default: 0x08)    */
+#define REG_PAGE_1_HTXBIDLEP2                              TX_PAGE_1, 0x6D
+
+#define MSK_PAGE_1_HTXBIDLEP2_HTX_BUSIDPRD_23_16           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6E HSIC TX BUSIDLEP 4th Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEP3                              TX_PAGE_1, 0x6E
+
+#define MSK_PAGE_1_HTXBIDLEP3_HTX_BUSIDPRD_31_24           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6F HSIC TX BUSIDLEC 1st Register                      (Default: 0x10)    */
+#define REG_PAGE_1_HTXBIDLEC0                              TX_PAGE_1, 0x6F
+
+#define MSK_PAGE_1_HTXBIDLEC0_HTX_BUSIDCHK_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x70 HSIC TX BUSIDLEC 2nd Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEC1                              TX_PAGE_1, 0x70
+
+#define MSK_PAGE_1_HTXBIDLEC1_HTX_BUSIDCHK_15_8            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x71 HSIC TX BUSIDLEC 3rd Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEC2                              TX_PAGE_1, 0x71
+
+#define MSK_PAGE_1_HTXBIDLEC2_HTX_BUSIDCHK_23_16           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x72 HSIC TX BUSIDLEC 4th Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXBIDLEC3                              TX_PAGE_1, 0x72
+
+#define MSK_PAGE_1_HTXBIDLEC3_HTX_BUSIDCHK_31_24           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x73 HSIC TX PRETOUT Low Register                       (Default: 0x10)    */
+#define REG_PAGE_1_HTXPRETOUTL                             TX_PAGE_1, 0x73
+
+#define MSK_PAGE_1_HTXPRETOUTL_HTX_STPRETOUT_7_0           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x74 HSIC TX PRETOUT High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXPRETOUTH                             TX_PAGE_1, 0x74
+
+#define MSK_PAGE_1_HTXPRETOUTH_HTX_STPRETOUT_15_8          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x75 HSIC TX BUF Register                               (Default: 0x08)    */
+#define REG_PAGE_1_HTXBUF                                  TX_PAGE_1, 0x75
+
+#define MSK_PAGE_1_HTXBUF_HTX_BUF_7_0                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x76 HSIC TX NNULLEOP Register                          (Default: 0x10)    */
+#define REG_PAGE_1_HTXNNEOP                                TX_PAGE_1, 0x76
+
+#define MSK_PAGE_1_HTXNNEOP_HTX_NNFEOP                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x77 HSIC TX OVRHOUT Low Register                       (Default: 0x33)    */
+#define REG_PAGE_1_HTXOVRHOL                               TX_PAGE_1, 0x77
+
+#define MSK_PAGE_1_HTXOVRHOL_HTX_OVRHOUT_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x78 HSIC TX OVRHOUT High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXOVRHOH                               TX_PAGE_1, 0x78
+
+#define MSK_PAGE_1_HTXOVRHOH_HTX_OVRHOUT_9_8               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x79 HSIC TX Status 1st Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HTXSTA1                                 TX_PAGE_1, 0x79
+
+#define MSK_PAGE_1_HTXSTA1_HTX_STATUS_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7A HSIC TX Status 2nd Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HTXSTA2                                 TX_PAGE_1, 0x7A
+
+#define MSK_PAGE_1_HTXSTA2_HTX_STATUS_15_8                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7B HSIC TX Status 3rd Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HTXSTA3                                 TX_PAGE_1, 0x7B
+
+#define MSK_PAGE_1_HTXSTA3_HTX_STATUS_23_16                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7C HSIC TX Status 4th Register                        (Default: 0x00)    */
+#define REG_PAGE_1_HTXSTA4                                 TX_PAGE_1, 0x7C
+
+#define MSK_PAGE_1_HTXSTA4_HTX_STATUS_31_24                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7D HSIC TX INT Low Register                           (Default: 0x00)    */
+#define REG_PAGE_1_HTXINTL                                 TX_PAGE_1, 0x7D
+
+#define BIT_PAGE_1_HTXINTL_HTX_INTR7                       (0x01 << 7)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR6                       (0x01 << 6)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR5                       (0x01 << 5)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR4                       (0x01 << 4)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR3                       (0x01 << 3)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR2                       (0x01 << 2)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR1                       (0x01 << 1)
+#define BIT_PAGE_1_HTXINTL_HTX_INTR0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7E HSIC TX INT High Register                          (Default: 0x00)    */
+#define REG_PAGE_1_HTXINTH                                 TX_PAGE_1, 0x7E
+
+#define BIT_PAGE_1_HTXINTH_HTX_INTR15                      (0x01 << 7)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR14                      (0x01 << 6)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR13                      (0x01 << 5)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR12                      (0x01 << 4)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR11                      (0x01 << 3)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR10                      (0x01 << 2)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR9                       (0x01 << 1)
+#define BIT_PAGE_1_HTXINTH_HTX_INTR8                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7F HSIC TX INTMASK Low Register                       (Default: 0x00)    */
+#define REG_PAGE_1_HTXINTML                                TX_PAGE_1, 0x7F
+
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK7                  (0x01 << 7)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK6                  (0x01 << 6)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK5                  (0x01 << 5)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK4                  (0x01 << 4)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK3                  (0x01 << 3)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK2                  (0x01 << 2)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK1                  (0x01 << 1)
+#define BIT_PAGE_1_HTXINTML_HTX_INTRMASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 HSIC TX INTMASK High Register                      (Default: 0x00)    */
+#define REG_PAGE_1_HTXINTMH                                TX_PAGE_1, 0x80
+
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK15                 (0x01 << 7)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK14                 (0x01 << 6)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK13                 (0x01 << 5)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK12                 (0x01 << 4)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK11                 (0x01 << 3)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK10                 (0x01 << 2)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK9                  (0x01 << 1)
+#define BIT_PAGE_1_HTXINTMH_HTX_INTRMASK8                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 HSIC Keeper Register                               (Default: 0x00)    */
+#define REG_PAGE_1_KEEPER                                  TX_PAGE_1, 0x81
+
+#define MSK_PAGE_1_KEEPER_KEEPER_MODE_1_0                  (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 HSIC Keeper StartEnd Register                      (Default: 0x34)    */
+#define REG_PAGE_1_KPSTEND                                 TX_PAGE_1, 0x82
+
+#define MSK_PAGE_1_KPSTEND_KEEPER_END_3_0                  (0x0F << 4)
+#define MSK_PAGE_1_KPSTEND_KEEPER_START_3_0                (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x83 HSIC Flow Control General Register                 (Default: 0x02)    */
+#define REG_PAGE_1_FCGC                                    TX_PAGE_1, 0x83
+
+#define BIT_PAGE_1_FCGC_HSIC_FC_HOSTMODE                   (0x01 << 1)
+#define BIT_PAGE_1_FCGC_HSIC_FC_ENABLE                     (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x84 HSIC Flow Control CTR0 Register                    (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR0                                  TX_PAGE_1, 0x84
+
+#define MSK_PAGE_1_FCCTR0_HFC_CONF0                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x85 HSIC Flow Control CTR1 Register                    (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR1                                  TX_PAGE_1, 0x85
+
+#define MSK_PAGE_1_FCCTR1_HFC_CONF1                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x86 HSIC Flow Control CTR2 Register                    (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR2                                  TX_PAGE_1, 0x86
+
+#define MSK_PAGE_1_FCCTR2_HFC_CONF2                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x87 HSIC Flow Control CTR3 Register                    (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR3                                  TX_PAGE_1, 0x87
+
+#define MSK_PAGE_1_FCCTR3_HFC_CONF3                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x88 HSIC Flow Control CTR4 Register                    (Default: 0x8F)    */
+#define REG_PAGE_1_FCCTR4                                  TX_PAGE_1, 0x88
+
+
+#define MSK_PAGE_1_FCCTR4_HFC_CONF4                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x89 HSIC Flow Control CTR5 Register                    (Default: 0x80)    */
+#define REG_PAGE_1_FCCTR5                                  TX_PAGE_1, 0x89
+
+#define MSK_PAGE_1_FCCTR5_HFC_CONF5                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8A HSIC Flow Control CTR6 Register                    (Default: 0x13)    */
+#define REG_PAGE_1_FCCTR6                                  TX_PAGE_1, 0x8A
+
+#define MSK_PAGE_1_FCCTR6_HFC_CONF6                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8B HSIC Flow Control CTR7 Register                    (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR7                                  TX_PAGE_1, 0x8B
+
+#define MSK_PAGE_1_FCCTR7_HFC_CONF7                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8C HSIC Flow Control CTR8 Register                    (Default: 0x8F)    */
+#define REG_PAGE_1_FCCTR8                                  TX_PAGE_1, 0x8C
+
+#define MSK_PAGE_1_FCCTR8_HFC_CONF8                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8D HSIC Flow Control CTR9 Register                    (Default: 0x08)    */
+#define REG_PAGE_1_FCCTR9                                  TX_PAGE_1, 0x8D
+
+#define MSK_PAGE_1_FCCTR9_HFC_CONF9                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8E HSIC Flow Control CTR10 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR10                                 TX_PAGE_1, 0x8E
+
+#define MSK_PAGE_1_FCCTR10_HFC_CONF10                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8F HSIC Flow Control CTR11 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR11                                 TX_PAGE_1, 0x8F
+
+#define MSK_PAGE_1_FCCTR11_HFC_CONF11                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x90 HSIC Flow Control CTR12 Register                   (Default: 0xF9)    */
+#define REG_PAGE_1_FCCTR12                                 TX_PAGE_1, 0x90
+
+#define MSK_PAGE_1_FCCTR12_HFC_CONF12                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x91 HSIC Flow Control CTR13 Register                   (Default: 0xFC)    */
+#define REG_PAGE_1_FCCTR13                                 TX_PAGE_1, 0x91
+
+#define MSK_PAGE_1_FCCTR13_HFC_CONF13                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x92 HSIC Flow Control CTR14 Register                   (Default: 0xFF)    */
+#define REG_PAGE_1_FCCTR14                                 TX_PAGE_1, 0x92
+
+#define MSK_PAGE_1_FCCTR14_HFC_CONF14                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x93 HSIC Flow Control CTR15 Register                   (Default: 0x0F)    */
+#define REG_PAGE_1_FCCTR15                                 TX_PAGE_1, 0x93
+
+#define MSK_PAGE_1_FCCTR15_HFC_CONF15                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x94 HSIC Flow Control CTR16 Register                   (Default: 0x73)    */
+#define REG_PAGE_1_FCCTR16                                 TX_PAGE_1, 0x94
+
+#define MSK_PAGE_1_FCCTR16_HFC_CONF16                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x95 HSIC Flow Control CTR17 Register                   (Default: 0x1E)    */
+#define REG_PAGE_1_FCCTR17                                 TX_PAGE_1, 0x95
+
+#define MSK_PAGE_1_FCCTR17_HFC_CONF17                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x96 HSIC Flow Control CTR18 Register                   (Default: 0x05)    */
+#define REG_PAGE_1_FCCTR18                                 TX_PAGE_1, 0x96
+
+#define MSK_PAGE_1_FCCTR18_HFC_CONF18                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x97 HSIC Flow Control CTR19 Register                   (Default: 0x09)    */
+#define REG_PAGE_1_FCCTR19                                 TX_PAGE_1, 0x97
+
+#define MSK_PAGE_1_FCCTR19_HFC_CONF19                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x98 HSIC Flow Control CTR20 Register                   (Default: 0x68)    */
+#define REG_PAGE_1_FCCTR20                                 TX_PAGE_1, 0x98
+
+#define MSK_PAGE_1_FCCTR20_HFC_CONF20                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x99 HSIC Flow Control CTR21 Register                   (Default: 0x26)    */
+#define REG_PAGE_1_FCCTR21                                 TX_PAGE_1, 0x99
+
+#define MSK_PAGE_1_FCCTR21_HFC_CONF21                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9A HSIC Flow Control CTR22 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR22                                 TX_PAGE_1, 0x9A
+
+#define MSK_PAGE_1_FCCTR22_HFC_CONF22                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9B HSIC Flow Control CTR23 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR23                                 TX_PAGE_1, 0x9B
+
+#define MSK_PAGE_1_FCCTR23_HFC_CONF23                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9C HSIC Flow Control CTR24 Register                   (Default: 0xE2)    */
+#define REG_PAGE_1_FCCTR24                                 TX_PAGE_1, 0x9C
+
+#define MSK_PAGE_1_FCCTR24_HFC_CONF24                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9D HSIC Flow Control CTR25 Register                   (Default: 0x04)    */
+#define REG_PAGE_1_FCCTR25                                 TX_PAGE_1, 0x9D
+
+#define MSK_PAGE_1_FCCTR25_HFC_CONF25                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9E HSIC Flow Control CTR26 Register                   (Default: 0x4C)    */
+#define REG_PAGE_1_FCCTR26                                 TX_PAGE_1, 0x9E
+
+#define MSK_PAGE_1_FCCTR26_HFC_CONF26                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9F HSIC Flow Control CTR27 Register                   (Default: 0x1D)    */
+#define REG_PAGE_1_FCCTR27                                 TX_PAGE_1, 0x9F
+
+#define MSK_PAGE_1_FCCTR27_HFC_CONF27                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA0 HSIC Flow Control CTR28 Register                   (Default: 0xE4)    */
+#define REG_PAGE_1_FCCTR28                                 TX_PAGE_1, 0xA0
+
+#define MSK_PAGE_1_FCCTR28_HFC_CONF28                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA1 HSIC Flow Control CTR29 Register                   (Default: 0x57)    */
+#define REG_PAGE_1_FCCTR29                                 TX_PAGE_1, 0xA1
+
+#define MSK_PAGE_1_FCCTR29_HFC_CONF29                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA2 HSIC Flow Control CTR30 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR30                                 TX_PAGE_1, 0xA2
+
+#define MSK_PAGE_1_FCCTR30_HFC_CONF30                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA3 HSIC Flow Control CTR31 Register                   (Default: 0x04)    */
+#define REG_PAGE_1_FCCTR31                                 TX_PAGE_1, 0xA3
+
+#define MSK_PAGE_1_FCCTR31_HFC_CONF31                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA4 HSIC Flow Control CTR32 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR32                                 TX_PAGE_1, 0xA4
+
+#define MSK_PAGE_1_FCCTR32_HFC_CONF32                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA5 HSIC Flow Control CTR33 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR33                                 TX_PAGE_1, 0xA5
+
+#define MSK_PAGE_1_FCCTR33_HFC_CONF33                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA6 HSIC Flow Control CTR34 Register                   (Default: 0x01)    */
+#define REG_PAGE_1_FCCTR34                                 TX_PAGE_1, 0xA6
+
+#define MSK_PAGE_1_FCCTR34_HFC_CONF34                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA7 HSIC Flow Control CTR35 Register                   (Default: 0x40)    */
+#define REG_PAGE_1_FCCTR35                                 TX_PAGE_1, 0xA7
+
+#define MSK_PAGE_1_FCCTR35_HFC_CONF35                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA8 HSIC Flow Control CTR36 Register                   (Default: 0x11)    */
+#define REG_PAGE_1_FCCTR36                                 TX_PAGE_1, 0xA8
+
+#define MSK_PAGE_1_FCCTR36_HFC_CONF36                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA9 HSIC Flow Control CTR37 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR37                                 TX_PAGE_1, 0xA9
+
+#define MSK_PAGE_1_FCCTR37_HFC_CONF37                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAA HSIC Flow Control CTR38 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR38                                 TX_PAGE_1, 0xAA
+
+#define MSK_PAGE_1_FCCTR38_HFC_CONF38                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAB HSIC Flow Control CTR39 Register                   (Default: 0x01)    */
+#define REG_PAGE_1_FCCTR39                                 TX_PAGE_1, 0xAB
+
+#define MSK_PAGE_1_FCCTR39_HFC_CONF39                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAC HSIC Flow Control CTR40 Register                   (Default: 0xB0)    */
+#define REG_PAGE_1_FCCTR40                                 TX_PAGE_1, 0xAC
+
+#define MSK_PAGE_1_FCCTR40_HFC_CONF40                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAD HSIC Flow Control CTR41 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR41                                 TX_PAGE_1, 0xAD
+
+#define MSK_PAGE_1_FCCTR41_HFC_CONF41                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAE HSIC Flow Control CTR42 Register                   (Default: 0x83)    */
+#define REG_PAGE_1_FCCTR42                                 TX_PAGE_1, 0xAE
+
+#define MSK_PAGE_1_FCCTR42_HFC_CONF42                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAF HSIC Flow Control CTR43 Register                   (Default: 0x04)    */
+#define REG_PAGE_1_FCCTR43                                 TX_PAGE_1, 0xAF
+
+#define MSK_PAGE_1_FCCTR43_HFC_CONF43                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB0 HSIC Flow Control CTR44 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR44                                 TX_PAGE_1, 0xB0
+
+#define MSK_PAGE_1_FCCTR44_HFC_CONF44                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB1 HSIC Flow Control CTR45 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR45                                 TX_PAGE_1, 0xB1
+
+#define MSK_PAGE_1_FCCTR45_HFC_CONF45                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB2 HSIC Flow Control CTR46 Register                   (Default: 0x50)    */
+#define REG_PAGE_1_FCCTR46                                 TX_PAGE_1, 0xB2
+
+#define MSK_PAGE_1_FCCTR46_HFC_CONF46                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB3 HSIC Flow Control CTR47 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR47                                 TX_PAGE_1, 0xB3
+
+#define MSK_PAGE_1_FCCTR47_HFC_CONF47                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB4 HSIC Flow Control CTR48 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR48                                 TX_PAGE_1, 0xB4
+
+#define MSK_PAGE_1_FCCTR48_HFC_CONF48                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB5 HSIC Flow Control CTR49 Register                   (Default: 0x01)    */
+#define REG_PAGE_1_FCCTR49                                 TX_PAGE_1, 0xB5
+
+#define MSK_PAGE_1_FCCTR49_HFC_CONF49                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB6 HSIC Flow Control CTR50 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR50                                 TX_PAGE_1, 0xB6
+
+#define MSK_PAGE_1_FCCTR50_HFC_CONF50                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB7 HSIC Flow Control CTR51 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR51                                 TX_PAGE_1, 0xB7
+
+#define MSK_PAGE_1_FCCTR51_HFC_CONF51                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB8 HSIC Flow Control CTR52 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR52                                 TX_PAGE_1, 0xB8
+
+#define MSK_PAGE_1_FCCTR52_HFC_CONF52                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB9 HSIC Flow Control CTR53 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR53                                 TX_PAGE_1, 0xB9
+
+#define MSK_PAGE_1_FCCTR53_HFC_CONF53                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBA HSIC Flow Control CTR54 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR54                                 TX_PAGE_1, 0xBA
+
+#define MSK_PAGE_1_FCCTR54_HFC_CONF54                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB HSIC Flow Control CTR55 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCCTR55                                 TX_PAGE_1, 0xBB
+
+#define MSK_PAGE_1_FCCTR55_HFC_CONF55                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBC HSIC Flow Control STAT0 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT0                                 TX_PAGE_1, 0xBC
+
+#define MSK_PAGE_1_FCSTAT0_HFC_STAT0                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBD HSIC Flow Control STAT1 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT1                                 TX_PAGE_1, 0xBD
+
+#define MSK_PAGE_1_FCSTAT1_HFC_STAT1                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBE HSIC Flow Control STAT2 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT2                                 TX_PAGE_1, 0xBE
+
+#define MSK_PAGE_1_FCSTAT2_HFC_STAT2                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF HSIC Flow Control STAT3 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT3                                 TX_PAGE_1, 0xBF
+
+#define MSK_PAGE_1_FCSTAT3_HFC_STAT3                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 HSIC Flow Control STAT4 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT4                                 TX_PAGE_1, 0xC0
+
+#define MSK_PAGE_1_FCSTAT4_HFC_STAT4                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 HSIC Flow Control STAT5 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT5                                 TX_PAGE_1, 0xC1
+
+#define MSK_PAGE_1_FCSTAT5_HFC_STAT5                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 HSIC Flow Control STAT6 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT6                                 TX_PAGE_1, 0xC2
+
+#define MSK_PAGE_1_FCSTAT6_HFC_STAT6                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 HSIC Flow Control STAT7 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT7                                 TX_PAGE_1, 0xC3
+
+#define MSK_PAGE_1_FCSTAT7_HFC_STAT7                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 HSIC Flow Control STAT8 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT8                                 TX_PAGE_1, 0xC4
+
+#define MSK_PAGE_1_FCSTAT8_HFC_STAT8                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 HSIC Flow Control STAT9 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT9                                 TX_PAGE_1, 0xC5
+
+#define MSK_PAGE_1_FCSTAT9_HFC_STAT9                       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC6 HSIC Flow Control STAT10 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT10                                TX_PAGE_1, 0xC6
+
+#define MSK_PAGE_1_FCSTAT10_HFC_STAT10                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 HSIC Flow Control STAT11 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT11                                TX_PAGE_1, 0xC7
+
+#define MSK_PAGE_1_FCSTAT11_HFC_STAT11                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC8 HSIC Flow Control STAT12 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT12                                TX_PAGE_1, 0xC8
+
+#define MSK_PAGE_1_FCSTAT12_HFC_STAT12                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC9 HSIC Flow Control STAT13 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT13                                TX_PAGE_1, 0xC9
+
+#define MSK_PAGE_1_FCSTAT13_HFC_STAT13                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCA HSIC Flow Control STAT14 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT14                                TX_PAGE_1, 0xCA
+
+#define MSK_PAGE_1_FCSTAT14_HFC_STAT14                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCB HSIC Flow Control STAT15 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT15                                TX_PAGE_1, 0xCB
+
+#define MSK_PAGE_1_FCSTAT15_HFC_STAT15                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC HSIC Flow Control STAT16 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT16                                TX_PAGE_1, 0xCC
+
+#define MSK_PAGE_1_FCSTAT16_HFC_STAT16                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCD HSIC Flow Control STAT17 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT17                                TX_PAGE_1, 0xCD
+
+#define MSK_PAGE_1_FCSTAT17_HFC_STAT17                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE HSIC Flow Control STAT18 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT18                                TX_PAGE_1, 0xCE
+
+#define MSK_PAGE_1_FCSTAT18_HFC_STAT18                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF HSIC Flow Control STAT19 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT19                                TX_PAGE_1, 0xCF
+
+#define MSK_PAGE_1_FCSTAT19_HFC_STAT19                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD0 HSIC Flow Control STAT20 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT20                                TX_PAGE_1, 0xD0
+
+#define MSK_PAGE_1_FCSTAT20_HFC_STAT20                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD1 HSIC Flow Control STAT21 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT21                                TX_PAGE_1, 0xD1
+
+#define MSK_PAGE_1_FCSTAT21_HFC_STAT21                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD2 HSIC Flow Control STAT22 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT22                                TX_PAGE_1, 0xD2
+
+#define MSK_PAGE_1_FCSTAT22_HFC_STAT22                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD3 HSIC Flow Control STAT23 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT23                                TX_PAGE_1, 0xD3
+
+#define MSK_PAGE_1_FCSTAT23_HFC_STAT23                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD4 HSIC Flow Control STAT24 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT24                                TX_PAGE_1, 0xD4
+
+#define MSK_PAGE_1_FCSTAT24_HFC_STAT24                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD5 HSIC Flow Control STAT25 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT25                                TX_PAGE_1, 0xD5
+
+#define MSK_PAGE_1_FCSTAT25_HFC_STAT25                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD6 HSIC Flow Control STAT26 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT26                                TX_PAGE_1, 0xD6
+
+#define MSK_PAGE_1_FCSTAT26_HFC_STAT26                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD7 HSIC Flow Control STAT27 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT27                                TX_PAGE_1, 0xD7
+
+#define MSK_PAGE_1_FCSTAT27_HFC_STAT27                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 HSIC Flow Control STAT28 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT28                                TX_PAGE_1, 0xD8
+
+#define MSK_PAGE_1_FCSTAT28_HFC_STAT28                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 HSIC Flow Control STAT29 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT29                                TX_PAGE_1, 0xD9
+
+#define MSK_PAGE_1_FCSTAT29_HFC_STAT29                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDA HSIC Flow Control STAT30 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT30                                TX_PAGE_1, 0xDA
+
+#define MSK_PAGE_1_FCSTAT30_HFC_STAT30                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDB HSIC Flow Control STAT31 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT31                                TX_PAGE_1, 0xDB
+
+#define MSK_PAGE_1_FCSTAT31_HFC_STAT31                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDC HSIC Flow Control STAT32 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT32                                TX_PAGE_1, 0xDC
+
+#define MSK_PAGE_1_FCSTAT32_HFC_STAT32                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDD HSIC Flow Control STAT33 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT33                                TX_PAGE_1, 0xDD
+
+#define MSK_PAGE_1_FCSTAT33_HFC_STAT33                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDE HSIC Flow Control STAT34 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT34                                TX_PAGE_1, 0xDE
+
+#define MSK_PAGE_1_FCSTAT34_HFC_STAT34                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDF HSIC Flow Control STAT35 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT35                                TX_PAGE_1, 0xDF
+
+#define MSK_PAGE_1_FCSTAT35_HFC_STAT35                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE0 HSIC Flow Control STAT36 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT36                                TX_PAGE_1, 0xE0
+
+#define MSK_PAGE_1_FCSTAT36_HFC_STAT36                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE1 HSIC Flow Control STAT37 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT37                                TX_PAGE_1, 0xE1
+
+#define MSK_PAGE_1_FCSTAT37_HFC_STAT37                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE2 HSIC Flow Control STAT38 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT38                                TX_PAGE_1, 0xE2
+
+#define MSK_PAGE_1_FCSTAT38_HFC_STAT38                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE3 HSIC Flow Control STAT39 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT39                                TX_PAGE_1, 0xE3
+
+#define MSK_PAGE_1_FCSTAT39_HFC_STAT39                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE4 HSIC Flow Control STAT40 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT40                                TX_PAGE_1, 0xE4
+
+#define MSK_PAGE_1_FCSTAT40_HFC_STAT40                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE5 HSIC Flow Control STAT41 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT41                                TX_PAGE_1, 0xE5
+
+#define MSK_PAGE_1_FCSTAT41_HFC_STAT41                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE6 HSIC Flow Control STAT42 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT42                                TX_PAGE_1, 0xE6
+
+#define MSK_PAGE_1_FCSTAT42_HFC_STAT42                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE7 HSIC Flow Control STAT43 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT43                                TX_PAGE_1, 0xE7
+
+#define MSK_PAGE_1_FCSTAT43_HFC_STAT43                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE8 HSIC Flow Control STAT44 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT44                                TX_PAGE_1, 0xE8
+
+#define MSK_PAGE_1_FCSTAT44_HFC_STAT44                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE9 HSIC Flow Control STAT45 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT45                                TX_PAGE_1, 0xE9
+
+#define MSK_PAGE_1_FCSTAT45_HFC_STAT45                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEA HSIC Flow Control STAT46 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT46                                TX_PAGE_1, 0xEA
+
+#define MSK_PAGE_1_FCSTAT46_HFC_STAT46                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEB HSIC Flow Control STAT47 Register                  (Default: 0x00)    */
+#define REG_PAGE_1_FCSTAT47                                TX_PAGE_1, 0xEB
+
+#define MSK_PAGE_1_FCSTAT47_HFC_STAT47                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEC HSIC Flow Control INTR0 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR0                                 TX_PAGE_1, 0xEC
+
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR0_HFC0_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xED HSIC Flow Control INTR1 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR1                                 TX_PAGE_1, 0xED
+
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR1_HFC1_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEE HSIC Flow Control INTR2 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR2                                 TX_PAGE_1, 0xEE
+
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR2_HFC2_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEF HSIC Flow Control INTR3 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR3                                 TX_PAGE_1, 0xEF
+
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR3_HFC3_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF0 HSIC Flow Control INTR4 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR4                                 TX_PAGE_1, 0xF0
+
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR4_HFC4_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF1 HSIC Flow Control INTR5 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR5                                 TX_PAGE_1, 0xF1
+
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR5_HFC5_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF2 HSIC Flow Control INTR6 Register                   (Default: 0x20)    */
+#define REG_PAGE_1_FCINTR6                                 TX_PAGE_1, 0xF2
+
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR6_HFC6_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF3 HSIC Flow Control INTR7 Register                   (Default: 0x00)    */
+#define REG_PAGE_1_FCINTR7                                 TX_PAGE_1, 0xF3
+
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR7                      (0x01 << 7)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR6                      (0x01 << 6)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR5                      (0x01 << 5)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR4                      (0x01 << 4)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR3                      (0x01 << 3)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR2                      (0x01 << 2)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR1                      (0x01 << 1)
+#define BIT_PAGE_1_FCINTR7_HFC7_INTR0                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF4 HSIC Flow Control INTRMASK0 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK0                             TX_PAGE_1, 0xF4
+
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK0_HFC0_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF5 HSIC Flow Control INTRMASK1 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK1                             TX_PAGE_1, 0xF5
+
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK1_HFC1_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF6 HSIC Flow Control INTRMASK2 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK2                             TX_PAGE_1, 0xF6
+
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK2_HFC2_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF7 HSIC Flow Control INTRMASK3 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK3                             TX_PAGE_1, 0xF7
+
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK3_HFC3_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF8 HSIC Flow Control INTRMASK4 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK4                             TX_PAGE_1, 0xF8
+
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK4_HFC4_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF9 HSIC Flow Control INTRMASK5 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK5                             TX_PAGE_1, 0xF9
+
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK5_HFC5_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFA HSIC Flow Control INTRMASK6 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK6                             TX_PAGE_1, 0xFA
+
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK6_HFC6_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFB HSIC Flow Control INTRMASK7 Register               (Default: 0x00)    */
+#define REG_PAGE_1_FCINTRMASK7                             TX_PAGE_1, 0xFB
+
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK7              (0x01 << 7)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK6              (0x01 << 6)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK5              (0x01 << 5)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK4              (0x01 << 4)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK3              (0x01 << 3)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK2              (0x01 << 2)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK1              (0x01 << 1)
+#define BIT_PAGE_1_FCINTRMASK7_HFC7_INTRMASK0              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFC TDM Low Latency Register                           (Default: 0x20)    */
+#define REG_PAGE_1_TDMLLCTL                                TX_PAGE_1, 0xFC
+
+#define MSK_PAGE_1_TDMLLCTL_TRX_LL_SEL_MANUAL              (0x03 << 6)
+#define MSK_PAGE_1_TDMLLCTL_TRX_LL_SEL_MODE                (0x03 << 4)
+#define MSK_PAGE_1_TDMLLCTL_TTX_LL_SEL_MANUAL              (0x03 << 2)
+#define BIT_PAGE_1_TDMLLCTL_TTX_LL_TIE_LOW                 (0x01 << 1)
+#define BIT_PAGE_1_TDMLLCTL_TTX_LL_SEL_MODE                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFD TDM Byte Control Register                          (Default: 0x03)    */
+#define REG_PAGE_1_TDMBYTE                                 TX_PAGE_1, 0xFD
+
+#define BIT_PAGE_1_TDMBYTE_TTX_SLOT0_INTERLEAVING          (0x01 << 2)
+#define BIT_PAGE_1_TDMBYTE_TRX_8BIT_CBUS_IF                (0x01 << 1)
+#define BIT_PAGE_1_TDMBYTE_TTX_8BIT_CBUS_IF                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFE TDM Interleaving Target Register                   (Default: 0x0C)    */
+#define REG_PAGE_1_S0TGT                                   TX_PAGE_1, 0xFE
+
+#define MSK_PAGE_1_S0TGT_TTX_S0_TARGET                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFF TDM Interleaving Allowance Register                (Default: 0x02)    */
+#define REG_PAGE_1_S0ALLOW                                 TX_PAGE_1, 0xFF
+
+#define MSK_PAGE_1_S0ALLOW_TTX_S0_ALLOWANCE                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_2                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 TMDS Termination Control Register                  (Default: 0x00)    */
+#define REG_PAGE_2_TMDS_TERMCTRL0                          TX_PAGE_2, 0x01
+
+#define MSK_PAGE_2_TMDS_TERMCTRL0_TERM_SEL                 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 DVI ctrl #0 Register                               (Default: 0x00)    */
+#define REG_PAGE_2_DVI_CTRL0                               TX_PAGE_2, 0x02
+
+#define MSK_PAGE_2_DVI_CTRL0_ZCTL_RST_DLY__7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 DVI ctrl #1 Register                               (Default: 0x20)    */
+#define REG_PAGE_2_DVI_CTRL1                               TX_PAGE_2, 0x03
+
+#define BIT_PAGE_2_DVI_CTRL1_NO_ZONE2X                     (0x01 << 6)
+#define BIT_PAGE_2_DVI_CTRL1_PSEL                          (0x01 << 5)
+#define BIT_PAGE_2_DVI_CTRL1_USE_SCDT                      (0x01 << 4)
+#define MSK_PAGE_2_DVI_CTRL1_ZCTL_RST_DLY__11_8            (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 Rx MISC Register                                   (Default: 0x30)    */
+#define REG_PAGE_2_TMDS_MISC                               TX_PAGE_2, 0x04
+
+#define BIT_PAGE_2_TMDS_MISC_MHL_TEST                      (0x01 << 7)
+#define BIT_PAGE_2_TMDS_MISC_MHL_PP_EN                     (0x01 << 6)
+#define BIT_PAGE_2_TMDS_MISC_EQ_BIAS_EN                    (0x01 << 5)
+#define BIT_PAGE_2_TMDS_MISC_EN_GATE_CLK                   (0x01 << 4)
+#define MSK_PAGE_2_TMDS_MISC_DPCOLOR_CTL                   (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 TMDS 0 Clock Control Register 1                    (Default: 0x10)    */
+#define REG_PAGE_2_TMDS0_CCTRL1                            TX_PAGE_2, 0x10
+
+#define MSK_PAGE_2_TMDS0_CCTRL1_TEST_SEL                   (0x03 << 6)
+#define MSK_PAGE_2_TMDS0_CCTRL1_CLK1X_CTL                  (0x03 << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 TMDS Clock Enable Register                         (Default: 0x00)    */
+#define REG_PAGE_2_TMDS_CLK_EN                             TX_PAGE_2, 0x11
+
+#define BIT_PAGE_2_TMDS_CLK_EN_CLK_EN                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 TMDS Channel Enable Register                       (Default: 0x00)    */
+#define REG_PAGE_2_TMDS_CH_EN                              TX_PAGE_2, 0x12
+
+#define BIT_PAGE_2_TMDS_CH_EN_CH0_EN                       (0x01 << 4)
+#define BIT_PAGE_2_TMDS_CH_EN_CH12_EN                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 TMDS Termination Control Register 1                (Default: 0x80)    */
+#define REG_PAGE_2_TMDS_TERMCTRL1                          TX_PAGE_2, 0x13
+
+#define MSK_PAGE_2_TMDS_TERMCTRL1_TERM_CTL                 (0x07 << 5)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 Clock Detect Control Register                      (Default: 0xA0)    */
+#define REG_PAGE_2_CLKDETECT_CTL                           TX_PAGE_2, 0x14
+
+#define MSK_PAGE_2_CLKDETECT_CTL_CLKDETECT_CTL             (0x0F << 4)
+#define BIT_PAGE_2_CLKDETECT_CTL_LOBW                      (0x01 << 2)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 BGR_BIAS Register                                  (Default: 0x07)    */
+#define REG_PAGE_2_BGR_BIAS                                TX_PAGE_2, 0x15
+
+#define BIT_PAGE_2_BGR_BIAS_BGR_EN                         (0x01 << 7)
+#define MSK_PAGE_2_BGR_BIAS_BIAS_BGR_D                     (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 PLL_CONFIG0 Register                               (Default: 0x4B)    */
+#define REG_PAGE_2_PLL_CONFIG0                             TX_PAGE_2, 0x16
+
+#define MSK_PAGE_2_PLL_CONFIG0_PLL_CONFIG                  (0x1F << 3)
+#define MSK_PAGE_2_PLL_CONFIG0_PLL_VCO_IBIAS               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 PLL_CALREFSEL Register                             (Default: 0x09)    */
+#define REG_PAGE_2_PLL_CALREFSEL                           TX_PAGE_2, 0x17
+
+#define MSK_PAGE_2_PLL_CALREFSEL_PLL_MODE                  (0x03 << 6)
+#define MSK_PAGE_2_PLL_CALREFSEL_PLL_ICPCOMP               (0x03 << 4)
+#define MSK_PAGE_2_PLL_CALREFSEL_PLL_CALREFSEL             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 PLL_ICPCNT Register                                (Default: 0x8A)    */
+#define REG_PAGE_2_PLL_ICPCNT                              TX_PAGE_2, 0x18
+
+#define MSK_PAGE_2_PLL_ICPCNT_PLL_SZONE                    (0x03 << 6)
+#define BIT_PAGE_2_PLL_ICPCNT_PLL_SCPCAL                   (0x01 << 5)
+#define MSK_PAGE_2_PLL_ICPCNT_PLL_ICPCNT                   (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 PLL_SPLLBIAS Register                              (Default: 0xCC)    */
+#define REG_PAGE_2_PLL_SPLLBIAS                            TX_PAGE_2, 0x19
+
+#define BIT_PAGE_2_PLL_SPLLBIAS_PLL_EN                     (0x01 << 7)
+#define BIT_PAGE_2_PLL_SPLLBIAS_PLL_BIAS_EN                (0x01 << 6)
+#define MSK_PAGE_2_PLL_SPLLBIAS_PLL_SPLLBIAS               (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A PLL_VCOCAL Register                                (Default: 0xA9)    */
+#define REG_PAGE_2_PLL_VCOCAL                              TX_PAGE_2, 0x1A
+
+#define MSK_PAGE_2_PLL_VCOCAL_PLL_VCOCAL                   (0x0F << 4)
+#define MSK_PAGE_2_PLL_VCOCAL_PLL_VCOCAL_DEF               (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 TMDS 0 Digital EQ Value Register                   (Default: 0x3A)    */
+#define REG_PAGE_2_ALICE0_EQ_VAL                           TX_PAGE_2, 0x20
+
+#define MSK_PAGE_2_ALICE0_EQ_VAL_TMDS0_EQ_VAL_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 TMDS 0 Digital I2C EQ Register                     (Default: 0xE0)    */
+#define REG_PAGE_2_ALICE0_EQ_I2C                           TX_PAGE_2, 0x21
+
+#define MSK_PAGE_2_ALICE0_EQ_I2C_TMDS0_EQ_I2C_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 TMDS 0 Digital EQ_DATA0 Register                   (Default: 0xE0)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA0                         TX_PAGE_2, 0x22
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA0_TMDS0_EQ_DATA0_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 TMDS 0 Digital EQ_DATA1 Register                   (Default: 0xC0)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA1                         TX_PAGE_2, 0x23
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA1_TMDS0_EQ_DATA1_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x24 TMDS 0 Digital EQ_DATA2 Register                   (Default: 0xA0)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA2                         TX_PAGE_2, 0x24
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA2_TMDS0_EQ_DATA2_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x25 TMDS 0 Digital EQ_DATA3 Register                   (Default: 0x80)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA3                         TX_PAGE_2, 0x25
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA3_TMDS0_EQ_DATA3_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x26 TMDS 0 Digital EQ_DATA4 Register                   (Default: 0x60)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA4                         TX_PAGE_2, 0x26
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA4_TMDS0_EQ_DATA4_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x27 TMDS 0 Digital EQ_DATA5 Register                   (Default: 0x40)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA5                         TX_PAGE_2, 0x27
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA5_TMDS0_EQ_DATA5_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x28 TMDS 0 Digital EQ_DATA6 Register                   (Default: 0x20)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA6                         TX_PAGE_2, 0x28
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA6_TMDS0_EQ_DATA6_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x29 TMDS 0 Digital EQ_DATA7 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_EQ_DATA7                         TX_PAGE_2, 0x29
+
+#define MSK_PAGE_2_ALICE0_EQ_DATA7_TMDS0_EQ_DATA7_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x30 TMDS 0 Digital BW Value Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_BW_VAL                           TX_PAGE_2, 0x30
+
+#define MSK_PAGE_2_ALICE0_BW_VAL_TMDS0_BW_VAL_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x31 TMDS 0 Digital I2C BW Register                     (Default: 0x0A)    */
+#define REG_PAGE_2_ALICE0_BW_I2C                           TX_PAGE_2, 0x31
+
+#define MSK_PAGE_2_ALICE0_BW_I2C_TMDS0_BW_I2C_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x32 TMDS 0 Digital BW_DATA0 Register                   (Default: 0x07)    */
+#define REG_PAGE_2_ALICE0_BW_DATA0                         TX_PAGE_2, 0x32
+
+#define MSK_PAGE_2_ALICE0_BW_DATA0_TMDS0_BW_DATA0_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x33 TMDS 0 Digital BW_DATA1 Register                   (Default: 0x0E)    */
+#define REG_PAGE_2_ALICE0_BW_DATA1                         TX_PAGE_2, 0x33
+
+#define MSK_PAGE_2_ALICE0_BW_DATA1_TMDS0_BW_DATA1_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x34 TMDS 0 Digital BW_DATA2 Register                   (Default: 0x07)    */
+#define REG_PAGE_2_ALICE0_BW_DATA2                         TX_PAGE_2, 0x34
+
+#define MSK_PAGE_2_ALICE0_BW_DATA2_TMDS0_BW_DATA2_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x35 TMDS 0 Digital BW_DATA3 Register                   (Default: 0x07)    */
+#define REG_PAGE_2_ALICE0_BW_DATA3                         TX_PAGE_2, 0x35
+
+#define MSK_PAGE_2_ALICE0_BW_DATA3_TMDS0_BW_DATA3_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x38 TMDS 0 Digital VT Value Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_VAL                           TX_PAGE_2, 0x38
+
+#define MSK_PAGE_2_ALICE0_VT_VAL_TMDS0_VT_VAL_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x39 TMDS 0 Digital I2C VT Register                     (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_I2C                           TX_PAGE_2, 0x39
+
+#define MSK_PAGE_2_ALICE0_VT_I2C_TMDS0_VT_I2C_7_0          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A TMDS 0 Digital VT_DATA0 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_DATA0                         TX_PAGE_2, 0x3A
+
+#define MSK_PAGE_2_ALICE0_VT_DATA0_TMDS0_VT_DATA0_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3B TMDS 0 Digital VT_DATA1 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_DATA1                         TX_PAGE_2, 0x3B
+
+#define MSK_PAGE_2_ALICE0_VT_DATA1_TMDS0_VT_DATA1_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C TMDS 0 Digital VT_DATA2 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_DATA2                         TX_PAGE_2, 0x3C
+
+#define MSK_PAGE_2_ALICE0_VT_DATA2_TMDS0_VT_DATA2_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D TMDS 0 Digital VT_DATA3 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_VT_DATA3                         TX_PAGE_2, 0x3D
+
+#define MSK_PAGE_2_ALICE0_VT_DATA3_TMDS0_VT_DATA3_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x44 TMDS0 Digital Control 0 Register                   (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_CNTL0                            TX_PAGE_2, 0x44
+
+#define MSK_PAGE_2_ALICE0_CNTL0_TMDS0_CHAN_SEL_1_0         (0x03 << 6)
+#define BIT_PAGE_2_ALICE0_CNTL0_DVI0_RX_DIG_BYPASS         (0x01 << 5)
+#define BIT_PAGE_2_ALICE0_CNTL0_TMDS0_MODE_INV             (0x01 << 4)
+#define MSK_PAGE_2_ALICE0_CNTL0_TMDS0_BYP_MODE_CNTL_1_0    (0x03 << 1)
+#define BIT_PAGE_2_ALICE0_CNTL0_TMDS0_LANE_ALG_OFF         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x45 TMDS0 Digital Control 1 Register                   (Default: 0x06)    */
+#define REG_PAGE_2_ALICE0_CNTL1                            TX_PAGE_2, 0x45
+
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_DPLL_BW_SCAN_ON      (0x01 << 6)
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_W_SEL                (0x01 << 4)
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_EXT_BW               (0x01 << 3)
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_BV_SEL               (0x01 << 2)
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_EXT_EQ               (0x01 << 1)
+#define BIT_PAGE_2_ALICE0_CNTL1_TMDS0_EV_SEL               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x46 TMDS0 Digital Control 2 Register                   (Default: 0x02)    */
+#define REG_PAGE_2_ALICE0_CNTL2                            TX_PAGE_2, 0x46
+
+#define MSK_PAGE_2_ALICE0_CNTL2_TMDS0_EQ_MODE              (0x03 << 6)
+#define MSK_PAGE_2_ALICE0_CNTL2_TMDS0_PH_TAPS_1_0          (0x03 << 4)
+#define BIT_PAGE_2_ALICE0_CNTL2_TMDS0_EXT_SYNC             (0x01 << 3)
+#define MSK_PAGE_2_ALICE0_CNTL2_TMDS0_PH_BS_2_0            (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x47 TMDS0 Digital Control 3 Register                   (Default: 0xDC)    */
+#define REG_PAGE_2_ALICE0_CNTL3                            TX_PAGE_2, 0x47
+
+#define MSK_PAGE_2_ALICE0_CNTL3_TMDS0_STB_RSC_1_0          (0x03 << 6)
+#define MSK_PAGE_2_ALICE0_CNTL3_TMDS0_ALICE_EDGE_CNTL_5_0  (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x48 TMDS0 Digital Control 4 Register                   (Default: 0x80)    */
+#define REG_PAGE_2_ALICE0_CNTL4                            TX_PAGE_2, 0x48
+
+#define MSK_PAGE_2_ALICE0_CNTL4_TMDS0_RST_CON_1_0          (0x03 << 6)
+#define BIT_PAGE_2_ALICE0_CNTL4_TMDS0_RELX_EYE_ON          (0x01 << 4)
+#define BIT_PAGE_2_ALICE0_CNTL4_TMDS0_BP_FIX               (0x01 << 3)
+#define BIT_PAGE_2_ALICE0_CNTL4_TMDS0_DPLL_STRNGTH         (0x01 << 2)
+#define BIT_PAGE_2_ALICE0_CNTL4_TMDS0_LOW_MON              (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0x49 TMDS0 Digital Control 5 Register                   (Default: 0x02)    */
+#define REG_PAGE_2_ALICE0_CNTL5                            TX_PAGE_2, 0x49
+
+#define BIT_PAGE_2_ALICE0_CNTL5_TMDS0_GLT_ON               (0x01 << 6)
+#define BIT_PAGE_2_ALICE0_CNTL5_TMDS0_VLDCHK               (0x01 << 2)
+#define BIT_PAGE_2_ALICE0_CNTL5_TMDS0_EDON                 (0x01 << 1)
+#define BIT_PAGE_2_ALICE0_CNTL5_TMDS0_LOWLMT               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4B TMDS0 Digital Control 6 Register                   (Default: 0x06)    */
+#define REG_PAGE_2_ALICE0_CNTL7                            TX_PAGE_2, 0x4B
+
+#define BIT_PAGE_2_ALICE0_CNTL7_TMDS0_DC_CP_EN             (0x01 << 7)
+#define MSK_PAGE_2_ALICE0_CNTL7_TMDS0_DEC_CON_2_0          (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4C TMDS 0 Digital Zone Control Register               (Default: 0xE0)    */
+#define REG_PAGE_2_ALICE0_ZONE_CTRL                        TX_PAGE_2, 0x4C
+
+#define BIT_PAGE_2_ALICE0_ZONE_CTRL_ICRST_N                (0x01 << 7)
+#define BIT_PAGE_2_ALICE0_ZONE_CTRL_USE_INT_DIV20          (0x01 << 6)
+#define MSK_PAGE_2_ALICE0_ZONE_CTRL_SZONE_I2C              (0x03 << 4)
+#define MSK_PAGE_2_ALICE0_ZONE_CTRL_ZONE_CTRL              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D TMDS 0 Digital PLL Mode Control Register           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_MODE_CTRL                        TX_PAGE_2, 0x4D
+
+#define MSK_PAGE_2_ALICE0_MODE_CTRL_PLL_MODE_I2C           (0x03 << 2)
+#define MSK_PAGE_2_ALICE0_MODE_CTRL_DIV20_CTRL             (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x50 TMDS 0 Status 0 Register                           (Default: 0x02)    */
+#define REG_PAGE_2_ALICE0_STAT0                            TX_PAGE_2, 0x50
+
+#define MSK_PAGE_2_ALICE0_STAT0_TMDS0_B_BP_OUT_4_0         (0x1F << 1)
+#define BIT_PAGE_2_ALICE0_STAT0_TMDS0_EDOUT_B              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x51 TMDS 0 Status 1 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT1                            TX_PAGE_2, 0x51
+
+#define MSK_PAGE_2_ALICE0_STAT1_TMDS0_R_BP_OUT_4_0         (0x1F << 1)
+#define BIT_PAGE_2_ALICE0_STAT1_TMDS0_EDOUT_R              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x52 TMDS 0 Status 2 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT2                            TX_PAGE_2, 0x52
+
+#define MSK_PAGE_2_ALICE0_STAT2_TMDS0_R_BP_OUT_4_0         (0x1F << 1)
+#define BIT_PAGE_2_ALICE0_STAT2_TMDS0_EDOUT_R              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x53 TMDS 0 Status 3 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT3                            TX_PAGE_2, 0x53
+
+#define MSK_PAGE_2_ALICE0_STAT3_TMDS0_BIAS_B_3_0           (0x0F << 4)
+#define MSK_PAGE_2_ALICE0_STAT3_TMDS0_EOPEN_B_3_0          (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x54 TMDS 0 Status 4 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT4                            TX_PAGE_2, 0x54
+
+#define MSK_PAGE_2_ALICE0_STAT4_TMDS0_BIAS_G_3_0           (0x0F << 4)
+#define MSK_PAGE_2_ALICE0_STAT4_TMDS0_EOPEN_G_3_0          (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x55 TMDS 0 Status 5 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT5                            TX_PAGE_2, 0x55
+
+#define MSK_PAGE_2_ALICE0_STAT5_TMDS0_BIAS_R_3_0           (0x0F << 4)
+#define MSK_PAGE_2_ALICE0_STAT5_TMDS0_EOPEN_R_3_0          (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x56 TMDS 0 Status 6 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_ALICE0_STAT6                            TX_PAGE_2, 0x56
+
+#define MSK_PAGE_2_ALICE0_STAT6_TMDS0_SCAN_VAL_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 TMDS 0 BIST CNTL Register                          (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_CNTL                         TX_PAGE_2, 0x60
+
+#define MSK_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_DURATION_2_0 (0x07 << 5)
+#define BIT_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_START        (0x01 << 4)
+#define BIT_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_CONT_PROG_DURAT (0x01 << 3)
+#define BIT_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_VGB_MASK     (0x01 << 2)
+#define BIT_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_RESET        (0x01 << 1)
+#define BIT_PAGE_2_TMDS0_BIST_CNTL_TMDS0_BIST_ENABLE       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 TMDS 0 BIST DURATION0 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_DURATION0                    TX_PAGE_2, 0x61
+
+#define MSK_PAGE_2_TMDS0_BIST_DURATION0_TMDS0_BIST_DURATION_10_3 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x62 TMDS 0 BIST DURATION1 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_DURATION1                    TX_PAGE_2, 0x62
+
+#define MSK_PAGE_2_TMDS0_BIST_DURATION1_TMDS0_BIST_DURATION_18_11 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x63 TMDS 0 BIST DURATION2 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_DURATION2                    TX_PAGE_2, 0x63
+
+#define MSK_PAGE_2_TMDS0_BIST_DURATION2_TMDS0_BIST_DURATION_22_19 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x64 TMDS 0 BIST TEST SEL Register                      (Default: 0x02)    */
+#define REG_PAGE_2_TMDS0_BIST_TEST_SEL                     TX_PAGE_2, 0x64
+
+#define MSK_PAGE_2_TMDS0_BIST_TEST_SEL_TMDS0_BIST_TEST_SELECT (0x03 << 4)
+#define MSK_PAGE_2_TMDS0_BIST_TEST_SEL_TMDS0_BIST_PATTERN_SELECT (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x65 TMDS 0 BIST VIDEO_MODE Register                    (Default: 0x02)    */
+#define REG_PAGE_2_TMDS0_BIST_VIDEO_MODE                   TX_PAGE_2, 0x65
+
+#define BIT_PAGE_2_TMDS0_BIST_VIDEO_MODE_TMDS0_BIST_FORCE_DE (0x01 << 3)
+#define MSK_PAGE_2_TMDS0_BIST_VIDEO_MODE_TMDS0_BIST_VIDEO_MODE (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x66 TMDS 0 BIST 8BIT_PATTERN Register                  (Default: 0x55)    */
+#define REG_PAGE_2_TMDS0_BIST_8BIT_PATTERN                 TX_PAGE_2, 0x66
+
+#define MSK_PAGE_2_TMDS0_BIST_8BIT_PATTERN_TMDS0_BIST_8BIT_PATTERN (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x67 TMDS 0 BIST 10BIT_PATTERN_L Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_10BIT_PATTERN_L              TX_PAGE_2, 0x67
+
+#define MSK_PAGE_2_TMDS0_BIST_10BIT_PATTERN_L_TMDS0_BIST_10BIT_PATTERN_L (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x68 TMDS 0 BIST 10BIT_PATTERN_U Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_10BIT_PATTERN_U              TX_PAGE_2, 0x68
+
+#define MSK_PAGE_2_TMDS0_BIST_10BIT_PATTERN_U_TMDS0_BIST_10BIT_PATTERN_U (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x69 TMDS 0 BIST STATUS Register                        (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_STATUS                       TX_PAGE_2, 0x69
+
+#define MSK_PAGE_2_TMDS0_BIST_STATUS_TMDS0_BIST_CONFIG_STATUS (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6A TMDS 0 BIST RESULT Register                        (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_RESULT                       TX_PAGE_2, 0x6A
+
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_CNTL_ERROR (0x01 << 5)
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_OVERFLOW (0x01 << 4)
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_DE_ERROR (0x01 << 3)
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_VSYNC_ERROR (0x01 << 2)
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_HSYNC_ERROR (0x01 << 1)
+#define BIT_PAGE_2_TMDS0_BIST_RESULT_TMDS0_BIST_CONFIG_FAIL (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6B TMDS 0 BIST P_ERROR_COUNT_0 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_P_ERROR_COUNT_0              TX_PAGE_2, 0x6B
+
+#define MSK_PAGE_2_TMDS0_BIST_P_ERROR_COUNT_0_TMDS0_BIST_P_ERROR_COUNT_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6C TMDS 0 BIST P_ERROR_COUNT_1 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_P_ERROR_COUNT_1              TX_PAGE_2, 0x6C
+
+#define MSK_PAGE_2_TMDS0_BIST_P_ERROR_COUNT_1_TMDS0_BIST_P_ERROR_COUNT_1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6D TMDS 0 BIST R_ERROR_COUNT_0 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_R_ERROR_COUNT_0              TX_PAGE_2, 0x6D
+
+#define MSK_PAGE_2_TMDS0_BIST_R_ERROR_COUNT_0_TMDS0_BIST_R_ERROR_COUNT_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6E TMDS 0 BIST R_ERROR_COUNT_1 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_R_ERROR_COUNT_1              TX_PAGE_2, 0x6E
+
+#define MSK_PAGE_2_TMDS0_BIST_R_ERROR_COUNT_1_TMDS0_BIST_R_ERROR_COUNT_1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6F TMDS 0 BIST G_ERROR_COUNT_0 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_G_ERROR_COUNT_0              TX_PAGE_2, 0x6F
+
+#define MSK_PAGE_2_TMDS0_BIST_G_ERROR_COUNT_0_TMDS0_BIST_G_ERROR_COUNT_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x70 TMDS 0 BIST G_ERROR_COUNT_1 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_G_ERROR_COUNT_1              TX_PAGE_2, 0x70
+
+#define MSK_PAGE_2_TMDS0_BIST_G_ERROR_COUNT_1_TMDS0_BIST_G_ERROR_COUNT_1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x71 TMDS 0 BIST B_ERROR_COUNT_0 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_B_ERROR_COUNT_0              TX_PAGE_2, 0x71
+
+#define MSK_PAGE_2_TMDS0_BIST_B_ERROR_COUNT_0_TMDS0_BIST_B_ERROR_COUNT_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x72 TMDS 0 BIST B_ERROR_COUNT_1 Register               (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_B_ERROR_COUNT_1              TX_PAGE_2, 0x72
+
+#define MSK_PAGE_2_TMDS0_BIST_B_ERROR_COUNT_1_TMDS0_BIST_B_ERROR_COUNT_1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x73 TMDS 0 BIST CNTL_ERROR_COUNT Register              (Default: 0x00)    */
+#define REG_PAGE_2_TMDS0_BIST_CNTL_ERROR_COUNT             TX_PAGE_2, 0x73
+
+#define MSK_PAGE_2_TMDS0_BIST_CNTL_ERROR_COUNT_TMDS0_BIST_CNTL_ERROR_COUNT (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x75 MBIST_CTL1 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL1                              TX_PAGE_2, 0x75
+
+#define BIT_PAGE_2_MBIST_CTL1_MBIST_ERRMAP_EDID            (0x01 << 6)
+#define BIT_PAGE_2_MBIST_CTL1_MBIST_FAIL_EDID              (0x01 << 5)
+#define BIT_PAGE_2_MBIST_CTL1_MBIST_FINISH_EDID            (0x01 << 4)
+#define MSK_PAGE_2_MBIST_CTL1_MBIST_EMA_EDID               (0x07 << 1)
+#define BIT_PAGE_2_MBIST_CTL1_MBIST_MODE_EDID              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x76 MBIST_CTL2 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL2                              TX_PAGE_2, 0x76
+
+#define BIT_PAGE_2_MBIST_CTL2_MBIST_ERRMAP_DPRAM512X34     (0x01 << 6)
+#define BIT_PAGE_2_MBIST_CTL2_MBIST_FAIL_DPRAM512X34       (0x01 << 5)
+#define BIT_PAGE_2_MBIST_CTL2_MBIST_FINISH_DPRAM512X34     (0x01 << 4)
+#define MSK_PAGE_2_MBIST_CTL2_MBIST_EMAA_DPRAM512X34       (0x07 << 1)
+#define BIT_PAGE_2_MBIST_CTL2_MBIST_MODE_DPRAM512X34       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x77 MBIST_CTLHSIC2LINK Register                        (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTLH2L                            TX_PAGE_2, 0x77
+
+#define MSK_PAGE_2_MBIST_CTLH2L_MBIST_EMABH2L_DPRAM4096X8  (0x07 << 5)
+#define MSK_PAGE_2_MBIST_CTLH2L_MBIST_EMAAH2L_DPRAM4096X8  (0x07 << 2)
+#define BIT_PAGE_2_MBIST_CTLH2L_MBIST_RETENH2L_DPRAM4096X8 (0x01 << 1)
+#define BIT_PAGE_2_MBIST_CTLH2L_MBIST_MODEH2L_DPRAM4096X8  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x78 MBIST_CTLLINK2HSIC Register                        (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTLL2H                            TX_PAGE_2, 0x78
+
+#define MSK_PAGE_2_MBIST_CTLL2H_MBIST_EMABL2H_DPRAM4096X8  (0x07 << 5)
+#define MSK_PAGE_2_MBIST_CTLL2H_MBIST_EMAAL2H_DPRAM4096X8  (0x07 << 2)
+#define BIT_PAGE_2_MBIST_CTLL2H_MBIST_RETENL2H_DPRAM4096X8 (0x01 << 1)
+#define BIT_PAGE_2_MBIST_CTLL2H_MBIST_MODEL2H_DPRAM4096X8  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x79 MBIST_ROM_CTL1 Register                            (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_ROM_CTL1                          TX_PAGE_2, 0x79
+
+#define MSK_PAGE_2_MBIST_ROM_CTL1_MBIST_EMAB_DPRAM512X34   (0x07 << 5)
+#define MSK_PAGE_2_MBIST_ROM_CTL1_MBIST_EMA_ROM32768X8     (0x07 << 1)
+#define BIT_PAGE_2_MBIST_ROM_CTL1_MBIST_MODE_ROM32768X8    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7A MBIST_ROM_STATUS1 Register                         (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_ROM_STATUS1                       TX_PAGE_2, 0x7A
+
+#define MSK_PAGE_2_MBIST_ROM_STATUS1_MBIST_SOUT_ROM32768X8_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7B MBIST_ROM_STATUS2 Register                         (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_ROM_STATUS2                       TX_PAGE_2, 0x7B
+
+#define MSK_PAGE_2_MBIST_ROM_STATUS2_MBIST_SOUT_ROM32768X8_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7C MBIST_ROM_STATUS3 Register                         (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_ROM_STATUS3                       TX_PAGE_2, 0x7C
+
+#define MSK_PAGE_2_MBIST_ROM_STATUS3_MBIST_SOUT_ROM32768X8_23_16 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7D MBIST_ROM_STATUS4 Register                         (Default: 0x40)    */
+#define REG_PAGE_2_MBIST_ROM_STATUS4                       TX_PAGE_2, 0x7D
+
+#define BIT_PAGE_2_MBIST_ROM_STATUS4_MBIST_SIGOUT_ROM32768X8 (0x01 << 7)
+#define BIT_PAGE_2_MBIST_ROM_STATUS4_MBIST_SHIFTEND_ROM32768X8 (0x01 << 6)
+#define BIT_PAGE_2_MBIST_ROM_STATUS4_MBIST_FAIL_ROM32768X8 (0x01 << 5)
+#define BIT_PAGE_2_MBIST_ROM_STATUS4_MBIST_FINISH_ROM32768X8 (0x01 << 4)
+#define MSK_PAGE_2_MBIST_ROM_STATUS4_MBIST_SOUT_ROM32768X8_27_24 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7E MBIST_CTL3 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL3                              TX_PAGE_2, 0x7E
+
+#define BIT_PAGE_2_MBIST_CTL3_MBIST_ERRMAP_SPRAM256X8      (0x01 << 6)
+#define BIT_PAGE_2_MBIST_CTL3_MBIST_FAIL_SPRAM256X8        (0x01 << 5)
+#define BIT_PAGE_2_MBIST_CTL3_MBIST_FINISH_SPRAM256X8      (0x01 << 4)
+#define MSK_PAGE_2_MBIST_CTL3_MBIST_EMA_SPRAM256X8         (0x07 << 1)
+#define BIT_PAGE_2_MBIST_CTL3_MBIST_MODE_SPRAM256X8        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7F MBIST_CTL4 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL4                              TX_PAGE_2, 0x7F
+
+#define BIT_PAGE_2_MBIST_CTL4_MBIST_ERRMAP_SPRAM1024X32    (0x01 << 6)
+#define BIT_PAGE_2_MBIST_CTL4_MBIST_FAIL_SPRAM1024X32      (0x01 << 5)
+#define BIT_PAGE_2_MBIST_CTL4_MBIST_FINISH_SPRAM1024X32    (0x01 << 4)
+#define MSK_PAGE_2_MBIST_CTL4_MBIST_EMA_SPRAM1024X32       (0x07 << 1)
+#define BIT_PAGE_2_MBIST_CTL4_MBIST_MODE_SPRAM1024X32      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 MBIST_CTL5 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL5                              TX_PAGE_2, 0x80
+
+#define BIT_PAGE_2_MBIST_CTL5_MBIST_ERRMAP_SPRAM16384X8    (0x01 << 6)
+#define BIT_PAGE_2_MBIST_CTL5_MBIST_FAIL_SPRAM16384X8      (0x01 << 5)
+#define BIT_PAGE_2_MBIST_CTL5_MBIST_FINISH_SPRAM16384X8    (0x01 << 4)
+#define MSK_PAGE_2_MBIST_CTL5_MBIST_EMA_SPRAM16384X8       (0x07 << 1)
+#define BIT_PAGE_2_MBIST_CTL5_MBIST_MODE_SPRAM16384X8      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 MHL Tx Control 2nd Register                        (Default: 0x00)    */
+#define REG_PAGE_2_MHLTX_CTL2                              TX_PAGE_2, 0x81
+
+#define BIT_PAGE_2_MHLTX_CTL2_TX_DATA_INV                  (0x01 << 6)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 MBIST_dpram4096x8 Status Register                  (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_HSIC                              TX_PAGE_2, 0x82
+
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_ERRMAPL2H_DPRAM4096X8  (0x01 << 6)
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_FAILL2H_DPRAM4096X8    (0x01 << 5)
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_FINISHL2H_DPRAM4096X8  (0x01 << 4)
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_ERRMAPH2L_DPRAM4096X8  (0x01 << 2)
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_FAILH2L_DPRAM4096X8    (0x01 << 1)
+#define BIT_PAGE_2_MBIST_HSIC_MBIST_FINISHH2L_DPRAM4096X8  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x84 MHL Tx Control 5th Register                        (Default: 0x1F)    */
+#define REG_PAGE_2_MHLTX_CTL5                              TX_PAGE_2, 0x84
+
+#define MSK_PAGE_2_MHLTX_CTL5_TX_CLK_SHAPE_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x85 MHL Tx Control 6th Register                        (Default: 0xA0)    */
+#define REG_PAGE_2_MHLTX_CTL6                              TX_PAGE_2, 0x85
+
+#define MSK_PAGE_2_MHLTX_CTL6_EMI_SEL                      (0x07 << 5)
+#define MSK_PAGE_2_MHLTX_CTL6_TX_CLK_SHAPE_9_8             (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x86 MBIST_CTL6 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL6                              TX_PAGE_2, 0x86
+
+#define MSK_PAGE_2_MBIST_CTL6_MBIST_EMAB_RDPRAM288X8       (0x07 << 5)
+#define MSK_PAGE_2_MBIST_CTL6_MBIST_EMAA_RDPRAM288X8       (0x07 << 2)
+#define BIT_PAGE_2_MBIST_CTL6_MBIST_RET_RDPRAM288X8        (0x01 << 1)
+#define BIT_PAGE_2_MBIST_CTL6_MBIST_MODE_RDPRAM288X8       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x87 MBIST_CTL7 Register                                (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_CTL7                              TX_PAGE_2, 0x87
+
+#define MSK_PAGE_2_MBIST_CTL7_MBIST_EMAB_XDPRAM288X8       (0x07 << 5)
+#define MSK_PAGE_2_MBIST_CTL7_MBIST_EMAA_XDPRAM288X8       (0x07 << 2)
+#define BIT_PAGE_2_MBIST_CTL7_MBIST_RET_XDPRAM288X8        (0x01 << 1)
+#define BIT_PAGE_2_MBIST_CTL7_MBIST_MODE_XDPRAM288X8       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x88 MBIST_XDPRDP288x8 Status Register                  (Default: 0x00)    */
+#define REG_PAGE_2_MBIST_DP288X8STA                        TX_PAGE_2, 0x88
+
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_ERRMAP_XPRAM288X8 (0x01 << 5)
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_FAIL_XDPRAM288X8 (0x01 << 4)
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_FINISH_XDPRAM288X8 (0x01 << 3)
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_ERRMAP_RDPRAM288X8 (0x01 << 2)
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_FAIL_RDPRAM288X8 (0x01 << 1)
+#define BIT_PAGE_2_MBIST_DP288X8STA_MBIST_FINISH_RDPRAM288X8 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x90 Packet Filter0 Register                            (Default: 0x00)    */
+#define REG_PAGE_2_PKT_FILTER_0                            TX_PAGE_2, 0x90
+
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_CEA_GAMUT_PKT         (0x01 << 7)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_CEA_CP_PKT            (0x01 << 6)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_MPEG_PKT              (0x01 << 5)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_SPIF_PKT              (0x01 << 4)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_AIF_PKT               (0x01 << 3)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_AVI_PKT               (0x01 << 2)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_CTS_PKT               (0x01 << 1)
+#define BIT_PAGE_2_PKT_FILTER_0_DROP_GCP_PKT               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x91 Packet Filter1 Register                            (Default: 0x00)    */
+#define REG_PAGE_2_PKT_FILTER_1                            TX_PAGE_2, 0x91
+
+#define BIT_PAGE_2_PKT_FILTER_1_VSI_OVERRIDE_DIS           (0x01 << 7)
+#define BIT_PAGE_2_PKT_FILTER_1_AVI_OVERRIDE_DIS           (0x01 << 6)
+#define BIT_PAGE_2_PKT_FILTER_1_DROP_AUDIO_PKT             (0x01 << 3)
+#define BIT_PAGE_2_PKT_FILTER_1_DROP_GEN2_PKT              (0x01 << 2)
+#define BIT_PAGE_2_PKT_FILTER_1_DROP_GEN_PKT               (0x01 << 1)
+#define BIT_PAGE_2_PKT_FILTER_1_DROP_VSIF_PKT              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x92 DROP GEN PACKET TYPE 0 Register                    (Default: 0x00)    */
+#define REG_PAGE_2_DROP_GEN_TYPE_0                         TX_PAGE_2, 0x92
+
+#define MSK_PAGE_2_DROP_GEN_TYPE_0_DROP_GEN_TYPE           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x93 DROP GEN PACKET TYPE 1 Register                    (Default: 0x00)    */
+#define REG_PAGE_2_DROP_GEN_TYPE_1                         TX_PAGE_2, 0x93
+
+#define MSK_PAGE_2_DROP_GEN_TYPE_1_DROP_GEN2_TYPE          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA0 TMDS Clock Status Register Page 3                  (Default: 0x10)    */
+#define REG_PAGE_2_TMDS_CSTAT_P3                           TX_PAGE_2, 0xA0
+
+#define BIT_PAGE_2_TMDS_CSTAT_P3_RX_HDMI_CP_CLR_MUTE       (0x01 << 7)
+#define BIT_PAGE_2_TMDS_CSTAT_P3_RX_HDMI_CP_SET_MUTE       (0x01 << 6)
+#define BIT_PAGE_2_TMDS_CSTAT_P3_RX_HDMI_CP_NEW_CP         (0x01 << 5)
+#define BIT_PAGE_2_TMDS_CSTAT_P3_RX_HDMI_MUTE_ON           (0x01 << 4)
+#define BIT_PAGE_2_TMDS_CSTAT_P3_SCDT                      (0x01 << 1)
+
+#define BIT_PAGE_2_TMDS_CSTAT_P3_CKDT                      (0x01 << 0)
+#define VAL_PAGE_2_TMDS_CSTAT_P3_CKDT_STOPPED              (0x00 << 0)
+#define VAL_PAGE_2_TMDS_CSTAT_P3_CKDT_DETECTED             (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA1 RX_HDMI Control Register0                          (Default: 0x10)    */
+#define REG_PAGE_2_RX_HDMI_CTRL0                           TX_PAGE_2, 0xA1
+
+#define BIT_PAGE_2_RX_HDMI_CTRL0_BYP_DVIFILT_SYNC          (0x01 << 5)
+#define BIT_PAGE_2_RX_HDMI_CTRL0_HDMI_MODE_EN_ITSELF_CLR   (0x01 << 4)
+#define BIT_PAGE_2_RX_HDMI_CTRL0_HDMI_MODE_SW_VALUE        (0x01 << 3)
+#define BIT_PAGE_2_RX_HDMI_CTRL0_HDMI_MODE_OVERWRITE       (0x01 << 2)
+#define BIT_PAGE_2_RX_HDMI_CTRL0_RX_HDMI_HDMI_MODE_EN      (0x01 << 1)
+#define BIT_PAGE_2_RX_HDMI_CTRL0_RX_HDMI_HDMI_MODE         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA2 RX_HDMI Control Register1                          (Default: 0x50)    */
+#define REG_PAGE_2_RX_HDMI_CTRL1                           TX_PAGE_2, 0xA2
+
+#define MSK_PAGE_2_RX_HDMI_CTRL1_AV_MUTE_GET_CON           (0x03 << 6)
+#define MSK_PAGE_2_RX_HDMI_CTRL1_MUTE_CON                  (0x03 << 4)
+#define BIT_PAGE_2_RX_HDMI_CTRL1_AUDIO_MUTE                (0x01 << 3)
+#define BIT_PAGE_2_RX_HDMI_CTRL1_VIDEO_MUTE                (0x01 << 2)
+#define BIT_PAGE_2_RX_HDMI_CTRL1_ECC_AUTO_AUDIO_MUTE       (0x01 << 1)
+#define BIT_PAGE_2_RX_HDMI_CTRL1_ECC_AUTO_VIDEO_MUTE       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA3 RX_HDMI Control Register2                          (Default: 0x38)    */
+#define REG_PAGE_2_RX_HDMI_CTRL2                           TX_PAGE_2, 0xA3
+
+#define BIT_PAGE_2_RX_HDMI_CTRL2_USE_AV_MUTE               (0x01 << 3)
+#define VAL_PAGE_2_RX_HDMI_CTRL2_USE_AV_MUTE_DISABLE       (0x00 << 3)
+#define VAL_PAGE_2_RX_HDMI_CTRL2_USE_AV_MUTE_ENABLE        (0x01 << 3)
+
+#define BIT_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL               (0x01 << 0)
+#define VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_AVI           (0x00 << 0)
+#define VAL_PAGE_2_RX_HDMI_CTRL2_VSI_MON_SEL_VSI           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA4 RX_HDMI Control Register3                          (Default: 0x0F)    */
+#define REG_PAGE_2_RX_HDMI_CTRL3                           TX_PAGE_2, 0xA4
+
+#define MSK_PAGE_2_RX_HDMI_CTRL3_PP_MODE_CLK_EN            (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA5 RX_HDMI Control Register4                          (Default: 0x30)    */
+#define REG_PAGE_2_RX_HDMI_CTRL4                           TX_PAGE_2, 0xA5
+
+#define MSK_PAGE_2_RX_HDMI_CTRL4_NO_PKT_CNT                (0x0F << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA6 RX_HDMI Status Register0                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_STAT0                           TX_PAGE_2, 0xA6
+
+#define BIT_PAGE_2_RX_HDMI_STAT0_RX_HDMI_DOWMSMPL_ON       (0x01 << 2)
+#define BIT_PAGE_2_RX_HDMI_STAT0_RX_HDMI_RGB2YCC_ON        (0x01 << 1)
+#define BIT_PAGE_2_RX_HDMI_STAT0_RX_HDMI_PP_MODE_ON        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA9 rx_hdmi_criteria_hen Register                      (Default: 0x0C)    */
+#define REG_PAGE_2_RX_HDMI_CRITERIA_HEN                    TX_PAGE_2, 0xA9
+
+#define BIT_PAGE_2_RX_HDMI_CRITERIA_HEN_BYPASSSYNCFILTER   (0x01 << 6)
+#define BIT_PAGE_2_RX_HDMI_CRITERIA_HEN_BYPASSDATAALIGN    (0x01 << 5)
+#define MSK_PAGE_2_RX_HDMI_CRITERIA_HEN_CRITERIA_HEN       (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAA rx_hdmi_criteria_prmbl Register                    (Default: 0x06)    */
+#define REG_PAGE_2_RX_HDMI_CRITERIA_PRMBL                  TX_PAGE_2, 0xAA
+
+#define MSK_PAGE_2_RX_HDMI_CRITERIA_PRMBL_CRITERIA_PRMBL   (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAB rx_hdmi BCH corrected threshold Register           (Default: 0x01)    */
+#define REG_PAGE_2_RX_HDMI_BCH_CORRECTED_THRESHOLD         TX_PAGE_2, 0xAB
+
+#define MSK_PAGE_2_RX_HDMI_BCH_CORRECTED_THRESHOLD_BCH_CORRECTED_THRESHOLD (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAC rx_hdmi Clear Buffer Register                      (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_CLR_BUFFER                      TX_PAGE_2, 0xAC
+
+#define MSK_PAGE_2_RX_HDMI_CLR_BUFFER_AIF4VSI_CMP          (0x03 << 6)
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_USE_AIF4VSI          (0x01 << 5)
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_W_AVI        (0x01 << 4)
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_IEEE_ID_CHK_EN   (0x01 << 3)
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_SWAP_VSI_IEEE_ID     (0x01 << 2)
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_AIF_CLR_EN           (0x01 << 1)
+
+#define BIT_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_EN           (0x01 << 0)
+#define VAL_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_EN_STALE     (0x00 << 0)
+#define VAL_PAGE_2_RX_HDMI_CLR_BUFFER_VSI_CLR_EN_CLEAR     (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAD RX_HDMI AIF Header Register                        (Default: 0x84)    */
+#define REG_PAGE_2_RX_HDMI_AIF_HEADER                      TX_PAGE_2, 0xAD
+
+#define MSK_PAGE_2_RX_HDMI_AIF_HEADER_RX_HDMI_AIF_HEADER   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAE RX_HDMI VSI Header Register                        (Default: 0x81)    */
+#define REG_PAGE_2_RX_HDMI_VSI_HEADER                      TX_PAGE_2, 0xAE
+
+#define MSK_PAGE_2_RX_HDMI_VSI_HEADER_RX_HDMI_VSI_HEADER   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAF RX_HDMI ACP Header Register                        (Default: 0x04)    */
+#define REG_PAGE_2_RX_HDMI_ACP_DEC_SYNC                    TX_PAGE_2, 0xAF
+
+#define MSK_PAGE_2_RX_HDMI_ACP_DEC_SYNC_RX_HDMI_ACP_DEC_SYNC (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB1 RX_HDMI ISRC1 Header Register                      (Default: 0x05)    */
+#define REG_PAGE_2_RX_HDMI_ISRC1_HEADER                    TX_PAGE_2, 0xB1
+
+#define MSK_PAGE_2_RX_HDMI_ISRC1_HEADER_RX_HDMI_ISRC1_HEADER (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB2 RX_HDMI ISRC2 Header Register                      (Default: 0x06)    */
+#define REG_PAGE_2_RX_HDMI_ISRC2_HEADER                    TX_PAGE_2, 0xB2
+
+#define MSK_PAGE_2_RX_HDMI_ISRC2_HEADER_RX_HDMI_ISRC2_HEADER (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB3 RX_HDMI SPD Header Register                        (Default: 0x83)    */
+#define REG_PAGE_2_RX_HDMI_SPD_DEC_SYNC                    TX_PAGE_2, 0xB3
+
+#define MSK_PAGE_2_RX_HDMI_SPD_DEC_SYNC_RX_HDMI_SPD_DEC_SYNC (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB4 RX_HDMI VSI ID in PB1 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_ALT_VSI_PB1                     TX_PAGE_2, 0xB4
+
+#define MSK_PAGE_2_RX_HDMI_ALT_VSI_PB1_RX_HDMI_ALT_VSI_PB1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB5 RX_HDMI VSI ID in PB2 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_ALT_VSI_PB2                     TX_PAGE_2, 0xB5
+
+#define MSK_PAGE_2_RX_HDMI_ALT_VSI_PB2_RX_HDMI_ALT_VSI_PB2 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB6 RX_HDMI VSI ID in PB3 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_ALT_VSI_PB3                     TX_PAGE_2, 0xB6
+
+#define MSK_PAGE_2_RX_HDMI_ALT_VSI_PB3_RX_HDMI_ALT_VSI_PB3 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB7 RX_HDMI VSI ID in PB4 Register                     (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_ALT_VSI_PB4                     TX_PAGE_2, 0xB7
+
+#define MSK_PAGE_2_RX_HDMI_ALT_VSI_PB4_RX_HDMI_ALT_VSI_PB4 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB8 RX_HDMI VSI Header1 Register                       (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_HEADER1                 TX_PAGE_2, 0xB8
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_HEADER1_RX_HDMI_MON_PKT_HEADER_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB9 RX_HDMI VSI Header2 Register                       (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_HEADER2                 TX_PAGE_2, 0xB9
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_HEADER2_RX_HDMI_MON_PKT_HEADER_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBA RX_HDMI VSI Length Register                        (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_LENGTH                  TX_PAGE_2, 0xBA
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_LENGTH_RX_HDMI_MON_PKT_LENGTH (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB RX_HDMI VSI PB0 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_0                    TX_PAGE_2, 0xBB
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_0_RX_HDMI_MON_PKT_PB_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBC RX_HDMI VSI PB1 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_1                    TX_PAGE_2, 0xBC
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_1_RX_HDMI_MON_PKT_PB_1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBD RX_HDMI VSI PB2 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_2                    TX_PAGE_2, 0xBD
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_2_RX_HDMI_MON_PKT_PB_2 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBE RX_HDMI VSI PB3 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_3                    TX_PAGE_2, 0xBE
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_3_RX_HDMI_MON_PKT_PB_3 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF RX_HDMI VSI PB4 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_4                    TX_PAGE_2, 0xBF
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_4_RX_HDMI_MON_PKT_PB_4 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 RX_HDMI VSI PB5 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_5                    TX_PAGE_2, 0xC0
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_5_RX_HDMI_MON_PKT_PB_5 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 RX_HDMI VSI PB6 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_6                    TX_PAGE_2, 0xC1
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_6_RX_HDMI_MON_PKT_PB_6 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 RX_HDMI VSI PB7 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_7                    TX_PAGE_2, 0xC2
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_7_RX_HDMI_MON_PKT_PB_7 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 RX_HDMI VSI PB8 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_8                    TX_PAGE_2, 0xC3
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_8_RX_HDMI_MON_PKT_PB_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 RX_HDMI VSI PB9 Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_9                    TX_PAGE_2, 0xC4
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_9_RX_HDMI_MON_PKT_PB_9 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 RX_HDMI VSI PB10 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_10                   TX_PAGE_2, 0xC5
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_10_RX_HDMI_MON_PKT_PB_10 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC6 RX_HDMI VSI PB11 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_11                   TX_PAGE_2, 0xC6
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_11_RX_HDMI_MON_PKT_PB_11 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 RX_HDMI VSI PB12 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_12                   TX_PAGE_2, 0xC7
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_12_RX_HDMI_MON_PKT_PB_12 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC8 RX_HDMI VSI PB13 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_13                   TX_PAGE_2, 0xC8
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_13_RX_HDMI_MON_PKT_PB_13 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC9 RX_HDMI VSI PB14 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_14                   TX_PAGE_2, 0xC9
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_14_RX_HDMI_MON_PKT_PB_14 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCA RX_HDMI VSI PB15 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_15                   TX_PAGE_2, 0xCA
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_15_RX_HDMI_MON_PKT_PB_15 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCB RX_HDMI VSI PB16 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_16                   TX_PAGE_2, 0xCB
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_16_RX_HDMI_MON_PKT_PB_16 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC RX_HDMI VSI PB17 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_17                   TX_PAGE_2, 0xCC
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_17_RX_HDMI_MON_PKT_PB_17 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCD RX_HDMI VSI PB18 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_18                   TX_PAGE_2, 0xCD
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_18_RX_HDMI_MON_PKT_PB_18 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE RX_HDMI VSI PB19 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_19                   TX_PAGE_2, 0xCE
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_19_RX_HDMI_MON_PKT_PB_19 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF RX_HDMI VSI PB20 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_20                   TX_PAGE_2, 0xCF
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_20_RX_HDMI_MON_PKT_PB_20 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD0 RX_HDMI VSI PB21 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_21                   TX_PAGE_2, 0xD0
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_21_RX_HDMI_MON_PKT_PB_21 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD1 RX_HDMI VSI PB22 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_22                   TX_PAGE_2, 0xD1
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_22_RX_HDMI_MON_PKT_PB_22 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD2 RX_HDMI VSI PB23 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_23                   TX_PAGE_2, 0xD2
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_23_RX_HDMI_MON_PKT_PB_23 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD3 RX_HDMI VSI PB24 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_24                   TX_PAGE_2, 0xD3
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_24_RX_HDMI_MON_PKT_PB_24 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD4 RX_HDMI VSI PB25 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_25                   TX_PAGE_2, 0xD4
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_25_RX_HDMI_MON_PKT_PB_25 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD5 RX_HDMI VSI PB26 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_26                   TX_PAGE_2, 0xD5
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_26_RX_HDMI_MON_PKT_PB_26 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD6 RX_HDMI VSI PB27 Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MON_PKT_PB_27                   TX_PAGE_2, 0xD6
+
+#define MSK_PAGE_2_RX_HDMI_MON_PKT_PB_27_RX_HDMI_MON_PKT_PB_27 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD7 RX_HDMI VSI MHL Monitor Register                   (Default: 0x3C)    */
+#define REG_PAGE_2_RX_HDMI_VSIF_MHL_MON                    TX_PAGE_2, 0xD7
+
+#define MSK_PAGE_2_RX_HDMI_VSIF_MHL_MON_RX_HDMI_MHL_3D_FORMAT (0x0F << 2)
+#define MSK_PAGE_2_RX_HDMI_VSIF_MHL_MON_RX_HDMI_MHL_VID_FORMAT (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 RX_HDMI VSI MHL Extended 3D Format Register        (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_EXTD                   TX_PAGE_2, 0xD8
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_EXTD_MHL_VFMT_EXTD_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 RX_HDMI VSI MHL rsv3 3D Format Register            (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_RSV3                   TX_PAGE_2, 0xD9
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_RSV3_MHL_VFMT_RSV3_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDA RX_HDMI VSI MHL rsv4 3D Format Register            (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_RSV4                   TX_PAGE_2, 0xDA
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_RSV4_MHL_VFMT_RSV4_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDB RX_HDMI VSI MHL rsv5 3D Format Register            (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_RSV5                   TX_PAGE_2, 0xDB
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_RSV5_MHL_VFMT_RSV5_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDC RX_HDMI VSI MHL rsv6 3D Format Register            (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_RSV6                   TX_PAGE_2, 0xDC
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_RSV6_MHL_VFMT_RSV6_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDD RX_HDMI VSI MHL rsv7 3D Format Register            (Default: 0x00)    */
+#define REG_PAGE_2_RX_HDMI_MHL_VFMT_RSV7                   TX_PAGE_2, 0xDD
+
+#define MSK_PAGE_2_RX_HDMI_MHL_VFMT_RSV7_MHL_VFMT_RSV7_5_0 (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE0 Interrupt Source 9 Register                        (Default: 0x00)    */
+#define REG_PAGE_2_INTR9                                   TX_PAGE_2, 0xE0
+
+#define BIT_PAGE_2_INTR9_INTR9_STAT6                       (0x01 << 6)
+#define BIT_PAGE_2_INTR9_INTR9_STAT5                       (0x01 << 5)
+#define BIT_PAGE_2_INTR9_INTR9_STAT4                       (0x01 << 4)
+#define BIT_PAGE_2_INTR9_INTR9_STAT1                       (0x01 << 1)
+#define BIT_PAGE_2_INTR9_INTR9_STAT0                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE1 Interrupt 9 Mask Register                          (Default: 0x00)    */
+#define REG_PAGE_2_INTR9_MASK                              TX_PAGE_2, 0xE1
+
+#define BIT_PAGE_2_INTR9_MASK_INTR9_MASK6                  (0x01 << 6)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK6_DISABLE          (0x00 << 6)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK6_ENABLE           (0x01 << 6)
+
+#define BIT_PAGE_2_INTR9_MASK_INTR9_MASK5                  (0x01 << 5)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK5_DISABLE          (0x00 << 5)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK5_ENABLE           (0x01 << 5)
+
+#define BIT_PAGE_2_INTR9_MASK_INTR9_MASK4                  (0x01 << 4)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK4_DISABLE          (0x00 << 4)
+#define VAL_PAGE_2_INTR9_MASK_INTR9_MASK4_ENABLE           (0x01 << 4)
+
+#define BIT_PAGE_2_INTR9_MASK_INTR9_MASK1                  (0x01 << 1)
+#define BIT_PAGE_2_INTR9_MASK_INTR9_MASK0                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE2 TPI CBUS Start Register                            (Default: 0x00)    */
+#define REG_PAGE_2_TPI_CBUS_START                          TX_PAGE_2, 0xE2
+
+#define BIT_PAGE_2_TPI_CBUS_START_RCP_REQ_START            (0x01 << 7)
+#define BIT_PAGE_2_TPI_CBUS_START_RCPK_REPLY_START         (0x01 << 6)
+#define BIT_PAGE_2_TPI_CBUS_START_RCPE_REPLY_START         (0x01 << 5)
+#define BIT_PAGE_2_TPI_CBUS_START_PUT_LINK_MODE_START      (0x01 << 4)
+#define BIT_PAGE_2_TPI_CBUS_START_PUT_DCAPCHG_START        (0x01 << 3)
+#define BIT_PAGE_2_TPI_CBUS_START_PUT_DCAPRDY_START        (0x01 << 2)
+#define BIT_PAGE_2_TPI_CBUS_START_GET_EDID_START_0         (0x01 << 1)
+#define BIT_PAGE_2_TPI_CBUS_START_GET_DEVCAP_START         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE3 EDID Control Register                              (Default: 0x10)    */
+#define REG_PAGE_2_EDID_CTRL                               TX_PAGE_2, 0xE3
+
+#define BIT_PAGE_2_EDID_CTRL_EDID_PRIME_VALID              (0x01 << 7)
+#define VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_DISABLE      (0x00 << 7)
+#define VAL_PAGE_2_EDID_CTRL_EDID_PRIME_VALID_ENABLE       (0x01 << 7)
+
+#define BIT_PAGE_2_EDID_CTRL_XDEVCAP_EN                    (0x01 << 6)
+
+#define BIT_PAGE_2_EDID_CTRL_DEVCAP_SEL                    (0x01 << 5)
+#define VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_EDID            (0x00 << 5)
+#define VAL_PAGE_2_EDID_CTRL_DEVCAP_SELECT_DEVCAP          (0x01 << 5)
+
+#define BIT_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO           (0x01 << 4)
+#define VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_DISABLE   (0x00 << 4)
+#define VAL_PAGE_2_EDID_CTRL_EDID_FIFO_ADDR_AUTO_ENABLE    (0x01 << 4)
+
+#define BIT_PAGE_2_EDID_CTRL_INVALID_BKSV                  (0x01 << 1)
+
+#define BIT_PAGE_2_EDID_CTRL_EDID_MODE_EN                  (0x01 << 0)
+#define VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_DISABLE          (0x00 << 0)
+#define VAL_PAGE_2_EDID_CTRL_EDID_MODE_EN_ENABLE           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE4 EDID Status Register                               (Default: 0x00)    */
+#define REG_PAGE_2_EDID_STAT                               TX_PAGE_2, 0xE4
+
+#define BIT_PAGE_2_EDID_STAT_MSC_STATUS_BUSY               (0x01 << 4)
+#define BIT_PAGE_2_EDID_STAT_MSC_DEVCAP_VALID              (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE5 CBUS LINK_MODE Register                            (Default: 0x0B)    */
+#define REG_PAGE_2_CBUS_LINK_MODE                          TX_PAGE_2, 0xE5
+
+#define MSK_PAGE_2_CBUS_LINK_MODE_CBUS_LINK_MODE           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE6 RCPE ERRCODE Register                              (Default: 0x00)    */
+#define REG_PAGE_2_RCPE_ERRCODE                            TX_PAGE_2, 0xE6
+
+#define MSK_PAGE_2_RCPE_ERRCODE_RCPE_ERRCODE               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE7 RCPK KEYCODE Register                              (Default: 0x00)    */
+#define REG_PAGE_2_RCPK_KEYCODE                            TX_PAGE_2, 0xE7
+
+#define MSK_PAGE_2_RCPK_KEYCODE_RCPK_KEYCODE               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE8 RCP KEYCODE Register                               (Default: 0x00)    */
+#define REG_PAGE_2_RCP_KEYCODE                             TX_PAGE_2, 0xE8
+
+#define MSK_PAGE_2_RCP_KEYCODE_RCP_KEYCODE                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE9 EDID FIFO Addr Register                            (Default: 0x00)    */
+#define REG_PAGE_2_EDID_FIFO_ADDR                          TX_PAGE_2, 0xE9
+
+#define MSK_PAGE_2_EDID_FIFO_ADDR_EDID_FIFO_ADDR           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEA EDID FIFO Write Data Register                      (Default: 0x00)    */
+#define REG_PAGE_2_EDID_FIFO_WR_DATA                       TX_PAGE_2, 0xEA
+
+#define MSK_PAGE_2_EDID_FIFO_WR_DATA_EDID_FIFO_WR_DATA     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEB EDID/DEVCAP FIFO Internal Addr Register            (Default: 0x00)    */
+#define REG_PAGE_2_EDID_FIFO_ADDR_MON                      TX_PAGE_2, 0xEB
+
+#define MSK_PAGE_2_EDID_FIFO_ADDR_MON_EDID_FIFO_ADDR_MON   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEC EDID FIFO Read Data Register                       (Default: 0x00)    */
+#define REG_PAGE_2_EDID_FIFO_RD_DATA                       TX_PAGE_2, 0xEC
+
+#define MSK_PAGE_2_EDID_FIFO_RD_DATA_EDID_FIFO_RD_DATA     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xED EDID DDC Segment Pointer Register                  (Default: 0x00)    */
+#define REG_PAGE_2_EDID_START_EXT                          TX_PAGE_2, 0xED
+
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_8         (0x01 << 7)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_7         (0x01 << 6)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_6         (0x01 << 5)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_5         (0x01 << 4)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_4         (0x01 << 3)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_3         (0x01 << 2)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_2         (0x01 << 1)
+#define BIT_PAGE_2_EDID_START_EXT_GET_EDID_START_1         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEE RXBIST CNTL Register                               (Default: 0x00)    */
+#define REG_PAGE_2_RX_PHY_BIST_CNTL                        TX_PAGE_2, 0xEE
+
+#define BIT_PAGE_2_RX_PHY_BIST_CNTL_RX_GATING_EN           (0x01 << 6)
+#define MSK_PAGE_2_RX_PHY_BIST_CNTL_RXPAT98_1_0            (0x03 << 4)
+#define BIT_PAGE_2_RX_PHY_BIST_CNTL_RXENABLE_CTR_ALIGH_OFF (0x01 << 3)
+#define BIT_PAGE_2_RX_PHY_BIST_CNTL_RXBAC_FLAG_SEL         (0x01 << 2)
+#define BIT_PAGE_2_RX_PHY_BIST_CNTL_RXBAC_EN               (0x01 << 1)
+#define BIT_PAGE_2_RX_PHY_BIST_CNTL_RXBIST_EN              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEF RXBIST INST LOW Register                           (Default: 0x00)    */
+#define REG_PAGE_2_RX_PHY_BIST_INST_LOW                    TX_PAGE_2, 0xEF
+
+#define MSK_PAGE_2_RX_PHY_BIST_INST_LOW_RXINSTRUCTION_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF0 RXBIST INST HIGH Register                          (Default: 0x00)    */
+#define REG_PAGE_2_RX_PHY_BIST_INST_HIGH                   TX_PAGE_2, 0xF0
+
+#define MSK_PAGE_2_RX_PHY_BIST_INST_HIGH_RXBIST_STATE_2    (0x03 << 6)
+#define MSK_PAGE_2_RX_PHY_BIST_INST_HIGH_RXBIST_STATE_1    (0x03 << 4)
+#define MSK_PAGE_2_RX_PHY_BIST_INST_HIGH_RXBIST_STATE_0    (0x03 << 2)
+#define MSK_PAGE_2_RX_PHY_BIST_INST_HIGH_RXINSTRUCTION_9_8 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF1 RXBIST STATUS Register                             (Default: 0x00)    */
+#define REG_PAGE_2_RX_PHY_BIST_STATUS                      TX_PAGE_2, 0xF1
+
+#define MSK_PAGE_2_RX_PHY_BIST_STATUS_RXBIST_ERROR         (0x07 << 4)
+#define BIT_PAGE_2_RX_PHY_BIST_STATUS_RXBAC_ERROR          (0x01 << 3)
+#define BIT_PAGE_2_RX_PHY_BIST_STATUS_RXBIST_DONE          (0x01 << 2)
+#define BIT_PAGE_2_RX_PHY_BIST_STATUS_RXBIST_ON            (0x01 << 1)
+#define BIT_PAGE_2_RX_PHY_BIST_STATUS_RXBIST_RUN           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF2 TX IP BIST CNTL and Status Register                (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_CNTLSTA                      TX_PAGE_2, 0xF2
+
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXBIST_DONE          (0x01 << 5)
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXBIST_ON            (0x01 << 4)
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXBIST_RUN           (0x01 << 3)
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXCLK_HALF_SEL       (0x01 << 2)
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXBIST_EN            (0x01 << 1)
+#define BIT_PAGE_2_TX_IP_BIST_CNTLSTA_TXBIST_SEL           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF3 TX IP BIST INST LOW Register                       (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_INST_LOW                     TX_PAGE_2, 0xF3
+
+#define MSK_PAGE_2_TX_IP_BIST_INST_LOW_TXINSTRUCTION_7_0   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF4 TX IP BIST INST HIGH Register                      (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_INST_HIGH                    TX_PAGE_2, 0xF4
+
+#define MSK_PAGE_2_TX_IP_BIST_INST_HIGH_TXINSTRUCTION_10_8 (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF5 TX IP BIST PATTERN LOW Register                    (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_PAT_LOW                      TX_PAGE_2, 0xF5
+
+#define MSK_PAGE_2_TX_IP_BIST_PAT_LOW_TXPATTERN_7_0        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF6 TX IP BIST PATTERN HIGH Register                   (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_PAT_HIGH                     TX_PAGE_2, 0xF6
+
+#define MSK_PAGE_2_TX_IP_BIST_PAT_HIGH_TXPATTERN_9_8       (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF7 TX IP BIST CONFIGURE LOW Register                  (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_CONF_LOW                     TX_PAGE_2, 0xF7
+
+#define MSK_PAGE_2_TX_IP_BIST_CONF_LOW_TXCONFIGURE_7_0     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF8 TX IP BIST CONFIGURE HIGH Register                 (Default: 0x00)    */
+#define REG_PAGE_2_TX_IP_BIST_CONF_HIGH                    TX_PAGE_2, 0xF8
+
+#define MSK_PAGE_2_TX_IP_BIST_CONF_HIGH_TXCONFIGURE_9_8    (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF9 HSIC RX BIST CNTL Register                         (Default: 0x00)    */
+#define REG_PAGE_2_HSIC_RX_BIST_CNTL                       TX_PAGE_2, 0xF9
+
+#define MSK_PAGE_2_HSIC_RX_BIST_CNTL_HRX_ODD               (0x03 << 4)
+#define MSK_PAGE_2_HSIC_RX_BIST_CNTL_HRX_INVERT            (0x03 << 2)
+#define BIT_PAGE_2_HSIC_RX_BIST_CNTL_HRX_RUN_CTRL          (0x01 << 1)
+#define BIT_PAGE_2_HSIC_RX_BIST_CNTL_HRX_BIST_EN           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFA HSIC RX BIST PATTERN Register                      (Default: 0x00)    */
+#define REG_PAGE_2_HSIC_RX_BIST_PAT                        TX_PAGE_2, 0xFA
+
+#define MSK_PAGE_2_HSIC_RX_BIST_PAT_HRX_PATTERN            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFB HSIC RXTX BIST STATUS Register                     (Default: 0x10)    */
+#define REG_PAGE_2_HSIC_RX_BIST_STATUS                     TX_PAGE_2, 0xFB
+
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HTXBIST_DONE        (0x01 << 7)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HTXBIST_RUN         (0x01 << 6)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HRX_STROBE          (0x01 << 4)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HRX_DATA            (0x01 << 3)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HRXBIST_ERROR       (0x01 << 2)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HRXBIST_DONE        (0x01 << 1)
+#define BIT_PAGE_2_HSIC_RX_BIST_STATUS_HRXBIST_RUN         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFC HSIC TX BIST CNTL1 Register                        (Default: 0x10)    */
+#define REG_PAGE_2_HSIC_TX_BIST_CNTL1                      TX_PAGE_2, 0xFC
+
+#define MSK_PAGE_2_HSIC_TX_BIST_CNTL1_HTX_NUM_KEEP_CYCLE   (0x03 << 4)
+#define BIT_PAGE_2_HSIC_TX_BIST_CNTL1_HTX_RUN_CTRL         (0x01 << 2)
+#define BIT_PAGE_2_HSIC_TX_BIST_CNTL1_HTX_BIST_EN          (0x01 << 1)
+#define BIT_PAGE_2_HSIC_TX_BIST_CNTL1_HTX_BIST_SEL         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFD HSIC TX BIST CNTL2 Register                        (Default: 0x00)    */
+#define REG_PAGE_2_HSIC_TX_BIST_CNTL2                      TX_PAGE_2, 0xFD
+
+#define MSK_PAGE_2_HSIC_TX_BIST_CNTL2_HTX_STROBE_ODD       (0x03 << 6)
+#define MSK_PAGE_2_HSIC_TX_BIST_CNTL2_HTX_STROBE_INVERT    (0x03 << 4)
+#define MSK_PAGE_2_HSIC_TX_BIST_CNTL2_HTX_DATA_ODD         (0x03 << 2)
+#define MSK_PAGE_2_HSIC_TX_BIST_CNTL2_HTX_DATA_INVERT      (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFE HSIC TX BIST DATA PATTERN Register                 (Default: 0x00)    */
+#define REG_PAGE_2_HSIC_TX_BIST_DATA_PAT                   TX_PAGE_2, 0xFE
+
+#define MSK_PAGE_2_HSIC_TX_BIST_DATA_PAT_HTX_DATA_PATTERN  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFF HSIC TX BIST STROBE PATTERN Register               (Default: 0xF0)    */
+#define REG_PAGE_2_HSIC_TX_BIST_STROBE_PAT                 TX_PAGE_2, 0xFF
+
+#define MSK_PAGE_2_HSIC_TX_BIST_STROBE_PAT_HTX_STROBE_PATTERN (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_3                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x00 E-MSC General Control Register                     (Default: 0x00)    */
+#define REG_PAGE_3_GENCTL                                  TX_PAGE_3, 0x00
+
+#define BIT_PAGE_3_GENCTL_SPEC_TRANS_DIS                   (0x01 << 7)
+#define BIT_PAGE_3_GENCTL_DIS_XMIT_ERR_STATE               (0x01 << 6)
+#define BIT_PAGE_3_GENCTL_SPI_MISO_EDGE                    (0x01 << 5)
+#define BIT_PAGE_3_GENCTL_SPI_MOSI_EDGE                    (0x01 << 4)
+#define BIT_PAGE_3_GENCTL_CLR_EMSC_RFIFO                   (0x01 << 3)
+#define BIT_PAGE_3_GENCTL_CLR_EMSC_XFIFO                   (0x01 << 2)
+#define BIT_PAGE_3_GENCTL_START_TRAIN_SEQ                  (0x01 << 1)
+#define BIT_PAGE_3_GENCTL_EMSC_EN                          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 E-MSC Comma Char1 Register                         (Default: 0x96)    */
+#define REG_PAGE_3_COMMACH1                                TX_PAGE_3, 0x01
+
+#define MSK_PAGE_3_COMMACH1_COMMA_CHAR1                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 E-MSC Comma Char2 Register                         (Default: 0x69)    */
+#define REG_PAGE_3_COMMACH2                                TX_PAGE_3, 0x02
+
+#define MSK_PAGE_3_COMMACH2_COMMA_CHAR2                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 E-MSC Null Char Register                           (Default: 0x00)    */
+#define REG_PAGE_3_NULLCH                                  TX_PAGE_3, 0x03
+
+#define MSK_PAGE_3_NULLCH_NULL_CHAR                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 E-MSC Train Char Register                          (Default: 0xFF)    */
+#define REG_PAGE_3_TRAINCH                                 TX_PAGE_3, 0x04
+
+#define MSK_PAGE_3_TRAINCH_TRAIN_CHAR                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x05 E-MSC Comma ErrorCNT Register                      (Default: 0x03)    */
+#define REG_PAGE_3_COMMECNT                                TX_PAGE_3, 0x05
+
+#define BIT_PAGE_3_COMMECNT_I2C_TO_EMSC_EN                 (0x01 << 7)
+#define MSK_PAGE_3_COMMECNT_COMMA_CHAR_ERR_CNT             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x06 E-MSC Comma Window Register                        (Default: 0x18)    */
+#define REG_PAGE_3_COMMAWIN                                TX_PAGE_3, 0x06
+
+#define MSK_PAGE_3_COMMAWIN_COMMA_CHAR_WIN                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x07 E-MSC TX Train ByteCnt Low Register                (Default: 0x04)    */
+#define REG_PAGE_3_TXTRAINBCNTL                            TX_PAGE_3, 0x07
+
+#define MSK_PAGE_3_TXTRAINBCNTL_TXTRAIN_CHAR_BYTE_CNT_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 E-MSC TX Train ByteCnt High Register               (Default: 0x01)    */
+#define REG_PAGE_3_TXTRAINBCNTH                            TX_PAGE_3, 0x08
+
+#define BIT_PAGE_3_TXTRAINBCNTH_TXTRAIN_CHAR_BYTE_CNT_8    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 E-MSC Skip ByteCnt Low Register                    (Default: 0x04)    */
+#define REG_PAGE_3_SKIPBCNTL                               TX_PAGE_3, 0x09
+
+#define MSK_PAGE_3_SKIPBCNTL_SKIP_BYTE_CNT_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A E-MSC Skip ByteCnt High Register                   (Default: 0x01)    */
+#define REG_PAGE_3_SKIPBCNTH                               TX_PAGE_3, 0x0A
+
+#define BIT_PAGE_3_SKIPBCNTH_SKIP_BYTE_CNT_8               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0B E-MSC Rcv Tout Register                            (Default: 0x09)    */
+#define REG_PAGE_3_EMSCRCVTOUT                             TX_PAGE_3, 0x0B
+
+#define MSK_PAGE_3_EMSCRCVTOUT_EMSC_RCV_TOUT_MSB           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C E-MSC Xmit Tout Register                           (Default: 0x14)    */
+#define REG_PAGE_3_EMSCXMITTOUT                            TX_PAGE_3, 0x0C
+
+#define MSK_PAGE_3_EMSCXMITTOUT_EMSC_XMIT_TOUT_MSB         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D E-MSC Tx Xmit Retry Max Low  Register              (Default: 0x20)    */
+#define REG_PAGE_3_EMSCXMITRETRYMAXL                       TX_PAGE_3, 0x0D
+
+#define MSK_PAGE_3_EMSCXMITRETRYMAXL_EMSC_XMIT_RETRY_MAX_MSB_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E E-MSC Tx Xmit Retry Max High Register              (Default: 0x00)    */
+#define REG_PAGE_3_EMSCXMITRETRYMAXH                       TX_PAGE_3, 0x0E
+
+#define MSK_PAGE_3_EMSCXMITRETRYMAXH_EMSC_XMIT_RETRY_MAX_MSB_10_8 (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F E-MSC Tx Xmit Retry Limit Register                 (Default: 0xFF)    */
+#define REG_PAGE_3_EMSCXMITRETRYLMT                        TX_PAGE_3, 0x0F
+
+#define MSK_PAGE_3_EMSCXMITRETRYLMT_EMSC_XMIT_RETRY_LIMIT  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 SPI CBUSWr SlowMode DummyCnt Register              (Default: 0x0C)    */
+#define REG_PAGE_3_SPICWRDCNT                              TX_PAGE_3, 0x10
+
+#define MSK_PAGE_3_SPICWRDCNT_SPI_CBUSWRDCNT               (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 SPI CBUSRd SlowMode DummyCnt Register              (Default: 0x13)    */
+#define REG_PAGE_3_SPICRDDCNT                              TX_PAGE_3, 0x11
+
+#define MSK_PAGE_3_SPICRDDCNT_SPI_CBUSRDDCNT               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 EMSC Space Check Register                          (Default: 0x04)    */
+#define REG_PAGE_3_EMSCSPCHK                               TX_PAGE_3, 0x12
+
+#define MSK_PAGE_3_EMSCSPCHK_SPACE_CHECK_NUM               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 EMSC Wait Check Register                           (Default: 0x10)    */
+#define REG_PAGE_3_EMSCWTCHK                               TX_PAGE_3, 0x13
+
+#define MSK_PAGE_3_EMSCWTCHK_WAIT_CHECK_SPACE_CNT          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 E-MSC Xmit Status Register                         (Default: 0x00)    */
+#define REG_PAGE_3_EMSCXMITSTAT                            TX_PAGE_3, 0x14
+
+#define MSK_PAGE_3_EMSCXMITSTAT_EMSC_XMITSTAT              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 E-MSC Rcvd Status Register                         (Default: 0x00)    */
+#define REG_PAGE_3_EMSCRCVDSTAT                            TX_PAGE_3, 0x15
+
+#define MSK_PAGE_3_EMSCRCVDSTAT_EMSC_RCVDSTAT              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 MEM XFIFO ByteCnt Status Register                  (Default: 0x00)    */
+#define REG_PAGE_3_MEMXFIFOBCNT                            TX_PAGE_3, 0x16
+
+#define MSK_PAGE_3_MEMXFIFOBCNT_MEM_XFIFO_BYTE_CNT_4_0     (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 MEM RFIFO ByteCnt Status Register                  (Default: 0x00)    */
+#define REG_PAGE_3_MEMRFIFOBCNT                            TX_PAGE_3, 0x17
+
+#define MSK_PAGE_3_MEMRFIFOBCNT_MEM_RFIFO_BYTE_CNT_4_0     (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 E-MSC XFIFO ByteCnt Status Low Register            (Default: 0x00)    */
+#define REG_PAGE_3_EMSCXFIFOBCNTL                          TX_PAGE_3, 0x18
+
+#define MSK_PAGE_3_EMSCXFIFOBCNTL_EMSC_XFIFO_BYTE_CNT_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 E-MSC XFIFO ByteCnt Status High Register           (Default: 0x00)    */
+#define REG_PAGE_3_EMSCXFIFOBCNTH                          TX_PAGE_3, 0x19
+
+#define BIT_PAGE_3_EMSCXFIFOBCNTH_EMSC_XFIFO_BYTE_CNT_8    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A E-MSC RFIFO ByteCnt Status Low Register            (Default: 0x00)    */
+#define REG_PAGE_3_EMSCRFIFOBCNTL                          TX_PAGE_3, 0x1A
+
+#define MSK_PAGE_3_EMSCRFIFOBCNTL_EMSC_RFIFO_BYTE_CNT_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1B E-MSC RFIFO ByteCnt Status High Register           (Default: 0x00)    */
+#define REG_PAGE_3_EMSCRFIFOBCNTH                          TX_PAGE_3, 0x1B
+
+#define BIT_PAGE_3_EMSCRFIFOBCNTH_EMSC_RFIFO_BYTE_CNT_8    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1C E-MSC XFIFO Space Status Low Register              (Default: 0x20)    */
+#define REG_PAGE_3_EMSCXFIFOSPACEL                         TX_PAGE_3, 0x1C
+
+#define MSK_PAGE_3_EMSCXFIFOSPACEL_EMSC_XFIFO_SPACE_7_0    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1D E-MSC XFIFO Space Status High Register             (Default: 0x01)    */
+#define REG_PAGE_3_EMSCXFIFOSPACEH                         TX_PAGE_3, 0x1D
+
+#define BIT_PAGE_3_EMSCXFIFOSPACEH_EMSC_XFIFO_SPACE_8      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1E SPI Burst Cnt Status Register                      (Default: 0x00)    */
+#define REG_PAGE_3_SPIBURSTCNT                             TX_PAGE_3, 0x1E
+
+#define MSK_PAGE_3_SPIBURSTCNT_SPI_BURST_CNT               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1F EMSC XMIT TOState Register                         (Default: 0x00)    */
+#define REG_PAGE_3_EMSCTOSTT                               TX_PAGE_3, 0x1F
+
+#define MSK_PAGE_3_EMSCTOSTT_XMIT_TIMEOUT_STATE            (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 EMSC PRAM XFIFO Byte Count  Register               (Default: 0x00)    */
+#define REG_PAGE_3_PRAMXFFFBCNT                            TX_PAGE_3, 0x20
+
+#define MSK_PAGE_3_PRAMXFFFBCNT_PRAM_XFIFO_BYTE_CNT        (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 EMSC PRAM RFIFO Byte Count  Register               (Default: 0x00)    */
+#define REG_PAGE_3_PRAMRFFFBCNT                            TX_PAGE_3, 0x21
+
+#define MSK_PAGE_3_PRAMRFFFBCNT_PRAM_RFIFO_BYTE_CNT        (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 SPI Burst Status and SWRST Register                (Default: 0x00)    */
+#define REG_PAGE_3_SPIBURSTSTAT                            TX_PAGE_3, 0x22
+
+#define BIT_PAGE_3_SPIBURSTSTAT_SPI_HDCPRST                (0x01 << 7)
+#define BIT_PAGE_3_SPIBURSTSTAT_SPI_CBUSRST                (0x01 << 6)
+#define BIT_PAGE_3_SPIBURSTSTAT_SPI_SRST                   (0x01 << 5)
+#define BIT_PAGE_3_SPIBURSTSTAT_EMSC_NORMAL_MODE           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 E-MSC Interrupt Register                           (Default: 0x00)    */
+#define REG_PAGE_3_EMSCINTR                                TX_PAGE_3, 0x23
+
+#define BIT_PAGE_3_EMSCINTR_EMSC_XFIFO_EMPTY               (0x01 << 7)
+#define BIT_PAGE_3_EMSCINTR_EMSC_XMIT_ACK_TOUT             (0x01 << 6)
+#define BIT_PAGE_3_EMSCINTR_SPI_EMSC_READ_ERR              (0x01 << 5)
+#define BIT_PAGE_3_EMSCINTR_SPI_EMSC_WRITE_ERR             (0x01 << 4)
+#define BIT_PAGE_3_EMSCINTR_SPI_COMMA_CHAR_ERR             (0x01 << 3)
+#define BIT_PAGE_3_EMSCINTR_EMSC_XMITDONE                  (0x01 << 2)
+#define BIT_PAGE_3_EMSCINTR_EMSC_XMIT_GNT_TOUT             (0x01 << 1)
+#define BIT_PAGE_3_EMSCINTR_SPI_DVLD                       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x24 E-MSC Interrupt Mask Register                      (Default: 0x00)    */
+#define REG_PAGE_3_EMSCINTRMASK                            TX_PAGE_3, 0x24
+
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK7             (0x01 << 7)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK6             (0x01 << 6)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK5             (0x01 << 5)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK4             (0x01 << 4)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK3             (0x01 << 3)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK2             (0x01 << 2)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK1             (0x01 << 1)
+#define BIT_PAGE_3_EMSCINTRMASK_EMSC_INTRMASK0             (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x25 E-MSC RX Train ByteCnt Low Register                (Default: 0x04)    */
+#define REG_PAGE_3_RXTRAINBCNTL                            TX_PAGE_3, 0x25
+
+#define MSK_PAGE_3_RXTRAINBCNTL_RXTRAIN_CHAR_BYTE_CNT_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x26 E-MSC RX Train ByteCnt High Register               (Default: 0x01)    */
+#define REG_PAGE_3_RXTRAINBCNTH                            TX_PAGE_3, 0x26
+
+#define BIT_PAGE_3_RXTRAINBCNTH_RXTRAIN_CHAR_BYTE_CNT_8    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x27 E-MSC Grant Retry Cnt Status Register              (Default: 0x00)    */
+#define REG_PAGE_3_EMSCGNTRTYCNT                           TX_PAGE_3, 0x27
+
+#define MSK_PAGE_3_EMSCGNTRTYCNT_EMSC_GNT_RETRY_CNT        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x28 E-MSC ACK Retry Cnt Status Register                (Default: 0x00)    */
+#define REG_PAGE_3_EMSCACKRTYCNT                           TX_PAGE_3, 0x28
+
+#define MSK_PAGE_3_EMSCACKRTYCNT_EMSC_ACK_RETRY_CNT        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x29 SPI E-MSC FIFO Status Register                     (Default: 0x00)    */
+#define REG_PAGE_3_SPIEMSCFIFOSTAT                         TX_PAGE_3, 0x29
+
+#define MSK_PAGE_3_SPIEMSCFIFOSTAT_SPI_EMSC_FIFO_STATUS    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2A I2C E-MSC XMIT FIFO Write Port Register            (Default: 0x00)    */
+#define REG_PAGE_3_EMSC_XMIT_WRITE_PORT                    TX_PAGE_3, 0x2A
+
+#define MSK_PAGE_3_EMSC_XMIT_WRITE_PORT_EMSC_XMIT_WRITE_PORT (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2B I2C E-MSC RCV FIFO Write Port Register             (Default: 0x00)    */
+#define REG_PAGE_3_EMSC_RCV_READ_PORT                      TX_PAGE_3, 0x2B
+
+#define MSK_PAGE_3_EMSC_RCV_READ_PORT_EMSC_RCV_READ_PORT   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x30 MHL Top Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_3_MHL_TOP_CTL                             TX_PAGE_3, 0x30
+
+#define BIT_PAGE_3_MHL_TOP_CTL_MHL3_DOC_SEL                (0x01 << 7)
+#define BIT_PAGE_3_MHL_TOP_CTL_MHL_PP_SEL                  (0x01 << 6)
+#define MSK_PAGE_3_MHL_TOP_CTL_IF_TIMING_CTL               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x31 MHL DataPath 1st Ctl Register                      (Default: 0xBC)    */
+#define REG_PAGE_3_MHL_DP_CTL0                             TX_PAGE_3, 0x31
+
+#define BIT_PAGE_3_MHL_DP_CTL0_DP_OE                       (0x01 << 7)
+#define BIT_PAGE_3_MHL_DP_CTL0_TX_OE_OVR                   (0x01 << 6)
+#define MSK_PAGE_3_MHL_DP_CTL0_TX_OE                       (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x32 MHL DataPath 2nd Ctl Register                      (Default: 0xBB)    */
+#define REG_PAGE_3_MHL_DP_CTL1                             TX_PAGE_3, 0x32
+
+#define MSK_PAGE_3_MHL_DP_CTL1_CK_SWING_CTL                (0x0F << 4)
+#define MSK_PAGE_3_MHL_DP_CTL1_DT_SWING_CTL                (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x33 MHL DataPath 3rd Ctl Register                      (Default: 0x2F)    */
+#define REG_PAGE_3_MHL_DP_CTL2                             TX_PAGE_3, 0x33
+
+#define BIT_PAGE_3_MHL_DP_CTL2_CLK_BYPASS_EN               (0x01 << 7)
+#define MSK_PAGE_3_MHL_DP_CTL2_DAMP_TERM_SEL               (0x03 << 4)
+#define MSK_PAGE_3_MHL_DP_CTL2_CK_TERM_SEL                 (0x03 << 2)
+#define MSK_PAGE_3_MHL_DP_CTL2_DT_TERM_SEL                 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x34 MHL DataPath 4th Ctl Register                      (Default: 0x48)    */
+#define REG_PAGE_3_MHL_DP_CTL3                             TX_PAGE_3, 0x34
+
+#define MSK_PAGE_3_MHL_DP_CTL3_DT_DRV_VNBC_CTL             (0x0F << 4)
+#define MSK_PAGE_3_MHL_DP_CTL3_DT_DRV_VNB_CTL              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x35 MHL DataPath 5th Ctl Register                      (Default: 0x48)    */
+#define REG_PAGE_3_MHL_DP_CTL4                             TX_PAGE_3, 0x35
+
+#define MSK_PAGE_3_MHL_DP_CTL4_CK_DRV_VNBC_CTL             (0x0F << 4)
+#define MSK_PAGE_3_MHL_DP_CTL4_CK_DRV_VNB_CTL              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x36 MHL DataPath 6th Ctl Register                      (Default: 0x3F)    */
+#define REG_PAGE_3_MHL_DP_CTL5                             TX_PAGE_3, 0x36
+
+#define BIT_PAGE_3_MHL_DP_CTL5_RSEN_EN_OVR                 (0x01 << 7)
+#define BIT_PAGE_3_MHL_DP_CTL5_RSEN_EN                     (0x01 << 6)
+#define MSK_PAGE_3_MHL_DP_CTL5_DAMP_TERM_VGS_CTL           (0x03 << 4)
+#define MSK_PAGE_3_MHL_DP_CTL5_CK_TERM_VGS_CTL             (0x03 << 2)
+#define MSK_PAGE_3_MHL_DP_CTL5_DT_TERM_VGS_CTL             (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x37 MHL PLL 1st Ctl Register                           (Default: 0x05)    */
+#define REG_PAGE_3_MHL_PLL_CTL0                            TX_PAGE_3, 0x37
+
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_EN                 (0x01 << 7)
+#define MSK_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO              (0x07 << 4) // bits 6:4
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_10         (0x07 << 4) // 3'b111 5/10 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_6          (0x06 << 4) // 3'b110 5/6 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_4          (0x05 << 4) // 3'b101 5/4 hdmi_clk_freq
+//TODO: #define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_2          (0x04 << 4) // 3'b100 5/2 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_5          (0x03 << 4) // 3'b011 5/5 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_3          (0x02 << 4) // 3'b010 5/3 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_2_PRIME    (0x01 << 4) // 3'b001 5/2 hdmi_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_AUD_CLK_RATIO_5_1          (0x00 << 4) // 3'b000 5/1 hdmi_clk_freq
+
+#define MSK_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO             (0x03 << 2)
+#define BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_4X          (0x03 << 2) // 2'b11 4x mode, hdmi_clk_freq = 4*pxl_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_2X          (0x02 << 2) // 2'b10 2x mode, hdmi_clk_freq = 2*pxl_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_1X          (0x01 << 2) // 2'b01 1x mode, hdmi_clk_freq = 1*pxl_clk_freq
+#define BIT_PAGE_3_MHL_PLL_CTL0_HDMI_CLK_RATIO_HALF_X      (0x00 << 2) // 2'b00 0.5x mode, hdmi_clk_freq = 0.5*pxl_clk_freq
+
+#define BIT_PAGE_3_MHL_PLL_CTL0_CRYSTAL_CLK_SEL            (0x01 << 1)
+#define BIT_PAGE_3_MHL_PLL_CTL0_ZONE_MASK_OE               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x38 MHL PLL 2nd Ctl Register                           (Default: 0xFC)    */
+#define REG_PAGE_3_MHL_PLL_CTL1                            TX_PAGE_3, 0x38
+
+#define MSK_PAGE_3_MHL_PLL_CTL1_FVCO_CTL                   (0x0F << 4)
+#define MSK_PAGE_3_MHL_PLL_CTL1_PLL_BW_CTL                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x39 MHL PLL 3rd Ctl Register                           (Default: 0x80)    */
+#define REG_PAGE_3_MHL_PLL_CTL2                            TX_PAGE_3, 0x39
+
+#define BIT_PAGE_3_MHL_PLL_CTL2_CLKDETECT_EN               (0x01 << 7)
+#define BIT_PAGE_3_MHL_PLL_CTL2_MEAS_FVCO                  (0x01 << 3)
+#define BIT_PAGE_3_MHL_PLL_CTL2_PLL_FAST_LOCK              (0x01 << 2)
+#define MSK_PAGE_3_MHL_PLL_CTL2_PLL_LF_SEL                 (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A MHL BIAS 1st Ctl Register                          (Default: 0xB8)    */
+#define REG_PAGE_3_MHL_BIAS_CTL0                           TX_PAGE_3, 0x3A
+
+#define BIT_PAGE_3_MHL_BIAS_CTL0_BIAS_SEL                  (0x01 << 7)
+#define MSK_PAGE_3_MHL_BIAS_CTL0_BIAS_SW_CTL               (0x07 << 4)
+#define MSK_PAGE_3_MHL_BIAS_CTL0_BGR_CTL                   (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3B MHL BIAS 2nd Ctl Register                          (Default: 0x07)    */
+#define REG_PAGE_3_MHL_BIAS_CTL1                           TX_PAGE_3, 0x3B
+
+#define MSK_PAGE_3_MHL_BIAS_CTL1_RSWING_CTL                (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C MHL BIAS 3rd Ctl Register                          (Default: 0x07)    */
+#define REG_PAGE_3_MHL_BIAS_CTL2                           TX_PAGE_3, 0x3C
+
+#define MSK_PAGE_3_MHL_BIAS_CTL2_BIAS_TERM_SEL             (0x03 << 3)
+#define MSK_PAGE_3_MHL_BIAS_CTL2_IBIAS_SEL                 (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D MHL Misc 1st Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_3_MHL_MISC_CTL0                           TX_PAGE_3, 0x3D
+
+#define MSK_PAGE_3_MHL_MISC_CTL0_TEST_MODE                 (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3E MHL Misc 2nd Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_3_MHL_MISC_CTL1                           TX_PAGE_3, 0x3E
+
+#define MSK_PAGE_3_MHL_MISC_CTL1_RSV_7_0                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3F MHL Misc 3rd Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_3_MHL_MISC_CTL2                           TX_PAGE_3, 0x3F
+
+#define MSK_PAGE_3_MHL_MISC_CTL2_RSV_15_8                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x40 MHL CBUS 1st Ctl Register                          (Default: 0x12)    */
+#define REG_PAGE_3_MHL_CBUS_CTL0                           TX_PAGE_3, 0x40
+
+#define BIT_PAGE_3_MHL_CBUS_CTL0_CBUS_RGND_VBIAS_734       (0x00)
+
+#define BIT_PAGE_3_MHL_CBUS_CTL0_CBUS_DRV_SEL_STRONG       (0x02) /* default */
+
+#define BIT_PAGE_3_MHL_CBUS_CTL0_CBUS_RGND_TEST_MODE       (0x01 << 7)
+#define MSK_PAGE_3_MHL_CBUS_CTL0_CBUS_RGND_VTH_CTL         (0x03 << 4)
+#define MSK_PAGE_3_MHL_CBUS_CTL0_CBUS_RES_TEST_SEL         (0x03 << 2)
+#define MSK_PAGE_3_MHL_CBUS_CTL0_CBUS_DRV_SEL              (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 MHL CBUS 2nd Ctl Register                          (Default: 0x03)    */
+#define REG_PAGE_3_MHL_CBUS_CTL1                           TX_PAGE_3, 0x41
+
+#define BIT_PAGE_3_MHL_CBUS_CTL1_1115_OHM                  (0x04)
+
+#define MSK_PAGE_3_MHL_CBUS_CTL1_CBUS_RGND_RES_CTL         (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 MHL CoC 1st Ctl Register                           (Default: 0xC3)    */
+#define REG_PAGE_3_MHL_COC_CTL0                            TX_PAGE_3, 0x42
+
+#define BIT_PAGE_3_MHL_COC_CTL0_COC_BIAS_EN                (0x01 << 7)
+#define MSK_PAGE_3_MHL_COC_CTL0_COC_BIAS_CTL               (0x07 << 4)
+#define MSK_PAGE_3_MHL_COC_CTL0_COC_TERM_CTL               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x43 MHL CoC 2nd Ctl Register                           (Default: 0x87)    */
+#define REG_PAGE_3_MHL_COC_CTL1                            TX_PAGE_3, 0x43
+
+#define BIT_PAGE_3_MHL_COC_CTL1_COC_EN                     (0x01 << 7)
+#define MSK_PAGE_3_MHL_COC_CTL1_COC_DRV_CTL                (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x46 MHL CoC 5th Ctl Register                           (Default: 0x28)    */
+#define REG_PAGE_3_MHL_COC_CTL4                            TX_PAGE_3, 0x46
+
+#define MSK_PAGE_3_MHL_COC_CTL4_COC_IF_CTL                 (0x0F << 4)
+#define MSK_PAGE_3_MHL_COC_CTL4_COC_SLEW_CTL               (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x47 MHL CoC 6th Ctl Register                           (Default: 0x0D)    */
+#define REG_PAGE_3_MHL_COC_CTL5                            TX_PAGE_3, 0x47
+
+#define MSK_PAGE_3_MHL_COC_CTL5_COC_RSV_7_0                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x48 MHL CoC 7th Ctl Register                           (Default: 0x80)    */
+#define REG_PAGE_3_MHL_COC_CTL6                            TX_PAGE_3, 0x48
+
+#define MSK_PAGE_3_MHL_COC_CTL6_COC_RSV_15_8               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x49 MHL DoC 1st Ctl Register                           (Default: 0x00)    */
+#define REG_PAGE_3_MHL_DOC_CTL0                            TX_PAGE_3, 0x49
+
+#define BIT_PAGE_3_MHL_DOC_CTL0_DOC_RXDATA_EN              (0x01 << 7)
+#define BIT_PAGE_3_MHL_DOC_CTL0_DOC_CK_EN                  (0x01 << 6)
+#define MSK_PAGE_3_MHL_DOC_CTL0_DOC_OPMODE                 (0x03 << 1)
+#define BIT_PAGE_3_MHL_DOC_CTL0_DOC_RXBIAS_EN              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4A MHL DoC 2nd Ctl Register                           (Default: 0x03)    */
+#define REG_PAGE_3_MHL_DOC_CTL1                            TX_PAGE_3, 0x4A
+
+#define MSK_PAGE_3_MHL_DOC_CTL1_DOC_BIAS                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D MHL DoC 5th Ctl Register                           (Default: 0x42)    */
+#define REG_PAGE_3_MHL_DOC_CTL4                            TX_PAGE_3, 0x4D
+
+#define MSK_PAGE_3_MHL_DOC_CTL4_DOC_RSV_7_0                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4E MHL DoC 5th Ctl Register                           (Default: 0x00)    */
+#define REG_PAGE_3_MHL_DOC_CTL5                            TX_PAGE_3, 0x4E
+
+#define MSK_PAGE_3_MHL_DOC_CTL5_DOC_IF                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4F MHL Oscillator 1st Ctl Register                    (Default: 0x00)    */
+#define REG_PAGE_3_MHL_OSC_CTL0                            TX_PAGE_3, 0x4F
+
+#define MSK_PAGE_3_MHL_OSC_CTL0_OSC_CTL                    (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 Tx Zone Ctl0 Register                              (Default: 0x08)    */
+#define REG_PAGE_3_TX_ZONE_CTL0                            TX_PAGE_3, 0x60
+
+#define MSK_PAGE_3_TX_ZONE_CTL0_MAX_DIFF_LIMIT             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 Tx Zone Ctl1 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_TX_ZONE_CTL1                            TX_PAGE_3, 0x61
+
+#define MSK_PAGE_3_TX_ZONE_CTL1_TX_ZONE_CTRL_MODE          (0x08 << 0)
+#define MSK_PAGE_3_TX_ZONE_CTL1_TX_ZONE_CTRL               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x62 Tx Zone Ctl2 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_TX_ZONE_CTL2                            TX_PAGE_3, 0x62
+
+#define MSK_PAGE_3_TX_ZONE_CTL2_TX_ZONE                    (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x63 Tx Zone Ctl3 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_TX_ZONE_CTL3                            TX_PAGE_3, 0x63
+
+#define MSK_PAGE_3_TX_ZONE_CTL3_TX_ZONE_CTRL3              (0x03 << 6)
+#define MSK_PAGE_3_TX_ZONE_CTL3_HRV_ZONE_CTRL3             (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x64 MHL3 Tx Zone Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_3_MHL3_TX_ZONE_CTL                        TX_PAGE_3, 0x64
+
+#define BIT_PAGE_3_MHL3_TX_ZONE_CTL_MHL2_INTPLT_ZONE_MANU_EN (0x01 << 7)
+#define MSK_PAGE_3_MHL3_TX_ZONE_CTL_MHL3_TX_ZONE           (0x03 << 0)
+
+#define VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_6GBPS              (0x00 << 0)
+#define VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_3GBPS              (0x01 << 0)
+#define VAL_PAGE_3_TX_ZONE_CTL3_TX_ZONE_1_5GBPS            (0x02 << 0)
+/*----------------------------------------------------------------------------*/
+/* 0x70 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP0                            TX_PAGE_3, 0x70
+
+#define MSK_PAGE_3_HDCP2X_TEMP0_HDCP2X_TEMP0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x71 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP1                            TX_PAGE_3, 0x71
+
+#define MSK_PAGE_3_HDCP2X_TEMP1_HDCP2X_TEMP1               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x72 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP2                            TX_PAGE_3, 0x72
+
+#define MSK_PAGE_3_HDCP2X_TEMP2_HDCP2X_TEMP2               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x73 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP3                            TX_PAGE_3, 0x73
+
+#define MSK_PAGE_3_HDCP2X_TEMP3_HDCP2X_TEMP3               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x74 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP4                            TX_PAGE_3, 0x74
+
+#define MSK_PAGE_3_HDCP2X_TEMP4_HDCP2X_TEMP4               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x75 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP5                            TX_PAGE_3, 0x75
+
+#define MSK_PAGE_3_HDCP2X_TEMP5_HDCP2X_TEMP5               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x76 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP6                            TX_PAGE_3, 0x76
+
+#define MSK_PAGE_3_HDCP2X_TEMP6_HDCP2X_TEMP6               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x77 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP7                            TX_PAGE_3, 0x77
+
+#define MSK_PAGE_3_HDCP2X_TEMP7_HDCP2X_TEMP7               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x78 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP8                            TX_PAGE_3, 0x78
+
+#define MSK_PAGE_3_HDCP2X_TEMP8_HDCP2X_TEMP8               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x79 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP9                            TX_PAGE_3, 0x79
+
+#define MSK_PAGE_3_HDCP2X_TEMP9_HDCP2X_TEMP9               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7A HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP10                           TX_PAGE_3, 0x7A
+
+#define MSK_PAGE_3_HDCP2X_TEMP10_HDCP2X_TEMP10             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7B HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP11                           TX_PAGE_3, 0x7B
+
+#define MSK_PAGE_3_HDCP2X_TEMP11_HDCP2X_TEMP11             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7C HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP12                           TX_PAGE_3, 0x7C
+
+#define MSK_PAGE_3_HDCP2X_TEMP12_HDCP2X_TEMP12             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7D HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP13                           TX_PAGE_3, 0x7D
+
+#define MSK_PAGE_3_HDCP2X_TEMP13_HDCP2X_TEMP13             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7E HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP14                           TX_PAGE_3, 0x7E
+
+#define MSK_PAGE_3_HDCP2X_TEMP14_HDCP2X_TEMP14             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7F HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP15                           TX_PAGE_3, 0x7F
+
+#define MSK_PAGE_3_HDCP2X_TEMP15_HDCP2X_TEMP15             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP16                           TX_PAGE_3, 0x80
+
+#define MSK_PAGE_3_HDCP2X_TEMP16_HDCP2X_TEMP16             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP17                           TX_PAGE_3, 0x81
+
+#define MSK_PAGE_3_HDCP2X_TEMP17_HDCP2X_TEMP17             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP18                           TX_PAGE_3, 0x82
+
+#define MSK_PAGE_3_HDCP2X_TEMP18_HDCP2X_TEMP18             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x83 HDCP Temp Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TEMP19                           TX_PAGE_3, 0x83
+
+#define MSK_PAGE_3_HDCP2X_TEMP19_HDCP2X_TEMP19             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x90 HDCP Software Reset Register                       (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TX_SRST                          TX_PAGE_3, 0x90
+
+#define BIT_PAGE_3_HDCP2X_TX_SRST_HDCP2X_DDCM_RST          (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_TX_SRST_HDCP2X_ERST              (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_TX_SRST_HDCP2X_PRST_AUTO         (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_TX_SRST_HDCP2X_PRST              (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_TX_SRST_HDCP2X_CRST              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x91 HDCP Polling Control and Status Register           (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_POLL_CS                          TX_PAGE_3, 0x91
+
+#define BIT_PAGE_3_HDCP2X_POLL_CS_HDCP2X_DIS_POLL_GNT      (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_POLL_CS_HDCP2X_DIS_POLL_EN       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x92 HDCP SPI Starting Address Lo Register              (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_SPI_START_ADDR_LO                TX_PAGE_3, 0x92
+
+#define MSK_PAGE_3_HDCP2X_SPI_START_ADDR_LO_HDCP2X_SPI_S_ADDR_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x93 HDCP SPI Starting Address Hi Register              (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_SPI_START_ADDR_HI                TX_PAGE_3, 0x93
+
+#define MSK_PAGE_3_HDCP2X_SPI_START_ADDR_HI_HDCP2X_SPI_S_ADDR_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x94 HDCP SPI Signature Starting Address Lo Register    (Default: 0x80)    */
+#define REG_PAGE_3_HDCP2X_SPI_SIGN_START_ADDR_LO           TX_PAGE_3, 0x94
+
+#define MSK_PAGE_3_HDCP2X_SPI_SIGN_START_ADDR_LO_HDCP2X_SPI_SI_S_ADDR_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x95 HDCP SPI Signature Starting Address Hi Register    (Default: 0x3F)    */
+#define REG_PAGE_3_HDCP2X_SPI_SIGN_START_ADDR_HI           TX_PAGE_3, 0x95
+
+#define MSK_PAGE_3_HDCP2X_SPI_SIGN_START_ADDR_HI_HDCP2X_SPI_SI_S_ADDR_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x96 HDCP SPI Signature Ending Address Lo Register      (Default: 0xFF)    */
+#define REG_PAGE_3_HDCP2X_SPI_SIGN_END_ADDR_LO             TX_PAGE_3, 0x96
+
+#define MSK_PAGE_3_HDCP2X_SPI_SIGN_END_ADDR_LO_HDCP2X_SPI_SI_E_ADDR_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x97 HDCP SPI Signature Ending Address Hi Register      (Default: 0x3F)    */
+#define REG_PAGE_3_HDCP2X_SPI_SIGN_END_ADDR_HI             TX_PAGE_3, 0x97
+
+#define MSK_PAGE_3_HDCP2X_SPI_SIGN_END_ADDR_HI_HDCP2X_SPI_SI_E_ADDR_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x98 HDCP Interrupt 0 Register                          (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_INTR0                            TX_PAGE_3, 0x98
+
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT7         (0x01 << 7)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT6         (0x01 << 6)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT5         (0x01 << 5)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT4         (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT3         (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT2         (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT1         (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_INTR0_HDCP2X_INTR0_STAT0         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x99 HDCP Interrupt 0 Mask Register                     (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_INTR0_MASK                       TX_PAGE_3, 0x99
+
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK7    (0x01 << 7)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK6    (0x01 << 6)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK5    (0x01 << 5)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK4    (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK3    (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK2    (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK1    (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_INTR0_MASK_HDCP2X_INTR0_MASK0    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA0 HDCP General Control 0 Register                    (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_CTRL_0                           TX_PAGE_3, 0xA0
+
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_ENCRYPT_EN         (0x01 << 7)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_POLINT_SEL         (0x01 << 6)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_POLINT_OVR         (0x01 << 5)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_PRECOMPUTE         (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_HDMIMODE           (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_REPEATER           (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_HDCPTX             (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_CTRL_0_HDCP2X_EN                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA1 HDCP General Control 1 Register                    (Default: 0x04)    */
+#define REG_PAGE_3_HDCP2X_CTRL_1                           TX_PAGE_3, 0xA1
+
+#define MSK_PAGE_3_HDCP2X_CTRL_1_HDCP2X_REAUTH_MSK_3_0     (0x0F << 4)
+#define BIT_PAGE_3_HDCP2X_CTRL_1_HDCP2X_HPD_SW             (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_CTRL_1_HDCP2X_HPD_OVR            (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_CTRL_1_HDCP2X_REAUTH_SW          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA2 HDCP General Control 1 Register                    (Default: 0xA0)    */
+#define REG_PAGE_3_HDCP2X_CTRL_2                           TX_PAGE_3, 0xA2
+
+#define MSK_PAGE_3_HDCP2X_CTRL_2_HDCP2X_CPVER_3_0          (0x0F << 4)
+#define BIT_PAGE_3_HDCP2X_CTRL_2_HDCP2X_SPI_ADDR_RESET     (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_CTRL_2_HDCP2X_CUPD_START         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA3 HDCP CUPD Size Lo Register                         (Default: 0x80)    */
+#define REG_PAGE_3_HDCP2X_CUPD_SIZE_LO                     TX_PAGE_3, 0xA3
+
+#define MSK_PAGE_3_HDCP2X_CUPD_SIZE_LO_HDCP2X_CUPD_SIZE_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA4 HDCP CUPD Size Hi Register                         (Default: 0x3F)    */
+#define REG_PAGE_3_HDCP2X_CUPD_SIZE_HI                     TX_PAGE_3, 0xA4
+
+#define MSK_PAGE_3_HDCP2X_CUPD_SIZE_HI_HDCP2X_CUPD_SIZE_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA5 HDCP Misc Control Register                         (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_MISC_CTRL                        TX_PAGE_3, 0xA5
+
+#define BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_SMNG_XFER_START (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_SMNG_WR_START (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_SMNG_WR     (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_RCVID_RD_START (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_MISC_CTRL_HDCP2X_RPT_RCVID_RD    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA6 HDCP RPT SMNG K Register                           (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SMNG_K                       TX_PAGE_3, 0xA6
+
+#define MSK_PAGE_3_HDCP2X_RPT_SMNG_K_HDCP2X_RPT_SMNG_K_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA7 HDCP RPT SMNG In Register                          (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SMNG_IN                      TX_PAGE_3, 0xA7
+
+#define MSK_PAGE_3_HDCP2X_RPT_SMNG_IN_HDCP2X_RPT_SMNG_IN   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA8 HDCP General Staus Register                        (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GEN_STATUS                       TX_PAGE_3, 0xA8
+
+#define BIT_PAGE_3_HDCP2X_GEN_STATUS_HDCP2X_RPT_REPEATER   (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_GEN_STATUS_HDCP2X_PRG_SEL        (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_GEN_STATUS_HDCP2X_CUPD_DONE      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA9 HDCP Misc Staus Register                           (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_MISC_STATUS                      TX_PAGE_3, 0xA9
+
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_HDCP1DEV_DSTRM (0x01 << 5)
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_HDCP20RPT_DSTRM (0x01 << 4)
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_MX_CASC_EXC (0x01 << 3)
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_MX_DEVS_EXC (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_SMNG_XFER_DONE (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_MISC_STATUS_HDCP2X_RPT_RCVID_CHANGED (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAA HDCP Auth Status Register                          (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_AUTH_STAT                        TX_PAGE_3, 0xAA
+
+#define MSK_PAGE_3_HDCP2X_AUTH_STAT_HDCP2X_AUTH_STAT_7_0   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAB HDCP State Status Register                         (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_STATE                            TX_PAGE_3, 0xAB
+
+#define MSK_PAGE_3_HDCP2X_STATE_HDCP2X_STATE_7_0           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAC HDCP RPT RCVID Out Register                        (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVID_OUT                    TX_PAGE_3, 0xAC
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVID_OUT_HDCP2X_RPT_RCVID_OUT_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAD HDCP Depth Status Register                         (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_DEPTH                        TX_PAGE_3, 0xAD
+
+#define MSK_PAGE_3_HDCP2X_RPT_DEPTH_HDCP2X_RPT_DEPTH_7_0   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAE HDCP Devcnt Status Register                        (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_DEVCNT                       TX_PAGE_3, 0xAE
+
+#define MSK_PAGE_3_HDCP2X_RPT_DEVCNT_HDCP2X_RPT_DEVCNT_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAF HDCP Stream Counter Byte 0 Register                (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_STM_CTR0                         TX_PAGE_3, 0xAF
+
+#define MSK_PAGE_3_HDCP2X_STM_CTR0_HDCP2X_STM_CTR_7_0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB0 HDCP Stream Counter Byte 1 Register                (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_STM_CTR1                         TX_PAGE_3, 0xB0
+
+#define MSK_PAGE_3_HDCP2X_STM_CTR1_HDCP2X_STM_CTR_15_8     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB1 HDCP Stream Counter Byte 2 Register                (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_STM_CTR2                         TX_PAGE_3, 0xB1
+
+#define MSK_PAGE_3_HDCP2X_STM_CTR2_HDCP2X_STM_CTR_23_16    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB2 HDCP Stream Counter Byte 3 Register                (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_STM_CTR3                         TX_PAGE_3, 0xB2
+
+#define MSK_PAGE_3_HDCP2X_STM_CTR3_HDCP2X_STM_CTR_31_24    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB3 HDCP TP0  Register                                 (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_TP0                              TX_PAGE_3, 0xB3
+
+#define MSK_PAGE_3_HDCP2X_TP0_HDCP2X_TP0_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB4 HDCP TP1  Register                                 (Default: 0x75)    */
+#define REG_PAGE_3_HDCP2X_TP1                              TX_PAGE_3, 0xB4
+
+#define MSK_PAGE_3_HDCP2X_TP1_HDCP2X_TP1_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB5 HDCP TP2 Register                                  (Default: 0x01)    */
+#define REG_PAGE_3_HDCP2X_TP2                              TX_PAGE_3, 0xB5
+
+#define MSK_PAGE_3_HDCP2X_TP2_HDCP2X_TP2_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB6 HDCP TP3  Register                                 (Default: 0x32)    */
+#define REG_PAGE_3_HDCP2X_TP3                              TX_PAGE_3, 0xB6
+
+#define MSK_PAGE_3_HDCP2X_TP3_HDCP2X_TP3_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB7 HDCP TP4  Register                                 (Default: 0x14)    */
+#define REG_PAGE_3_HDCP2X_TP4                              TX_PAGE_3, 0xB7
+
+#define MSK_PAGE_3_HDCP2X_TP4_HDCP2X_TP4_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB8 HDCP TP5  Register                                 (Default: 0x64)    */
+#define REG_PAGE_3_HDCP2X_TP5                              TX_PAGE_3, 0xB8
+
+#define MSK_PAGE_3_HDCP2X_TP5_HDCP2X_TP5_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB9 HDCP TP6 Register                                  (Default: 0x02)    */
+#define REG_PAGE_3_HDCP2X_TP6                              TX_PAGE_3, 0xB9
+
+#define MSK_PAGE_3_HDCP2X_TP6_HDCP2X_TP6_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBA HDCP TP7  Register                                 (Default: 0x0A)    */
+#define REG_PAGE_3_HDCP2X_TP7                              TX_PAGE_3, 0xBA
+
+#define MSK_PAGE_3_HDCP2X_TP7_HDCP2X_TP7_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB HDCP TP8  Register                                 (Default: 0x0A)    */
+#define REG_PAGE_3_HDCP2X_TP8                              TX_PAGE_3, 0xBB
+
+#define MSK_PAGE_3_HDCP2X_TP8_HDCP2X_TP8_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBC HDCP TP9  Register                                 (Default: 0x14)    */
+#define REG_PAGE_3_HDCP2X_TP9                              TX_PAGE_3, 0xBC
+
+#define MSK_PAGE_3_HDCP2X_TP9_HDCP2X_TP9_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBD HDCP TP10 Register                                 (Default: 0x14)    */
+#define REG_PAGE_3_HDCP2X_TP10                             TX_PAGE_3, 0xBD
+
+#define MSK_PAGE_3_HDCP2X_TP10_HDCP2X_TP10_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBE HDCP TP11  Register                                (Default: 0xC8)    */
+#define REG_PAGE_3_HDCP2X_TP11                             TX_PAGE_3, 0xBE
+
+#define MSK_PAGE_3_HDCP2X_TP11_HDCP2X_TP11_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF HDCP TP12  Register                                (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TP12                             TX_PAGE_3, 0xBF
+
+#define MSK_PAGE_3_HDCP2X_TP12_HDCP2X_TP12_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 HDCP TP13  Register                                (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TP13                             TX_PAGE_3, 0xC0
+
+#define MSK_PAGE_3_HDCP2X_TP13_HDCP2X_TP13_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 HDCP TP14 Register                                 (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TP14                             TX_PAGE_3, 0xC1
+
+#define MSK_PAGE_3_HDCP2X_TP14_HDCP2X_TP14_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 HDCP TP15  Register                                (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_TP15                             TX_PAGE_3, 0xC2
+
+#define MSK_PAGE_3_HDCP2X_TP15_HDCP2X_TP15_7_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 HDCP GP In 0 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_IN0                           TX_PAGE_3, 0xC3
+
+#define MSK_PAGE_3_HDCP2X_GP_IN0_HDCP2X_GP_IN0_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 HDCP GP In 1 Register                              (Default: 0x22)    */
+#define REG_PAGE_3_HDCP2X_GP_IN1                           TX_PAGE_3, 0xC4
+
+#define MSK_PAGE_3_HDCP2X_GP_IN1_HDCP2X_GP_IN1_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 HDCP GP In 2 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_IN2                           TX_PAGE_3, 0xC5
+
+#define MSK_PAGE_3_HDCP2X_GP_IN2_HDCP2X_GP_IN2_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC6 HDCP GP In 3 Register                              (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_IN3                           TX_PAGE_3, 0xC6
+
+#define MSK_PAGE_3_HDCP2X_GP_IN3_HDCP2X_GP_IN3_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 HDCP GP Out 0 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_OUT0                          TX_PAGE_3, 0xC7
+
+#define MSK_PAGE_3_HDCP2X_GP_OUT0_HDCP2X_GP_OUT0_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC8 HDCP GP Out 1 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_OUT1                          TX_PAGE_3, 0xC8
+
+#define MSK_PAGE_3_HDCP2X_GP_OUT1_HDCP2X_GP_OUT1_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC9 HDCP GP Out 2 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_OUT2                          TX_PAGE_3, 0xC9
+
+#define MSK_PAGE_3_HDCP2X_GP_OUT2_HDCP2X_GP_OUT2_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCA HDCP GP Out 3 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_GP_OUT3                          TX_PAGE_3, 0xCA
+
+#define MSK_PAGE_3_HDCP2X_GP_OUT3_HDCP2X_GP_OUT3_7_0       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCB HDCP Seq V Byte 0 Register                         (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_0                  TX_PAGE_3, 0xCB
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_0_HDCP2X_RPT_SEQ_NUM_V_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC HDCP GP Out 1 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_1                  TX_PAGE_3, 0xCC
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_1_HDCP2X_RPT_SEQ_NUM_V_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCD HDCP GP Out 2 Register                             (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_2                  TX_PAGE_3, 0xCD
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_V_2_HDCP2X_RPT_SEQ_NUM_V_23_16 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE HDCP RPT Seq M Byte 0 Register                     (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_0                  TX_PAGE_3, 0xCE
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_0_HDCP2X_RPT_SEQ_NUM_M_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF HDCP RPT Seq M Byte 1 Register                     (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_1                  TX_PAGE_3, 0xCF
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_1_HDCP2X_RPT_SEQ_NUM_M_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD0 HDCP RPT Seq M Byte 0 Register                     (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_2                  TX_PAGE_3, 0xD0
+
+#define MSK_PAGE_3_HDCP2X_RPT_SEQ_NUM_M_2_HDCP2X_RPT_SEQ_NUM_M_23_16 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD1 HDCP Repeater RCVR ID 0 Register                   (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVR_ID0                     TX_PAGE_3, 0xD1
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVR_ID0_HDCP2X_RCVR_ID_7_0  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD2 HDCP Repeater RCVR ID 1 Register                   (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVR_ID1                     TX_PAGE_3, 0xD2
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVR_ID1_HDCP2X_RCVR_ID_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD3 HDCP Repeater RCVR ID 2 Register                   (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVR_ID2                     TX_PAGE_3, 0xD3
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVR_ID2_HDCP2X_RCVR_ID_23_16 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD4 HDCP Repeater RCVR ID 3 Register                   (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVR_ID3                     TX_PAGE_3, 0xD4
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVR_ID3_HDCP2X_RCVR_ID_31_24 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD5 HDCP Repeater RCVR ID 4 Register                   (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_RPT_RCVR_ID4                     TX_PAGE_3, 0xD5
+
+#define MSK_PAGE_3_HDCP2X_RPT_RCVR_ID4_HDCP2X_RCVR_ID_39_32 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD6 HDCP Poll Interval 0 Register                      (Default: 0x0A)    */
+#define REG_PAGE_3_HDCP2X_POLL_VAL0                        TX_PAGE_3, 0xD6
+
+#define MSK_PAGE_3_HDCP2X_POLL_VAL0_HDCP2X_POL_VAL0_7_0    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD7 HDCP Poll Interval 1 Register                      (Default: 0x32)    */
+#define REG_PAGE_3_HDCP2X_POLL_VAL1                        TX_PAGE_3, 0xD7
+
+#define MSK_PAGE_3_HDCP2X_POLL_VAL1_HDCP2X_POL_VAL1_7_0    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 HDCP DDCM Status Register                          (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_DDCM_STS                         TX_PAGE_3, 0xD8
+
+#define MSK_PAGE_3_HDCP2X_DDCM_STS_HDCP2X_DDCM_ERR_STS_3_0 (0x0F << 4)
+#define MSK_PAGE_3_HDCP2X_DDCM_STS_HDCP2X_DDCM_CTL_CS_3_0  (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 HDCP Ring OSC Bist Register                        (Default: 0x00)    */
+#define REG_PAGE_3_HDCP2X_ROSC_BIST                        TX_PAGE_3, 0xD9
+
+#define BIT_PAGE_3_HDCP2X_ROSC_BIST_HDCP2X_RINGOSC_BIST_FAIL (0x01 << 2)
+#define BIT_PAGE_3_HDCP2X_ROSC_BIST_HDCP2X_RINGOSC_BIST_DONE (0x01 << 1)
+#define BIT_PAGE_3_HDCP2X_ROSC_BIST_HDCP2X_RINGOSC_BIST_START (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE0 HDMI2MHL3 Control Register                         (Default: 0x0A)    */
+#define REG_PAGE_3_M3_CTRL                                 TX_PAGE_3, 0xE0
+
+#define BIT_PAGE_3_M3_CTRL_EXTMHL3_EN                      (0x01 << 5)
+#define BIT_PAGE_3_M3_CTRL_H2M_SWRST                       (0x01 << 4)
+#define BIT_PAGE_3_M3_CTRL_SW_MHL3_SEL                     (0x01 << 3)
+#define BIT_PAGE_3_M3_CTRL_M3AV_EN                         (0x01 << 2)
+#define BIT_PAGE_3_M3_CTRL_ENC_TMDS                        (0x01 << 1)
+#define BIT_PAGE_3_M3_CTRL_MHL3_MASTER_EN                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE1 HDMI2MHL3 Port0 Control Register                   (Default: 0x04)    */
+#define REG_PAGE_3_M3_P0CTRL                               TX_PAGE_3, 0xE1
+
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_HDCP_ENC_EN           (0x01 << 4)
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_UNLIMIT_EN            (0x01 << 3)
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_HDCP_EN               (0x01 << 2)
+
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE            (0x01 << 1)
+#define VAL_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE_NORMAL     (0x00)
+#define VAL_PAGE_3_M3_P0CTRL_MHL3_P0_PIXEL_MODE_PACKED     (0x02)
+
+#define BIT_PAGE_3_M3_P0CTRL_MHL3_P0_PORT_EN               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE3 HDMI2MHL3 Lane Register                            (Default: 0x00)    */
+#define REG_PAGE_3_M3_NLN                                  TX_PAGE_3, 0xE3
+
+#define MSK_PAGE_3_M3_NLN_MHL3_NUM_LANE                    (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE4 HDMI2MHL3 Payload Low Register                     (Default: 0xFC)    */
+#define REG_PAGE_3_M3_PLDL                                 TX_PAGE_3, 0xE4
+
+#define MSK_PAGE_3_M3_PLDL_MHL3_MAX_PAYLOAD_7_0            (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE5 HDMI2MHL3 Payload High Register                    (Default: 0x00)    */
+#define REG_PAGE_3_M3_PLDH                                 TX_PAGE_3, 0xE5
+
+#define MSK_PAGE_3_M3_PLDH_MHL3_MAX_PAYLOAD_9_8            (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE6 HDMI2MHL3 Scramble Control Register                (Default: 0x41)    */
+#define REG_PAGE_3_M3_SCTRL                                TX_PAGE_3, 0xE6
+
+#define MSK_PAGE_3_M3_SCTRL_MHL3_SR_LENGTH                 (0x0F << 4)
+#define BIT_PAGE_3_M3_SCTRL_MHL3_SCRAMBLER_EN              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE7 HDMI2MHL3 SR Period Low Register                   (Default: 0x96)    */
+#define REG_PAGE_3_M3_SRPL                                 TX_PAGE_3, 0xE7
+
+#define MSK_PAGE_3_M3_SRPL_MHL3_SR_PERIOD_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE8 HDMI2MHL3 SR Period High Register                  (Default: 0x98)    */
+#define REG_PAGE_3_M3_SRPH                                 TX_PAGE_3, 0xE8
+
+#define MSK_PAGE_3_M3_SRPH_MHL3_SR_PERIOD_15_8             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE9 HDMI2MHL3 Type #1 Register                         (Default: 0x21)    */
+#define REG_PAGE_3_M3_TYPE1                                TX_PAGE_3, 0xE9
+
+#define MSK_PAGE_3_M3_TYPE1_MHL3_TYPE_HDCP_PKT             (0x0F << 4)
+#define MSK_PAGE_3_M3_TYPE1_MHL3_TYPE_HDMI_PKT             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEA HDMI2MHL3 Type #2 Register                         (Default: 0x03)    */
+#define REG_PAGE_3_M3_TYPE2                                TX_PAGE_3, 0xEA
+
+#define MSK_PAGE_3_M3_TYPE2_MHL3_TYPE_HDMI2_PKT            (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEB HDMI2MHL3 K_SR Register                            (Default: 0x00)    */
+#define REG_PAGE_3_M3_KSR                                  TX_PAGE_3, 0xEB
+
+#define MSK_PAGE_3_M3_KSR_MHL3_K_SR                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEC HDMI2MHL3 K_SOP Register                           (Default: 0x01)    */
+#define REG_PAGE_3_M3_KSOP                                 TX_PAGE_3, 0xEC
+
+#define MSK_PAGE_3_M3_KSOP_MHL3_K_SOP                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xED HDMI2MHL3 K_EOP Register                           (Default: 0x02)    */
+#define REG_PAGE_3_M3_KEOP                                 TX_PAGE_3, 0xED
+
+#define MSK_PAGE_3_M3_KEOP_MHL3_K_EOP                      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF0 HISC PD Control Register                           (Default: 0x1B)    */
+#define REG_PAGE_3_HSIC_PD_CTL                             TX_PAGE_3, 0xF0
+
+#define BIT_PAGE_3_HSIC_PD_CTL_PDN_LDO                     (0x01 << 5)
+#define BIT_PAGE_3_HSIC_PD_CTL_EN_RX                       (0x01 << 4)
+#define BIT_PAGE_3_HSIC_PD_CTL_PDB_SKEW                    (0x01 << 3)
+#define BIT_PAGE_3_HSIC_PD_CTL_SCPCAL_MAIN                 (0x01 << 2)
+#define BIT_PAGE_3_HSIC_PD_CTL_ENBALE_IGEN_MAIN            (0x01 << 1)
+#define BIT_PAGE_3_HSIC_PD_CTL_PDB_MAIN                    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF1 HSIC VCOCAL Register                               (Default: 0x00)    */
+#define REG_PAGE_3_HSIC_VCOCAL                             TX_PAGE_3, 0xF1
+
+#define MSK_PAGE_3_HSIC_VCOCAL_VCO_BIAS_MAIN               (0x07 << 4)
+#define MSK_PAGE_3_HSIC_VCOCAL_VOCAL_MAIN                  (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF2 HSIC Div Ctl Register                              (Default: 0x05)    */
+#define REG_PAGE_3_DIV_CTL_MAIN                            TX_PAGE_3, 0xF2
+
+#define MSK_PAGE_3_DIV_CTL_MAIN_PRE_DIV_CTL_MAIN           (0x07 << 2)
+#define MSK_PAGE_3_DIV_CTL_MAIN_FB_DIV_CTL_MAIN            (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF3 HSIC ICP Ctl Register                              (Default: 0x03)    */
+#define REG_PAGE_3_ICP_CTL_MAIN                            TX_PAGE_3, 0xF3
+
+#define MSK_PAGE_3_ICP_CTL_MAIN_ICP_CTL_MAIN               (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF4 HSIC Bias Bgr Register                             (Default: 0x37)    */
+#define REG_PAGE_3_BIAS_BGR                                TX_PAGE_3, 0xF4
+
+#define MSK_PAGE_3_BIAS_BGR_VCOCAL_DEF_MAIN                (0x07 << 4)
+#define MSK_PAGE_3_BIAS_BGR_BIAS_BGR_D                     (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF5 HSIC SPLL Bias Register                            (Default: 0x00)    */
+#define REG_PAGE_3_SPLL_BIAS                               TX_PAGE_3, 0xF5
+
+#define MSK_PAGE_3_SPLL_BIAS_LBW_MAIN                      (0x03 << 4)
+#define MSK_PAGE_3_SPLL_BIAS_SPLLBIAS_MAIN                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF6 HSIC VCOCAL Skew Register                          (Default: 0x00)    */
+#define REG_PAGE_3_HSIC_VCOCAL_SKEW                        TX_PAGE_3, 0xF6
+
+#define MSK_PAGE_3_HSIC_VCOCAL_SKEW_VCO_CTL_SKEW           (0x0F << 4)
+#define MSK_PAGE_3_HSIC_VCOCAL_SKEW_VOCAL_SKEW             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF7 HSIC Div Ctl Skew Register                         (Default: 0x00)    */
+#define REG_PAGE_3_DIV_CTL_SKEW                            TX_PAGE_3, 0xF7
+
+#define MSK_PAGE_3_DIV_CTL_SKEW_PRE_DIV_CTL_SKEW           (0x03 << 2)
+#define MSK_PAGE_3_DIV_CTL_SKEW_FB_DIV_CTL_SKEW            (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF8 HSIC ICP Ctl Skew Register                         (Default: 0x04)    */
+#define REG_PAGE_3_ICP_CTL_SKEW                            TX_PAGE_3, 0xF8
+
+#define MSK_PAGE_3_ICP_CTL_SKEW_ICP_CTL_SKEW               (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF9 HSIC Config Register                               (Default: 0x00)    */
+#define REG_PAGE_3_HSIC_CONFIG                             TX_PAGE_3, 0xF9
+
+#define MSK_PAGE_3_HSIC_CONFIG_CONFIG_HSIC                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFA HSIC LDO CTL Register                              (Default: 0x2B)    */
+#define REG_PAGE_3_LDO_CTL                                 TX_PAGE_3, 0xFA
+
+#define MSK_PAGE_3_LDO_CTL_SEL_VREF                        (0x03 << 4)
+#define BIT_PAGE_3_LDO_CTL_SEL_OPAMP_BIASI                 (0x01 << 3)
+#define BIT_PAGE_3_LDO_CTL_SEL_INT_COMP                    (0x01 << 2)
+#define MSK_PAGE_3_LDO_CTL_BLEED_CURRENT                   (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFB HSIC Slew CTL Register                             (Default: 0x40)    */
+#define REG_PAGE_3_SLEW_CTL                                TX_PAGE_3, 0xFB
+
+#define MSK_PAGE_3_SLEW_CTL_SEL_SLICE                      (0x07 << 4)
+#define MSK_PAGE_3_SLEW_CTL_SLEW_CTL                       (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFC HSIC Clkdetect Register                            (Default: 0x00)    */
+#define REG_PAGE_3_CLKDETECT                               TX_PAGE_3, 0xFC
+
+#define BIT_PAGE_3_CLKDETECT_CLKDETECT_MAIN                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_4                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x00 MHL Capability 1st Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_0                            TX_PAGE_4, 0x00
+
+#define MSK_PAGE_4_MHL_DEVCAP_0_MHL_DEVCAP_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 MHL Capability 2nd Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_1                            TX_PAGE_4, 0x01
+
+#define MSK_PAGE_4_MHL_DEVCAP_1_MHL_DEVCAP_1               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 MHL Capability 3rd Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_2                            TX_PAGE_4, 0x02
+
+#define MSK_PAGE_4_MHL_DEVCAP_2_MHL_DEVCAP_2               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 MHL Capability 4th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_3                            TX_PAGE_4, 0x03
+
+#define MSK_PAGE_4_MHL_DEVCAP_3_MHL_DEVCAP_3               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 MHL Capability 5th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_4                            TX_PAGE_4, 0x04
+
+#define MSK_PAGE_4_MHL_DEVCAP_4_MHL_DEVCAP_4               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x05 MHL Capability 6th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_5                            TX_PAGE_4, 0x05
+
+#define MSK_PAGE_4_MHL_DEVCAP_5_MHL_DEVCAP_5               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x06 MHL Capability 7th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_6                            TX_PAGE_4, 0x06
+
+#define MSK_PAGE_4_MHL_DEVCAP_6_MHL_DEVCAP_6               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x07 MHL Capability 8th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_7                            TX_PAGE_4, 0x07
+
+#define MSK_PAGE_4_MHL_DEVCAP_7_MHL_DEVCAP_7               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 MHL Capability 9th Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_8                            TX_PAGE_4, 0x08
+
+#define MSK_PAGE_4_MHL_DEVCAP_8_MHL_DEVCAP_8               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 MHL Capability 10th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_9                            TX_PAGE_4, 0x09
+
+#define MSK_PAGE_4_MHL_DEVCAP_9_MHL_DEVCAP_9               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A MHL Capability 11th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_A                            TX_PAGE_4, 0x0A
+
+#define MSK_PAGE_4_MHL_DEVCAP_A_MHL_DEVCAP_A               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0B MHL Capability 12th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_B                            TX_PAGE_4, 0x0B
+
+#define MSK_PAGE_4_MHL_DEVCAP_B_MHL_DEVCAP_B               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C MHL Capability 13th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_C                            TX_PAGE_4, 0x0C
+
+#define MSK_PAGE_4_MHL_DEVCAP_C_MHL_DEVCAP_C               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D MHL Capability 14th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_D                            TX_PAGE_4, 0x0D
+
+#define MSK_PAGE_4_MHL_DEVCAP_D_MHL_DEVCAP_D               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E MHL Capability 15th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_E                            TX_PAGE_4, 0x0E
+
+#define MSK_PAGE_4_MHL_DEVCAP_E_MHL_DEVCAP_E               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F MHL Capability 16th Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_4_MHL_DEVCAP_F                            TX_PAGE_4, 0x0F
+
+#define MSK_PAGE_4_MHL_DEVCAP_F_MHL_DEVCAP_F               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 MHL Interrupt 1st Byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_INT_0                               TX_PAGE_4, 0x20
+
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT7               (0x01 << 7)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT6               (0x01 << 6)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT5               (0x01 << 5)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT4               (0x01 << 4)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT3               (0x01 << 3)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT2               (0x01 << 2)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT1               (0x01 << 1)
+#define BIT_PAGE_4_MHL_INT_0_MHL_INT_0_STAT0               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 MHL Interrupt 2nd Byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_INT_1                               TX_PAGE_4, 0x21
+
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT7               (0x01 << 7)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT6               (0x01 << 6)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT5               (0x01 << 5)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT4               (0x01 << 4)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT3               (0x01 << 3)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT2               (0x01 << 2)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT1               (0x01 << 1)
+#define BIT_PAGE_4_MHL_INT_1_MHL_INT_1_STAT0               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 MHL Interrupt 3rd Byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_INT_2                               TX_PAGE_4, 0x22
+
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT7               (0x01 << 7)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT6               (0x01 << 6)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT5               (0x01 << 5)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT4               (0x01 << 4)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT3               (0x01 << 3)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT2               (0x01 << 2)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT1               (0x01 << 1)
+#define BIT_PAGE_4_MHL_INT_2_MHL_INT_2_STAT0               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 MHL Interrupt 4th Byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_INT_3                               TX_PAGE_4, 0x23
+
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT7               (0x01 << 7)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT6               (0x01 << 6)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT5               (0x01 << 5)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT4               (0x01 << 4)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT3               (0x01 << 3)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT2               (0x01 << 2)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT1               (0x01 << 1)
+#define BIT_PAGE_4_MHL_INT_3_MHL_INT_3_STAT0               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x30 Device Status 1st byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_STAT_0                              TX_PAGE_4, 0x30
+
+#define MSK_PAGE_4_MHL_STAT_0_MHL_STAT_0                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x31 Device Status 2nd byte Register                    (Default: 0x03)    */
+#define REG_PAGE_4_MHL_STAT_1                              TX_PAGE_4, 0x31
+
+#define MSK_PAGE_4_MHL_STAT_1_MHL_STAT_1                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x32 Device Status 3rd byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_STAT_2                              TX_PAGE_4, 0x32
+
+#define MSK_PAGE_4_MHL_STAT_2_MHL_STAT_2                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x33 Device Status 4th byte Register                    (Default: 0x00)    */
+#define REG_PAGE_4_MHL_STAT_3                              TX_PAGE_4, 0x33
+
+#define MSK_PAGE_4_MHL_STAT_3_MHL_STAT_3                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x40 CBUS Scratch Pad 1st Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_0                            TX_PAGE_4, 0x40
+
+#define MSK_PAGE_4_MHL_SCRPAD_0_MHL_SCRPAD_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 CBUS Scratch Pad 2nd Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_1                            TX_PAGE_4, 0x41
+
+#define MSK_PAGE_4_MHL_SCRPAD_1_MHL_SCRPAD_1               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 CBUS Scratch Pad 3rd Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_2                            TX_PAGE_4, 0x42
+
+#define MSK_PAGE_4_MHL_SCRPAD_2_MHL_SCRPAD_2               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x43 CBUS Scratch Pad 4th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_3                            TX_PAGE_4, 0x43
+
+#define MSK_PAGE_4_MHL_SCRPAD_3_MHL_SCRPAD_3               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x44 CBUS Scratch Pad 5th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_4                            TX_PAGE_4, 0x44
+
+#define MSK_PAGE_4_MHL_SCRPAD_4_MHL_SCRPAD_4               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x45 CBUS Scratch Pad 6th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_5                            TX_PAGE_4, 0x45
+
+#define MSK_PAGE_4_MHL_SCRPAD_5_MHL_SCRPAD_5               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x46 CBUS Scratch Pad 7th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_6                            TX_PAGE_4, 0x46
+
+#define MSK_PAGE_4_MHL_SCRPAD_6_MHL_SCRPAD_6               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x47 CBUS Scratch Pad 8th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_7                            TX_PAGE_4, 0x47
+
+#define MSK_PAGE_4_MHL_SCRPAD_7_MHL_SCRPAD_7               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x48 CBUS Scratch Pad 9th Byte Register                 (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_8                            TX_PAGE_4, 0x48
+
+#define MSK_PAGE_4_MHL_SCRPAD_8_MHL_SCRPAD_8               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x49 CBUS Scratch Pad 10th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_9                            TX_PAGE_4, 0x49
+
+#define MSK_PAGE_4_MHL_SCRPAD_9_MHL_SCRPAD_9               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4A CBUS Scratch Pad 11th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_A                            TX_PAGE_4, 0x4A
+
+#define MSK_PAGE_4_MHL_SCRPAD_A_MHL_SCRPAD_A               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4B CBUS Scratch Pad 12th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_B                            TX_PAGE_4, 0x4B
+
+#define MSK_PAGE_4_MHL_SCRPAD_B_MHL_SCRPAD_B               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4C CBUS Scratch Pad 13th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_C                            TX_PAGE_4, 0x4C
+
+#define MSK_PAGE_4_MHL_SCRPAD_C_MHL_SCRPAD_C               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D CBUS Scratch Pad 14th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_D                            TX_PAGE_4, 0x4D
+
+#define MSK_PAGE_4_MHL_SCRPAD_D_MHL_SCRPAD_D               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4E CBUS Scratch Pad 15th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_E                            TX_PAGE_4, 0x4E
+
+#define MSK_PAGE_4_MHL_SCRPAD_E_MHL_SCRPAD_E               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4F CBUS Scratch Pad 16th Byte Register                (Default: 0x00)    */
+#define REG_PAGE_4_MHL_SCRPAD_F                            TX_PAGE_4, 0x4F
+
+#define MSK_PAGE_4_MHL_SCRPAD_F_MHL_SCRPAD_F               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 MHL Extended Capability 1st Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_0                         TX_PAGE_4, 0x80
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_0_MHL_EXTDEVCAP_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 MHL Extended Capability 2nd Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_1                         TX_PAGE_4, 0x81
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_1_MHL_EXTDEVCAP_1         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 MHL Extended Capability 3rd Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_2                         TX_PAGE_4, 0x82
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_2_MHL_EXTDEVCAP_2         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x83 MHL Extended Capability 4th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_3                         TX_PAGE_4, 0x83
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_3_MHL_EXTDEVCAP_3         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x84 MHL Extended Capability 5th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_4                         TX_PAGE_4, 0x84
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_4_MHL_EXTDEVCAP_4         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x85 MHL Extended Capability 6th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_5                         TX_PAGE_4, 0x85
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_5_MHL_EXTDEVCAP_5         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x86 MHL Extended Capability 7th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_6                         TX_PAGE_4, 0x86
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_6_MHL_EXTDEVCAP_6         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x87 MHL Extended Capability 8th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_7                         TX_PAGE_4, 0x87
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_7_MHL_EXTDEVCAP_7         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x88 MHL Extended Capability 9th Byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_8                         TX_PAGE_4, 0x88
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_8_MHL_EXTDEVCAP_8         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x89 MHL Extended Capability 10th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_9                         TX_PAGE_4, 0x89
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_9_MHL_EXTDEVCAP_9         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8A MHL Extended Capability 11th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_A                         TX_PAGE_4, 0x8A
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_A_MHL_EXTDEVCAP_A         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8B MHL Extended Capability 12th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_B                         TX_PAGE_4, 0x8B
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_B_MHL_EXTDEVCAP_B         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8C MHL Extended Capability 13th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_C                         TX_PAGE_4, 0x8C
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_C_MHL_EXTDEVCAP_C         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8D MHL Extended Capability 14th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_D                         TX_PAGE_4, 0x8D
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_D_MHL_EXTDEVCAP_D         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8E MHL Extended Capability 15th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_E                         TX_PAGE_4, 0x8E
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_E_MHL_EXTDEVCAP_E         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8F MHL Extended Capability 16th Byte Register         (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTDEVCAP_F                         TX_PAGE_4, 0x8F
+
+#define MSK_PAGE_4_MHL_EXTDEVCAP_F_MHL_EXTDEVCAP_F         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x90 Device Extended Status 1st byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_0                           TX_PAGE_4, 0x90
+
+#define MSK_PAGE_4_MHL_EXTSTAT_0_MHL_EXTSTAT_0             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x91 Device Extended Status 2nd byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1                           TX_PAGE_4, 0x91
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1_MHL_EXTSTAT_1             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x92 Device Extended Status 3rd byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_2                           TX_PAGE_4, 0x92
+
+#define MSK_PAGE_4_MHL_EXTSTAT_2_MHL_EXTSTAT_2             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x93 Device Extended Status 4th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_3                           TX_PAGE_4, 0x93
+
+#define MSK_PAGE_4_MHL_EXTSTAT_3_MHL_EXTSTAT_3             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x94 Device Extended Status 5th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_4                           TX_PAGE_4, 0x94
+
+#define MSK_PAGE_4_MHL_EXTSTAT_4_MHL_EXTSTAT_4             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x95 Device Extended Status 6th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_5                           TX_PAGE_4, 0x95
+
+#define MSK_PAGE_4_MHL_EXTSTAT_5_MHL_EXTSTAT_5             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x96 Device Extended Status 7th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_6                           TX_PAGE_4, 0x96
+
+#define MSK_PAGE_4_MHL_EXTSTAT_6_MHL_EXTSTAT_6             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x97 Device Extended Status 8th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_7                           TX_PAGE_4, 0x97
+
+#define MSK_PAGE_4_MHL_EXTSTAT_7_MHL_EXTSTAT_7             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x98 Device Extended Status 9th byte Register           (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_8                           TX_PAGE_4, 0x98
+
+#define MSK_PAGE_4_MHL_EXTSTAT_8_MHL_EXTSTAT_8             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x99 Device Extended Status 10th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_9                           TX_PAGE_4, 0x99
+
+#define MSK_PAGE_4_MHL_EXTSTAT_9_MHL_EXTSTAT_9             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9A Device Extended Status 11th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_A                           TX_PAGE_4, 0x9A
+
+#define MSK_PAGE_4_MHL_EXTSTAT_A_MHL_EXTSTAT_A             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9B Device Extended Status 12th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_B                           TX_PAGE_4, 0x9B
+
+#define MSK_PAGE_4_MHL_EXTSTAT_B_MHL_EXTSTAT_B             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9C Device Extended Status 13th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_C                           TX_PAGE_4, 0x9C
+
+#define MSK_PAGE_4_MHL_EXTSTAT_C_MHL_EXTSTAT_C             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9D Device Extended Status 14th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_D                           TX_PAGE_4, 0x9D
+
+#define MSK_PAGE_4_MHL_EXTSTAT_D_MHL_EXTSTAT_D             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9E Device Extended Status 15th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_E                           TX_PAGE_4, 0x9E
+
+#define MSK_PAGE_4_MHL_EXTSTAT_E_MHL_EXTSTAT_E             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9F Device Extended Status 16th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_F                           TX_PAGE_4, 0x9F
+
+#define MSK_PAGE_4_MHL_EXTSTAT_F_MHL_EXTSTAT_F             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA0 Device Extended Status 17th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_10                          TX_PAGE_4, 0xA0
+
+#define MSK_PAGE_4_MHL_EXTSTAT_10_MHL_EXTSTAT_10           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA1 Device Extended Status 18th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_11                          TX_PAGE_4, 0xA1
+
+#define MSK_PAGE_4_MHL_EXTSTAT_11_MHL_EXTSTAT_11           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA2 Device Extended Status 19th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_12                          TX_PAGE_4, 0xA2
+
+#define MSK_PAGE_4_MHL_EXTSTAT_12_MHL_EXTSTAT_12           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA3 Device Extended Status 20th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_13                          TX_PAGE_4, 0xA3
+
+#define MSK_PAGE_4_MHL_EXTSTAT_13_MHL_EXTSTAT_13           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA4 Device Extended Status 21th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_14                          TX_PAGE_4, 0xA4
+
+#define MSK_PAGE_4_MHL_EXTSTAT_14_MHL_EXTSTAT_14           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA5 Device Extended Status 22th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_15                          TX_PAGE_4, 0xA5
+
+#define MSK_PAGE_4_MHL_EXTSTAT_15_MHL_EXTSTAT_15           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA6 Device Extended Status 23th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_16                          TX_PAGE_4, 0xA6
+
+#define MSK_PAGE_4_MHL_EXTSTAT_16_MHL_EXTSTAT_16           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA7 Device Extended Status 24th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_17                          TX_PAGE_4, 0xA7
+
+#define MSK_PAGE_4_MHL_EXTSTAT_17_MHL_EXTSTAT_17           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA8 Device Extended Status 25th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_18                          TX_PAGE_4, 0xA8
+
+#define MSK_PAGE_4_MHL_EXTSTAT_18_MHL_EXTSTAT_18           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA9 Device Extended Status 26th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_19                          TX_PAGE_4, 0xA9
+
+#define MSK_PAGE_4_MHL_EXTSTAT_19_MHL_EXTSTAT_19           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAA Device Extended Status 27th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1A                          TX_PAGE_4, 0xAA
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1A_MHL_EXTSTAT_1A           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAB Device Extended Status 28th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1B                          TX_PAGE_4, 0xAB
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1B_MHL_EXTSTAT_1B           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAC Device Extended Status 29th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1C                          TX_PAGE_4, 0xAC
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1C_MHL_EXTSTAT_1C           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAD Device Extended Status 30th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1D                          TX_PAGE_4, 0xAD
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1D_MHL_EXTSTAT_1D           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAE Device Extended Status 31th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1E                          TX_PAGE_4, 0xAE
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1E_MHL_EXTSTAT_1E           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAF Device Extended Status 32th byte Register          (Default: 0x00)    */
+#define REG_PAGE_4_MHL_EXTSTAT_1F                          TX_PAGE_4, 0xAF
+
+#define MSK_PAGE_4_MHL_EXTSTAT_1F_MHL_EXTSTAT_1F           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_6                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 TPI DTD Byte2 Register                             (Default: 0x00)    */
+#define REG_PAGE_6_TPI_DTD_B2                              TX_PAGE_6, 0x02
+
+#define MSK_PAGE_6_TPI_DTD_B2_DTDB2                        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x07 TPI DTD Byte7 Register                             (Default: 0x00)    */
+#define REG_PAGE_6_TPI_MISC                                TX_PAGE_6, 0x07
+
+#define BIT_PAGE_6_TPI_MISC_ONLY_BKSV_DONE_SEL             (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 TPI Pixel Repetition Data Register                 (Default: 0x40)    */
+#define REG_PAGE_6_TPI_PRD                                 TX_PAGE_6, 0x08
+
+#define MSK_PAGE_6_TPI_PRD_TCLK_SEL                        (0x03 << 6)
+#define BIT_PAGE_6_TPI_PRD_EDGE                            (0x01 << 4)
+#define MSK_PAGE_6_TPI_PRD_ICLK                            (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 Input Format Register                              (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INPUT                               TX_PAGE_6, 0x09
+
+#define BIT_PAGE_6_TPI_INPUT_EXTENDEDBITMODE               (0x01 << 7)
+#define BIT_PAGE_6_TPI_INPUT_ENDITHER                      (0x01 << 6)
+#define MSK_PAGE_6_TPI_INPUT_INPUT_QUAN_RANGE              (0x03 << 2)
+#define MSK_PAGE_6_TPI_INPUT_INPUT_FORMAT                  (0x03 << 0)
+#define VAL_PAGE_6_INPUT_FORMAT_RGB                        (0x00 << 0)
+#define VAL_PAGE_6_INPUT_FORMAT_YCBCR444                   (0x01 << 0)
+#define VAL_PAGE_6_INPUT_FORMAT_YCBCR422                   (0x02 << 0)
+#define VAL_PAGE_6_INPUT_FORMAT_INTERNAL_RGB               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A Output Format Register                             (Default: 0x00)    */
+#define REG_PAGE_6_TPI_OUTPUT                              TX_PAGE_6, 0x0A
+
+#define BIT_PAGE_6_TPI_OUTPUT_CSCMODE709                   (0x01 << 4)
+#define MSK_PAGE_6_TPI_OUTPUT_OUTPUT_QUAN_RANGE            (0x03 << 2)
+#define MSK_PAGE_6_TPI_OUTPUT_OUTPUT_FORMAT                (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C TPI AVI Check Sum Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_CHSUM                           TX_PAGE_6, 0x0C
+
+#define MSK_PAGE_6_TPI_AVI_CHSUM_AVI_CHECKSUM              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D TPI AVI Data Byte 1 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE1                           TX_PAGE_6, 0x0D
+
+#define MSK_PAGE_6_TPI_AVI_BYTE1_AVI_DBYTE1                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E TPI AVI Data Byte 2 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE2                           TX_PAGE_6, 0x0E
+
+#define MSK_PAGE_6_TPI_AVI_BYTE2_AVI_DBYTE2                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F TPI AVI Data Byte 3 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE3                           TX_PAGE_6, 0x0F
+
+#define MSK_PAGE_6_TPI_AVI_BYTE3_AVI_DBYTE3                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 TPI AVI Data Byte 4 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE4                           TX_PAGE_6, 0x10
+
+#define MSK_PAGE_6_TPI_AVI_BYTE4_AVI_DBYTE4                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 TPI AVI Data Byte 5 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE5                           TX_PAGE_6, 0x11
+
+#define MSK_PAGE_6_TPI_AVI_BYTE5_AVI_DBYTE5                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 TPI AVI Data Byte 6 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE6                           TX_PAGE_6, 0x12
+
+#define MSK_PAGE_6_TPI_AVI_BYTE6_AVI_DBYTE6                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 TPI AVI Data Byte 7 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE7                           TX_PAGE_6, 0x13
+
+#define MSK_PAGE_6_TPI_AVI_BYTE7_AVI_DBYTE7                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 TPI AVI Data Byte 8 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE8                           TX_PAGE_6, 0x14
+
+#define MSK_PAGE_6_TPI_AVI_BYTE8_AVI_DBYTE8                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 TPI AVI Data Byte 9 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE9                           TX_PAGE_6, 0x15
+
+#define MSK_PAGE_6_TPI_AVI_BYTE9_AVI_DBYTE9                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 TPI AVI Data Byte 10 Register                      (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE10                          TX_PAGE_6, 0x16
+
+#define MSK_PAGE_6_TPI_AVI_BYTE10_AVI_DBYTE10              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 TPI AVI Data Byte 11 Register                      (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE11                          TX_PAGE_6, 0x17
+
+#define MSK_PAGE_6_TPI_AVI_BYTE11_AVI_DBYTE11              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 TPI AVI Data Byte 12 Register                      (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE12                          TX_PAGE_6, 0x18
+
+#define MSK_PAGE_6_TPI_AVI_BYTE12_AVI_DBYTE12              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 TPI AVI Data Byte 13 Register                      (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AVI_BYTE13                          TX_PAGE_6, 0x19
+
+#define MSK_PAGE_6_TPI_AVI_BYTE13_AVI_DBYTE13              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A TPI System Control Register                        (Default: 0x00)    */
+#define REG_PAGE_6_TPI_SC                                  TX_PAGE_6, 0x1A
+
+#define BIT_PAGE_6_TPI_SC_TPI_UPDATE_FLG                   (0x01 << 7)
+#define BIT_PAGE_6_TPI_SC_TPI_REAUTH_CTL                   (0x01 << 6)
+#define BIT_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_1                (0x01 << 5)
+
+#define BIT_PAGE_6_TPI_SC_REG_TMDS_OE                      (0x01 << 4)
+#define VAL_PAGE_6_TPI_SC_REG_TMDS_OE_ACTIVE               (0x00 << 4)
+#define VAL_PAGE_6_TPI_SC_REG_TMDS_OE_POWER_DOWN           (0x01 << 4)
+
+#define BIT_PAGE_6_TPI_SC_TPI_AV_MUTE                      (0x01 << 3)
+#define VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_NORMAL               (0x00 << 3)
+#define VAL_PAGE_6_TPI_SC_TPI_AV_MUTE_MUTED                (0x01 << 3)
+
+#define BIT_PAGE_6_TPI_SC_DDC_GPU_REQUEST                  (0x01 << 2)
+#define BIT_PAGE_6_TPI_SC_DDC_TPI_SW                       (0x01 << 1)
+
+#define BIT_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0                (0x01 << 0)
+#define VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_DVI            (0x00 << 0)
+#define VAL_PAGE_6_TPI_SC_TPI_OUTPUT_MODE_0_HDMI           (0x01 << 0)
+
+
+/*----------------------------------------------------------------------------*/
+/* 0x1B TPI Device ID Register                             (Default: 0xB2)    */
+#define REG_PAGE_6_TPI_DEV_ID                              TX_PAGE_6, 0x1B
+
+#define MSK_PAGE_6_TPI_DEV_ID_TPI_DEV_ID                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1C TPI Device Revision ID Register                    (Default: 0x00)    */
+#define REG_PAGE_6_TPI_REV_ID                              TX_PAGE_6, 0x1C
+
+#define MSK_PAGE_6_TPI_REV_ID_DEV_REV_ID                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1D TPI Vendor Byte 3 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_VENDOR_B3                           TX_PAGE_6, 0x1D
+
+#define MSK_PAGE_6_TPI_VENDOR_B3_VENDOR_B3                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x29 TPI COPP Query Data Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_COPP_DATA1                          TX_PAGE_6, 0x29
+
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_GPROT               (0x01 << 7)
+#define VAL_TPI_COPP_GPROT_NONE                            (0x00 << 7)
+#define VAL_TPI_COPP_GPROT_SECURE                          (0x01 << 7)
+
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_LPROT               (0x01 << 6)
+#define VAL_TPI_COPP_LPROT_NONE                     	   (0x00 << 6)
+#define VAL_TPI_COPP_LPROT_SECURE                          (0x01 << 6)
+
+#define MSK_PAGE_6_TPI_COPP_DATA1_COPP_LINK_STATUS         (0x03 << 4)
+#define VAL_TPI_COPP_LINK_STATUS_NORMAL                    (0x00 << 4)
+#define VAL_TPI_COPP_LINK_STATUS_LINK_LOST                 (0x01 << 4)
+#define VAL_TPI_COPP_LINK_STATUS_RENEGOTIATION_REQ         (0x02 << 4)
+#define VAL_TPI_COPP_LINK_STATUS_LINK_SUSPENDED            (0x03 << 4)
+
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_HDCP_REP            (0x01 << 3)
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_CONNTYPE_0          (0x01 << 2)
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_PROTYPE             (0x01 << 1)
+#define BIT_PAGE_6_TPI_COPP_DATA1_COPP_CONNTYPE_1          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2A TPI COPP Control Data Register                     (Default: 0x00)    */
+#define REG_PAGE_6_TPI_COPP_DATA2                          TX_PAGE_6, 0x2A
+
+#define BIT_PAGE_6_TPI_COPP_DATA2_INTR_ENCRYPTION          (0x01 << 5)
+#define BIT_PAGE_6_TPI_COPP_DATA2_KSV_FORWARD              (0x01 << 4)
+#define BIT_PAGE_6_TPI_COPP_DATA2_INTERM_RI_CHECK_EN       (0x01 << 3)
+#define BIT_PAGE_6_TPI_COPP_DATA2_DOUBLE_RI_CHECK          (0x01 << 2)
+#define BIT_PAGE_6_TPI_COPP_DATA2_DDC_SHORT_RI_RD          (0x01 << 1)
+
+#define BIT_PAGE_6_TPI_COPP_DATA2_COPP_PROTLEVEL           (0x01 << 0)
+#define VAL_PAGE_6_TPI_COPP_PROTLEVEL_MIN                  (0x00 << 0)
+#define VAL_PAGE_6_TPI_COPP_PROTLEVEL_MAX                  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2B TPI Write BKSV1 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_WR_BKSV_1                           TX_PAGE_6, 0x2B
+
+#define MSK_PAGE_6_TPI_WR_BKSV_1_BKSV0                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2C TPI Write BKSV2 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_WR_BKSV_2                           TX_PAGE_6, 0x2C
+
+#define MSK_PAGE_6_TPI_WR_BKSV_2_BKSV1                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2D TPI_Write BKSV3 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_WR_BKSV_3                           TX_PAGE_6, 0x2D
+
+#define MSK_PAGE_6_TPI_WR_BKSV_3_BKSV2                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2E TPI Write BKSV4 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_WR_BKSV_4                           TX_PAGE_6, 0x2E
+
+#define MSK_PAGE_6_TPI_WR_BKSV_4_BKSV3                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x2F TPI Write BKSV5 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_WR_BKSV_5                           TX_PAGE_6, 0x2F
+
+#define MSK_PAGE_6_TPI_WR_BKSV_5_BKSV4                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x30 TPI HDCP Revision Register                         (Default: 0x12)    */
+#define REG_PAGE_6_TPI_HDCP_REV                            TX_PAGE_6, 0x30
+
+#define MSK_PAGE_6_TPI_HDCP_REV_TPI_HDCP_REV               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x31 TPI KSV and V' Value Data Register                 (Default: 0x00)    */
+#define REG_PAGE_6_TPI_KSV_V                               TX_PAGE_6, 0x31
+
+#define MSK_PAGE_6_TPI_KSV_V_AUTH_STATE                    (0x03 << 6)
+#define BIT_PAGE_6_TPI_KSV_V_COPP_VSEL_RDY                 (0x01 << 3)
+#define MSK_PAGE_6_TPI_KSV_V_TPI_V_SEL                     (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x32 TPI V' Value Byte 0 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_VVALUE_B0                           TX_PAGE_6, 0x32
+
+#define MSK_PAGE_6_TPI_VVALUE_B0_TPI_VP_HX_B0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x33 TPI V' Value Byte 1 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_VVALUE_B1                           TX_PAGE_6, 0x33
+
+#define MSK_PAGE_6_TPI_VVALUE_B1_TPI_VP_HX_B1              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x34 TPI V' Value Byte 2 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_VVALUE_B2                           TX_PAGE_6, 0x34
+
+#define MSK_PAGE_6_TPI_VVALUE_B2_TPI_VP_HX_B2              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x35 TPI V' Value Byte 3 Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_VVALUE_B3                           TX_PAGE_6, 0x35
+
+#define MSK_PAGE_6_TPI_VVALUE_B3_TPI_VP_HX_B3              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x36 TPI AKSV_1 Register                                (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AKSV_1                              TX_PAGE_6, 0x36
+
+#define MSK_PAGE_6_TPI_AKSV_1_TPI_AKSV0                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x37 TPI AKSV_2 Register                                (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AKSV_2                              TX_PAGE_6, 0x37
+
+#define MSK_PAGE_6_TPI_AKSV_2_TPI_AKSV1                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x38 TPI AKSV_3 Register                                (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AKSV_3                              TX_PAGE_6, 0x38
+
+#define MSK_PAGE_6_TPI_AKSV_3_TPI_AKSV2                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x39 TPI AKSV_4 Register                                (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AKSV_4                              TX_PAGE_6, 0x39
+
+#define MSK_PAGE_6_TPI_AKSV_4_TPI_AKSV3                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A TPI AKSV_5 Register                                (Default: 0x00)    */
+#define REG_PAGE_6_TPI_AKSV_5                              TX_PAGE_6, 0x3A
+
+#define MSK_PAGE_6_TPI_AKSV_5_TPI_AKSV4                    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C TPI Interrupt Enable Register                      (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INTR_EN                             TX_PAGE_6, 0x3C
+
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_7               (0x01 << 7)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_6               (0x01 << 6)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_5               (0x01 << 5)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_3               (0x01 << 3)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_2               (0x01 << 2)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_1               (0x01 << 1)
+#define BIT_PAGE_6_TPI_INTR_EN_TPI_INTR_EN_0               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D TPI Interrupt Status Low Byte Register             (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INTR_ST0                            TX_PAGE_6, 0x3D
+
+#define BIT_PAGE_6_TPI_INTR_ST0_TPI_AUTH_CHNGE_STAT        (0x01 << 7)
+#define BIT_PAGE_6_TPI_INTR_ST0_TPI_V_RDY_STAT             (0x01 << 6)
+#define BIT_PAGE_6_TPI_INTR_ST0_TPI_COPP_CHNGE_STAT        (0x01 << 5)
+#define BIT_PAGE_6_TPI_INTR_ST0_KSV_FIFO_FIRST_STAT        (0x01 << 3)
+#define BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_BCAPS_DONE_STAT  (0x01 << 2)
+#define BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_BCAPS_ERR_STAT   (0x01 << 1)
+#define BIT_PAGE_6_TPI_INTR_ST0_READ_BKSV_ERR_STAT         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 TPI KSV FIFO Fill Level Status Register            (Default: 0x00)    */
+#define REG_PAGE_6_TPI_KSV_FIFO_STAT                       TX_PAGE_6, 0x41
+
+#define BIT_PAGE_6_TPI_KSV_FIFO_STAT_KSV_FIFO_LAST         (0x01 << 7)
+#define MSK_PAGE_6_TPI_KSV_FIFO_STAT_KSV_FIFO_BYTES        (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 TPI KSV FIFO Forward Port Register                 (Default: 0x00)    */
+#define REG_PAGE_6_TPI_KSV_FIFO_FORW                       TX_PAGE_6, 0x42
+
+#define MSK_PAGE_6_TPI_KSV_FIFO_FORW_KSV_FIFO_FORWARD      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x44 TPI DS BCAPS Status Register                       (Default: 0x00)    */
+#define REG_PAGE_6_TPI_DS_BCAPS                            TX_PAGE_6, 0x44
+
+#define MSK_PAGE_6_TPI_DS_BCAPS_DS_BCAPS                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x45 TPI BStatus1 Register                              (Default: 0x00)    */
+#define REG_PAGE_6_TPI_BSTATUS1                            TX_PAGE_6, 0x45
+
+#define BIT_PAGE_6_TPI_BSTATUS1_DS_DEV_EXCEED              (0x01 << 7)
+#define MSK_PAGE_6_TPI_BSTATUS1_DS_DEV_CNT                 (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x46 TPI BStatus2 Register                              (Default: 0x10)    */
+#define REG_PAGE_6_TPI_BSTATUS2                            TX_PAGE_6, 0x46
+
+#define MSK_PAGE_6_TPI_BSTATUS2_DS_BSTATUS                 (0x07 << 5)
+#define BIT_PAGE_6_TPI_BSTATUS2_DS_HDMI_MODE               (0x01 << 4)
+#define BIT_PAGE_6_TPI_BSTATUS2_DS_CASC_EXCEED             (0x01 << 3)
+#define MSK_PAGE_6_TPI_BSTATUS2_DS_DEPTH                   (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4B TPI Video Mute Low Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_6_VID_MUTE0                               TX_PAGE_6, 0x4B
+
+#define MSK_PAGE_6_VID_MUTE0_VIDEO_MUTE_DATA_7_0           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D TPI Video Mute Mid Byte Register                   (Default: 0x00)    */
+#define REG_PAGE_6_VID_MUTE1                               TX_PAGE_6, 0x4D
+
+#define MSK_PAGE_6_VID_MUTE1_VIDEO_MUTE_DATA_15_8          (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4F TPI Video Mute High Byte Register                  (Default: 0x00)    */
+#define REG_PAGE_6_VID_MUTE2                               TX_PAGE_6, 0x4F
+
+#define MSK_PAGE_6_VID_MUTE2_VIDEO_MUTE_DATA_23_16         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 TPI Sync Generation Control Register               (Default: 0x00)    */
+#define REG_PAGE_6_TPI_SYNC_GEN                            TX_PAGE_6, 0x60
+
+#define BIT_PAGE_6_TPI_SYNC_GEN_ENDEMUX                    (0x01 << 5)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 TPI Video Sync Polarity Detection Register         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_POL_DETECT                          TX_PAGE_6, 0x61
+
+#define BIT_PAGE_6_TPI_POL_DETECT_INTERLACEDOUT            (0x01 << 2)
+#define BIT_PAGE_6_TPI_POL_DETECT_VSYNCPOLOUT              (0x01 << 1)
+#define BIT_PAGE_6_TPI_POL_DETECT_HSYNCPOLOUT              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6A TPI Video H Resolution #1 Register                 (Default: 0x00)    */
+#define REG_PAGE_6_TPI_H_RESL                              TX_PAGE_6, 0x6A
+
+#define MSK_PAGE_6_TPI_H_RESL_HRESOUT_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6B TPI Video H Resolution #2 Register                 (Default: 0x00)    */
+#define REG_PAGE_6_TPI_H_RESH                              TX_PAGE_6, 0x6B
+
+#define MSK_PAGE_6_TPI_H_RESH_HRESOUT_12_8                 (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6C TPI Video V Refresh Low Register                   (Default: 0x00)    */
+#define REG_PAGE_6_TPI_V_RESL                              TX_PAGE_6, 0x6C
+
+#define MSK_PAGE_6_TPI_V_RESL_VRESOUT_7_0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6D TPI Video V Refresh High Register                  (Default: 0x00)    */
+#define REG_PAGE_6_TPI_V_RESH                              TX_PAGE_6, 0x6D
+
+#define MSK_PAGE_6_TPI_V_RESH_VRESOUT_10_8                 (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x79 TPI HW Debug #1 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG1                             TX_PAGE_6, 0x79
+
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_KSV_LIST_DONE          (0x01 << 7)
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_BSTATUS_DONE           (0x01 << 6)
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_KSV_FIFO_RDY_DONE      (0x01 << 5)
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_R0_PRIME_DONE          (0x01 << 4)
+#define BIT_PAGE_6_TPI_HW_DBG1_WRITE_AKSV_DONE             (0x01 << 3)
+#define BIT_PAGE_6_TPI_HW_DBG1_WRITE_AN_DONE               (0x01 << 2)
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_RX_REPEATER_DONE       (0x01 << 1)
+#define BIT_PAGE_6_TPI_HW_DBG1_READ_BKSV_DONE              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7A TPI HW Debug #2 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG2                             TX_PAGE_6, 0x7A
+
+#define BIT_PAGE_6_TPI_HW_DBG2_READ_RI_2ND_DONE            (0x01 << 2)
+#define BIT_PAGE_6_TPI_HW_DBG2_READ_RI_PRIME_DONE          (0x01 << 1)
+#define BIT_PAGE_6_TPI_HW_DBG2_READ_V_PRIME_DONE           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7B TPI HW Debug #3 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG3                             TX_PAGE_6, 0x7B
+
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_KSV_LIST_ERR           (0x01 << 7)
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_BSTATUS_ERR            (0x01 << 6)
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_KSV_FIFO_RDY_ERR       (0x01 << 5)
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_R0_PRIME_ERR           (0x01 << 4)
+#define BIT_PAGE_6_TPI_HW_DBG3_WRITE_AKSV_ERR              (0x01 << 3)
+#define BIT_PAGE_6_TPI_HW_DBG3_WRITE_AN_ERR                (0x01 << 2)
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_RX_REPEATER_ERR        (0x01 << 1)
+#define BIT_PAGE_6_TPI_HW_DBG3_READ_BKSV_ERR               (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7C TPI HW Debug #4 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG4                             TX_PAGE_6, 0x7C
+
+#define BIT_PAGE_6_TPI_HW_DBG4_READ_RI_2ND_ERR             (0x01 << 2)
+#define BIT_PAGE_6_TPI_HW_DBG4_READ_RI_PRIME_ERR           (0x01 << 1)
+#define BIT_PAGE_6_TPI_HW_DBG4_READ_V_PRIME_ERR            (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7D TPI HW Debug #5 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG5                             TX_PAGE_6, 0x7D
+
+#define MSK_PAGE_6_TPI_HW_DBG5_TPI_DS_AUTH_CS              (0x0F << 4)
+#define MSK_PAGE_6_TPI_HW_DBG5_TPI_HW_CS                   (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x7F TPI HW Debug #7 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG7                             TX_PAGE_6, 0x7F
+
+#define MSK_PAGE_6_TPI_HW_DBG7_TPI_DDCM_CTL_CS_3_0         (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 TPI HW Debug #8 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG8                             TX_PAGE_6, 0x80
+
+#define MSK_PAGE_6_TPI_HW_DBG8_DDC_HDCP_ACC_NMB_7_0        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 TPI HW Debug #9 Register                           (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_DBG9                             TX_PAGE_6, 0x81
+
+#define MSK_PAGE_6_TPI_HW_DBG9_DDC_HDCP_ACC_NMB_9_8        (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB9 TPI HW Optimization Control #1 Register            (Default: 0x07)    */
+#define REG_PAGE_6_TPI_HW_OPT1                             TX_PAGE_6, 0xB9
+
+#define BIT_PAGE_6_TPI_HW_OPT1_DDC_DELAY_CNT_8             (0x01 << 7)
+#define MSK_PAGE_6_TPI_HW_OPT1_TPI_AUTH_RETRY_CNT_2_0      (0x07 << 4)
+#define MSK_PAGE_6_TPI_HW_OPT1_TPI_R0_CALC_TIME_3_0        (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBA TPI HW Optimization Control #2 Register            (Default: 0x01)    */
+#define REG_PAGE_6_TPI_HW_OPT2                             TX_PAGE_6, 0xBA
+
+#define MSK_PAGE_6_TPI_HW_OPT2_DDC_DELAY_CNT_7_0           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB TPI HW Optimization Control #3 Register            (Default: 0x00)    */
+#define REG_PAGE_6_TPI_HW_OPT3                             TX_PAGE_6, 0xBB
+
+#define BIT_PAGE_6_TPI_HW_OPT3_DDC_DEBUG                   (0x01 << 7)
+#define BIT_PAGE_6_TPI_HW_OPT3_RI_CHECK_SKIP               (0x01 << 3)
+#define BIT_PAGE_6_TPI_HW_OPT3_TPI_DDC_BURST_MODE          (0x01 << 2)
+#define MSK_PAGE_6_TPI_HW_OPT3_TPI_DDC_REQ_LEVEL           (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF TPI Info Frame Select Register                     (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_FSEL                           TX_PAGE_6, 0xBF
+
+#define BIT_PAGE_6_TPI_INFO_FSEL_TPI_INFO_EN               (0x01 << 7)
+#define BIT_PAGE_6_TPI_INFO_FSEL_TPI_INFO_RPT              (0x01 << 6)
+#define BIT_PAGE_6_TPI_INFO_FSEL_TPI_INFO_READ_FLAG        (0x01 << 5)
+#define MSK_PAGE_6_TPI_INFO_FSEL_TPI_INFO_SEL              (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 TPI Info Byte #0 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B0                             TX_PAGE_6, 0xC0
+
+#define MSK_PAGE_6_TPI_INFO_B0_MODE_BYTE0                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 TPI Info Byte #1 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B1                             TX_PAGE_6, 0xC1
+
+#define MSK_PAGE_6_TPI_INFO_B1_MODE_BYTE1                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 TPI Info Byte #2 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B2                             TX_PAGE_6, 0xC2
+
+#define MSK_PAGE_6_TPI_INFO_B2_MODE_BYTE2                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 TPI Info Byte #3 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B3                             TX_PAGE_6, 0xC3
+
+#define MSK_PAGE_6_TPI_INFO_B3_MODE_BYTE3                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 TPI Info Byte #4 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B4                             TX_PAGE_6, 0xC4
+
+#define MSK_PAGE_6_TPI_INFO_B4_MODE_BYTE4                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 TPI Info Byte #5 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B5                             TX_PAGE_6, 0xC5
+
+#define MSK_PAGE_6_TPI_INFO_B5_MODE_BYTE5                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC6 TPI Info Byte #6 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B6                             TX_PAGE_6, 0xC6
+
+#define MSK_PAGE_6_TPI_INFO_B6_MODE_BYTE6                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 TPI Info Byte #7 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B7                             TX_PAGE_6, 0xC7
+
+#define MSK_PAGE_6_TPI_INFO_B7_MODE_BYTE7                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC8 TPI Info Byte #8 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B8                             TX_PAGE_6, 0xC8
+
+#define MSK_PAGE_6_TPI_INFO_B8_MODE_BYTE8                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC9 TPI Info Byte #9 Register                          (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B9                             TX_PAGE_6, 0xC9
+
+#define MSK_PAGE_6_TPI_INFO_B9_MODE_BYTE9                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCA TPI Info Byte #10 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B10                            TX_PAGE_6, 0xCA
+
+#define MSK_PAGE_6_TPI_INFO_B10_MODE_BYTE10                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCB TPI Info Byte #11 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B11                            TX_PAGE_6, 0xCB
+
+#define MSK_PAGE_6_TPI_INFO_B11_MODE_BYTE11                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC TPI Info Byte #12 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B12                            TX_PAGE_6, 0xCC
+
+#define MSK_PAGE_6_TPI_INFO_B12_MODE_BYTE12                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCD TPI Info Byte #13 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B13                            TX_PAGE_6, 0xCD
+
+#define MSK_PAGE_6_TPI_INFO_B13_MODE_BYTE13                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE TPI Info Byte #14 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B14                            TX_PAGE_6, 0xCE
+
+#define MSK_PAGE_6_TPI_INFO_B14_MODE_BYTE14                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF TPI Info Byte #15 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B15                            TX_PAGE_6, 0xCF
+
+#define MSK_PAGE_6_TPI_INFO_B15_MODE_BYTE15                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD0 TPI Info Byte #16 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B16                            TX_PAGE_6, 0xD0
+
+#define MSK_PAGE_6_TPI_INFO_B16_MODE_BYTE16                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD1 TPI Info Byte #17 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B17                            TX_PAGE_6, 0xD1
+
+#define MSK_PAGE_6_TPI_INFO_B17_MODE_BYTE17                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD2 TPI Info Byte #18 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B18                            TX_PAGE_6, 0xD2
+
+#define MSK_PAGE_6_TPI_INFO_B18_MODE_BYTE18                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD3 TPI Info Byte #19 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B19                            TX_PAGE_6, 0xD3
+
+#define MSK_PAGE_6_TPI_INFO_B19_MODE_BYTE19                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD4 TPI Info Byte #20 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B20                            TX_PAGE_6, 0xD4
+
+#define MSK_PAGE_6_TPI_INFO_B20_MODE_BYTE20                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD5 TPI Info Byte #21 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B21                            TX_PAGE_6, 0xD5
+
+#define MSK_PAGE_6_TPI_INFO_B21_MODE_BYTE21                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD6 TPI Info Byte #22 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B22                            TX_PAGE_6, 0xD6
+
+#define MSK_PAGE_6_TPI_INFO_B22_MODE_BYTE22                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD7 TPI Info Byte #23 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B23                            TX_PAGE_6, 0xD7
+
+#define MSK_PAGE_6_TPI_INFO_B23_MODE_BYTE23                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 TPI Info Byte #24 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B24                            TX_PAGE_6, 0xD8
+
+#define MSK_PAGE_6_TPI_INFO_B24_MODE_BYTE24                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 TPI Info Byte #25 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B25                            TX_PAGE_6, 0xD9
+
+#define MSK_PAGE_6_TPI_INFO_B25_MODE_BYTE25                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDA TPI Info Byte #26 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B26                            TX_PAGE_6, 0xDA
+
+#define MSK_PAGE_6_TPI_INFO_B26_MODE_BYTE26                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDB TPI Info Byte #27 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B27                            TX_PAGE_6, 0xDB
+
+#define MSK_PAGE_6_TPI_INFO_B27_MODE_BYTE27                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDC TPI Info Byte #28 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B28                            TX_PAGE_6, 0xDC
+
+#define MSK_PAGE_6_TPI_INFO_B28_MODE_BYTE28                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDD TPI Info Byte #29 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B29                            TX_PAGE_6, 0xDD
+
+#define MSK_PAGE_6_TPI_INFO_B29_MODE_BYTE29                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDE TPI Info Byte #30 Register                         (Default: 0x00)    */
+#define REG_PAGE_6_TPI_INFO_B30                            TX_PAGE_6, 0xDE
+
+#define MSK_PAGE_6_TPI_INFO_B30_MODE_BYTE30                (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_7                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x00 CoC 1st Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_0                              TX_PAGE_7, 0x00
+
+#define BIT_PAGE_7_COC_STAT_0_COC_STATUS0_7                (0x01 << 7)
+#define BIT_PAGE_7_COC_STAT_0_COC_STATUS0_6                (0x01 << 6)
+#define MSK_PAGE_7_COC_STAT_0_COC_STATUS0_5_0              (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x01 CoC 2nd Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_1                              TX_PAGE_7, 0x01
+
+#define MSK_PAGE_7_COC_STAT_1_COC_STATUS1_7_6              (0x03 << 6)
+#define MSK_PAGE_7_COC_STAT_1_COC_STATUS1_5_0              (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x02 CoC 3rd Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_2                              TX_PAGE_7, 0x02
+
+#define MSK_PAGE_7_COC_STAT_2_COC_STATUS2_7_6              (0x03 << 6)
+#define MSK_PAGE_7_COC_STAT_2_COC_STATUS2_5_0              (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x03 CoC 4th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_3                              TX_PAGE_7, 0x03
+
+#define MSK_PAGE_7_COC_STAT_3_COC_STATUS3_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x04 CoC 5th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_4                              TX_PAGE_7, 0x04
+
+#define MSK_PAGE_7_COC_STAT_4_COC_STATUS4_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x05 CoC 6th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_5                              TX_PAGE_7, 0x05
+
+#define MSK_PAGE_7_COC_STAT_5_COC_STATUS5_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x06 CoC 7th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_6                              TX_PAGE_7, 0x06
+
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_7                (0x01 << 7)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_6                (0x01 << 6)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_5                (0x01 << 5)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_4                (0x01 << 4)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_3                (0x01 << 3)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_2                (0x01 << 2)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_1                (0x01 << 1)
+#define BIT_PAGE_7_COC_STAT_6_COC_STATUS6_0                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x07 CoC 8th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_7                              TX_PAGE_7, 0x07
+
+#define MSK_PAGE_7_COC_STAT_7_COC_STATUS7_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x08 CoC 9th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_8                              TX_PAGE_7, 0x08
+
+#define MSK_PAGE_7_COC_STAT_8_COC_STATUS8_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x09 CoC 10th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_9                              TX_PAGE_7, 0x09
+
+#define BIT_PAGE_7_COC_STAT_9_COC_STATUS9_7                (0x01 << 7)
+#define BIT_PAGE_7_COC_STAT_9_COC_STATUS9_6                (0x01 << 6)
+#define BIT_PAGE_7_COC_STAT_9_COC_STATUS9_5                (0x01 << 5)
+#define BIT_PAGE_7_COC_STAT_9_COC_STATUS9_4                (0x01 << 4)
+#define MSK_PAGE_7_COC_STAT_9_COC_STATUS9_3_0              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0A CoC 11th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_A                              TX_PAGE_7, 0x0A
+
+#define MSK_PAGE_7_COC_STAT_A_COC_STATUSA_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0B CoC 12th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_B                              TX_PAGE_7, 0x0B
+
+#define MSK_PAGE_7_COC_STAT_B_COC_STATUSB_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0C CoC 13th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_C                              TX_PAGE_7, 0x0C
+
+#define MSK_PAGE_7_COC_STAT_C_COC_STATUSC_7_3              (0x1F << 3)
+#define BIT_PAGE_7_COC_STAT_C_COC_STATUSC_2                (0x01 << 2)
+#define MSK_PAGE_7_COC_STAT_C_COC_STATUSC_1_0              (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0D CoC 14th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_D                              TX_PAGE_7, 0x0D
+
+#define MSK_PAGE_7_COC_STAT_D_COC_STATUSD_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0E CoC 15th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_E                              TX_PAGE_7, 0x0E
+
+#define MSK_PAGE_7_COC_STAT_E_COC_STATUSE_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x0F CoC 16th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_COC_STAT_F                              TX_PAGE_7, 0x0F
+
+#define MSK_PAGE_7_COC_STAT_F_COC_STATUSF_7_4              (0x0F << 4)
+#define MSK_PAGE_7_COC_STAT_F_COC_STATUSF_3_0              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x10 CoC 1st Ctl Register                               (Default: 0x40)    */
+#define REG_PAGE_7_COC_CTL0                                TX_PAGE_7, 0x10
+
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_7                 (0x01 << 7)
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_6                 (0x01 << 6)
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_5                 (0x01 << 5)
+#define MSK_PAGE_7_COC_CTL0_COC_CONTROL0_4_3               (0x03 << 3)
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_2                 (0x01 << 2)
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_1                 (0x01 << 1)
+#define BIT_PAGE_7_COC_CTL0_COC_CONTROL0_0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x11 CoC 2nd Ctl Register                               (Default: 0x0A)    */
+#define REG_PAGE_7_COC_CTL1                                TX_PAGE_7, 0x11
+
+#define MSK_PAGE_7_COC_CTL1_COC_CONTROL1_7_6               (0x03 << 6)
+#define MSK_PAGE_7_COC_CTL1_COC_CONTROL1_5_0               (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x12 CoC 3rd Ctl Register                               (Default: 0x14)    */
+#define REG_PAGE_7_COC_CTL2                                TX_PAGE_7, 0x12
+
+#define MSK_PAGE_7_COC_CTL2_COC_CONTROL2_7_6               (0x03 << 6)
+#define MSK_PAGE_7_COC_CTL2_COC_CONTROL2_5_0               (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x13 CoC 4th Ctl Register                               (Default: 0x40)    */
+#define REG_PAGE_7_COC_CTL3                                TX_PAGE_7, 0x13
+
+#define BIT_PAGE_7_COC_CTL3_COC_CONTROL3_7                 (0x01 << 7)
+#define MSK_PAGE_7_COC_CTL3_COC_CONTROL3_6_0               (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x14 CoC 5th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL4                                TX_PAGE_7, 0x14
+
+#define BIT_PAGE_7_COC_CTL4_COC_CONTROL4_7                 (0x01 << 7)
+#define MSK_PAGE_7_COC_CTL4_COC_CONTROL4_6_0               (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x15 CoC 6th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL5                                TX_PAGE_7, 0x15
+
+#define MSK_PAGE_7_COC_CTL5_COC_CONTROL5                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x16 CoC 7th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL6                                TX_PAGE_7, 0x16
+
+#define BIT_PAGE_7_COC_CTL6_COC_CONTROL6_7                 (0x01 << 7)
+#define BIT_PAGE_7_COC_CTL6_COC_CONTROL6_6                 (0x01 << 6)
+#define MSK_PAGE_7_COC_CTL6_COC_CONTROL6_5_0               (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x17 CoC 8th Ctl Register                               (Default: 0x06)    */
+#define REG_PAGE_7_COC_CTL7                                TX_PAGE_7, 0x17
+
+#define BIT_PAGE_7_COC_CTL7_COC_CONTROL7_7                 (0x01 << 7)
+#define BIT_PAGE_7_COC_CTL7_COC_CONTROL7_6                 (0x01 << 6)
+#define BIT_PAGE_7_COC_CTL7_COC_CONTROL7_5                 (0x01 << 5)
+#define MSK_PAGE_7_COC_CTL7_COC_CONTROL7_4_3               (0x03 << 3)
+#define MSK_PAGE_7_COC_CTL7_COC_CONTROL7_2_0               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x18 CoC 9th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL8                                TX_PAGE_7, 0x18
+
+#define MSK_PAGE_7_COC_CTL8_COC_CONTROL8                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x19 CoC 10th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL9                                TX_PAGE_7, 0x19
+
+#define MSK_PAGE_7_COC_CTL9_COC_CONTROL9                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1A CoC 11th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTLA                                TX_PAGE_7, 0x1A
+
+#define MSK_PAGE_7_COC_CTLA_COC_CONTROLA                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1B CoC 12th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTLB                                TX_PAGE_7, 0x1B
+
+#define MSK_PAGE_7_COC_CTLB_COC_CONTROLB                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1C CoC 13th Ctl Register                              (Default: 0x0F)    */
+#define REG_PAGE_7_COC_CTLC                                TX_PAGE_7, 0x1C
+
+#define MSK_PAGE_7_COC_CTLC_COC_CONTROLC                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1D CoC 14th Ctl Register                              (Default: 0x0A)    */
+#define REG_PAGE_7_COC_CTLD                                TX_PAGE_7, 0x1D
+
+#define BIT_PAGE_7_COC_CTLD_COC_CONTROLD_7                 (0x01 << 7)
+#define MSK_PAGE_7_COC_CTLD_COC_CONTROLD_6_0               (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1E CoC 15th Ctl Register                              (Default: 0x0A)    */
+#define REG_PAGE_7_COC_CTLE                                TX_PAGE_7, 0x1E
+
+#define BIT_PAGE_7_COC_CTLE_COC_CONTROLE_7                 (0x01 << 7)
+#define MSK_PAGE_7_COC_CTLE_COC_CONTROLE_6_0               (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x1F CoC 16th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTLF                                TX_PAGE_7, 0x1F
+
+#define MSK_PAGE_7_COC_CTLF_COC_CONTROLF                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x20 CoC 17th Ctl Register                              (Default: 0x15)    */
+#define REG_PAGE_7_COC_CTL10                               TX_PAGE_7, 0x20
+
+#define MSK_PAGE_7_COC_CTL10_COC_CONTROL10_7_4             (0x0F << 4)
+#define MSK_PAGE_7_COC_CTL10_COC_CONTROL10_3_0             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x21 CoC 18th Ctl Register                              (Default: 0x32)    */
+#define REG_PAGE_7_COC_CTL11                               TX_PAGE_7, 0x21
+
+#define MSK_PAGE_7_COC_CTL11_COC_CONTROL11_7_4             (0x0F << 4)
+#define MSK_PAGE_7_COC_CTL11_COC_CONTROL11_3_0             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x22 CoC 19th Ctl Register                              (Default: 0x04)    */
+#define REG_PAGE_7_COC_CTL12                               TX_PAGE_7, 0x22
+
+#define BIT_PAGE_7_COC_CTL12_COC_CONTROL12_7               (0x01 << 7)
+#define BIT_PAGE_7_COC_CTL12_COC_CONTROL12_6               (0x01 << 6)
+#define MSK_PAGE_7_COC_CTL12_COC_CONTROL12_5_0             (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x23 CoC 20th Ctl Register                              (Default: 0x76)    */
+#define REG_PAGE_7_COC_CTL13                               TX_PAGE_7, 0x23
+
+#define MSK_PAGE_7_COC_CTL13_COC_CONTROL13                 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x24 CoC 21st Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL14                               TX_PAGE_7, 0x24
+
+#define MSK_PAGE_7_COC_CTL14_COC_CONTROL14_7_4             (0x0F << 4)
+#define MSK_PAGE_7_COC_CTL14_COC_CONTROL14_3_0             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x25 CoC 22nd Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_COC_CTL15                               TX_PAGE_7, 0x25
+
+#define BIT_PAGE_7_COC_CTL15_COC_CONTROL15_7               (0x01 << 7)
+#define MSK_PAGE_7_COC_CTL15_COC_CONTROL15_6_4             (0x07 << 4)
+#define MSK_PAGE_7_COC_CTL15_COC_CONTROL15_3_0             (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x26 CoC Interrupt Register                             (Default: 0x00)    */
+#define REG_PAGE_7_COC_INTR                                TX_PAGE_7, 0x26
+
+#define BIT_PAGE_7_COC_INTR_COC_INTR_STAT4                 (0x01 << 4)
+#define BIT_PAGE_7_COC_INTR_COC_INTR_STAT3                 (0x01 << 3)
+#define BIT_PAGE_7_COC_INTR_COC_INTR_STAT2                 (0x01 << 2)
+#define BIT_PAGE_7_COC_INTR_COC_INTR_STAT1                 (0x01 << 1)
+#define BIT_PAGE_7_COC_INTR_COC_INTR_STAT0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x27 CoC Interrupt Mask Register                        (Default: 0x00)    */
+#define REG_PAGE_7_COC_INTR_MASK                           TX_PAGE_7, 0x27
+
+#define BIT_PAGE_7_COC_INTR_MASK_COC_INTR_MASK4            (0x01 << 4)
+#define BIT_PAGE_7_COC_INTR_MASK_COC_INTR_MASK3            (0x01 << 3)
+#define BIT_PAGE_7_COC_INTR_MASK_COC_INTR_MASK2            (0x01 << 2)
+#define BIT_PAGE_7_COC_INTR_MASK_COC_INTR_MASK1            (0x01 << 1)
+#define BIT_PAGE_7_COC_INTR_MASK_COC_INTR_MASK0            (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x28 CoC Misc 1st Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_7_COC_MISC_CTL0                           TX_PAGE_7, 0x28
+
+#define MSK_PAGE_7_COC_MISC_CTL0_COC_DBG_SEL               (0x03 << 3)
+#define BIT_PAGE_7_COC_MISC_CTL0_COC_DBG_EN                (0x01 << 2)
+#define BIT_PAGE_7_COC_MISC_CTL0_COC_OE                    (0x01 << 1)
+#define BIT_PAGE_7_COC_MISC_CTL0_COC_OE_OVR                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x38 DoC 1st Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_0                              TX_PAGE_7, 0x38
+
+#define BIT_PAGE_7_DOC_STAT_0_DOC_STATUS0_7                (0x01 << 7)
+#define BIT_PAGE_7_DOC_STAT_0_DOC_STATUS0_6                (0x01 << 6)
+#define MSK_PAGE_7_DOC_STAT_0_DOC_STATUS0_7_0              (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x39 DoC 2nd Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_1                              TX_PAGE_7, 0x39
+
+#define MSK_PAGE_7_DOC_STAT_1_DOC_STATUS1_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3A DoC 3rd Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_2                              TX_PAGE_7, 0x3A
+
+#define MSK_PAGE_7_DOC_STAT_2_DOC_STATUS2_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3B DoC 4th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_3                              TX_PAGE_7, 0x3B
+
+#define MSK_PAGE_7_DOC_STAT_3_DOC_STATUS3_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3C DoC 5th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_4                              TX_PAGE_7, 0x3C
+
+#define MSK_PAGE_7_DOC_STAT_4_DOC_STATUS4_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3D DoC 6th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_5                              TX_PAGE_7, 0x3D
+
+#define MSK_PAGE_7_DOC_STAT_5_DOC_STATUS5_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3E DoC 7th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_6                              TX_PAGE_7, 0x3E
+
+#define MSK_PAGE_7_DOC_STAT_6_DOC_STATUS6_7_4              (0x0F << 4)
+#define BIT_PAGE_7_DOC_STAT_6_DOC_STATUS6_3                (0x01 << 3)
+#define BIT_PAGE_7_DOC_STAT_6_DOC_STATUS6_2                (0x01 << 2)
+#define BIT_PAGE_7_DOC_STAT_6_DOC_STATUS6_1                (0x01 << 1)
+#define BIT_PAGE_7_DOC_STAT_6_DOC_STATUS6_0                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x3F DoC 8th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_7                              TX_PAGE_7, 0x3F
+
+#define MSK_PAGE_7_DOC_STAT_7_DOC_STATUS7_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x40 DoC 9th Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_8                              TX_PAGE_7, 0x40
+
+#define MSK_PAGE_7_DOC_STAT_8_DOC_STATUS8_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x41 DoC 10th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_9                              TX_PAGE_7, 0x41
+
+#define BIT_PAGE_7_DOC_STAT_9_DOC_STATUS9_7                (0x01 << 7)
+#define BIT_PAGE_7_DOC_STAT_9_DOC_STATUS9_6                (0x01 << 6)
+#define BIT_PAGE_7_DOC_STAT_9_DOC_STATUS9_5                (0x01 << 5)
+#define BIT_PAGE_7_DOC_STAT_9_DOC_STATUS9_4                (0x01 << 4)
+#define MSK_PAGE_7_DOC_STAT_9_DOC_STATUS9_3_0              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x42 DoC 11th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_A                              TX_PAGE_7, 0x42
+
+#define MSK_PAGE_7_DOC_STAT_A_DOC_STATUSA_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x43 DoC 12th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_B                              TX_PAGE_7, 0x43
+
+#define MSK_PAGE_7_DOC_STAT_B_DOC_STATUSB_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x44 DoC 13th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_C                              TX_PAGE_7, 0x44
+
+#define MSK_PAGE_7_DOC_STAT_C_DOC_STATUSC_7_6              (0x03 << 6)
+#define BIT_PAGE_7_DOC_STAT_C_DOC_STATUSC_5                (0x01 << 5)
+#define BIT_PAGE_7_DOC_STAT_C_DOC_STATUSC_4                (0x01 << 4)
+#define BIT_PAGE_7_DOC_STAT_C_DOC_STATUSC_3                (0x01 << 3)
+#define BIT_PAGE_7_DOC_STAT_C_DOC_STATUSC_2                (0x01 << 2)
+#define MSK_PAGE_7_DOC_STAT_C_DOC_STATUSC_1_0              (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x45 DoC 14th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_D                              TX_PAGE_7, 0x45
+
+#define MSK_PAGE_7_DOC_STAT_D_DOC_STATUSD_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x46 DoC 15th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_E                              TX_PAGE_7, 0x46
+
+#define MSK_PAGE_7_DOC_STAT_E_DOC_STATUSE_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x47 DoC 16th Status Register                           (Default: 0x00)    */
+#define REG_PAGE_7_DOC_STAT_F                              TX_PAGE_7, 0x47
+
+#define MSK_PAGE_7_DOC_STAT_F_DOC_STATUSF_7_0              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x48 DoC DRX Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_DRX                                 TX_PAGE_7, 0x48
+
+#define MSK_PAGE_7_DOC_DRX_DOC_DRX_7_0                     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x49 DoC FSM Status Register                            (Default: 0x00)    */
+#define REG_PAGE_7_DOC_FSM                                 TX_PAGE_7, 0x49
+
+#define MSK_PAGE_7_DOC_FSM_STATE_DOC_FSM_3_0               (0x0F << 4)
+#define MSK_PAGE_7_DOC_FSM_DOC_DRX_9_8                     (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4A DoC 1st CFG Register                               (Default: 0x15)    */
+#define REG_PAGE_7_DOC_CFG0                                TX_PAGE_7, 0x4A
+
+#define MSK_PAGE_7_DOC_CFG0_K_CHAR_1T0_7_4                 (0x0F << 4)
+#define MSK_PAGE_7_DOC_CFG0_K_CHAR_1T0_3_0                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4B DoC 2nd CFG Register                               (Default: 0x32)    */
+#define REG_PAGE_7_DOC_CFG1                                TX_PAGE_7, 0x4B
+
+#define MSK_PAGE_7_DOC_CFG1_K_CHAR_3T2_7_4                 (0x0F << 4)
+#define MSK_PAGE_7_DOC_CFG1_K_CHAR_3T2_3_0                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4C DoC 3rd CFG Register                               (Default: 0x04)    */
+#define REG_PAGE_7_DOC_CFG2                                TX_PAGE_7, 0x4C
+
+#define MSK_PAGE_7_DOC_CFG2_K_CHAR_5T4_7_4                 (0x0F << 4)
+#define MSK_PAGE_7_DOC_CFG2_K_CHAR_5T4_3_0                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4D DoC 4th CFG Register                               (Default: 0x76)    */
+#define REG_PAGE_7_DOC_CFG3                                TX_PAGE_7, 0x4D
+
+#define MSK_PAGE_7_DOC_CFG3_K_CHAR_7T6_7_4                 (0x0F << 4)
+#define MSK_PAGE_7_DOC_CFG3_K_CHAR_7T6_3_0                 (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4E DoC 5th CFG Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CFG4                                TX_PAGE_7, 0x4E
+
+#define MSK_PAGE_7_DOC_CFG4_DBG_STATE_DOC_FSM              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x4F DoC 6th CFG Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CFG5                                TX_PAGE_7, 0x4F
+
+#define MSK_PAGE_7_DOC_CFG5_DOC_CTRL_ALPHA_RL              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x50 DoC 7th CFG Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CFG6                                TX_PAGE_7, 0x50
+
+#define MSK_PAGE_7_DOC_CFG6_DOC_CTRL_ALPHA_RH              (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x51 DoC 1st Ctl Register                               (Default: 0x40)    */
+#define REG_PAGE_7_DOC_CTL0                                TX_PAGE_7, 0x51
+
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_7                 (0x01 << 7)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_6                 (0x01 << 6)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_5                 (0x01 << 5)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_4                 (0x01 << 4)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_3                 (0x01 << 3)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_2                 (0x01 << 2)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_1                 (0x01 << 1)
+#define BIT_PAGE_7_DOC_CTL0_DOC_CONTROL0_0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x52 DoC 2nd Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL1                                TX_PAGE_7, 0x52
+
+#define MSK_PAGE_7_DOC_CTL1_DOC_CONTROL1_7_5               (0x07 << 5)
+#define MSK_PAGE_7_DOC_CTL1_DOC_CONTROL1_4_2               (0x07 << 2)
+#define BIT_PAGE_7_DOC_CTL1_DOC_CONTROL1_1                 (0x01 << 1)
+#define BIT_PAGE_7_DOC_CTL1_DOC_CONTROL1_0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x53 DoC 3rd Ctl Register                               (Default: 0x35)    */
+#define REG_PAGE_7_DOC_CTL2                                TX_PAGE_7, 0x53
+
+#define MSK_PAGE_7_DOC_CTL2_DOC_CONTROL2                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x54 DoC 4th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL3                                TX_PAGE_7, 0x54
+
+#define BIT_PAGE_7_DOC_CTL3_DOC_CONTROL3_7                 (0x01 << 7)
+#define MSK_PAGE_7_DOC_CTL3_DOC_CONTROL3_6_0               (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x55 DoC 5th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL4                                TX_PAGE_7, 0x55
+
+#define MSK_PAGE_7_DOC_CTL4_DOC_CONTROL4_7_0               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x56 DoC 6th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL5                                TX_PAGE_7, 0x56
+
+#define MSK_PAGE_7_DOC_CTL5_DOC_CONTROL5_7_6               (0x03 << 6)
+#define MSK_PAGE_7_DOC_CTL5_DOC_CONTROL5_5_2               (0x0F << 2)
+#define MSK_PAGE_7_DOC_CTL5_DOC_CONTROL5_1_0               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x57 DoC 7th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL6                                TX_PAGE_7, 0x57
+
+#define BIT_PAGE_7_DOC_CTL6_DOC_CONTROL6_7                 (0x01 << 7)
+#define MSK_PAGE_7_DOC_CTL6_DOC_CONTROL6_6_4               (0x07 << 4)
+#define MSK_PAGE_7_DOC_CTL6_DOC_CONTROL6_3_0               (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x58 DoC 8th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL7                                TX_PAGE_7, 0x58
+
+#define BIT_PAGE_7_DOC_CTL7_DOC_CONTROL7_7                 (0x01 << 7)
+#define BIT_PAGE_7_DOC_CTL7_DOC_CONTROL7_6                 (0x01 << 6)
+#define BIT_PAGE_7_DOC_CTL7_DOC_CONTROL7_5                 (0x01 << 5)
+#define MSK_PAGE_7_DOC_CTL7_DOC_CONTROL7_4_3               (0x03 << 3)
+#define MSK_PAGE_7_DOC_CTL7_DOC_CONTROL7_2_0               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6C DoC 9th Ctl Register                               (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL8                                TX_PAGE_7, 0x6C
+
+#define MSK_PAGE_7_DOC_CTL8_DOC_CONTROL8_7_4               (0x0F << 4)
+#define MSK_PAGE_7_DOC_CTL8_DOC_CONTROL8_3_2               (0x03 << 2)
+#define MSK_PAGE_7_DOC_CTL8_DOC_CONTROL8_1_0               (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6D DoC 10th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTL9                                TX_PAGE_7, 0x6D
+
+#define MSK_PAGE_7_DOC_CTL9_DOC_CONTROL9                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6E DoC 11th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTLA                                TX_PAGE_7, 0x6E
+
+#define MSK_PAGE_7_DOC_CTLA_DOC_CONTROLA                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6F DoC 12th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTLB                                TX_PAGE_7, 0x6F
+
+#define MSK_PAGE_7_DOC_CTLB_DOC_CONTROLB                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x70 DoC 13th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTLC                                TX_PAGE_7, 0x70
+
+#define MSK_PAGE_7_DOC_CTLC_DOC_CONTROLC                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x71 DoC 14th Ctl Register                              (Default: 0x09)    */
+#define REG_PAGE_7_DOC_CTLD                                TX_PAGE_7, 0x71
+
+#define BIT_PAGE_7_DOC_CTLD_DOC_CONTROLD_7                 (0x01 << 7)
+#define MSK_PAGE_7_DOC_CTLD_DOC_CONTROLD_6_4               (0x07 << 4)
+#define MSK_PAGE_7_DOC_CTLD_DOC_CONTROLD_3_0               (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x72 DoC 15th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTLE                                TX_PAGE_7, 0x72
+
+#define MSK_PAGE_7_DOC_CTLE_DOC_CONTROLE                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x73 DoC 16th Ctl Register                              (Default: 0x00)    */
+#define REG_PAGE_7_DOC_CTLF                                TX_PAGE_7, 0x73
+
+#define MSK_PAGE_7_DOC_CTLF_DOC_CONTROLF                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x74 DoC Interrupt Register                             (Default: 0x00)    */
+#define REG_PAGE_7_DOC_INTR                                TX_PAGE_7, 0x74
+
+#define MSK_PAGE_7_DOC_INTR_                               (0x07 << 5)
+#define BIT_PAGE_7_DOC_INTR_DOC_INTR_STAT4                 (0x01 << 4)
+#define BIT_PAGE_7_DOC_INTR_DOC_INTR_STAT3                 (0x01 << 3)
+#define BIT_PAGE_7_DOC_INTR_DOC_INTR_STAT2                 (0x01 << 2)
+#define BIT_PAGE_7_DOC_INTR_DOC_INTR_STAT1                 (0x01 << 1)
+#define BIT_PAGE_7_DOC_INTR_DOC_INTR_STAT0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x75 DoC Interrupt Register                             (Default: 0x00)    */
+#define REG_PAGE_7_DOC_INTR_MASK                           TX_PAGE_7, 0x75
+
+#define BIT_PAGE_7_DOC_INTR_MASK_DOC_INTR_MASK4            (0x01 << 4)
+#define BIT_PAGE_7_DOC_INTR_MASK_DOC_INTR_MASK3            (0x01 << 3)
+#define BIT_PAGE_7_DOC_INTR_MASK_DOC_INTR_MASK2            (0x01 << 2)
+#define BIT_PAGE_7_DOC_INTR_MASK_DOC_INTR_MASK1            (0x01 << 1)
+#define BIT_PAGE_7_DOC_INTR_MASK_DOC_INTR_MASK0            (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x76 DoC Misc 1st Ctl Register                          (Default: 0x00)    */
+#define REG_PAGE_7_DOC_MISC_CTL0                           TX_PAGE_7, 0x76
+
+#define BIT_PAGE_7_DOC_MISC_CTL0_DOC_DBG_SEL               (0x01 << 3)
+#define BIT_PAGE_7_DOC_MISC_CTL0_DOC_DBG_EN                (0x01 << 2)
+#define BIT_PAGE_7_DOC_MISC_CTL0_DOC_OE                    (0x01 << 1)
+#define BIT_PAGE_7_DOC_MISC_CTL0_DOC_OE_OVR                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* Registers in TX_PAGE_5                                                     */
+/*----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------*/
+/* 0x60 CBUS WRITE_BURST Transmit 1st Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_0                          TX_PAGE_5, 0x60
+
+#define MSK_PAGE_5_WB_XMIT_DATA_0_WB_XMIT_DATA_0           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x61 CBUS WRITE_BURST Transmit 2nd Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_1                          TX_PAGE_5, 0x61
+
+#define MSK_PAGE_5_WB_XMIT_DATA_1_WB_XMIT_DATA_1           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x62 CBUS WRITE_BURST Transmit 3rd Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_2                          TX_PAGE_5, 0x62
+
+#define MSK_PAGE_5_WB_XMIT_DATA_2_WB_XMIT_DATA_2           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x63 CBUS WRITE_BURST Transmit 4th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_3                          TX_PAGE_5, 0x63
+
+#define MSK_PAGE_5_WB_XMIT_DATA_3_WB_XMIT_DATA_3           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x64 CBUS WRITE_BURST Transmit 5th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_4                          TX_PAGE_5, 0x64
+
+#define MSK_PAGE_5_WB_XMIT_DATA_4_WB_XMIT_DATA_4           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x65 CBUS WRITE_BURST Transmit 6th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_5                          TX_PAGE_5, 0x65
+
+#define MSK_PAGE_5_WB_XMIT_DATA_5_WB_XMIT_DATA_5           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x66 CBUS WRITE_BURST Transmit 7th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_6                          TX_PAGE_5, 0x66
+
+#define MSK_PAGE_5_WB_XMIT_DATA_6_WB_XMIT_DATA_6           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x67 CBUS WRITE_BURST Transmit 8th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_7                          TX_PAGE_5, 0x67
+
+#define MSK_PAGE_5_WB_XMIT_DATA_7_WB_XMIT_DATA_7           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x68 CBUS WRITE_BURST Transmit 9th Byte Register        (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_8                          TX_PAGE_5, 0x68
+
+#define MSK_PAGE_5_WB_XMIT_DATA_8_WB_XMIT_DATA_8           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x69 CBUS WRITE_BURST Transmit 10th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_9                          TX_PAGE_5, 0x69
+
+#define MSK_PAGE_5_WB_XMIT_DATA_9_WB_XMIT_DATA_9           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6A CBUS WRITE_BURST Transmit 11th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_A                          TX_PAGE_5, 0x6A
+
+#define MSK_PAGE_5_WB_XMIT_DATA_A_WB_XMIT_DATA_A           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6B CBUS WRITE_BURST Transmit 12th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_B                          TX_PAGE_5, 0x6B
+
+#define MSK_PAGE_5_WB_XMIT_DATA_B_WB_XMIT_DATA_B           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6C CBUS WRITE_BURST Transmit 13th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_C                          TX_PAGE_5, 0x6C
+
+#define MSK_PAGE_5_WB_XMIT_DATA_C_WB_XMIT_DATA_C           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6D CBUS WRITE_BURST Transmit 14th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_D                          TX_PAGE_5, 0x6D
+
+#define MSK_PAGE_5_WB_XMIT_DATA_D_WB_XMIT_DATA_D           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6E CBUS WRITE_BURST Transmit 15th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_E                          TX_PAGE_5, 0x6E
+
+#define MSK_PAGE_5_WB_XMIT_DATA_E_WB_XMIT_DATA_E           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x6F CBUS WRITE_BURST Transmit 16th Byte Register       (Default: 0x00)    */
+#define REG_PAGE_5_WB_XMIT_DATA_F                          TX_PAGE_5, 0x6F
+
+#define MSK_PAGE_5_WB_XMIT_DATA_F_WB_XMIT_DATA_F           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x80 Interrupt Mask 1st Register                        (Default: 0x00)    */
+#define REG_PAGE_5_MHL_INT_0_MASK                          TX_PAGE_5, 0x80
+
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK7          (0x01 << 7)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK6          (0x01 << 6)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK5          (0x01 << 5)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK4          (0x01 << 4)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK3          (0x01 << 3)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MHL_INT_0_MASK_MHL_INT_0_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x81 Interrupt Mask 2nd Register                        (Default: 0x00)    */
+#define REG_PAGE_5_MHL_INT_1_MASK                          TX_PAGE_5, 0x81
+
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK7          (0x01 << 7)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK6          (0x01 << 6)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK5          (0x01 << 5)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK4          (0x01 << 4)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK3          (0x01 << 3)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MHL_INT_1_MASK_MHL_INT_1_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x82 Interrupt Mask 3rd Register                        (Default: 0x00)    */
+#define REG_PAGE_5_MHL_INT_2_MASK                          TX_PAGE_5, 0x82
+
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK7          (0x01 << 7)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK6          (0x01 << 6)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK5          (0x01 << 5)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK4          (0x01 << 4)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK3          (0x01 << 3)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MHL_INT_2_MASK_MHL_INT_2_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x83 Interrupt Mask 4th Register                        (Default: 0x00)    */
+#define REG_PAGE_5_MHL_INT_3_MASK                          TX_PAGE_5, 0x83
+
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK7          (0x01 << 7)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK6          (0x01 << 6)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK5          (0x01 << 5)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK4          (0x01 << 4)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK3          (0x01 << 3)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MHL_INT_3_MASK_MHL_INT_3_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x84 MDT Reveive Time Out Register                      (Default: 0x00)    */
+#define REG_PAGE_5_MDT_RCV_TIMEOUT                         TX_PAGE_5, 0x84
+
+#define MSK_PAGE_5_MDT_RCV_TIMEOUT_MDT_RCV_TIMEOUT_MAX_MSB (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x85 MDT Transmit Time Out Register                     (Default: 0x00)    */
+#define REG_PAGE_5_MDT_XMIT_TIMEOUT                        TX_PAGE_5, 0x85
+
+#define MSK_PAGE_5_MDT_XMIT_TIMEOUT_MDT_XMIT_TIMEOUT_MAX_MSB (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x86 MDT Receive Control Register                       (Default: 0x00)    */
+#define REG_PAGE_5_MDT_RCV_CONTROL                         TX_PAGE_5, 0x86
+
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_RCV_EN              (0x01 << 7)
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_RFIFO_OVER_WR_EN    (0x01 << 4)
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_XFIFO_OVER_WR_EN    (0x01 << 3)
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_DISABLE             (0x01 << 2)
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_RFIFO_CLR_ALL       (0x01 << 1)
+#define BIT_PAGE_5_MDT_RCV_CONTROL_MDT_RFIFO_CLR_CUR       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x87 MDT Receive Read Port                              (Default: 0x00)    */
+#define REG_PAGE_5_MDT_RCV_READ_PORT                       TX_PAGE_5, 0x87
+
+#define MSK_PAGE_5_MDT_RCV_READ_PORT_MDT_RFIFO_DATA        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x88 MDT Transmit Control Register                      (Default: 0x70)    */
+#define REG_PAGE_5_MDT_XMIT_CONTROL                        TX_PAGE_5, 0x88
+
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_EN            (0x01 << 7)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_CMD_MERGE_EN  (0x01 << 6)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_FIXED_BURST_LEN (0x01 << 5)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_FIXED_AID     (0x01 << 4)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XMIT_SINGLE_RUN_EN (0x01 << 3)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_CLR_ABORT_WAIT     (0x01 << 2)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XFIFO_CLR_ALL      (0x01 << 1)
+#define BIT_PAGE_5_MDT_XMIT_CONTROL_MDT_XFIFO_CLR_CUR      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x89 MDT Receive WRITE Port                             (Default: 0x00)    */
+#define REG_PAGE_5_MDT_XMIT_WRITE_PORT                     TX_PAGE_5, 0x89
+
+#define MSK_PAGE_5_MDT_XMIT_WRITE_PORT_MDT_XFIFO_WDATA     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8A MDT RFIFO Status Register                          (Default: 0x00)    */
+#define REG_PAGE_5_MDT_RFIFO_STAT                          TX_PAGE_5, 0x8A
+
+#define MSK_PAGE_5_MDT_RFIFO_STAT_MDT_RFIFO_CNT            (0x07 << 5)
+#define MSK_PAGE_5_MDT_RFIFO_STAT_MDT_RFIFO_CUR_BYTE_CNT   (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8B MDT XFIFO Status Register                          (Default: 0x80)    */
+#define REG_PAGE_5_MDT_XFIFO_STAT                          TX_PAGE_5, 0x8B
+
+#define MSK_PAGE_5_MDT_XFIFO_STAT_MDT_XFIFO_LEVEL_AVAIL    (0x07 << 5)
+#define BIT_PAGE_5_MDT_XFIFO_STAT_MDT_XMIT_PRE_HS_EN       (0x01 << 4)
+#define MSK_PAGE_5_MDT_XFIFO_STAT_MDT_WRITE_BURST_LEN      (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8C MDT Interrupt 0 Register                           (Default: 0x0C)    */
+#define REG_PAGE_5_MDT_INT_0                               TX_PAGE_5, 0x8C
+
+#define BIT_PAGE_5_MDT_INT_0_MDT_INT_0_3                   (0x01 << 3)
+#define BIT_PAGE_5_MDT_INT_0_MDT_INT_0_2                   (0x01 << 2)
+#define BIT_PAGE_5_MDT_INT_0_MDT_INT_0_1                   (0x01 << 1)
+#define BIT_PAGE_5_MDT_INT_0_MDT_INT_0_0                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8D MDT Interrupt 0 Mask Register                      (Default: 0x00)    */
+#define REG_PAGE_5_MDT_INT_0_MASK                          TX_PAGE_5, 0x8D
+
+#define BIT_PAGE_5_MDT_INT_0_MASK_MDT_INT_0_MASK3          (0x01 << 3)
+#define BIT_PAGE_5_MDT_INT_0_MASK_MDT_INT_0_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MDT_INT_0_MASK_MDT_INT_0_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MDT_INT_0_MASK_MDT_INT_0_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8E MDT Interrupt 1 Register                           (Default: 0x00)    */
+#define REG_PAGE_5_MDT_INT_1                               TX_PAGE_5, 0x8E
+
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_7                   (0x01 << 7)
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_6                   (0x01 << 6)
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_5                   (0x01 << 5)
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_2                   (0x01 << 2)
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_1                   (0x01 << 1)
+#define BIT_PAGE_5_MDT_INT_1_MDT_INT_1_0                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x8F MDT Interrupt 1 Mask Register                      (Default: 0x00)    */
+#define REG_PAGE_5_MDT_INT_1_MASK                          TX_PAGE_5, 0x8F
+
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK7          (0x01 << 7)
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK6          (0x01 << 6)
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK5          (0x01 << 5)
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK2          (0x01 << 2)
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK1          (0x01 << 1)
+#define BIT_PAGE_5_MDT_INT_1_MASK_MDT_INT_1_MASK0          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x90 CBUS Vendor ID Register                            (Default: 0x01)    */
+#define REG_PAGE_5_CBUS_VENDOR_ID                          TX_PAGE_5, 0x90
+
+#define MSK_PAGE_5_CBUS_VENDOR_ID_CBUS_VENDOR_ID           (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x91 CBUS Connection Status Register                    (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_STATUS                             TX_PAGE_5, 0x91
+
+#define BIT_PAGE_5_CBUS_STATUS_MHL_CABLE_PRESENT           (0x01 << 4)
+#define BIT_PAGE_5_CBUS_STATUS_MSC_HB_SUCCESS              (0x01 << 3)
+#define BIT_PAGE_5_CBUS_STATUS_CBUS_HPD                    (0x01 << 2)
+#define BIT_PAGE_5_CBUS_STATUS_MHL_MODE                    (0x01 << 1)
+#define BIT_PAGE_5_CBUS_STATUS_CBUS_CONNECTED              (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x92 CBUS Interrupt 1st Register                        (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_INT_0                              TX_PAGE_5, 0x92
+
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT7             (0x01 << 7)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT6             (0x01 << 6)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT5             (0x01 << 5)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT4             (0x01 << 4)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT3             (0x01 << 3)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT2             (0x01 << 2)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT1             (0x01 << 1)
+#define BIT_PAGE_5_CBUS_INT_0_CBUS_INT_0_STAT0             (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x93 CBUS Interrupt Mask 1st Register                   (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_INT_0_MASK                         TX_PAGE_5, 0x93
+
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK7        (0x01 << 7)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK6        (0x01 << 6)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK5        (0x01 << 5)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK4        (0x01 << 4)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK3        (0x01 << 3)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK2        (0x01 << 2)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK1        (0x01 << 1)
+#define BIT_PAGE_5_CBUS_INT_0_MASK_CBUS_INT_0_MASK0        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x94 CBUS Interrupt 2nd Register                        (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_INT_1                              TX_PAGE_5, 0x94
+
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT7             (0x01 << 7)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT6             (0x01 << 6)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT5             (0x01 << 5)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT4             (0x01 << 4)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT3             (0x01 << 3)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT2             (0x01 << 2)
+#define BIT_PAGE_5_CBUS_INT_1_CBUS_INT_1_STAT0             (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x95 CBUS Interrupt Mask 2nd Register                   (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_INT_1_MASK                         TX_PAGE_5, 0x95
+
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK7        (0x01 << 7)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK6        (0x01 << 6)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK5        (0x01 << 5)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK4        (0x01 << 4)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK3        (0x01 << 3)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK2        (0x01 << 2)
+#define BIT_PAGE_5_CBUS_INT_1_MASK_CBUS_INT_1_MASK0        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x98 CBUS DDC Abort Interrupt Register                  (Default: 0x00)    */
+#define REG_PAGE_5_DDC_ABORT_INT                           TX_PAGE_5, 0x98
+
+#define BIT_PAGE_5_DDC_ABORT_INT_DDC_ABORT_INT_STAT7       (0x01 << 7)
+#define BIT_PAGE_5_DDC_ABORT_INT_DDC_ABORT_INT_STAT2       (0x01 << 2)
+#define BIT_PAGE_5_DDC_ABORT_INT_DDC_ABORT_INT_STAT1       (0x01 << 1)
+#define BIT_PAGE_5_DDC_ABORT_INT_DDC_ABORT_INT_STAT0       (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x99 CBUS DDC Abort Interrupt Mask Register             (Default: 0x00)    */
+#define REG_PAGE_5_DDC_ABORT_INT_MASK                      TX_PAGE_5, 0x99
+
+#define BIT_PAGE_5_DDC_ABORT_INT_MASK_DDC_ABORT_INT_MASK7  (0x01 << 7)
+#define BIT_PAGE_5_DDC_ABORT_INT_MASK_DDC_ABORT_INT_MASK2  (0x01 << 2)
+#define BIT_PAGE_5_DDC_ABORT_INT_MASK_DDC_ABORT_INT_MASK1  (0x01 << 1)
+#define BIT_PAGE_5_DDC_ABORT_INT_MASK_DDC_ABORT_INT_MASK0  (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9A CBUS MSC Requester Abort Interrupt Register        (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MT_ABORT_INT                        TX_PAGE_5, 0x9A
+
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT7 (0x01 << 7)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT5 (0x01 << 5)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT3 (0x01 << 3)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT2 (0x01 << 2)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT1 (0x01 << 1)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MSC_MT_ABORT_INT_STAT0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9B CBUS MSC Reqeuster Abort Interrupt Mask Register   (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MT_ABORT_INT_MASK                   TX_PAGE_5, 0x9B
+
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK7 (0x01 << 7)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK5 (0x01 << 5)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK3 (0x01 << 3)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK2 (0x01 << 2)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK1 (0x01 << 1)
+#define BIT_PAGE_5_MSC_MT_ABORT_INT_MASK_MSC_MT_ABORT_INT_MASK0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9C CBUS MSC Responder Abort Interrupt Register        (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_ABORT_INT                        TX_PAGE_5, 0x9C
+
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT7 (0x01 << 7)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT5 (0x01 << 5)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT4 (0x01 << 4)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT3 (0x01 << 3)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT2 (0x01 << 2)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT1 (0x01 << 1)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MSC_MR_ABORT_INT_STAT0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9D CBUS MSC Responder Abort Interrupt Mask Register   (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_ABORT_INT_MASK                   TX_PAGE_5, 0x9D
+
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK7 (0x01 << 7)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK5 (0x01 << 5)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK4 (0x01 << 4)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK3 (0x01 << 3)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK2 (0x01 << 2)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK1 (0x01 << 1)
+#define BIT_PAGE_5_MSC_MR_ABORT_INT_MASK_MSC_MR_ABORT_INT_MASK0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9E CBUS RX DISCOVERY interrupt Register               (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_RX_DISC_INT0                       TX_PAGE_5, 0x9E
+
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_CBUS_RXDISC_INTR0_STAT3 (0x01 << 3)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_CBUS_RXDISC_INTR0_STAT2 (0x01 << 2)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_CBUS_RXDISC_INTR0_STAT1 (0x01 << 1)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_CBUS_RXDISC_INTR0_STAT0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0x9F CBUS RX DISCOVERY Interrupt Mask Register          (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_RX_DISC_INT0_MASK                  TX_PAGE_5, 0x9F
+
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_MASK_CBUS_RXDISC_INTR0_MASK3 (0x01 << 3)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_MASK_CBUS_RXDISC_INTR0_MASK2 (0x01 << 2)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_MASK_CBUS_RXDISC_INTR0_MASK1 (0x01 << 1)
+#define BIT_PAGE_5_CBUS_RX_DISC_INT0_MASK_CBUS_RXDISC_INTR0_MASK0 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA0 CBUS_Link_Layer Control #1 Register                (Default: 0x18)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_1                     TX_PAGE_5, 0xA0
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_1_LNK_PACKET_LIMIT    (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA1 CBUS_Link_Layer Control #2 Register                (Default: 0x22)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_2                     TX_PAGE_5, 0xA1
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_2_LNK_GLITCH_FILTER_SEL (0x0F << 4)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_2_LNK_INI_TIMEOUT_MAX (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA2 CBUS_Link_Layer Control #3 Register                (Default: 0xC5)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_3                     TX_PAGE_5, 0xA2
+
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_3_LNK_SYNC_FILTER_EN  (0x01 << 7)
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_3_LNK_ARB_ID          (0x01 << 6)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_3_LNK_FWR_ACK_OFFSET  (0x07 << 3)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_3_LNK_RCV_BIT_CHECK_OPT (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA3 CBUS_Link_Layer Control #4 Register                (Default: 0xE2)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_4                     TX_PAGE_5, 0xA3
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_4_LNK_RCV_OPP_TIMEOUT_MAX (0x1F << 3)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_4_LNK_XMIT_OPP_TIMEOUT_MAX (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA4 CBUS_Link_Layer Control #5 Register                (Default: 0x2C)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_5                     TX_PAGE_5, 0xA4
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_5_LNK_LOW_TIMEOUT_MAX_MSB (0x0F << 4)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_5_LNK_HIGH_TIMEOUT_MAX_MSB (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA5 CBUS_Link_Layer Control #6 Register                (Default: 0x12)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_6                     TX_PAGE_5, 0xA5
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_6_LNK_CHECK_HIGH_LIMIT (0x07 << 3)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_6_LNK_DRV_HIGH_LIMIT  (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA6 CBUS_Link_Layer Control #7 Register                (Default: 0x30)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_7                     TX_PAGE_5, 0xA6
+
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_7_LNK_XMIT_BIT_TIME_SEL0 (0x01 << 5)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_7_LNK_XMIT_IDLE_TIMEOUT (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA7 CBUS_Link_Layer Control #8 Register                (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_8                     TX_PAGE_5, 0xA7
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_8_LNK_XMIT_BIT_TIME   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA8 CBUS_Link_Layer Control #9 Register                (Default: 0x3F)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_9                     TX_PAGE_5, 0xA8
+
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_9_LNK_XMIT_BIT_TIME_SEL1 (0x01 << 7)
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_9_LNK_INV_POLARITY    (0x01 << 6)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_9_LNK_CAL_FIFO_DEPTH  (0x07 << 3)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_9_LNK_CAL_BYTE_CNT_MIN (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xA9 CBUS_Link_Layer Control #10 Register               (Default: 0xAB)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_10                    TX_PAGE_5, 0xA9
+
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_10_LNK_CAL_ERROR_CHECK (0x01 << 7)
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_10_LNK_RCV_BIT_TIME_SEL (0x01 << 6)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_10_LNK_CAL_BIT_OFFSET (0x07 << 3)
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_10_LNK_CAL_SYNC_OFFSET (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAA CBUS_Link_Layer Control #11 Register               (Default: 0x81)    */
+#define REG_PAGE_5_CBUS_LINK_CONTROL_11                    TX_PAGE_5, 0xAA
+
+#define MSK_PAGE_5_CBUS_LINK_CONTROL_11_LNK_XMIT_RETRY_LIMIT (0x3F << 2)
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_11_LNK_NORM_BDY_CTL   (0x01 << 1)
+#define BIT_PAGE_5_CBUS_LINK_CONTROL_11_LNK_CAL_BDY_CTL    (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAB CBUS Ack Control Register                          (Default: 0x03)    */
+#define REG_PAGE_5_CBUS_ACK_CONTROL                        TX_PAGE_5, 0xAB
+
+#define MSK_PAGE_5_CBUS_ACK_CONTROL_LNK_ACK_WIN_WIDTH      (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAC CBUS Calibration Control Register                  (Default: 0x50)    */
+#define REG_PAGE_5_CBUS_CAL_CONTROL                        TX_PAGE_5, 0xAC
+
+#define BIT_PAGE_5_CBUS_CAL_CONTROL_LNK_EN_CAL_BY_NACK     (0x01 << 6)
+#define MSK_PAGE_5_CBUS_CAL_CONTROL_LNK_NACK_CNT_MAX       (0x3F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAD CBUS Link Layer Status #1 Register                 (Default: 0x1F)    */
+#define REG_PAGE_5_CBUS_LINK_STATUS_0                      TX_PAGE_5, 0xAD
+
+#define MSK_PAGE_5_CBUS_LINK_STATUS_0_LNK_RCV_BIT_TIME     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAE CBUS Xmit ERR CNT Register                         (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_XMIT_ERR_CNT                       TX_PAGE_5, 0xAE
+
+#define MSK_PAGE_5_CBUS_XMIT_ERR_CNT_LNK_XMIT_ERR_COUNT    (0x7F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xAF CBUS Bi-Phase ERR CNT Register                     (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_BIPHZ_ERR_CNT                      TX_PAGE_5, 0xAF
+
+#define MSK_PAGE_5_CBUS_BIPHZ_ERR_CNT_LNK_NORM_BIPHZ_ERR_CNT (0x0F << 4)
+#define MSK_PAGE_5_CBUS_BIPHZ_ERR_CNT_LNK_CAL_BIPHZ_ERR_CNT (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB0 CBUS Parity ERR CNT Register                       (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_PARITY_ERR_CNT                     TX_PAGE_5, 0xB0
+
+#define MSK_PAGE_5_CBUS_PARITY_ERR_CNT_LNK_RCV_ERR_COUNT   (0x0F << 4)
+#define MSK_PAGE_5_CBUS_PARITY_ERR_CNT_LNK_CAL_PARITY_ERR_CNT (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB1 CBUS_Link_Layer Sync Filter Control #1 Register    (Default: 0x52)    */
+#define REG_PAGE_5_CBUS_LINK_SYNC_CONTROL_1                TX_PAGE_5, 0xB1
+
+#define MSK_PAGE_5_CBUS_LINK_SYNC_CONTROL_1_LNK_SYNC_LOW_MAX_OFFSET (0x0F << 4)
+#define MSK_PAGE_5_CBUS_LINK_SYNC_CONTROL_1_LNK_SYNC_LOW_MIN_OFFSET (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB2 CBUS_Link_Layer Sync Filter Control #2 Register    (Default: 0x71)    */
+#define REG_PAGE_5_CBUS_LINK_SYNC_CONTROL_2                TX_PAGE_5, 0xB2
+
+#define MSK_PAGE_5_CBUS_LINK_SYNC_CONTROL_2_LNK_SYNC_BIT_MAX_OFFSET (0x0F << 4)
+#define MSK_PAGE_5_CBUS_LINK_SYNC_CONTROL_2_LNK_SYNC_BIT_MIN_OFFSET (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB5 MDT State Machine Status Register                  (Default: 0x00)    */
+#define REG_PAGE_5_MDT_SM_STAT                             TX_PAGE_5, 0xB5
+
+#define MSK_PAGE_5_MDT_SM_STAT_MDT_RCV_STATE               (0x0F << 4)
+#define MSK_PAGE_5_MDT_SM_STAT_MDT_XMIT_STATE              (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB6 MDT Peer Adopter ID Low Byte Register              (Default: 0x00)    */
+#define REG_PAGE_5_MDT_PEER_ADOPER_ID_LOW                  TX_PAGE_5, 0xB6
+
+#define MSK_PAGE_5_MDT_PEER_ADOPER_ID_LOW_PEER_ADOPTER_ID_7_0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB7 MDT Peer Adopter ID High Byte Register             (Default: 0x00)    */
+#define REG_PAGE_5_MDT_PEER_ADOPER_ID_HIGH                 TX_PAGE_5, 0xB7
+
+#define MSK_PAGE_5_MDT_PEER_ADOPER_ID_HIGH_PEER_ADOPTER_ID_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB8 CBUS MSC command trigger Register                  (Default: 0x00)    */
+#define REG_PAGE_5_MSC_COMMAND_START                       TX_PAGE_5, 0xB8
+
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_DEBUG_CMD         (0x01 << 5)
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_WRITE_BURST_CMD   (0x01 << 4)
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_WRITE_STAT_CMD    (0x01 << 3)
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_READ_DEVCAP_CMD   (0x01 << 2)
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_MSC_MSG_CMD       (0x01 << 1)
+#define BIT_PAGE_5_MSC_COMMAND_START_MSC_PEER_CMD          (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xB9 CBUS MSC Command/Offset Register                   (Default: 0x00)    */
+#define REG_PAGE_5_MSC_CMD_OR_OFFSET                       TX_PAGE_5, 0xB9
+
+#define MSK_PAGE_5_MSC_CMD_OR_OFFSET_MSC_MT_CMD_OR_OFFSET  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBA CBUS MSC 1st Transmit Data Register                (Default: 0x00)    */
+#define REG_PAGE_5_MSC_1ST_TRANSMIT_DATA                   TX_PAGE_5, 0xBA
+
+#define MSK_PAGE_5_MSC_1ST_TRANSMIT_DATA_MSC_MT_DATA0      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBB CBUS MSC 2nd Transmit Data Register                (Default: 0x00)    */
+#define REG_PAGE_5_MSC_2ND_TRANSMIT_DATA                   TX_PAGE_5, 0xBB
+
+#define MSK_PAGE_5_MSC_2ND_TRANSMIT_DATA_MSC_MT_DATA1      (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBC CBUS MSC Requester Received 1st Data Register      (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MT_RCVD_DATA0                       TX_PAGE_5, 0xBC
+
+#define MSK_PAGE_5_MSC_MT_RCVD_DATA0_MSC_MT_RCVD_DATA0     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBD CBUS MSC Requester Received 2nd Data Register      (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MT_RCVD_DATA1                       TX_PAGE_5, 0xBD
+
+#define MSK_PAGE_5_MSC_MT_RCVD_DATA1_MSC_MT_RCVD_DATA1     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBE CBUS MSC Requester Received State Register         (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MT_RCVD_STATE                       TX_PAGE_5, 0xBE
+
+#define MSK_PAGE_5_MSC_MT_RCVD_STATE_MSC_MT_RCVD_STATE     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xBF CBUS MSC Responder MSC_MSG Received 1st Data Register (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_MSC_MSG_RCVD_1ST_DATA            TX_PAGE_5, 0xBF
+
+#define MSK_PAGE_5_MSC_MR_MSC_MSG_RCVD_1ST_DATA_MSC_MR_MSC_MSG_RCVD_DATA0 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC0 CBUS MSC Responder MSC_MSG Received Data Register  (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_MSC_MSG_RCVD_2ND_DATA            TX_PAGE_5, 0xC0
+
+#define MSK_PAGE_5_MSC_MR_MSC_MSG_RCVD_2ND_DATA_MSC_MR_MSC_MSG_RCVD_DATA1 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC1 CBUS MSC Responder Received Offset Register        (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_RCVD_OFFSET                      TX_PAGE_5, 0xC1
+
+#define MSK_PAGE_5_MSC_MR_RCVD_OFFSET_MSC_MR_RCVD_OFFSET   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC2 CBUS MSC Responder Rcvd Data Register              (Default: 0x00)    */
+#define REG_PAGE_5_MSC_MR_RCVD_DATA                        TX_PAGE_5, 0xC2
+
+#define MSK_PAGE_5_MSC_MR_RCVD_DATA_MSC_MR_RCVD_DATA       (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC3 CBUS MSC Rcvd Data Cnt Register                    (Default: 0x00)    */
+#define REG_PAGE_5_MSC_RCVD_DATA_CNT                       TX_PAGE_5, 0xC3
+
+#define MSK_PAGE_5_MSC_RCVD_DATA_CNT_MSC_MR_RCVD_DATA_CNT  (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC4 CBUS MSC Heartbeat Control Register                (Default: 0x78)    */
+#define REG_PAGE_5_MSC_HEARTBEAT_CONTROL                   TX_PAGE_5, 0xC4
+
+#define BIT_PAGE_5_MSC_HEARTBEAT_CONTROL_MSC_HB_EN         (0x01 << 7)
+#define MSK_PAGE_5_MSC_HEARTBEAT_CONTROL_MSC_HB_FAIL_LIMIT (0x07 << 4)
+#define MSK_PAGE_5_MSC_HEARTBEAT_CONTROL_MSC_HB_PERIOD_MSB (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC5 CBUS MSC Heartbeat Fail Count Register             (Default: 0x00)    */
+#define REG_PAGE_5_MSC_HEARTBEAT_FAIL_CNT                  TX_PAGE_5, 0xC5
+
+#define MSK_PAGE_5_MSC_HEARTBEAT_FAIL_CNT_MSC_HB_FAIL_CNT  (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC6 CBUS MSC Write_Burst length Register               (Default: 0x0F)    */
+#define REG_PAGE_5_MSC_WRITE_BURST_DATA_LEN                TX_PAGE_5, 0xC6
+
+#define MSK_PAGE_5_MSC_WRITE_BURST_DATA_LEN_MSC_WRITE_BURST_LEN (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC7 CBUS MSC Compatibility Control Register            (Default: 0x12)    */
+#define REG_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL          TX_PAGE_5, 0xC7
+
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_DISABLE_MSC_ON_CBUS (0x01 << 6)
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_DISABLE_DDC_ON_CBUS (0x01 << 5)
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_DISABLE_GET_DDC_ERRORCODE (0x01 << 3)
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_DISABLE_GET_VS1_ERRORCODE (0x01 << 2)
+#define BIT_PAGE_5_CBUS_MSC_COMPATIBILITY_CONTROL_DISABLE_CAP_ID_COMMANDS (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC8 CBUS CEC Capture ID Low Byte Register              (Default: 0x00)    */
+#define REG_PAGE_5_CEC_CAPTURE_ID_LOW                      TX_PAGE_5, 0xC8
+
+#define MSK_PAGE_5_CEC_CAPTURE_ID_LOW_CEC_CAPTURE_ID_7_0   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xC9 CBUS CEC Capture ID High Byte Register             (Default: 0x00)    */
+#define REG_PAGE_5_CEC_CAPTURE_ID_HIGH                     TX_PAGE_5, 0xC9
+
+#define MSK_PAGE_5_CEC_CAPTURE_ID_HIGH_CEC_CAPTURE_ID_15_8 (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCA CBUS CEC Abort Reason Register                     (Default: 0x00)    */
+#define REG_PAGE_5_CEC_ERRORCODE                           TX_PAGE_5, 0xCA
+
+#define MSK_PAGE_5_CEC_ERRORCODE_CEC_ERRORCODE             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCB CBUS DDC Abort Reason Register                     (Default: 0x00)    */
+#define REG_PAGE_5_DDC_ERRORCODE                           TX_PAGE_5, 0xCB
+
+#define MSK_PAGE_5_DDC_ERRORCODE_DDC_ERRORCODE             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCC CBUS MSC Abort Reason Register                     (Default: 0x00)    */
+#define REG_PAGE_5_MSC_ERRORCODE                           TX_PAGE_5, 0xCC
+
+#define MSK_PAGE_5_MSC_ERRORCODE_MSC_ERRORCODE             (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCE CBUS DDC Fail Limit Register                       (Default: 0x05)    */
+#define REG_PAGE_5_CBUS_DDC_FAIL_LIMIT                     TX_PAGE_5, 0xCE
+
+#define MSK_PAGE_5_CBUS_DDC_FAIL_LIMIT_DDC_RETRY_FAIL_LIMIT (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xCF CBUS MSC Fail Limit Register                       (Default: 0x05)    */
+#define REG_PAGE_5_CBUS_MSC_FAIL_LIMIT                     TX_PAGE_5, 0xCF
+
+#define MSK_PAGE_5_CBUS_MSC_FAIL_LIMIT_MSC_RETRY_FAIL_LIMIT (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD1 CBUS DDC Time Out Register                         (Default: 0x0F)    */
+#define REG_PAGE_5_DDC_TIMEOUT                             TX_PAGE_5, 0xD1
+
+#define MSK_PAGE_5_DDC_TIMEOUT_DDC_TIMEOUT_MAX_MSB         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD2 CBUS MSC Time Out Register                         (Default: 0x07)    */
+#define REG_PAGE_5_MSC_TIMEOUT                             TX_PAGE_5, 0xD2
+
+#define MSK_PAGE_5_MSC_TIMEOUT_MSC_TIMEOUT_MAX_MSB         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD4 CBUS DDC Retry Interval Register                   (Default: 0x14)    */
+#define REG_PAGE_5_DDC_RETRY_INTERVAL                      TX_PAGE_5, 0xD4
+
+#define MSK_PAGE_5_DDC_RETRY_INTERVAL_DDC_RETRY_MAX_MSB    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD5 CBUS MSC Retry Interval Register                   (Default: 0x14)    */
+#define REG_PAGE_5_MSC_RETRY_INTERVAL                      TX_PAGE_5, 0xD5
+
+#define MSK_PAGE_5_MSC_RETRY_INTERVAL_MSC_RETRY_MAX_MSB    (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD6 CBUS DDC Master Speed Control Register             (Default: 0x40)    */
+#define REG_PAGE_5_CBUS_DDC_SPEED_CONTROL                  TX_PAGE_5, 0xD6
+
+#define MSK_PAGE_5_CBUS_DDC_SPEED_CONTROL_DDC_SPEED_CTRL   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD7 CBUS DDC START STOP Timing Control Register        (Default: 0x63)    */
+#define REG_PAGE_5_CBUS_DDC_ST_SP_TIMING_CONTROL           TX_PAGE_5, 0xD7
+
+#define MSK_PAGE_5_CBUS_DDC_ST_SP_TIMING_CONTROL_DDC_SP_TIMING_CTRL (0x0F << 4)
+#define MSK_PAGE_5_CBUS_DDC_ST_SP_TIMING_CONTROL_DDC_ST_TIMING_CTRL (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD8 CBUS MISC Control Register                         (Default: 0x0D)    */
+#define REG_PAGE_5_CBUS_MISC_CONTROL                       TX_PAGE_5, 0xD8
+
+#define BIT_PAGE_5_CBUS_MISC_CONTROL_SLOW_SL_ENH           (0x01 << 3)
+#define BIT_PAGE_5_CBUS_MISC_CONTROL_DEV_CAT_OVR           (0x01 << 2)
+#define BIT_PAGE_5_CBUS_MISC_CONTROL_RI_PREFETCH_EN        (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xD9 CBUS MISC Control Register                         (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_RCVD_PAYLOAD                       TX_PAGE_5, 0xD9
+
+#define MSK_PAGE_5_CBUS_RCVD_PAYLOAD_CBUS_RCVD_PAYLOAD     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDA CBUS MISC Control Register                         (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_RCVD_HC                            TX_PAGE_5, 0xDA
+
+#define MSK_PAGE_5_CBUS_RCVD_HC_CBUS_RCVD_HC               (0x07 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDB CBUS DDC EDID Slave Address Register               (Default: 0xA0)    */
+#define REG_PAGE_5_CBUS_DDC_EDID                           TX_PAGE_5, 0xDB
+
+#define MSK_PAGE_5_CBUS_DDC_EDID_CBUS_DDC_EDID_ADDR        (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDC CBUS3 Converter Control Register                   (Default: 0x84)    */
+#define REG_PAGE_5_CBUS3_CNVT                              TX_PAGE_5, 0xDC
+
+#define MSK_PAGE_5_CBUS3_CNVT_CBUS3_RETRYLMT               (0x0F << 4)
+#define MSK_PAGE_5_CBUS3_CNVT_CBUS3_PEERTOUT_SEL           (0x03 << 2)
+#define BIT_PAGE_5_CBUS3_CNVT_TEARCBUS_EN                  (0x01 << 1)
+#define BIT_PAGE_5_CBUS3_CNVT_CBUS3CNVT_EN                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDD CBUS3 Converter INTR Register                      (Default: 0x00)    */
+#define REG_PAGE_5_CBUS3_INTR                              TX_PAGE_5, 0xDD
+
+#define BIT_PAGE_5_CBUS3_INTR_CBUS3_INTR_1                 (0x01 << 1)
+#define BIT_PAGE_5_CBUS3_INTR_CBUS3_INTR_0                 (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDE CBUS3 Converter INTRMASK Register                  (Default: 0x00)    */
+#define REG_PAGE_5_CBUS3_INTRMASK                          TX_PAGE_5, 0xDE
+
+#define BIT_PAGE_5_CBUS3_INTRMASK_CBUS3_INTRMASK_1         (0x01 << 1)
+#define BIT_PAGE_5_CBUS3_INTRMASK_CBUS3_INTRMASK_0         (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xDF CBUS3 Converter Status Register                    (Default: 0x80)    */
+#define REG_PAGE_5_CBUS3_STATUS                            TX_PAGE_5, 0xDF
+
+#define BIT_PAGE_5_CBUS3_STATUS_TDM8BIF_EN                 (0x01 << 7)
+#define MSK_PAGE_5_CBUS3_STATUS_CBUS3_STATE                (0x1F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE0 Discovery Control1 Register                        (Default: 0x26)    */
+#define REG_PAGE_5_DISC_CTRL1                              TX_PAGE_5, 0xE0
+
+#define BIT_PAGE_5_DISC_CTRL1_CBUS_INTR_EN                 (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL1_HB_EN                        (0x01 << 6)
+#define MSK_PAGE_5_DISC_CTRL1_DISC_ATT                     (0x03 << 4)
+#define MSK_PAGE_5_DISC_CTRL1_DISC_CYC                     (0x03 << 2)
+#define BIT_PAGE_5_DISC_CTRL1_PON_N                        (0x01 << 1)
+#define BIT_PAGE_5_DISC_CTRL1_DISC_EN                      (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE1 Discovery Control2 Register                        (Default: 0x88)    */
+#define REG_PAGE_5_DISC_CTRL2                              TX_PAGE_5, 0xE1
+
+#define BIT_PAGE_5_DISC_CTRL2_DLYTRG_EN                    (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL2_SKIP_RGND                    (0x01 << 6)
+#define BIT_PAGE_5_DISC_CTRL2_HW_HB_EN                     (0x01 << 4)
+#define BIT_PAGE_5_DISC_CTRL2_CBUS100K_EN                  (0x01 << 3)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE2 Discovery Control3 Register                        (Default: 0x80)    */
+#define REG_PAGE_5_DISC_CTRL3                              TX_PAGE_5, 0xE2
+
+#define BIT_PAGE_5_DISC_CTRL3_COMM_IMME                    (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL3_FORCE_MHL                    (0x01 << 6)
+#define BIT_PAGE_5_DISC_CTRL3_DISC_SIMODE                  (0x01 << 5)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE3 Discovery Control4 Register                        (Default: 0x80)    */
+#define REG_PAGE_5_DISC_CTRL4                              TX_PAGE_5, 0xE3
+
+#define MSK_PAGE_5_DISC_CTRL4_CBUSDISC_PUP_SEL             (0x03 << 6)
+#define MSK_PAGE_5_DISC_CTRL4_CBUSIDLE_PUP_SEL             (0x03 << 4)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE4 Discovery Control5 Register                        (Default: 0x57)    */
+#define REG_PAGE_5_DISC_CTRL5                              TX_PAGE_5, 0xE4
+
+#define BIT_PAGE_5_DISC_CTRL5_DSM_OVRIDE                   (0x01 << 3)
+#define MSK_PAGE_5_DISC_CTRL5_CBUSMHL_PUP_SEL              (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE5 Discovery Control6 Register                        (Default: 0x11)    */
+#define REG_PAGE_5_DISC_CTRL6                              TX_PAGE_5, 0xE5
+
+#define BIT_PAGE_5_DISC_CTRL6_BLOCK_RGNDINT                (0x01 << 4)
+#define BIT_PAGE_5_DISC_CTRL6_CI2CA_POL                    (0x01 << 2)
+#define BIT_PAGE_5_DISC_CTRL6_CI2CA_WKUP                   (0x01 << 1)
+#define BIT_PAGE_5_DISC_CTRL6_SINGLE_ATT                   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE6 Discovery Control7 Register                        (Default: 0x00)    */
+#define REG_PAGE_5_DISC_CTRL7                              TX_PAGE_5, 0xE6
+
+#define BIT_PAGE_5_DISC_CTRL7_CBUSLVL_VAL                  (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL7_CBUSLVL_SW                   (0x01 << 6)
+#define BIT_PAGE_5_DISC_CTRL7_CBUS_DBGMODE                 (0x01 << 3)
+#define MSK_PAGE_5_DISC_CTRL7_RGND_INTP                    (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE7 Discovery Control8 Register                        (Default: 0x81)    */
+#define REG_PAGE_5_DISC_CTRL8                              TX_PAGE_5, 0xE7
+
+#define BIT_PAGE_5_DISC_CTRL8_NOMHLINT_CLR_BYPASS          (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL8_DELAY_CBUS_INTR_EN           (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE8 Discovery Control9 Register                        (Default: 0x54)    */
+#define REG_PAGE_5_DISC_CTRL9                              TX_PAGE_5, 0xE8
+
+#define BIT_PAGE_5_DISC_CTRL9_MHL3_RSEN_BYP                (0x01 << 7)
+#define BIT_PAGE_5_DISC_CTRL9_MHL3DISC_EN                  (0x01 << 6)
+#define BIT_PAGE_5_DISC_CTRL9_WAKE_DRVFLT                  (0x01 << 4)
+#define BIT_PAGE_5_DISC_CTRL9_NOMHL_EST                    (0x01 << 3)
+#define BIT_PAGE_5_DISC_CTRL9_DISC_PULSE_PROCEED           (0x01 << 2)
+#define BIT_PAGE_5_DISC_CTRL9_WAKE_PULSE_BYPASS            (0x01 << 1)
+#define BIT_PAGE_5_DISC_CTRL9_VBUS_OUTPUT_CAPABILITY_SRC   (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xE9 Discovery Control10 Register                       (Default: 0x8C)    */
+#define REG_PAGE_5_DISC_CTRL10                             TX_PAGE_5, 0xE9
+
+#define MSK_PAGE_5_DISC_CTRL10_TSRC_WAKE_PULSE_WIDTH_1     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEA Discovery Control11 Register                       (Default: 0x7A)    */
+#define REG_PAGE_5_DISC_CTRL11                             TX_PAGE_5, 0xEA
+
+#define MSK_PAGE_5_DISC_CTRL11_TSRC_WAKE_PULSE_WIDTH_2     (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEB Discovery Status1 Register                         (Default: 0x00)    */
+#define REG_PAGE_5_DISC_STAT1                              TX_PAGE_5, 0xEB
+
+#define BIT_PAGE_5_DISC_STAT1_PSM_OVRIDE                   (0x01 << 5)
+#define MSK_PAGE_5_DISC_STAT1_DISC_SM                      (0x0F << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEC Discovery Status2 Register                         (Default: 0x00)    */
+#define REG_PAGE_5_DISC_STAT2                              TX_PAGE_5, 0xEC
+
+#define BIT_PAGE_5_DISC_STAT2_CBUS_OE_POL                  (0x01 << 6)
+#define BIT_PAGE_5_DISC_STAT2_RSEN                         (0x01 << 4)
+
+#define MSK_PAGE_5_DISC_STAT2_MHL_VRSN                     (0x03 << 2)
+#define VAL_PAGE_5_DISC_STAT2_DEFAULT                      (0x00 << 2)
+#define VAL_PAGE_5_DISC_STAT2_MHL1_2                       (0x01 << 2)
+#define VAL_PAGE_5_DISC_STAT2_MHL3                         (0x02 << 2)
+#define VAL_PAGE_5_DISC_STAT2_RESERVED                     (0x03 << 2)
+
+#define MSK_PAGE_5_DISC_STAT2_RGND                         (0x03 << 0)
+#define VAL_PAGE_5_RGND_OPEN                               (0x00 << 0)
+#define VAL_PAGE_5_RGND_2K                                 (0x01 << 0)
+#define VAL_PAGE_5_RGND_1K                                 (0x02 << 0)
+#define VAL_PAGE_5_RGND_SHORT                              (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xED Interrupt CBUS_reg1 INTR0 Register                 (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_DISC_INTR0                         TX_PAGE_5, 0xED
+
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT7   (0x01 << 7)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT6   (0x01 << 6)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT5   (0x01 << 5)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT4   (0x01 << 4)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT3   (0x01 << 3)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT2   (0x01 << 2)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_CBUS_DISC_INTR0_STAT1   (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEE Interrupt CBUS_reg1 INTR0 Mask Register            (Default: 0x00)    */
+#define REG_PAGE_5_CBUS_DISC_INTR0_MASK                    TX_PAGE_5, 0xEE
+
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK7 (0x01 << 7)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK6 (0x01 << 6)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK5 (0x01 << 5)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK4 (0x01 << 4)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK3 (0x01 << 3)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK2 (0x01 << 2)
+#define BIT_PAGE_5_CBUS_DISC_INTR0_MASK_CBUS_DISC_INTR0_MASK1 (0x01 << 1)
+
+/*----------------------------------------------------------------------------*/
+/* 0xEF MHL TX Test Control Register                       (Default: 0x00)    */
+#define REG_PAGE_5_MHLTX_TESTCTRL                          TX_PAGE_5, 0xEF
+
+#define BIT_PAGE_5_MHLTX_TESTCTRL_EVAL_MODE                (0x01 << 5)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF0 CBUS HW HPD Retry Timer Register                   (Default: 0x49)    */
+#define REG_PAGE_5_CBUS_HPD_RETRY_TIMER                    TX_PAGE_5, 0xF0
+
+#define MSK_PAGE_5_CBUS_HPD_RETRY_TIMER_HW_HPD_RETRY_MAX_MSB (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF1 CBUS HW HPD Retry Limit Register                   (Default: 0x10)    */
+#define REG_PAGE_5_CBUS_HPD_RETRY_CNT                      TX_PAGE_5, 0xF1
+
+#define MSK_PAGE_5_CBUS_HPD_RETRY_CNT_HW_HPD_RETRY_LIMIT   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF2 CBUS HW HPD Enable Register                        (Default: 0x01)    */
+#define REG_PAGE_5_CBUS_HW_HPD_EN                          TX_PAGE_5, 0xF2
+
+#define BIT_PAGE_5_CBUS_HW_HPD_EN_HW_HPD_EN                (0x01 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF8 Debug Control Low Register                         (Default: 0x00)    */
+#define REG_PAGE_5_DBG_CTL_L                               TX_PAGE_5, 0xF8
+
+#define MSK_PAGE_5_DBG_CTL_L_DBG_CTL_7_0                   (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xF9 Debug Control High Register                        (Default: 0x00)    */
+#define REG_PAGE_5_DBG_CTL_H                               TX_PAGE_5, 0xF9
+
+#define MSK_PAGE_5_DBG_CTL_H_DBG_CTL_15_8                  (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFA Debug External Status Register                     (Default: 0x00)    */
+#define REG_PAGE_5_DBG_EXT_STAT                            TX_PAGE_5, 0xFA
+
+#define MSK_PAGE_5_DBG_EXT_STAT_DBG_EXT_STAT               (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFB Debug Internal Status Select Register              (Default: 0x00)    */
+#define REG_PAGE_5_DBG_INT_STAT_SEL                        TX_PAGE_5, 0xFB
+
+#define MSK_PAGE_5_DBG_INT_STAT_SEL_DBG_INT_STAT_SEL       (0x03 << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFC Debug Internal Status Low Register                 (Default: 0x00)    */
+#define REG_PAGE_5_DBG_INT_STAT_L                          TX_PAGE_5, 0xFC
+
+#define MSK_PAGE_5_DBG_INT_STAT_L_DBG_INT_STAT_7_0         (0xFF << 0)
+
+/*----------------------------------------------------------------------------*/
+/* 0xFD Debug Internal Status High Register                (Default: 0x00)    */
+#define REG_PAGE_5_DBG_INT_STAT_H                          TX_PAGE_5, 0xFD
+
+#define MSK_PAGE_5_DBG_INT_STAT_H_DBG_INT_STAT_15_8        (0xFF << 0)
+
+#define CachedRegRead(reg)  cache_##reg
+#define CachedRegWrite(reg, value) mhl_tx_reg_write(reg, cache_##reg=value);
+#define CachedRegModify(reg, mask, value) \
+{ \
+uint8_t holder = cache_##reg; \
+	cache_##reg &= ~(mask); \
+	cache_##reg |= ((mask) & value); \
+	if (holder != cache_##reg) \
+	{ \
+		mhl_tx_reg_write(reg, cache_##reg); \
+	} \
+}

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_emsc.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_emsc.h
@@ -1,0 +1,27 @@
+/*
+
+SiI8620 Linux Driver
+
+Copyright (C) 2013 Silicon Image, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation version 2.
+This program is distributed AS-IS WITHOUT ANY WARRANTY of any
+kind, whether express or implied; INCLUDING without the implied warranty
+of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE or NON-INFRINGEMENT.  See
+the GNU General Public License for more details at http://www.gnu.org/licenses/gpl-2.0.html.
+
+*/
+
+/*
+   @file si_emsc.h
+*/
+
+#ifndef _SI_EMSC_H_
+#define _SI_EMSC_H_
+
+#define EMSC_RCV_BUFFER_DEFAULT     256     // Default assumed size of peer block receive buffer
+#define BLK_STD_HEADER_LENGTH       2
+
+#endif /* #ifndef _SI_EMSC_H_ */

--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_infoframe.h
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/si_infoframe.h
@@ -1,0 +1,302 @@
+/*
+
+SiI8620 Linux Driver
+ 
+Copyright (C) 2013 Silicon Image, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation version 2.
+This program is distributed AS-IS WITHOUT ANY WARRANTY of any
+kind, whether express or implied; INCLUDING without the implied warranty
+of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE or NON-INFRINGEMENT.  See
+the GNU General Public License for more details at http://www.gnu.org/licenses/gpl-2.0.html.
+
+*/ 
+
+#if !defined(SI_INFOFRAME_H)
+#define SI_INFOFRAME_H
+#include "mhl_common.h"
+#include "mhl_defs.h"
+
+typedef struct __attribute__((__packed__)) _info_frame_header_t {
+	uint8_t  type_code;
+	uint8_t  version_number;
+	uint8_t  length;
+} info_frame_header_t;
+
+typedef enum
+{
+     acsRGB         = 0
+    ,acsYCbCr422    = 1
+    ,acsYCbCr444    = 2
+    ,acsFuture      = 3
+}AviColorSpace_e;
+
+/*
+ * AVI Info Frame Structure
+ */
+typedef struct __attribute__((__packed__)) _avi_info_frame_data_byte_1_t {
+	uint8_t			ScanInfo:2;
+	uint8_t			BarInfo:2;
+	uint8_t			ActiveFormatInfoPresent:1;
+	AviColorSpace_e	colorSpace:2;
+	uint8_t			futureMustBeZero:1;
+} avi_info_frame_data_byte_1_t;
+
+typedef struct __attribute__((__packed__)) _avi_info_frame_data_byte_2_t {
+	uint8_t			ActiveFormatAspectRatio:4;
+	uint8_t			PictureAspectRatio:2;
+	uint8_t			Colorimetry:2;
+} avi_info_frame_data_byte_2_t;
+
+typedef struct __attribute__((__packed__)) _avi_info_frame_data_byte_3_t {
+	uint8_t			NonUniformPictureScaling:2;
+ 	uint8_t 		RGBQuantizationRange:2;
+ 	uint8_t 		ExtendedColorimetry:3;
+ 	uint8_t 		ITContent:1;
+} avi_info_frame_data_byte_3_t;
+
+typedef struct __attribute__((__packed__)) _avi_info_frame_data_byte_4_t {
+	uint8_t			VIC:7;
+	uint8_t			futureMustBeZero:1;
+} avi_info_frame_data_byte_4_t;
+
+typedef enum
+{
+    cnGraphics  = 0
+    ,cnPhoto    = 1
+    ,cnCinema   = 2
+    ,cnGame     = 3
+}BitsContent_e;
+
+typedef enum
+{
+    aqLimitedRange = 0
+    ,aqFullRange    = 1
+    ,aqReserved0    = 2
+    ,aqReserved1    = 3
+}AviQuantization_e;
+
+typedef struct __attribute__((__packed__)) _avi_info_frame_data_byte_5_t {
+	uint8_t				pixelRepetionFactor:4;
+	BitsContent_e		content				:2;
+	AviQuantization_e	quantization		:2;
+} avi_info_frame_data_byte_5_t;
+
+typedef struct __attribute__((__packed__)) _hw_avi_named_payload_t {
+	uint8_t  checksum;
+	union {
+		struct __attribute__((__packed__)) {
+			avi_info_frame_data_byte_1_t	pb1;
+			avi_info_frame_data_byte_2_t	colorimetryAspectRatio;
+			avi_info_frame_data_byte_3_t	pb3;
+			avi_info_frame_data_byte_4_t	VIC;
+			avi_info_frame_data_byte_5_t	pb5;
+			uint8_t							LineNumEndTopBarLow;
+			uint8_t							LineNumEndTopBarHigh;
+			uint8_t							LineNumStartBottomBarLow;
+			uint8_t							LineNumStartBottomBarHigh;
+			uint8_t							LineNumEndLeftBarLow;
+			uint8_t							LineNumEndLeftBarHigh;
+			uint8_t							LineNumStartRightBarLow;
+			uint8_t							LineNumStartRightBarHigh;
+		} bitFields;
+		uint8_t	infoFrameData[13];
+	} ifData_u;
+} hw_avi_named_payload_t;
+
+// this union overlays the TPI HW for AVI InfoFrames, starting at REG_TPI_AVI_CHSUM.
+typedef union _hw_avi_payload_t {
+	hw_avi_named_payload_t	namedIfData;
+	uint8_t					ifData[14];
+} hw_avi_payload_t;
+
+typedef struct __attribute__((__packed__)) _avi_payload_t {
+	hw_avi_payload_t	hwPayLoad;
+	uint8_t				byte_14;
+	uint8_t				byte_15;
+} avi_payload_t;
+
+typedef struct __attribute__((__packed__)) _avi_info_frame_t {
+	info_frame_header_t		header;
+	avi_payload_t			payLoad;
+} avi_info_frame_t;
+
+// these values determine the interpretation of PB5
+typedef enum
+{
+     hvfNoAdditionalHDMIVideoFormatPresent =0
+    ,hvfExtendedResolutionFormatPresent    =1
+    ,hvf3DFormatIndicationPresent          =2
+}HDMI_Video_Format_e;
+
+typedef enum {
+     tdsFramePacking = 0x00
+    ,tdsTopAndBottom = 0x06
+    ,tdsSideBySide   = 0x08
+} _3D_structure_e;
+
+typedef enum
+{
+     tdedHorizontalSubSampling    = 0x0
+    ,tdedQuincunxOddLeftOddRight  = 0x4
+    ,tdedQuincunxOddLeftEvenRight = 0x5
+    ,tdedQuincunxEvenLeftOddRight = 0x6
+    ,tdedQuincunxEvenLeftEvenRight= 0x7
+
+}ThreeDExtData_e;
+
+typedef enum
+{
+    tdmdParallaxIso23022_3Section6_x_2_2 = 0
+}ThreeDMetaDataType_e;
+
+typedef struct __attribute__((__packed__)) _vendor_specific_payload_t {
+	uint8_t             checksum;
+	uint8_t             IEEERegistrationIdentifier[3];  // must be 0x000C03 Little Endian
+	struct __attribute__((__packed__)){
+		unsigned		reserved:5;
+
+		HDMI_Video_Format_e HDMI_Video_Format:3; //HDMI_Video_Format_e
+	} pb4;
+	union {
+		uint8_t HDMI_VIC;
+		struct __attribute__((__packed__)) _ThreeDStructure {
+			unsigned	reserved:3;
+			unsigned	ThreeDMetaPresent:1;
+            _3D_structure_e	threeDStructure:4;  //_3D_structure_e
+        } ThreeDStructure;
+	} pb5;
+	struct __attribute__((__packed__)) {
+		uint8_t		reserved:4;
+		uint8_t		threeDExtData:4; //ThreeDExtData_e
+	} pb6;
+	struct __attribute__((__packed__)) _PB7 {
+		uint8_t		threeDMetaDataLength:5;
+		uint8_t		threeDMetaDataType:3; //ThreeDMetaDataType_e
+	} pb7;
+} vendor_specific_payload_t;
+
+typedef struct __attribute__((__packed__)) _vendor_specific_info_frame_t {
+	info_frame_header_t			header;
+	vendor_specific_payload_t	payLoad;
+} vendor_specific_info_frame_t;
+
+/*
+ * MPEG Info Frame Structure
+ * Table 8-11 on page 141 of HDMI Spec v1.4
+ */
+typedef struct __attribute__((__packed__)) {
+	info_frame_header_t	header;
+	uint8_t		checksum;
+	uint8_t		byte_1;
+	uint8_t		byte_2;
+	uint8_t		byte_3;
+	uint8_t		byte_4;
+	uint8_t		byte_5;
+	uint8_t		byte_6;
+} unr_info_frame_t;
+
+typedef struct SI_PACK_THIS_STRUCT _mhl3_vsif_t{
+
+	info_frame_header_t header;
+	uint8_t	checksum;
+	uint8_t	iee_oui[3];
+	uint8_t	pb4;
+	uint8_t pb5_reserved;
+	uint8_t pb6;
+	MHL_high_low_t mhl_hev_fmt_type;
+	uint8_t pb9;
+
+	MHL_high_low_t av_delay_sync;
+}mhl3_vsif_t;
+
+/* the enum's in the following section are 
+	defined "in position" to avoid 
+	shifting on the fly 
+*/
+#define MHL3_VSIF_TYPE		0x81
+#define MHL3_VSIF_VERSION	0x03
+#define IEEE_OUI_MHL3 0x76A61D
+#define	PB4_MASK_MHL_VID_FMT		0x03
+enum mhl_vid_fmt_e{
+	 mhl_vid_fmt_no_additional	= 0x00
+	,mhl_vid_fmt_3d_fmt_present = 0x01
+	,mhl_vid_fmt_multi_view		= 0x02
+	,mhl_vid_fmt_dual_3d		= 0x03
+};
+#define PB4_MASK_MHL_3D_FMT_TYPE	0x1C
+enum mhl_3d_fmt_type_e{
+	 mhl_3d_fmt_type_frame_sequential			=0x00
+	,mhl_3d_fmt_type_top_bottom					=0x04
+	,mhl_3d_fmt_type_left_right					=0x08
+	,mhl_3d_fmt_type_frame_sequential_top_bottom=0x0C
+	,mhl_3d_fmt_type_frame_sequential_left_right=0x10
+	,mhl_3d_fmt_type_top_bottom_left_right		=0x14
+};
+#define PB4_MASK_SEP_AUD			0x20
+enum mhl_sep_audio_e{
+	 mhl_sep_audio_not_available	=0x00
+	,mhl_sep_audio_available		=0x20
+};
+#define PB4_MASK_RESERVED			0xC0
+#define MHL3_VSIF_PB4(vid_fmt,_3d_fmt_type,sep_aud) \
+(uint8_t)(((vid_fmt      )& PB4_MASK_MHL_VID_FMT) \
+		 |((_3d_fmt_type )& PB4_MASK_MHL_3D_FMT_TYPE) \
+		 |((sep_aud		)& PB4_MASK_SEP_AUD) )
+
+#define PB6_MASK_MHL_HEV_FMT		0x03
+enum mhl_hev_fmt_e{
+	 mhl_hev_fmt_no_additional	= 0
+	,mhl_hev_fmt_hev_present	=1
+	,mhl_hev_fmt_reserved_2	=2
+	,mhl_hev_fmt_reserved_3	=3
+};
+#define PB6_MASK_RESERVED			0xFC
+#define MHL3_VSIF_PB6(hev_fmt) (uint8_t)((hev_fmt) & PB6_MASK_MHL_HEV_FMT)
+
+#define PB9_MASK_AV_DELAY_SYNC_19_16	0x0F
+#define PB9_MASK_AV_DELAY_DIR			0x10
+enum mhl_av_delay_dir_e{
+	 mhl_av_delay_dir_audio_earlier	=0x00
+	,mhl_av_delay_dir_video_earlier	=0x10
+};
+#define PB9_MASK_RESERVED				0xE0
+#define MHL3_VSIF_PB9(delay_sync,delay_dir) \
+(uint8_t)((((delay_sync) >> 16)& PB9_MASK_AV_DELAY_SYNC_19_16) \
+		| ( (delay_dir)        & PB9_MASK_AV_DELAY_DIR) )
+
+typedef struct __attribute__((__packed__)) _info_frame_t {
+	union {
+		info_frame_header_t				header;
+		avi_info_frame_t				avi;
+		vendor_specific_info_frame_t	vendorSpecific;
+		mhl3_vsif_t						mhl3_vsif;
+		unr_info_frame_t				unr;
+	} body;
+} info_frame_t;
+
+typedef enum
+{
+        // just define these three for now
+     InfoFrameType_AVI
+    ,InfoFrameType_VendorSpecific
+    ,InfoFrameType_VendorSpecific_MHL3
+    ,InfoFrameType_Audio
+
+}InfoFrameType_e;
+
+
+#ifdef ENABLE_DUMP_INFOFRAME //(
+
+void DumpIncomingInfoFrameImpl(char *pszId,char *pszFile,int iLine,info_frame_t *pInfoFrame,uint8_t length);
+#define DumpIncomingInfoFrame(pData,length) DumpIncomingInfoFrameImpl(#pData,__FILE__,__LINE__,(info_frame_t *)pData,length)
+
+#else //)(
+
+#define DumpIncomingInfoFrame(pData,length) /* do nothing */
+
+#endif //)
+
+#endif /* if !defined(SI_INFOFRAME_H) */


### PR DESCRIPTION
The previous driver we included in the kernel was incomplete.
It was required to allow the charger driver to be happy by
creating the required MHL power supply.

Also, that driver was coming from the latest release for Leo and
that was incomplete.

The new driver comes from an old release (unfortunately), intended
for Sirius.
