### PR TITLE
msm: mdss: fix transitions from low power mode to off

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -1256,23 +1256,23 @@ int mdss_mdp_cmd_stop(struct mdss_mdp_ctl *ctl, int panel_power_state)
 	}
 
 	mutex_lock(&ctl->offlock);
-	if (__mdss_mdp_cmd_is_panel_power_on_interactive(ctx)) {
-		if (mdss_panel_is_power_on_lp(panel_power_state)) {
-			/*
-			 * If we are transitioning from interactive to low
-			 * power, then we need to send events to the interface
-			 * so that the panel can be configured in low power
-			 * mode.
-			 */
-			send_panel_events = true;
-			if (mdss_panel_is_power_on_ulp(panel_power_state))
-				turn_off_clocks = true;
-		} else if (mdss_panel_is_power_off(panel_power_state)) {
-			send_panel_events = true;
+	if (mdss_panel_is_power_off(panel_power_state)) {
+		/* Transition to display off */
+		send_panel_events = true;
+		turn_off_clocks = true;
+		panel_off = true;
+	} else if (__mdss_mdp_cmd_is_panel_power_on_interactive(ctx)) {
+		/*
+		 * If we are transitioning from interactive to low
+		 * power, then we need to send events to the interface
+		 * so that the panel can be configured in low power
+		 * mode.
+		 */
+		send_panel_events = true;
+		if (mdss_panel_is_power_on_ulp(panel_power_state))
 			turn_off_clocks = true;
-			panel_off = true;
-		}
 	} else {
+		/* Transitions between low power and ultra low power */
 		if (mdss_panel_is_power_on_ulp(panel_power_state)) {
 			/*
 			 * If we are transitioning from low power to ultra low


### PR DESCRIPTION
Current implementation incorrectly handles the transitions from display
low power modes to display off. This could lead to DSI panel and
regulators not getting properly turned off. Fix this issue by ensuring
that DSI interface is correctly shut down during this transition.

Conflicts:
    drivers/video/msm/mdss/mdss_mdp_intf_cmd.c

Change-Id: I7c20c04d20fd2f443c61b83f229ce4bd2b46f814
Signed-off-by: Aravind Venkateswaran aravindh@codeaurora.org
