### PR TITLE
input: ts: clearpad: Fix gcc warning

### DIFF
--- a/drivers/input/touchscreen/clearpad_core.c
+++ b/drivers/input/touchscreen/clearpad_core.c
@@ -3477,7 +3477,7 @@ static int clearpad_command_open(struct clearpad_t *this,
 	} else {
 		this->flash.buffer_size = image_size;
 		dev_info(&this->pdev->dev,
-			"prepared buffer size=%<u\n", this->flash.buffer_size);
+			"prepared buffer size=%u\n", this->flash.buffer_size);
 	}
 	UNLOCK(this);
 	return rc;


### PR DESCRIPTION
kernel/sony/msm/drivers/input/touchscreen/clearpad_core.c: In function 'clearpad_command_open':
kernel/sony/msm/drivers/input/touchscreen/clearpad_core.c:3479:3: warning: unknown conversion type character '<' in format [-Wformat=]
   dev_info(&this->pdev->dev,
   ^
kernel/sony/msm/drivers/input/touchscreen/clearpad_core.c:3479:3: warning: too many arguments for format [-Wformat-extra-args]

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I4bf6e5c042abb188798d4be4a9bf84a75f25d074
