### PR TITLE
spi: spi_qsd: Reduce latency for non-shared cores

### DIFF
--- a/Documentation/devicetree/bindings/spi/spi_qsd.txt
+++ b/Documentation/devicetree/bindings/spi/spi_qsd.txt
@@ -36,6 +36,7 @@ Optional properties:
  - qcom,rt-priority : whether spi message queue is set to run as a realtime task.
   With this spi transaction message pump with high (realtime) priority to reduce
   the transfer latency on the bus by minimising the delay between a transfer request
+ - qcom,shared : whether this qup is shared with other ee's
 
 Optional properties which are required for support of BAM-mode:
 - qcom,ver-reg-exists : Boolean. When present, allows driver to verify if HW

--- a/include/linux/qcom-spi.h
+++ b/include/linux/qcom-spi.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014 The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2015 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -17,14 +17,24 @@
 /**
  * msm_spi_platform_data: msm spi-controller's configuration data
  *
+ * @max_clock_speed max spi clock speed
  * @active_only when set, votes when system active and removes the vote when
  *       system goes idle (optimises for performance). When unset, voting using
  *       runtime pm (optimizes for power).
  * @master_id master id number of the controller's wrapper (BLSP or GSBI).
  *       When zero, clock path voting is disabled.
- * @rt when set, spi will pump transaction messages with high (realtime)
- *	priority to reduce the transfer latency on the bus by minimising
- *	the delay between a transfer request.
+ * @gpio_config pointer to function for configuring gpio
+ * @gpio_release pointer to function for releasing gpio pins
+ * @dma_config function poniter for configuring dma engine
+ * @pm_lat power management latency
+ * @infinite_mode use FIFO mode in infinite mode
+ * @ver_reg_exists if the version register exists
+ * @use_beam true if BAM is available
+ * @bam_consumer_pipe_index BAM conusmer pipe
+ * @bam_producer_pipe_index BAM producer pipe
+ * @rt_priority true if RT thread
+ * @use_pinctrl true if pinctrl library is used
+ * @is_shared true when qup is shared between ee's
  */
 struct msm_spi_platform_data {
 	u32 max_clock_speed;
@@ -42,4 +52,5 @@ struct msm_spi_platform_data {
 	u32  bam_producer_pipe_index;
 	bool rt_priority;
 	bool use_pinctrl;
+	bool is_shared;
 };


### PR DESCRIPTION
Resource aqquistion on a per transfer level incures
a noticable latency penalty.  This change removes
this latency by doing resource aqquisition as part
of runtime-pm on non-shared cores.

Change-Id: I112c10f52342ca7143b2286c72bba49ba7c8e49f
Signed-off-by: Dan Sneddon dsneddon@codeaurora.org
Signed-off-by: Kiran Gunda kgunda@codeaurora.org
