### PR TITLE
arm: DT: fix ramoops buffers

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -18,7 +18,7 @@
                compatible = "ramoops";
                status = "ok";
 
-               android,ramoops-buffer-start = <0x3eae0000>;
+               android,ramoops-buffer-start = <0x3e9e0000>;
                android,ramoops-buffer-size = <0x100000>;
                android,ramoops-console-size = <0x80000>;
                android,ramoops-record-size = <0x7F800>;

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
@@ -25,7 +25,7 @@
                compatible = "ramoops";
                status = "ok";
 
-               android,ramoops-buffer-start = <0x3eae0000>;
+               android,ramoops-buffer-start = <0x3e9e0000>;
                android,ramoops-buffer-size = <0x100000>;
                android,ramoops-console-size = <0x80000>;
                android,ramoops-record-size = <0x7F800>;

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -16,7 +16,7 @@
 		compatible = "ramoops";
 		status = "ok";
 
-		android,ramoops-buffer-start = <0x7fe00000>;
+		android,ramoops-buffer-start = <0x3e9e0000>;
 		android,ramoops-buffer-size = <0x100000>;
 		android,ramoops-console-size = <0x80000>;
 		android,ramoops-record-size = <0x7F800>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
@@ -15,9 +15,9 @@
 &soc {
 	ramoops {
 		compatible = "ramoops";
-		status = "disable";
+		status = "ok";
 
-		android,ramoops-buffer-start = <0x7fe00000>;
+		android,ramoops-buffer-start = <0x3e9e0000>;
 		android,ramoops-buffer-size = <0x100000>;
 		android,ramoops-console-size = <0x80000>;
 		android,ramoops-record-size = <0x7F800>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
@@ -13,10 +13,6 @@
  */
 
 &soc {
-        ramoops {
-                status = "ok";
-	};
-
 	/* I2C : BLSP8 */
 	i2c@f9964000 {
 		synaptics_clearpad@2c {

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
@@ -13,10 +13,6 @@
  */
 
 &soc {
-        ramoops {
-                android,ramoops-buffer-start = <0xdff00000>;
-        };
-
 	/* I2C : BLSP8 */
 	i2c@f9964000 {
 		synaptics_clearpad@2c {

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
@@ -13,10 +13,6 @@
  */
 
 &soc {
-        ramoops {
-                android,ramoops-buffer-start = <0xdff00000>;
-        };
-
 	/* I2C : BLSP8 */
 	i2c@f9964000 {
 		synaptics_clearpad@2c {


### PR DESCRIPTION
i cant test, but buffer start was not in reserved mem 
i guess this error can produce random reboot on device where it was enabled
