### PR TITLE
dt: amami: fix blacklines on novatek jdi panels.

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
@@ -520,8 +520,7 @@
 				15 01 00 00 00 00 02 26 00
 				15 01 00 00 00 00 02 FF 00];
 		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BA 03
-				15 01 00 00 00 00 02 C2 03
-				39 01 00 00 00 00 06 3B 03 02 03 08 04
+				15 01 00 00 00 00 02 C2 08
 				15 01 00 00 00 00 02 FB 01
 				15 01 00 00 00 00 02 FF 01
 				15 01 00 00 00 00 02 75 00
@@ -934,6 +933,8 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
 		qcom,mdss-dsi-panel-timings = [7a 1a 12 00 3e 42 16 20 14 03 04 00];
 		qcom,mdss-dsi-t-clk-post = <0x0c>;
 		qcom,mdss-dsi-t-clk-pre = <0x1a>;


### PR DESCRIPTION
copy values from stock for jdi variant. But keep dsi_video_mode.
Might be ugly but takes care of the black lines issue w/o affecting the other panels.

Signed-off-by: Erik Castricum erikcas1972@gmail.com
