### PR TITLE
video: mdss_dsi_panel_driver: Remove TLMM config, move props to paren…

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
@@ -421,6 +421,11 @@
 	qcom,btc-disabled = <1>;
 };
 
+&mdss_mdp {
+	somc,pwr-positive5-gpio = <&msmgpio 2 0>;
+	somc,pwr-negative5-gpio = <&msmgpio 3 0>;
+};
+
 &mdss_dsi0 {
 	qcom,platform-enable-gpio = <&msmgpio 52 0>;
 	qcom,dsi-pref-prim-pan = <&dsi_nt35521_720_vid_truly63>;

--- a/arch/arm/mach-msm/board-8226-yukon_seagull-gpiomux.c
+++ b/arch/arm/mach-msm/board-8226-yukon_seagull-gpiomux.c
@@ -690,6 +690,28 @@ static void msm_gpiomux_sdc3_install(void)
 static void msm_gpiomux_sdc3_install(void) {}
 #endif /* CONFIG_MMC_MSM_SDC3_SUPPORT */
 
+static struct gpiomux_setting display_drv_active = {
+	.func = GPIOMUX_FUNC_GPIO,
+	.drv = GPIOMUX_DRV_2MA,
+	.pull = GPIOMUX_PULL_DOWN,
+	.dir = GPIO_CFG_OUTPUT,
+};
+
+static struct msm_gpiomux_config seagull_display_configs[] __initdata = {
+	{ /* Positive 5 (V+) */
+		.gpio	  = 2,
+		.settings = {
+			[GPIOMUX_ACTIVE]    = &display_drv_active,
+		},
+	},
+	{ /* Negative 5 (V-) */
+		.gpio	  = 3,
+		.settings = {
+			[GPIOMUX_ACTIVE]    = &display_drv_active,
+		},
+	},
+};
+
 void __init msm8226_init_gpiomux(void)
 {
 	int rc;
@@ -728,6 +750,8 @@ void __init msm8226_init_gpiomux(void)
 	msm_gpiomux_install(audio_act_cfgs,
 			ARRAY_SIZE(audio_act_cfgs));
 	msm_gpiomux_install(&cam_front_det, 1);
+
+	msm_gpiomux_install(seagull_display_configs, 1);
 
 	if (of_board_is_cdp() || of_board_is_mtp() || of_board_is_xpm())
 		msm_gpiomux_install(usb_otg_sw_configs,

--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -3851,8 +3851,6 @@ error:
 int mdss_dsi_panel_gpios(struct device_node *node,
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 {
-#ifndef CONFIG_ARM64
-	/* TODO: Migrate TLMM conf to device-specific GPIOMUX / Pinctrl */
 	struct mdss_panel_specific_pdata *spec_pdata = ctrl_pdata->spec_pdata;
 	int rc = 0;
 
@@ -3864,16 +3862,6 @@ int mdss_dsi_panel_gpios(struct device_node *node,
 		rc = gpio_request(spec_pdata->disp_p5, "disp_p5");
 		if (rc)
 			pr_warn("Error requesting P5 GPIO\n");
-
-		rc = gpio_tlmm_config(GPIO_CFG(
-			spec_pdata->disp_p5, 0,
-			GPIO_CFG_OUTPUT,
-			GPIO_CFG_PULL_DOWN,
-			GPIO_CFG_2MA),
-			GPIO_CFG_ENABLE);
-		if (rc)
-			pr_err("Unable to configure P5 GPIO TLMM\n");
-
 	} else
 		pr_warn("%s:%d Unable to get valid DISP P5 GPIO\n",
 						__func__, __LINE__);
@@ -3886,24 +3874,11 @@ int mdss_dsi_panel_gpios(struct device_node *node,
 		rc = gpio_request(spec_pdata->disp_n5, "disp_n5");
 		if (rc)
 			pr_warn("Error requesting N5 GPIO\n");
-
-		rc = gpio_tlmm_config(GPIO_CFG(
-			spec_pdata->disp_n5, 0,
-			GPIO_CFG_OUTPUT,
-			GPIO_CFG_PULL_DOWN,
-			GPIO_CFG_2MA),
-			GPIO_CFG_ENABLE);
-		if (rc)
-			pr_err("Unable to configure N5 GPIO TLMM\n");
 	} else
 		pr_warn("%s:%d Unable to get valid DISP N5 GPIO\n",
 						__func__, __LINE__);
 
 	return rc;
-#else
-	return 0;
-#endif
-
 }
 
 static int mdss_dsi_panel_create_fs(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
@@ -4071,7 +4046,7 @@ exit_lcd_id:
 	alt_panelid_cmd = of_property_read_bool(node,
 						"somc,alt-panelid-cmd");
 	if (alt_panelid_cmd)
-		mdss_dsi_panel_gpios(node, ctrl_pdata);
+		mdss_dsi_panel_gpios(parent, ctrl_pdata);
 
 	rc = mdss_panel_parse_dt(node, ctrl_pdata,
 		spec_pdata->driver_ic, index, NULL);


### PR DESCRIPTION
…t node

Remove TLMM configuration for display N5/P5 GPIOs, plus move those
properties to its parent node.
Reflect the changes into Seagull DT.
