### PR TITLE
video: msm: MHL: SII8620: fix incomplete sysfs implementation

### DIFF
--- a/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx_rcp.c
+++ b/drivers/video/msm/mdss/mhl_sii8620_8061_drv/mhl_tx_rcp.c
@@ -177,7 +177,7 @@ struct rcp_info {
 
 static struct rcp_info s_rcp_info = {0};
 
-static ssize_t mhl_tx_rcp_mouse_mode(struct device *dev,
+static ssize_t mhl_tx_rcp_mouse_mode_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
 	sscanf(buf, "%d", &mouse_mode);
@@ -185,7 +185,13 @@ static ssize_t mhl_tx_rcp_mouse_mode(struct device *dev,
 	return count;
 }
 
-static ssize_t mhl_tx_rcp_mouse_move_distance_dx(struct device *dev,
+static ssize_t mhl_tx_rcp_mouse_mode_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", mouse_mode);
+}
+
+static ssize_t mhl_tx_rcp_mouse_move_distance_dx_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
 	sscanf(buf, "%d", &mouse_move_distance_dx);
@@ -194,13 +200,25 @@ static ssize_t mhl_tx_rcp_mouse_move_distance_dx(struct device *dev,
 	return count;
 }
 
-static ssize_t mhl_tx_rcp_mouse_move_distance_dy(struct device *dev,
+static ssize_t mhl_tx_rcp_mouse_move_distance_dx_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", mouse_move_distance_dx);
+}
+
+static ssize_t mhl_tx_rcp_mouse_move_distance_dy_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
 	sscanf(buf, "%d", &mouse_move_distance_dy);
 	pr_debug("%s: mouse_move_distance_dy = %d\n",
 		 __func__, mouse_move_distance_dy);
 	return count;
+}
+
+static ssize_t mhl_tx_rcp_mouse_move_distance_dy_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", mouse_move_distance_dy);
 }
 
 static void mhl_tx_rcp_key_release_timer(unsigned long data)
@@ -347,11 +365,14 @@ static void mhl_tx_rcp_common_resource_free(void)
 }
 /* ----------------------- global functions -----------------------*/
 static DEVICE_ATTR(mouse_move_distance_dx, 0660,
-				NULL, mhl_tx_rcp_mouse_move_distance_dx);
+				mhl_tx_rcp_mouse_move_distance_dx_show,
+				mhl_tx_rcp_mouse_move_distance_dx_store);
 static DEVICE_ATTR(mouse_move_distance_dy, 0660,
-				NULL, mhl_tx_rcp_mouse_move_distance_dy);
+				mhl_tx_rcp_mouse_move_distance_dy_show,
+				mhl_tx_rcp_mouse_move_distance_dy_store);
 static DEVICE_ATTR(mouse_mode, 0660,
-				NULL, mhl_tx_rcp_mouse_mode);
+				mhl_tx_rcp_mouse_mode_show,
+				mhl_tx_rcp_mouse_mode_store);
 
 int mhl_tx_rcp_init(struct device *parent)
 {


### PR DESCRIPTION
fix:

<4>[    0.550585] ------------[ cut here ]------------
<4>[    0.550598] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/core.c:576 device_create_file+0x64/0x8c()
<4>[    0.550604] Attribute aksv: write permission without 'store'
<4>[    0.550610] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 3.10.49-gd0a13f5-00318-g4c7a4f7 #12
<4>[    0.550638] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    0.550652] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    0.550662] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d294>](warn_slowpath_fmt+0x2c/0x3c)
<4>[    0.550672] [<c012d294>](warn_slowpath_fmt+0x2c/0x3c) from [<c045c91c>](device_create_file+0x64/0x8c)
<4>[    0.550683] [<c045c91c>](device_create_file+0x64/0x8c) from [<c039de5c>](mhl_device_initialize+0xdc/0x17c)
<4>[    0.550699] [<c039de5c>](mhl_device_initialize+0xdc/0x17c) from [<c1024240>](mhl_pf_init+0x134/0x194)
<4>[    0.550713] [<c1024240>](mhl_pf_init+0x134/0x194) from [<c1000b08>](do_one_initcall+0xb8/0x160)
<4>[    0.550722] [<c1000b08>](do_one_initcall+0xb8/0x160) from [<c1000cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    0.550733] [<c1000cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a67e6c>](kernel_init+0xc/0xe4)
<4>[    0.550745] [<c0a67e6c>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    0.550768] ---[ end trace 96034f8246f42da7 ]---
<4>[    0.550778] ------------[ cut here ]------------
<4>[    0.550786] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/core.c:576 device_create_file+0x64/0x8c()
<4>[    0.550790] Attribute tmds: write permission without 'store'
<4>[    0.550796] CPU: 0 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.49-gd0a13f5-00318-g4c7a4f7 #12
<4>[    0.550805] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    0.550815] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    0.550824] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d294>](warn_slowpath_fmt+0x2c/0x3c)
<4>[    0.550833] [<c012d294>](warn_slowpath_fmt+0x2c/0x3c) from [<c045c91c>](device_create_file+0x64/0x8c)
<4>[    0.550842] [<c045c91c>](device_create_file+0x64/0x8c) from [<c039de74>](mhl_device_initialize+0xf4/0x17c)
<4>[    0.550852] [<c039de74>](mhl_device_initialize+0xf4/0x17c) from [<c1024240>](mhl_pf_init+0x134/0x194)
<4>[    0.550862] [<c1024240>](mhl_pf_init+0x134/0x194) from [<c1000b08>](do_one_initcall+0xb8/0x160)
<4>[    0.550870] [<c1000b08>](do_one_initcall+0xb8/0x160) from [<c1000cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    0.550879] [<c1000cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a67e6c>](kernel_init+0xc/0xe4)
<4>[    0.550888] [<c0a67e6c>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    0.550894] ---[ end trace 96034f8246f42da8 ]---
<4>[    0.550938] ------------[ cut here ]------------
<4>[    0.550948] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/core.c:579 device_create_file+0x7c/0x8c()
<4>[    0.550952] Attribute mouse_move_distance_dx: read permission without 'show'
<4>[    0.550958] CPU: 0 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.49-gd0a13f5-00318-g4c7a4f7 #12
<4>[    0.550968] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    0.550978] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    0.550987] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d294>](warn_slowpath_fmt+0x2c/0x3c)
<4>[    0.550996] [<c012d294>](warn_slowpath_fmt+0x2c/0x3c) from [<c045c934>](device_create_file+0x7c/0x8c)
<4>[    0.551009] [<c045c934>](device_create_file+0x7c/0x8c) from [<c03a6744>](mhl_tx_rcp_init+0x70/0x108)
<4>[    0.551021] [<c03a6744>](mhl_tx_rcp_init+0x70/0x108) from [<c1024248>](mhl_pf_init+0x13c/0x194)
<4>[    0.551032] [<c1024248>](mhl_pf_init+0x13c/0x194) from [<c1000b08>](do_one_initcall+0xb8/0x160)
<4>[    0.551040] [<c1000b08>](do_one_initcall+0xb8/0x160) from [<c1000cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    0.551049] [<c1000cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a67e6c>](kernel_init+0xc/0xe4)
<4>[    0.551058] [<c0a67e6c>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    0.551063] ---[ end trace 96034f8246f42da9 ]---
<4>[    0.551071] ------------[ cut here ]------------
<4>[    0.551079] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/core.c:579 device_create_file+0x7c/0x8c()
<4>[    0.551083] Attribute mouse_move_distance_dy: read permission without 'show'
<4>[    0.551089] CPU: 0 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.49-gd0a13f5-00318-g4c7a4f7 #12
<4>[    0.551099] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    0.551108] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    0.551118] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d294>](warn_slowpath_fmt+0x2c/0x3c)
<4>[    0.551127] [<c012d294>](warn_slowpath_fmt+0x2c/0x3c) from [<c045c934>](device_create_file+0x7c/0x8c)
<4>[    0.551137] [<c045c934>](device_create_file+0x7c/0x8c) from [<c03a675c>](mhl_tx_rcp_init+0x88/0x108)
<4>[    0.551149] [<c03a675c>](mhl_tx_rcp_init+0x88/0x108) from [<c1024248>](mhl_pf_init+0x13c/0x194)
<4>[    0.551159] [<c1024248>](mhl_pf_init+0x13c/0x194) from [<c1000b08>](do_one_initcall+0xb8/0x160)
<4>[    0.551167] [<c1000b08>](do_one_initcall+0xb8/0x160) from [<c1000cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    0.551176] [<c1000cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a67e6c>](kernel_init+0xc/0xe4)
<4>[    0.551185] [<c0a67e6c>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    0.551191] ---[ end trace 96034f8246f42daa ]---
<4>[    0.551199] ------------[ cut here ]------------
<4>[    0.551206] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/core.c:579 device_create_file+0x7c/0x8c()
<4>[    0.551211] Attribute mouse_mode: read permission without 'show'
<4>[    0.551217] CPU: 0 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.49-gd0a13f5-00318-g4c7a4f7 #12
<4>[    0.551226] [<c010b750>](unwind_backtrace+0x0/0x11c) from [<c0109a3c>](show_stack+0x10/0x14)
<4>[    0.551236] [<c0109a3c>](show_stack+0x10/0x14) from [<c012d21c>](warn_slowpath_common+0x48/0x68)
<4>[    0.551245] [<c012d21c>](warn_slowpath_common+0x48/0x68) from [<c012d294>](warn_slowpath_fmt+0x2c/0x3c)
<4>[    0.551254] [<c012d294>](warn_slowpath_fmt+0x2c/0x3c) from [<c045c934>](device_create_file+0x7c/0x8c)
<4>[    0.551264] [<c045c934>](device_create_file+0x7c/0x8c) from [<c03a6784>](mhl_tx_rcp_init+0xb0/0x108)
<4>[    0.551275] [<c03a6784>](mhl_tx_rcp_init+0xb0/0x108) from [<c1024248>](mhl_pf_init+0x13c/0x194)
<4>[    0.551286] [<c1024248>](mhl_pf_init+0x13c/0x194) from [<c1000b08>](do_one_initcall+0xb8/0x160)
<4>[    0.551294] [<c1000b08>](do_one_initcall+0xb8/0x160) from [<c1000cb8>](kernel_init_freeable+0x108/0x1cc)
<4>[    0.551303] [<c1000cb8>](kernel_init_freeable+0x108/0x1cc) from [<c0a67e6c>](kernel_init+0xc/0xe4)
<4>[    0.551312] [<c0a67e6c>](kernel_init+0xc/0xe4) from [<c0106258>](ret_from_fork+0x14/0x3c)
<4>[    0.551318] ---[ end trace 96034f8246f42dab ]---

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I1f3f6a2bacae7eb53384f78282e2043ac614ea5a
