### PR TITLE
i2c-msm-v2: avoid unnecessary DMA init and channel free

### DIFF
--- a/drivers/i2c/busses/i2c-msm-v2.c
+++ b/drivers/i2c/busses/i2c-msm-v2.c
@@ -1389,7 +1389,7 @@ static int i2c_msm_dma_init(struct i2c_msm_ctrl *ctrl)
 	dma_addr_t      tags_space_phy_addr;
 
 	/* check if DMA core is initialized */
-	if (dma->state > I2C_MSM_DMA_INIT_CORE)
+	if (dma->state > I2C_MSM_DMA_INIT_NONE)
 		goto dma_core_is_init;
 
 	/*
@@ -2234,7 +2234,13 @@ static void i2c_msm_pm_xfer_end(struct i2c_msm_ctrl *ctrl)
 
 	atomic_set(&ctrl->xfer.is_active, 0);
 
-	i2c_msm_dma_free_channels(ctrl);
+	/*
+	 * DMA resources are freed due to multi-EE use case.
+	 * Other EEs can potentially use the DMA
+	 * resources with in the same runtime PM vote.
+	 */
+	if (ctrl->xfer.mode_id == I2C_MSM_XFER_MODE_DMA)
+		i2c_msm_dma_free_channels(ctrl);
 
 	i2c_msm_pm_clk_disable_unprepare(ctrl);
 	if (pm_runtime_enabled(ctrl->dev)) {


### PR DESCRIPTION
Ensure that DMA initialization occurs once and
DMA channel API is called in appropriate mode.

Change-Id: I347aad9848737be2d0fd5c5bd4c5f909c7c69e19
Signed-off-by: Naveen Kaje nkaje@codeaurora.org
