### PR TITLE
input: TS: clearpad_core: Fix gpio_reset DT probe

### DIFF
--- a/drivers/input/touchscreen/clearpad_core.c
+++ b/drivers/input/touchscreen/clearpad_core.c
@@ -4418,8 +4418,10 @@ static int clearpad_touch_config_dt(struct clearpad_t *this)
 
 	this->gpio_reset = of_get_named_gpio(devnode,
 						"synaptics,reset_gpio", 0);
-	if (!gpio_is_valid(this->gpio_reset))
+	if (!gpio_is_valid(this->gpio_reset)) {
 		dev_warn(&this->pdev->dev, "no gpio_reset config\n");
+		this->gpio_reset = 0;
+	}
 
 	this->use_pinctrl = of_property_read_bool(devnode,
 						"synaptics,use-pinctrl");


### PR DESCRIPTION
If we can't find the required property, set the GPIO to zero,
so that we won't have to check for gpio_is_valid everytime
and we won't fail anymore.

This GPIO is not mandatory, some platforms don't need it.
