### PR TITLE
Eagle: add support for msm8226-v2 chipset

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -29,6 +29,7 @@ dtb-$(CONFIG_MACH_SONY_AMAMI_ROW)	+= msm8974-v2.0-1-rhine_amami_row.dtb
 dtb-$(CONFIG_MACH_SONY_AMAMI_ROW)	+= msm8974-v2.2-rhine_amami_row.dtb
 
 # MSM8226
+dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8226-yukon_eagle-720p-mtp.dtb
 dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
 dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
 dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8926-yukon_tianchi.dtb

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dts
@@ -1,0 +1,71 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/dts-v1/;
+#include "msm8226-v2.dtsi"
+#include "msm8226-memory.dtsi"
+#include "msm8226-qseecom.dtsi"
+#include "msm8226-sharedmem.dtsi"
+#include "msm8226-yukon_eagle-720p-mtp.dtsi"
+#include "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,eagle_dsds";
+	qcom,board-id = <8 0>;
+
+	memory {
+		alt_peripheral_mem: peripheral_region@8000000 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x08000000 0x5c00000>;
+			label = "peripheral_mem";
+		};
+	};
+
+};
+
+&modem_mem {
+	status = "disabled";
+};
+
+&peripheral_mem {
+	status = "disabled";
+};
+
+&qsecom_mem {
+	linux,memory-limit = <0x0>;
+};
+
+&clock_gcc {
+	compatible = "qcom,gcc-8226-v2";
+};
+
+&soc {
+	qcom,mdss_dsi@fd922800 {
+		/delete-property/ qcom,platform-te-gpio;
+	};
+
+	qcom,spi@f9923000 {
+		status = "disabled";
+	};
+
+	qcom,pronto@fb21b000 {
+		linux,contiguous-region = <&alt_peripheral_mem>;
+	};
+};
+
+&usb_otg {
+	/delete-property/ qcom,hsusb-otg-disable-reset;
+	qcom,ahb-async-bridge-bypass;
+};

--- a/arch/arm/mach-msm/Makefile.boot
+++ b/arch/arm/mach-msm/Makefile.boot
@@ -15,6 +15,7 @@
 
 # MSM8226
    zreladdr-$(CONFIG_ARCH_MSM8226)	:= 0x00008000
+	dtb-$(CONFIG_MACH_SONY_EAGLE)   += msm8226-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
         dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-yukon_tianchi_dsds.dtb

--- a/arch/arm/mach-msm/board-8226-yukon_eagle-gpiomux.c
+++ b/arch/arm/mach-msm/board-8226-yukon_eagle-gpiomux.c
@@ -123,6 +123,17 @@ static struct gpiomux_setting gpio_keys_suspend = {
 	.pull = GPIOMUX_PULL_NONE,
 };
 
+static struct gpiomux_setting gpio_spi_cs_act_config = {
+	.func = GPIOMUX_FUNC_1,
+	.drv = GPIOMUX_DRV_6MA,
+	.pull = GPIOMUX_PULL_DOWN,
+};
+static struct gpiomux_setting gpio_spi_susp_config = {
+	.func = GPIOMUX_FUNC_GPIO,
+	.drv = GPIOMUX_DRV_2MA,
+	.pull = GPIOMUX_PULL_DOWN,
+};
+
 static struct gpiomux_setting wcnss_5wire_suspend_cfg = {
 	.func = GPIOMUX_FUNC_GPIO,
 	.drv  = GPIOMUX_DRV_2MA,
@@ -276,6 +287,16 @@ static struct msm_gpiomux_config msm_blsp_configs[] __initdata = {
 		.settings = {
 			[GPIOMUX_ACTIVE] = &gpio_i2c_config,
 			[GPIOMUX_SUSPENDED] = &gpio_i2c_config,
+		},
+	},
+};
+
+static struct msm_gpiomux_config msm_blsp_spi_cs_config[] __initdata = {
+	{
+		.gpio      = 2,		/* BLSP1 QUP1 SPI_CS1 */
+		.settings = {
+			[GPIOMUX_ACTIVE] = &gpio_spi_cs_act_config,
+			[GPIOMUX_SUSPENDED] = &gpio_spi_susp_config,
 		},
 	},
 };
@@ -695,6 +716,10 @@ void __init msm8226_init_gpiomux(void)
 
 	msm_gpiomux_install(msm_blsp_configs,
 			ARRAY_SIZE(msm_blsp_configs));
+
+	if (machine_is_msm8226())
+			msm_gpiomux_install(msm_blsp_spi_cs_config,
+			ARRAY_SIZE(msm_blsp_spi_cs_config));
 
 	msm_gpiomux_install(wcnss_5wire_interface,
 				ARRAY_SIZE(wcnss_5wire_interface));

--- a/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
@@ -117,7 +117,8 @@ static void msm_actuator_parse_i2c_params(struct msm_actuator_ctrl_t *a_ctrl,
 					i2c_byte2 = (value & 0xFF00) >> 8;
 				}
 			} else {
-				if (of_machine_is_compatible("somc,eagle"))
+				if (of_machine_is_compatible("somc,eagle") ||
+					of_machine_is_compatible("somc,eagle_dsds"))
 					i2c_byte1 = ((value & 0x0300) >> 8) | 0xF4;
 				else
 					i2c_byte1 = (value & 0xFF00) >> 8;

--- a/drivers/media/platform/msm/camera_v2/sensor/eeprom/msm_eeprom.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/eeprom/msm_eeprom.c
@@ -344,7 +344,8 @@ static int read_eeprom_memory(struct msm_eeprom_ctrl_t *e_ctrl,
 			}
 			memptr += emap[j].mem.valid_size;
 		}
-		if (of_machine_is_compatible("somc,eagle")) {
+		if (of_machine_is_compatible("somc,eagle") ||
+				of_machine_is_compatible("somc,eagle_dsds")) {
 			if (j == 0) {
 				/*After A1 for AWB and AF,A3 A5 A7 for lsc*/
 				eb_info->i2c_slaveaddr = 0xA3;

--- a/drivers/media/platform/msm/camera_v2/sensor/imx134.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/imx134.c
@@ -159,7 +159,8 @@ static int __init imx134_init_module(void)
 					imx134_seagull_power_setting;
 		imx134_s_ctrl.power_setting_array.size =
 					ARRAY_SIZE(imx134_seagull_power_setting);
-	} else if (of_machine_is_compatible("somc,eagle")) {
+	} else if (of_machine_is_compatible("somc,eagle") ||
+			of_machine_is_compatible("somc,eagle_dsds")) {
 		imx134_s_ctrl.power_setting_array.power_setting =
 					imx134_eagle_power_setting;
 		imx134_s_ctrl.power_setting_array.size =

--- a/drivers/power/qpnp-charger.c
+++ b/drivers/power/qpnp-charger.c
@@ -6628,13 +6628,14 @@ qpnp_charger_probe(struct spmi_device *spmi)
 		goto fail_chg_enable;
 	}
 
-	if (!of_machine_is_compatible("qcom,msm8926")) {
-		chip->ext_vbus_psy = power_supply_get_by_name("ext-vbus");
-		if (!chip->ext_vbus_psy) {
-			pr_err("ext-vbus supply not found deferring probe\n");
-			rc = -EPROBE_DEFER;
-			goto fail_chg_enable;
-		}
+	if (!of_machine_is_compatible("qcom,msm8926") &&
+		!of_machine_is_compatible("qcom,msm8226")) {
+			chip->ext_vbus_psy = power_supply_get_by_name("ext-vbus");
+			if (!chip->ext_vbus_psy) {
+				pr_err("ext-vbus supply not found deferring probe\n");
+				rc = -EPROBE_DEFER;
+				goto fail_chg_enable;
+			}
 	}
 
 	mutex_init(&chip->jeita_configure_lock);


### PR DESCRIPTION
Eagle: add support for msm8226-v2 chipset. Also, keep cameradriver working for this chipset.
Qpnp-charger does not check for ext-vbus on 8926, and should not do so for 8226-v2. 

Confirmed working on D2305 fully. D2302 still needs dualsim detection
