### PR TITLE
arm: DT: shinano: leo: fix JDI panel

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
@@ -1010,23 +1010,23 @@
 			0xFF 0x00 0x00 0x3B 0x00 0x3B 0x8000 0x8000 0x8000>;
 	};
 
-	dsi_novatek_jdi_1080_cmd: somc,novatek_jdi_1080p_cmd_panel {
-		qcom,mdss-dsi-panel-name = "jdi novatek 1080p cmd";
+	dsi_novatek_jdi_1080_video: somc,novatek_jdi_1080p_vid_panel {
+		qcom,mdss-dsi-panel-name = "jdi novatek 1080p video";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
-		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-panel-width = <1080>;
 		qcom,mdss-dsi-panel-height = <1920>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-front-porch = <112>;
+		qcom,mdss-dsi-h-back-porch = <76>;
+		qcom,mdss-dsi-h-pulse-width = <4>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-front-porch = <233>;
-		qcom,mdss-dsi-v-pulse-width = <2>;
+		qcom,mdss-dsi-v-back-porch = <4>;
+		qcom,mdss-dsi-v-front-porch = <8>;
+		qcom,mdss-dsi-v-pulse-width = <4>;
 		qcom,mdss-dsi-h-left-border = <0>;
 		qcom,mdss-dsi-h-right-border = <0>;
 		qcom,mdss-dsi-v-top-border = <0>;
@@ -1036,31 +1036,16 @@
 		qcom,mdss-dsi-border-color = <0>;
 		somc,mdss-dsi-init-command = [23 01 00 00 00 00 02 FF 10
 				05 01 00 00 14 00 01 01
-				23 01 00 00 00 00 02 FF 10
-				23 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 BB 10
+				15 01 00 00 00 00 02 BB 03
 				15 01 00 00 00 00 02 35 00
-				15 01 00 00 00 00 02 44 03
-				23 01 00 00 00 00 02 FF E0
-				23 01 00 00 00 00 02 B5 86
-				23 01 00 00 00 00 02 B6 77
-				23 01 00 00 00 00 02 B8 AD
-				23 01 00 00 00 00 02 FB 01
-				23 01 00 00 00 00 02 FF 20
-				23 01 00 00 00 00 02 10 04
-				23 01 00 00 00 00 02 FB 01
-				23 01 00 00 00 00 02 FF 24
-				23 01 00 00 00 00 02 92 95
-				23 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 C4 20
-				23 01 00 00 00 00 02 FF 10
-				23 01 00 00 00 00 02 FB 01
-				05 01 00 00 64 00 01 11];
-		qcom,mdss-dsi-on-command = [05 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
-				05 01 00 00 14 00 01 28
+				39 01 00 00 00 00 05 2A 00 00 04 37
+				39 01 00 00 00 00 05 2B 00 00 07 7F
+				39 01 00 00 00 00 04 3B 03 08 08];
+		qcom,mdss-dsi-on-command = [05 01 00 00 64 00 01 11
+				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-off-command = [05 01 00 00 14 00 01 28
 				05 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
 		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-h-sync-pulse = <1>;
 		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
@@ -1070,15 +1055,9 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-te-pin-select = <1>;
-		qcom,mdss-dsi-wr-mem-start = <0x2c>;
-		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
-		qcom,mdss-dsi-te-dcs-command = <1>;
-		qcom,mdss-dsi-te-check-enable;
-		qcom,mdss-dsi-te-using-te-pin;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6C 2A 3A 2C 03 04 00];
 		qcom,mdss-dsi-lp11-init;
-		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -1100,12 +1079,13 @@
 				00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
 				00 02 45 00 00 00 00 01 97];
-		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-disp-on-in-hs = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
 		somc,lcd-id = <1>;
 		somc,lcd-id-adc = <565000 653000>;
-		somc,disp-en-on-post = <20>;
+		somc,disp-en-on-post = <10>;
 		somc,pw-on-rst-seq = <1 15>;
+		somc,disp-en-off-post = <200>;
 		somc,pw-off-rst-seq = <0 0>;
 		somc,pw-down-period = <100>;
 
@@ -1340,28 +1320,6 @@
 			0x00 0xDF 0x04 0x07 0x00 0x03 0x8000 0x5a00 0x5200
 			0x00 0xE0 0x00 0x03 0x00 0x03 0x8000 0x5400 0x4d00
 			0xFF 0x00 0x00 0x3B 0x00 0x3B 0x8000 0x8000 0x8000>;
-
-		somc,chenge-fps-command = [15 01 00 00 00 00 02 FF 24
-				15 01 00 00 00 00 02 92 95
-				15 01 00 00 00 00 02 FF 10
-				15 01 00 00 00 00 02 44 03];
-		somc,chenge-fps-default = <0x95>;
-		somc,display-clock = <17330000>;
-		somc,driver-ic-vbp = <8>;
-		somc,driver-ic-vfp = <8>;
-		somc,chenge-fps-cmds-num = <1>;
-		somc,chenge-fps-payload-num = <1>;
-
-		somc,chenge-wait-update = <0>;
-		somc,chenge-wait-on = <0 0>;
-		somc,chenge-wait-off = <0 0>;
-		somc,chenge-wait-cmds-num = <0 0>;
-		somc,fps-threshold = <47400>;
-		somc,te-c-update = <1>;
-		somc,te-c-mode-60fps = <0x03 0x00>;
-		somc,te-c-mode-45fps = <0x05 0x00>;
-		somc,te-c-cmds-num = <3>;
-		somc,te-c-payload-num = <1>;
 	};
 
 	dsi_novatek_auo_1080_vid: somc,novatek_auo_1080p_video_panel {


### PR DESCRIPTION
Some leo's panels implementation was referring to JDI CMD mode panels,
but we don't want to always use CMD mode for various reasons, such as
performance degradation and driver problems.

Refactor the panel timings and initialization to allow video mode
to be used with those ones, also solving the pixels corruption
issue happening on the current kernel revision as of 08/05/2015
(BF64.1.2.1-RB1.05.00.02.019.067).

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ib620b468152b80e4888e9d6c052c9c86ea54512c
