### PR TITLE
[GENERIC + TULIP FIX] video: msm: mdss: Fix continuous splash and video mode on pinctrl

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -881,6 +881,11 @@ int mdss_dsi_pinctrl_set_state(
 	struct pinctrl_state *pin_state;
 	int rc = -EFAULT;
 
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	if (ctrl_pdata->spec_pdata->disp_on_in_boot)
+		return 0;
+#endif
+
 	if (IS_ERR_OR_NULL(ctrl_pdata->pin_res.pinctrl))
 		return PTR_ERR(ctrl_pdata->pin_res.pinctrl);
 

--- a/drivers/video/msm/mdss/mdss_dsi.h
+++ b/drivers/video/msm/mdss/mdss_dsi.h
@@ -304,6 +304,7 @@ struct mdss_panel_power_seq {
 };
 
 struct mdss_panel_specific_pdata {
+	bool disp_on_in_boot;
 	bool detected;
 	int driver_ic;
 	int32_t lcd_id;

--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -1670,6 +1670,15 @@ static inline int mdss_dsi_panel_power_off_ex(struct mdss_panel_data *pdata)
 		return -EINVAL;
 	}
 
+
+	/*
+	 * Continuous splash and video mode required the first
+	 * pinctrl setup not to be done: set disp_on_in_boot to
+	 * false in order to resume normal mdss pinctrl operation.
+	 * Now we can safely shut mdss/display down and back up.
+	 */
+	spec_pdata->disp_on_in_boot = false;
+
 	/* If we have to detect the panel NOW, don't power it off */
 	if (skip_first_off && spec_pdata->panel_detect) {
 		skip_first_off = 0;
@@ -4046,6 +4055,8 @@ int mdss_dsi_panel_init(struct device_node *node,
 		return -EINVAL;
 	}
 
+	spec_pdata->disp_on_in_boot = display_on_in_boot;
+
 	dsi_ctrl_np = of_parse_phandle(node,
 		"qcom,mdss-dsi-panel-controller", 0);
 	if (!dsi_ctrl_np) {
@@ -4084,7 +4095,7 @@ int mdss_dsi_panel_init(struct device_node *node,
 				__func__, vsn_gpio);
 	}
 
-	if ((!display_on_in_boot) || (!index))
+	if ((!spec_pdata->disp_on_in_boot) || (!index))
 		mdss_dsi_pinctrl_set_state(ctrl_pdata, true);
 
 	/* Panel detection setup */
@@ -4132,7 +4143,7 @@ exit_lcd_id:
 		pr_info("%s: physical:%d\n", __func__, spec_pdata->adc_uv);
 	}
 
-	if (!display_on_in_boot)
+	if (!spec_pdata->disp_on_in_boot)
 		mdss_dsi_pinctrl_set_state(ctrl_pdata, false);
 
 	alt_panelid_cmd = of_property_read_bool(node,
@@ -4147,7 +4158,7 @@ exit_lcd_id:
 		goto error;
 	}
 
-	cont_splash_enabled = display_on_in_boot;
+	cont_splash_enabled = spec_pdata->disp_on_in_boot;
 
 	if (!cont_splash_enabled) {
 		pr_info("%s:%d Continuous splash flag not found.\n",


### PR DESCRIPTION
We have to NOT reset the pinctrl state if we want to see the
splash screen that has been spawned by the bootloader on our
display.

While at it, restructure the usage of display_on_in_boot in
the unified panel driver for Sony devices.
