### PR TITLE
msm: vidc: fix error handling during hardware overload error

### DIFF
--- a/drivers/media/platform/msm/vidc/msm_vidc_common.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc_common.c
@@ -1914,7 +1914,7 @@ static int msm_comm_session_abort(struct msm_vidc_inst *inst)
 	} else {
 		rc = 0;
 	}
-
+	msm_comm_session_clean(inst);
 	return rc;
 }
 

--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -2739,8 +2739,14 @@ static int venus_hfi_session_end(void *session)
 		HFI_CMD_SYS_SESSION_END);
 }
 
-static int venus_hfi_session_abort(void *session)
+static int venus_hfi_session_abort(void *sess)
 {
+	struct hal_session *session;
+	session = sess;
+	if (!session || !session->device) {
+		dprintk(VIDC_ERR, "Invalid Params\n");
+		return -EINVAL;
+	}
 	venus_hfi_flush_debug_queue(
 		((struct hal_session *)session)->device, NULL);
 	return venus_hfi_send_session_cmd(session,


### PR DESCRIPTION
when hardware overload error happens, session_abort gets called
multiple times as part of error handling and cleanup. This results
in firmware timing out for successive commands. Firmware timeout
sends sys_error to all clients causing all sessions to close. This
change cleans the last session and allows previous running sessions
to continue.

Change-Id: Ia7ab600af2345896a4bb17dc726d0bdc473f93fe
Signed-off-by: Ashray Kulkarni ashrayk@codeaurora.org
