### PR TITLE
qdsp6v2 fixes

### DIFF
--- a/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
@@ -755,7 +755,9 @@ static long audio_aio_process_event_req_common(struct q6audio_aio *audio,
 	if (audio->eos_rsp && !list_empty(&audio->in_queue)) {
 		pr_debug("%s[%p]:Send flush command to release read buffers"\
 			" held up in DSP\n", __func__, audio);
+		mutex_lock(&audio->lock);
 		audio_aio_flush(audio);
+		mutex_unlock(&audio->lock);
 	}
 
 	return rc;

--- a/sound/soc/msm/qdsp6v2/msm-pcm-routing-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-pcm-routing-v2.c
@@ -637,7 +637,7 @@ int msm_pcm_routing_reg_phy_compr_stream(int fe_id, bool perf_mode,
 					 path_type, sample_rate, channels,
 					 topology, perf_mode, bit_width,
 					 app_type, acdb_dev_id);
-			if ((copp_idx < 0) &&
+			if ((copp_idx < 0) ||
 				(copp_idx >= MAX_COPPS_PER_PORT)) {
 				pr_err("%s:adm open failed coppid:%d\n",
 				__func__, copp_idx);


### PR DESCRIPTION
misc: qcom: qdsp6v2: fix missing global lock for flush
Missing mutex may cause failure on flush command if it is called
back to back.

---

ASoC: msm: qdsp6v2: fix copp_idx range check
copp_idx can never be less than 0 and at the same time greater than
MAX_COPPS_PER_PORT. So condition should be '||'.
