### PR TITLE
[BF64] General cleanup, fix warnings

### DIFF
--- a/arch/arm/include/asm/ftrace.h
+++ b/arch/arm/include/asm/ftrace.h
@@ -45,7 +45,7 @@ void *return_address(unsigned int);
 
 #else
 
-extern inline void *return_address(unsigned int level)
+static inline void *return_address(unsigned int level)
 {
 	return NULL;
 }

--- a/arch/arm/kernel/return_address.c
+++ b/arch/arm/kernel/return_address.c
@@ -63,11 +63,6 @@ void *return_address(unsigned int level)
 #warning "TODO: return_address should use unwind tables"
 #endif
 
-void *return_address(unsigned int level)
-{
-	return NULL;
-}
-
 #endif /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) / else */
 
 EXPORT_SYMBOL_GPL(return_address);

--- a/arch/arm/kernel/return_address.c
+++ b/arch/arm/kernel/return_address.c
@@ -59,10 +59,6 @@ void *return_address(unsigned int level)
 
 #else /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) */
 
-#if defined(CONFIG_ARM_UNWIND)
-#warning "TODO: return_address should use unwind tables"
-#endif
-
 #endif /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) / else */
 
 EXPORT_SYMBOL_GPL(return_address);

--- a/arch/arm/kernel/return_address.c
+++ b/arch/arm/kernel/return_address.c
@@ -57,8 +57,6 @@ void *return_address(unsigned int level)
 		return NULL;
 }
 
-#else /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) */
-
-#endif /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) / else */
+#endif /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) */
 
 EXPORT_SYMBOL_GPL(return_address);

--- a/arch/arm/mach-msm/board-sony_shinano-wifi.c
+++ b/arch/arm/mach-msm/board-sony_shinano-wifi.c
@@ -165,6 +165,8 @@ static void *shinano_wifi_mem_prealloc(int section, unsigned long size)
 int shinano_wifi_set_power(int on)
 {
 	int gpio = qpnp_pin_map("pm8941-gpio", WIFI_POWER_PMIC_GPIO);
+	int ret;
+
 	if (!wifi_batfet) {
 		wifi_batfet = regulator_get(NULL, "batfet");
 		if (IS_ERR_OR_NULL(wifi_batfet)) {
@@ -175,7 +177,10 @@ int shinano_wifi_set_power(int on)
 	}
 	if (on) {
 		if (!batfet_ena && wifi_batfet) {
-			regulator_enable(wifi_batfet);
+			ret = regulator_enable(wifi_batfet);
+			if (ret != 0)
+				pr_warn("%s: Can't enable batfet regulator!\n",
+								__func__);
 			batfet_ena = 1;
 		}
 	}

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -236,6 +236,7 @@ void bluesleep_sleep_wakeup(void)
 static int bluesleep_rfkill_set_power(void *data, bool blocked)
 {
 	int regOnGpio;
+	int ret;
 
 	BT_DBG("Bluetooth device set power\n");
 
@@ -256,8 +257,12 @@ static int bluesleep_rfkill_set_power(void *data, bool blocked)
 				regOnGpio);
 			return 0;
 		}
-		if (bt_batfet)
-			regulator_enable(bt_batfet);
+		if (bt_batfet) {
+			ret = regulator_enable(bt_batfet);
+			if (ret != 0)
+				pr_warn("%s: Can't enable regulator!\n",
+								__func__);
+		}
 		gpio_set_value(bsi->bt_reg_on, 1);
 		gpio_set_value(bsi->ext_wake, 1);
 	} else {

--- a/drivers/hid/hid-ntrig.c
+++ b/drivers/hid/hid-ntrig.c
@@ -859,14 +859,14 @@ not_claimed_input:
 	return 1;
 }
 
-static void ntrig_input_configured(struct hid_device *hid,
+static int ntrig_input_configured(struct hid_device *hid,
 		struct hid_input *hidinput)
 
 {
 	struct input_dev *input = hidinput->input;
 
 	if (hidinput->report->maxfield < 1)
-		return;
+		return 0;
 
 	switch (hidinput->report->field[0]->application) {
 	case HID_DG_PEN:
@@ -890,6 +890,8 @@ static void ntrig_input_configured(struct hid_device *hid,
 							"N-Trig MultiTouch";
 		break;
 	}
+
+	return 0;
 }
 
 static int ntrig_probe(struct hid_device *hdev, const struct hid_device_id *id)

--- a/drivers/misc/pm8941-flash.c
+++ b/drivers/misc/pm8941-flash.c
@@ -442,7 +442,7 @@ static ssize_t pm8941_set_mode(struct device *ldev,
 
 	if (data->scheduled) {
 		mutex_unlock(&data->lock);
-		flush_delayed_work_sync(&data->dwork);
+		flush_delayed_work(&data->dwork);
 		mutex_lock(&data->lock);
 	} else {
 		rc = pm_reg_masked_write(data, STROBE_CONTROL,

--- a/drivers/misc/pn547.c
+++ b/drivers/misc/pn547.c
@@ -474,7 +474,8 @@ static int pn547_probe(struct i2c_client *client,
 	if (gpio_is_valid(platform_data->pvdd_en_gpio)) {
 		ret = gpio_request(platform_data->pvdd_en_gpio, "nfc_pvdd_en");
 		if (ret)
-			pr_warn("%s: Failed to request nfc_pvdd_en GPIO\n");
+			pr_warn("%s: Failed to request nfc_pvdd_en GPIO\n",
+								 __func__);
 	}
 
 	pn547_dev = kzalloc(sizeof(*pn547_dev), GFP_KERNEL);
@@ -622,7 +623,6 @@ err_get_clock:
 #endif
 	kfree(pn547_dev);
 err_exit:
-err_pvdd_en:
 	gpio_free(platform_data->pvdd_en_gpio);
 #ifdef CONFIG_NFC_PN547_CLOCK_REQUEST
 	gpio_free(platform_data->clk_req_gpio);

--- a/sound/soc/codecs/wcd9xxx-mbhc.c
+++ b/sound/soc/codecs/wcd9xxx-mbhc.c
@@ -5198,7 +5198,6 @@ static int wcd9xxx_detect_impedance(struct wcd9xxx_mbhc *mbhc, uint32_t *zl,
 				    uint32_t *zr)
 {
 	int i;
-	int ret = 0;
 	int valid_z = 0;
 	u8 micb_mbhc_val;
 	s16 l[3], r[3];

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -672,6 +672,7 @@ static int msm_ext_spkramp_event(struct snd_soc_dapm_widget *w,
 
 }
 
+#ifndef CONFIG_MACH_SONY_SHINANO
 static int msm_ext_spkramp_ultrasound_event(struct snd_soc_dapm_widget *w,
 			     struct snd_kcontrol *k, int event)
 {
@@ -698,6 +699,7 @@ static int msm_ext_spkramp_ultrasound_event(struct snd_soc_dapm_widget *w,
 
 	return 0;
 }
+#endif
 
 static int msm_snd_enable_codec_ext_clk(struct snd_soc_codec *codec, int enable,
 					bool dapm)


### PR DESCRIPTION
No functional changes, nothing harmful has been fixed.
This is just a cleanup to fix various warnings seen during the build process. There's also a future-proofing commit (pm8941-flash) that is replacing the usage of a deprecated function with the correct one: even there, no functional changes.

Just cleanup.
Oh, did I say cleanup? :)
