### PR TITLE
drivers: bcmdhd: fix compilation process

### DIFF
--- a/drivers/net/wireless/bcmdhd/dhd_linux.c
+++ b/drivers/net/wireless/bcmdhd/dhd_linux.c
@@ -5724,7 +5724,7 @@ dhd_preinit_ioctls(dhd_pub_t *dhd)
 			kfree(eventmask_msg);
 			goto done;
 		}
-#if !defined(CONFIG_MACH_SONY_SCORPION) ||
+#if !defined(CONFIG_MACH_SONY_SCORPION) || \
 		!defined(CONFIG_MACH_SONY_SCORPION_WINDY)
 	} else if (ret2 < 0 && ret2 != BCME_UNSUPPORTED) {
 		DHD_ERROR(("%s read event mask ext failed %d\n", __FUNCTION__, ret2));


### PR DESCRIPTION
"\" is required

fix:

kernel/sony/msm/drivers/net/wireless/bcmdhd/dhd_linux.c: In function 'dhd_preinit_ioctls':
kernel/sony/msm/drivers/net/wireless/bcmdhd/dhd_linux.c:5727:43: error: operator '||' has no right operand
^

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I599eaf1bdef66879e8d79dc7d399ece37a4b4d46
