### PR TITLE
SMB1360 -- Report battery technology and charger model

### DIFF
--- a/drivers/power/smb1360-charger-fg.c
+++ b/drivers/power/smb1360-charger-fg.c
@@ -1429,6 +1429,11 @@ static int smb1360_battery_get_property(struct power_supply *psy,
 	case POWER_SUPPLY_PROP_SYSTEM_TEMP_LEVEL:
 		val->intval = chip->therm_lvl_sel;
 		break;
+	case POWER_SUPPLY_PROP_TECHNOLOGY:
+		val->intval = POWER_SUPPLY_TECHNOLOGY_LION;
+		break;
+	case POWER_SUPPLY_PROP_MODEL_NAME:
+		val->strval = "smb1360-fg";
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
Battery technology is always Li-ion (as SMB1360 should only support
lithium ion batteries), charger model is smb1360-fg (fuel gauge).
