### PR TITLE
arm: DT: Sony: Fix sensor-mode for IMX200 sensors

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
@@ -206,7 +206,7 @@
 			qcom,csi-lane-assign = <0x4320>;
 			qcom,csi-lane-mask = <0x1F>;
 			qcom,sensor-position = <0>;
-			qcom,sensor-mode = <1>;
+			qcom,sensor-mode = <0>;
 			qcom,cci-master = <0>;
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-camera-sensor-leo.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-camera-sensor-leo.dtsi
@@ -205,7 +205,7 @@
 			qcom,csi-lane-assign = <0x4320>;
 			qcom,csi-lane-mask = <0x1F>;
 			qcom,sensor-position = <0>;
-			qcom,sensor-mode = <1>;
+			qcom,sensor-mode = <0>;
 			qcom,cci-master = <0>;
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-camera-sensor-sirius.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-camera-sensor-sirius.dtsi
@@ -205,7 +205,7 @@
 			qcom,csi-lane-assign = <0x4320>;
 			qcom,csi-lane-mask = <0x1F>;
 			qcom,sensor-position = <0>;
-			qcom,sensor-mode = <1>;
+			qcom,sensor-mode = <0>;
 			qcom,cci-master = <0>;
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-camera-sensor-aries.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-camera-sensor-aries.dtsi
@@ -205,7 +205,7 @@
 			qcom,csi-lane-assign = <0x4320>;
 			qcom,csi-lane-mask = <0x1F>;
 			qcom,sensor-position = <0>;
-			qcom,sensor-mode = <1>;
+			qcom,sensor-mode = <0>;
 			qcom,cci-master = <0>;
 		};
 


### PR DESCRIPTION
It shall be 0(zero), because it is a 2D back camera.
