### PR TITLE
cpuquiet: rqbalance: Fix logic bug for non-HMP SoC

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -918,7 +918,7 @@ static int rqbalance_start(void)
 		max_sys_cpus++;
 
 	/* Set value as target MAX on-line number of CPUs */
-	nr_run_thresholds[max_sys_cpus - 1] = UINT_MAX;
+	nr_run_thresholds[max_sys_cpus] = UINT_MAX;
 
 	/* HACK: Adjust dual-core thresholds for non-HMP SoCs */
 	if (!soc_is_hmp) {


### PR DESCRIPTION
After counting the number of CPUs in the system, we are setting
UINT_MAX in the nr_run_thresholds struct at CPUn-1, instead of CPUn.
This is a logic bug.
