### PR TITLE
arm: dts: Fix DT property search

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -657,7 +657,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <1>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor.dtsi
@@ -91,7 +91,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <0>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius.dtsi
@@ -504,7 +504,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <0>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
@@ -491,7 +491,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <0>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
@@ -503,7 +503,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <0>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
@@ -696,7 +696,7 @@
 				label = "wled";
 				linux,name = "wled:backlight";
 				linux,default-trigger = "bkl-trigger";
-				qcom,cs-out-en = <1>;
+				qcom,cs-out-en;
 				qcom,cabc-en = <0>;
 				qcom,op-fdbck = <0>;
 				qcom,default-state = "on";


### PR DESCRIPTION
if qcom,cs-out-en exists via of_property_read_bool:

<4>[    5.118119] ------------[ cut here ]------------
<4>[    5.121703] WARNING: at ../../../../../../kernel/sony/msm/include/linux/of.h:555 qpnp_leds_probe+0x554/0x2324()
<4>[    5.131788] CPU: 3 PID: 1 Comm: swapper/0 Not tainted 3.10.49-gd0a13f5-00308-g8b5bcdc-dirty #6
<4>[    5.140397] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    5.148978] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    5.157919] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d434>](warn_slowpath_null+0x18/0x20)
<6>[    5.161653] mmc1: BKOPS_EN bit = 1
<4>[    5.170942] [<c012d434>](warn_slowpath_null+0x18/0x20) from [<c075468c>](qpnp_leds_probe+0x554/0x2324)
<6>[    5.176278] mmc1: new HS400 MMC card at address 0001
<6>[    5.176608] mmcblk0: mmc1:0001 016GE2 14.6 GiB
<6>[    5.176713] mmcblk0rpmb: mmc1:0001 016GE2 partition 3 4.00 MiB
<6>[    5.179567]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 p21 p22 p23 p24 p25
<4>[    5.205843] [<c075468c>](qpnp_leds_probe+0x554/0x2324) from [<c04c1120>](spmi_drv_probe+0x10/0x14)
<4>[    5.214930] [<c04c1120>](spmi_drv_probe+0x10/0x14) from [<c0455af0>](driver_probe_device+0x134/0x344)
<4>[    5.224323] [<c0455af0>](driver_probe_device+0x134/0x344) from [<c0455dac>](__driver_attach+0x68/0x8c)
<4>[    5.233789] [<c0455dac>](__driver_attach+0x68/0x8c) from [<c0454208>](bus_for_each_dev+0x70/0x84)
<4>[    5.242813] [<c0454208>](bus_for_each_dev+0x70/0x84) from [<c045499c>](bus_add_driver+0xf4/0x238)
<4>[    5.251841] [<c045499c>](bus_add_driver+0xf4/0x238) from [<c04564f4>](driver_register+0x9c/0x124)
<4>[    5.260871] [<c04564f4>](driver_register+0x9c/0x124) from [<c0f00b08>](do_one_initcall+0xb8/0x160)
<4>[    5.269987] [<c0f00b08>](do_one_initcall+0xb8/0x160) from [<c0f00cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    5.279626] [<c0f00cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a5ac18>](kernel_init+0xc/0xe4)
<4>[    5.288735] [<c0a5ac18>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    5.297092] ---[ end trace 761167f3682cb2cf ]---
<3>[    5.301640] !!!!!!!!!!!!!!!!!!DT!!!!!!!!!!!!!!!! propname: qcom,cs-out-en

Boolean properties have no value cells.
The "value" of a boolean property is determined by the presence or absence
of the property itself, and value cells are disregarded entirely.

Declaring a boolean property with a nonzero number of value cells is a common
configuration error, since even a boolean property having a value of 0 will be
treated as "true" by the DT framework.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ib41ef30552b22a49e52b62a246fd53381f86cea2
