### PR TITLE
eagle: fix truly panel init // add support for msm8226-v2

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -36,6 +36,7 @@ dtb-$(CONFIG_MACH_SONY_AMAMI_ROW)	+= msm8974-v2.0-1-rhine_amami_row.dtb
 dtb-$(CONFIG_MACH_SONY_AMAMI_ROW)	+= msm8974-v2.2-rhine_amami_row.dtb
 
 # MSM8226
+dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8226-yukon_eagle-720p-mtp.dtb
 dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
 dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
 dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8926-yukon_tianchi.dtb

--- a/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-eagle.dtsi
@@ -94,7 +94,7 @@
 		];
 
 		qcom,mdss-dsi-off-command = [
-		        05 01 00 00 96 00 02 28 00 /* display off */
+			05 01 00 00 96 00 02 28 00 /* display off */
 			05 01 00 00 96 00 02 10 00 /* enter sleep */];
 		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
 		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
@@ -224,7 +224,7 @@
 			29 01 00 00 00 00 02 00 00
 			29 01 00 00 00 00 11
 			E1 00 0c 11 0E 07 0e 08 05 0C 0e 0a 00 06 0e 06 00
-			29 01 00 00 00 00 00 00 00
+			29 01 00 00 00 00 02 00 00
 			29 01 00 00 00 00 11
 			E2 00 0c 11 0E 07 0e 08 05 0C 0e 0a 00 06 0e 06 00
 			29 01 00 00 00 00 02 00 80
@@ -318,4 +318,3 @@
 		somc,panel-id-read-cmds;
 	};
 };
-

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_eagle-720p-mtp.dts
@@ -1,0 +1,71 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/dts-v1/;
+#include "msm8226-v2.dtsi"
+#include "msm8226-memory.dtsi"
+#include "msm8226-qseecom.dtsi"
+#include "msm8226-sharedmem.dtsi"
+#include "msm8226-yukon_eagle-720p-mtp.dtsi"
+#include "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,eagle_dsds";
+	qcom,board-id = <8 0>;
+
+	memory {
+		alt_peripheral_mem: peripheral_region@8000000 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x08000000 0x5c00000>;
+			label = "peripheral_mem";
+		};
+	};
+
+};
+
+&modem_mem {
+	status = "disabled";
+};
+
+&peripheral_mem {
+	status = "disabled";
+};
+
+&qsecom_mem {
+	linux,memory-limit = <0x0>;
+};
+
+&clock_gcc {
+	compatible = "qcom,gcc-8226-v2";
+};
+
+&soc {
+	qcom,mdss_dsi@fd922800 {
+		/delete-property/ qcom,platform-te-gpio;
+	};
+
+	qcom,spi@f9923000 {
+		status = "disabled";
+	};
+
+	qcom,pronto@fb21b000 {
+		linux,contiguous-region = <&alt_peripheral_mem>;
+	};
+};
+
+&usb_otg {
+	/delete-property/ qcom,hsusb-otg-disable-reset;
+	qcom,ahb-async-bridge-bypass;
+};

--- a/arch/arm/mach-msm/Makefile.boot
+++ b/arch/arm/mach-msm/Makefile.boot
@@ -12,6 +12,7 @@
 
 # MSM8226
    zreladdr-$(CONFIG_ARCH_MSM8226)	:= 0x00008000
+	dtb-$(CONFIG_MACH_SONY_EAGLE)   += msm8226-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
         dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-yukon_tianchi_dsds.dtb

--- a/arch/arm/mach-msm/board-sony_yukon_eagle-gpiomux.c
+++ b/arch/arm/mach-msm/board-sony_yukon_eagle-gpiomux.c
@@ -123,6 +123,17 @@ static struct gpiomux_setting gpio_keys_suspend = {
 	.pull = GPIOMUX_PULL_NONE,
 };
 
+static struct gpiomux_setting gpio_spi_cs_act_config = {
+	.func = GPIOMUX_FUNC_1,
+	.drv = GPIOMUX_DRV_6MA,
+	.pull = GPIOMUX_PULL_DOWN,
+};
+static struct gpiomux_setting gpio_spi_susp_config = {
+	.func = GPIOMUX_FUNC_GPIO,
+	.drv = GPIOMUX_DRV_2MA,
+	.pull = GPIOMUX_PULL_DOWN,
+};
+
 static struct gpiomux_setting wcnss_5wire_suspend_cfg = {
 	.func = GPIOMUX_FUNC_GPIO,
 	.drv  = GPIOMUX_DRV_2MA,
@@ -276,6 +287,16 @@ static struct msm_gpiomux_config msm_blsp_configs[] __initdata = {
 		.settings = {
 			[GPIOMUX_ACTIVE] = &gpio_i2c_config,
 			[GPIOMUX_SUSPENDED] = &gpio_i2c_config,
+		},
+	},
+};
+
+static struct msm_gpiomux_config msm_blsp_spi_cs_config[] __initdata = {
+	{
+		.gpio      = 2,		/* BLSP1 QUP1 SPI_CS1 */
+		.settings = {
+			[GPIOMUX_ACTIVE] = &gpio_spi_cs_act_config,
+			[GPIOMUX_SUSPENDED] = &gpio_spi_susp_config,
 		},
 	},
 };
@@ -695,6 +716,10 @@ void __init msm8226_init_gpiomux(void)
 
 	msm_gpiomux_install(msm_blsp_configs,
 			ARRAY_SIZE(msm_blsp_configs));
+
+	if (machine_is_msm8226())
+			msm_gpiomux_install(msm_blsp_spi_cs_config,
+			ARRAY_SIZE(msm_blsp_spi_cs_config));
 
 	msm_gpiomux_install(wcnss_5wire_interface,
 				ARRAY_SIZE(wcnss_5wire_interface));


### PR DESCRIPTION
- Add support for msm8226-v2
- truly panel remained black on boot. Fix it in dsi-panel-eagle.dtsi

<6>[    0.458888] mdss_panel_parse_dt:3677, Unable to read SoMC Phy regulator                       settings
<3>[    0.458896] mdss_panel_parse_dt:3692, Unable to read Phy lane configure<3>[    0.458975] mdss_dsi_parse_dcs_cmds: Cannot find property:  somc,mdss-dsi-early-init-command
<3>[    0.458982] mdss_dsi_parse_dcs_cmds: Cannot find property:  somc,mdss-dsi-init-command
<3>[    0.458996] mdss_dsi_parse_dcs_cmds: dtsi cmd=0 error, len=4366 <<<<=======
