### PR TITLE
thermal: msm8974-tsens: Add missing include for no-debugging cases

### DIFF
--- a/drivers/thermal/msm8974-tsens.c
+++ b/drivers/thermal/msm8974-tsens.c
@@ -24,6 +24,7 @@
 #include <linux/msm_tsens.h>
 #include <linux/err.h>
 #include <linux/of.h>
+#include <linux/sched.h>
 
 #define CREATE_TRACE_POINTS
 #include <trace/trace_thermal.h>


### PR DESCRIPTION
sched.h is being implicitly included if debugging features are
activated in the kernel configuration.
We want to not have any implicit inclusion in our sources, also
because we may want to deactivate debugging in favor of performance.
