### PR TITLE
eagle: fix voldown key on alternative hw

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dtsi
@@ -259,6 +259,10 @@
 		compatible = "qcom,spi-qup-v2";
 		status = "disabled";
 	};
+
+	vol_down {
+		gpios = <&msmgpio 109 0x1>;
+	};
 };
 
 &rpm_bus {


### PR DESCRIPTION
Some eagle devices have voldown on gpio 109

Signed-off-by: Erik Castricum erikcas1972@gmail.com
