### PR TITLE
coresight: add tpda enable validation checks in sysfs show functions

### DIFF
--- a/drivers/coresight/coresight-tpda.c
+++ b/drivers/coresight/coresight-tpda.c
@@ -436,6 +436,11 @@ static ssize_t tpda_show_global_flush_req(struct device *dev,
 
 	mutex_lock(&drvdata->lock);
 
+	if (!drvdata->enable) {
+		mutex_unlock(&drvdata->lock);
+		return -EPERM;
+	}
+
 	TPDA_UNLOCK(drvdata);
 	val = tpda_readl(drvdata, TPDA_CR);
 	TPDA_LOCK(drvdata);
@@ -484,6 +489,11 @@ static ssize_t tpda_show_port_flush_req(struct device *dev,
 	unsigned long val;
 
 	mutex_lock(&drvdata->lock);
+
+	if (!drvdata->enable) {
+		mutex_unlock(&drvdata->lock);
+		return -EPERM;
+	}
 
 	TPDA_UNLOCK(drvdata);
 	val = tpda_readl(drvdata, TPDA_FLUSH_CR);


### PR DESCRIPTION
TPDA clocks are voted during TPDA enable and un-voted during TPDA
disable. Read TPDA registers only when TPDA is enabled to avoid
any unclocked access. Add TPDA enable validation checks before
reading TPDA flush registers via sysfs show functions. These validation
checks are already present in sysfs store functions used for making TPDA
flush request.

CRs-Fixed: 819721
Change-Id: Icbb530d9a1c1aad516f137c3faaf4c7d0373265c
Signed-off-by: Sarangdhar Joshi spjoshi@codeaurora.org
