### PR TITLE
lpm: Free the allocated resource to avoid memory leak

### DIFF
--- a/drivers/cpuidle/lpm-levels.c
+++ b/drivers/cpuidle/lpm-levels.c
@@ -845,6 +845,8 @@ static void register_cpu_lpm_stats(struct lpm_cpu *cpu,
 
 	lpm_stats_config_level("cpu", level_name, cpu->nlevels,
 			parent->stats, &parent->child_cpus);
+
+	kfree(level_name);
 }
 
 static void register_cluster_lpm_stats(struct lpm_cluster *cl,


### PR DESCRIPTION
Free the allocated memory for level_name to avoid the
memory leak in regsiter_cpu_lpm_stats().

Change-Id: I24f0feff2e05963986eaaf54610a8a5ed079b692
Signed-off-by: Mohammed Khajapasha mkhaja@codeaurora.org
