### PR TITLE
Karin: Fix SPI node for touchscreen

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
@@ -58,7 +58,7 @@
 		qcom,master-id = <86>;
 
 		qcom,use-pinctrl;
-		pinctrl-names = "default", "sleep";
+		pinctrl-names = "spi_default", "spi_sleep";
 		pinctrl-0 = <&msm_gpio_25_act &msm_gpio_26_act &msm_gpio_27_spi_act &msm_gpio_28_spi_act>;
 		pinctrl-1 = <&msm_gpio_25_sus &msm_gpio_26_sus &msm_gpio_27_spi_sus &msm_gpio_28_spi_sus>;
 


### PR DESCRIPTION
It's spi_default and spi_sleep for us.
