### PR TITLE
arm: DT: Shinano: Fix camera nodes, fix gpios

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_camera.dtsi
@@ -45,7 +45,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <105000 0 85600>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 15 0>, <&msm_gpio 94 0>;
+		gpios = <&msmgpio 15 0>, <&msmgpio 94 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;
@@ -56,10 +56,10 @@
 		status = "ok";
 	};
 
-	qcom,camera@1 {
+	qcom,camera@2 {
 		cell-index = <1>;
 		compatible = "qcom,camera";
-		reg = <0x1>;
+		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <0>;
@@ -71,7 +71,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <105000 0 85600>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 15 0>, <&msm_gpio 104 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius_camera.dtsi
@@ -57,10 +57,10 @@
 		status = "ok";
 	};
 
-	qcom,camera@1 {
+	qcom,camera@2 {
 		cell-index = <1>;
 		compatible = "qcom,camera";
-		reg = <0x1>;
+		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <90>;
@@ -72,7 +72,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries_camera.dtsi
@@ -53,10 +53,10 @@
 		status = "ok";
 	};
 
-	qcom,camera@1 {
+	qcom,camera@2 {
 		cell-index = <1>;
 		compatible = "qcom,camera";
-		reg = <0x1>;
+		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <90>;
@@ -68,7 +68,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo_camera.dtsi
@@ -57,10 +57,10 @@
 		status = "ok";
 	};
 
-	qcom,camera@1 {
+	qcom,camera@2 {
 		cell-index = <1>;
 		compatible = "qcom,camera";
-		reg = <0x1>;
+		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <90>;
@@ -72,7 +72,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_camera.dtsi
@@ -41,7 +41,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <105000 0 85600>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 15 0>, <&msm_gpio 94 0>;
+		gpios = <&msmgpio 15 0>, <&msmgpio 94 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;
@@ -52,10 +52,10 @@
 		status = "ok";
 	};
 
-	qcom,camera@1 {
+	qcom,camera@2 {
 		cell-index = <1>;
 		compatible = "qcom,camera";
-		reg = <0x1>;
+		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <0>;
@@ -67,7 +67,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <105000 0 85600>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 15 0>, <&msm_gpio 104 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;


### PR DESCRIPTION
Front Facing Camera uses mclk2, hence use camera@2 to get the
right clock for it.
Also, fix a mistake in GPIO spec, msm_gpio is for pinctrl,
while msmgpio is for gpiomux.
