### PR TITLE
iommu: Fix __msm_map_iommu_common()

### DIFF
--- a/drivers/iommu/msm_iommu_mapping.c
+++ b/drivers/iommu/msm_iommu_mapping.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -430,6 +430,7 @@ static int __msm_map_iommu_common(
 		iommu_meta = msm_iommu_meta_create(dma_buf, table, size);
 
 		if (IS_ERR(iommu_meta)) {
+			mutex_unlock(&msm_iommu_map_mutex);
 			ret = PTR_ERR(iommu_meta);
 			goto out;
 		}
@@ -484,7 +485,7 @@ static int __msm_map_iommu_common(
 out_unlock:
 	mutex_unlock(&iommu_meta->lock);
 out:
-	if (iommu_meta)
+	if (!IS_ERR(iommu_meta))
 		msm_iommu_meta_put(iommu_meta);
 	return ret;
 


### PR DESCRIPTION
When msm_iommu_meta_create() returns error, msm_iommu_map_mutex is not
getting unlocked and error pointer is being passed to
msm_iommu_meta_put(). Fix this.

CRs-Fixed: 803179
Change-Id: I7c1c615bc697693b2036351340065af3f080ed63
Signed-off-by: Neha Atri natri@codeaurora.org
