### PR TITLE
Aosp/add truly

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
@@ -581,7 +581,6 @@
 		somc,no-vsn-gpio;
 		somc,no-vsp-gpio;
 		somc,panel-id-read-cmds;
-		qcom,mdss-pan-flip-ud;
 		qcom,cont-splash-disabled;
 	};
 };

--- a/arch/arm/mach-msm/board-8226-yukon_eagle-gpiomux.c
+++ b/arch/arm/mach-msm/board-8226-yukon_eagle-gpiomux.c
@@ -199,6 +199,13 @@ static struct gpiomux_setting lcd_rst_sus_cfg = {
 
 static struct msm_gpiomux_config msm_lcd_configs[] __initdata = {
 	{
+		.gpio = 23,
+		.settings = {
+			[GPIOMUX_ACTIVE]    = &lcd_rst_act_cfg,
+			[GPIOMUX_SUSPENDED] = &lcd_rst_sus_cfg,
+		},
+	},
+	{
 		.gpio = 25,		/* LCD Reset */
 		.settings = {
 			[GPIOMUX_ACTIVE]    = &lcd_rst_act_cfg,


### PR DESCRIPTION
This fixes the paneldetection for truly panels on M2.

Tested on my wifes M2 aqua. Now bring that device to service point because of dirty main cam lens (@kholk we donot happen to have a kernel solution for that? :P)
