### PR TITLE
misc: qcom: qdsp6v2: fix uninitialized variable

### DIFF
--- a/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
@@ -1939,7 +1939,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		struct msm_audio_buf_cfg cfg;
 		struct msm_audio_buf_cfg32 cfg_32;
 		mutex_lock(&audio->lock);
-		if (copy_from_user(&cfg, (void *)arg, sizeof(cfg))) {
+		if (copy_from_user(&cfg_32, (void *)arg, sizeof(cfg_32))) {
 			pr_err("%s: copy_from_user for AUDIO_SET_CONFIG_32 failed\n",
 				__func__);
 			rc = -EFAULT;


### PR DESCRIPTION
Wrong variable is used for copy_from_user().
It causes user setting is not set properly to audio drivers.

Signed-off-by: Fred Oh fred@codeaurora.org
Change-Id: I1d54b9b20d3664045c24ffa2066ecc1b7abe5e87
