### PR TITLE
ASoC: qdsp6v2: fixes

### DIFF
--- a/drivers/soc/qcom/qdsp6v2/msm_audio_ion.c
+++ b/drivers/soc/qcom/qdsp6v2/msm_audio_ion.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -47,6 +47,7 @@ int msm_audio_ion_alloc(const char *name, struct ion_client **client,
 			ion_phys_addr_t *paddr, size_t *pa_len, void **vaddr)
 {
 	int rc = -EINVAL;
+	unsigned long err_ion_ptr = 0;
 
 	if ((msm_audio_ion_data.smmu_enabled == true) &&
 	    (msm_audio_ion_data.group == NULL)) {
@@ -74,12 +75,11 @@ int msm_audio_ion_alloc(const char *name, struct ion_client **client,
 					ION_HEAP(ION_SYSTEM_HEAP_ID), 0);
 		}
 		if (IS_ERR_OR_NULL((void *) (*handle))) {
-			if ((void *)(*handle) != NULL)
-				rc = *(int *)(*handle);
-			else
-				rc = -ENOMEM;
-			pr_err("%s:ION mem alloc fail rc=%d, smmu_enabled=%d\n",
-				__func__, rc, msm_audio_ion_data.smmu_enabled);
+			if (IS_ERR((void *)(*handle)))
+				err_ion_ptr = PTR_ERR((int *)(*handle));
+			pr_err("%s:ION alloc fail err ptr=%ld, smmu_enabled=%d\n",
+			__func__, err_ion_ptr, msm_audio_ion_data.smmu_enabled);
+			rc = -ENOMEM;
 			goto err_ion_client;
 		}
 	} else {

--- a/drivers/soc/qcom/qdsp6v2/voice_svc.c
+++ b/drivers/soc/qcom/qdsp6v2/voice_svc.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -103,6 +103,13 @@ static int32_t qdsp_apr_callback(struct apr_client_data *data, void *priv)
 		} else if (data->reset_proc == APR_DEST_MODEM) {
 			pr_debug("%s: Received Modem reset event\n", __func__);
 		}
+		/* Set the remaining member variables to default values
+			for RESET_EVENTS */
+		data->payload_size = 0;
+		data->payload = NULL;
+		data->src_port = 0;
+		data->dest_port = 0;
+		data->token = 0;
 	}
 
 	spin_lock_irqsave(&prtd->response_lock, spin_flags);


### PR DESCRIPTION
1. Handle ion alloc failure correctly 
2. Fix crash in voice_svc driver during SSR 
