### PR TITLE
arm: DT: Ivy: Add postpoweron no reset quirk to MDP

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-ivy.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-ivy.dtsi
@@ -20,6 +20,7 @@
 &mdss_mdp {
 	somc,dric-gpio = <&msm_gpio 56 0>;
 	somc,mul-channel-scaling = <3>;
+	somc,postpwron-no-reset-quirk;
 
 	dsi_novatek_jdi_1080_cmd: somc,novatek_jdi_1080p_cmd_panel {
 		qcom,mdss-dsi-panel-name = "7";


### PR DESCRIPTION
We have continuous splash there and the panel+MDSS are already
up and running: we don't need to reset anything, otherwise
we will get into an inconsistent state.
