### PR TITLE
arm: Rhine: Correct camera DT and clock source fixup

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-amami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-amami_row.dtsi
@@ -13,9 +13,9 @@
  */
 
 &cci {
-	actuator0: qcom,actuator@18 {
+	actuator0: qcom,actuator@0 {
 		cell-index = <0>;
-		reg = <0x18>;
+		reg = <0x0>;
 		compatible = "qcom,actuator";
 		qcom,cci-master = <0>;
 		cam_vaf-supply = <&pm8941_l23>;
@@ -37,10 +37,11 @@
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;
-		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
-		qcom,cam-vreg-min-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-op-mode = <85000 0 103000>;
+		cam_vaf-supply = <&pm8941_l23>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-op-mode = <105000 0 85600 106500>;
 		qcom,gpio-no-mux = <0>;
 		gpios = <&msmgpio 15 0>, <&msmgpio 94 0>;
 		qcom,gpio-reset = <1>;
@@ -51,6 +52,7 @@
 		qcom,sensor-mode = <0>;
 		qcom,cci-master = <0>;
 		status = "ok";
+		clock-names = "cam_src_clk", "cam_clk";
 	};
 
 	qcom,camera@1 {
@@ -68,7 +70,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;
@@ -76,6 +78,9 @@
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;
+		clock-names = "cam_src_clk", "cam_clk";
+
+		status="disable";
 	};
 
 	eeprom1: qcom,eeprom@a1 {

--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
@@ -12,9 +12,9 @@
  */
 
 &cci {
-	actuator0: qcom,actuator@18 {
+	actuator0: qcom,actuator@0 {
 		cell-index = <0>;
-		reg = <0x18>;
+		reg = <0x0>;
 		compatible = "qcom,actuator";
 		qcom,cci-master = <0>;
 		cam_vaf-supply = <&pm8941_l23>;
@@ -36,10 +36,11 @@
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;
-		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
-		qcom,cam-vreg-min-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-op-mode = <85000 0 103000>;
+		cam_vaf-supply = <&pm8941_l23>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-op-mode = <105000 0 85600 106500>;
 		qcom,gpio-no-mux = <0>;
 		gpios = <&msmgpio 15 0>, <&msmgpio 94 0>;
 		qcom,gpio-reset = <1>;
@@ -50,6 +51,7 @@
 		qcom,sensor-mode = <0>;
 		qcom,cci-master = <0>;
 		status = "ok";
+		clock-names = "cam_src_clk", "cam_clk";
 	};
 
 	qcom,camera@1 {
@@ -67,7 +69,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;
@@ -75,6 +77,9 @@
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;
+		clock-names = "cam_src_clk", "cam_clk";
+
+		status="disable";
 	};
 
 	eeprom1: qcom,eeprom@a1 {

--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
@@ -13,9 +13,9 @@
  */
 
 &cci {
-	actuator0: qcom,actuator@18 {
+	actuator0: qcom,actuator@0 {
 		cell-index = <0>;
-		reg = <0x18>;
+		reg = <0x0>;
 		compatible = "qcom,actuator";
 		qcom,cci-master = <0>;
 		cam_vaf-supply = <&pm8941_l23>;
@@ -37,10 +37,11 @@
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;
-		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
-		qcom,cam-vreg-min-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
-		qcom,cam-vreg-op-mode = <85000 0 103000>;
+		cam_vaf-supply = <&pm8941_l23>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2700000 2800000>;
+		qcom,cam-vreg-op-mode = <105000 0 85600 106500>;
 		qcom,gpio-no-mux = <0>;
 		gpios = <&msmgpio 15 0>, <&msmgpio 94 0>;
 		qcom,gpio-reset = <1>;
@@ -51,6 +52,7 @@
 		qcom,sensor-mode = <0>;
 		qcom,cci-master = <0>;
 		status = "ok";
+		clock-names = "cam_src_clk", "cam_clk";
 	};
 
 	qcom,camera@1 {
@@ -68,7 +70,7 @@
 		qcom,cam-vreg-max-voltage = <1200000 0 2700000>;
 		qcom,cam-vreg-op-mode = <85000 0 103000>;
 		qcom,gpio-no-mux = <0>;
-		gpios = <&msm_gpio 17 0>, <&msm_gpio 18 0>;
+		gpios = <&msmgpio 17 0>, <&msmgpio 18 0>;
 		qcom,gpio-reset = <1>;
 		qcom,gpio-req-tbl-num = <0 1>;
 		qcom,gpio-req-tbl-flags = <1 0>;
@@ -76,6 +78,9 @@
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;
+		clock-names = "cam_src_clk", "cam_clk";
+
+		status="disable";
 	};
 
 	eeprom1: qcom,eeprom@a1 {

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -227,6 +227,31 @@
 		};
 	};
 
+	qcom,cpp@fda04000 {
+		qcom,min-clock-rate = <266670000>;
+	};
+
+	qcom,ispif@fda0A000 {
+		clock-names = "ispif_ahb_clk",
+			"csi0_src_clk", "csi0_clk",
+			"csi0_pix_clk", "csi0_rdi_clk",
+			"csi1_src_clk", "csi1_clk",
+			"csi1_pix_clk", "csi1_rdi_clk",
+			"csi2_src_clk", "csi2_clk",
+			"csi2_pix_clk", "csi2_rdi_clk",
+			"csi3_src_clk", "csi3_clk",
+			"csi3_pix_clk", "csi3_rdi_clk",
+			"vfe0_clk_src", "camss_vfe_vfe0_clk", "camss_csi_vfe0_clk",
+			"vfe1_clk_src", "camss_vfe_vfe1_clk", "camss_csi_vfe1_clk";
+		qcom,clock-rates = <0
+			200000000 0 0 0
+			200000000 0 0 0
+			200000000 0 0 0
+			200000000 0 0 0
+			266670000 0 0
+			266670000 0 0>;
+	};
+
 	qcom,vfe@fda10000 {
 		ds-entries = <17>;
 		ds-regs = <0xBD8 0xBDC 0xBE0 0xBE4 0xBE8
@@ -238,8 +263,8 @@
 				0xCCCC1111 0xCCCC1111 0xCCCC1111
 				0xCCCC1111 0xCCCC1111 0xCCCC1111
 				0xCCCC1111 0x00000103>;
-		max-clk-nominal = <400000000>;
-		max-clk-turbo = <533330000>;
+		max-clk-nominal = <266670000>;
+		max-clk-turbo =   <320000000>;
 	};
 
 	qcom,vfe@fda14000 {
@@ -282,8 +307,8 @@
 				0xCCCC1111 0xCCCC1111 0xCCCC1111
 				0xCCCC1111 0xCCCC1111 0xCCCC1111
 				0xCCCC1111 0x00000103>;
-		max-clk-nominal = <400000000>;
-		max-clk-turbo = <533330000>;
+		max-clk-nominal = <266670000>;
+		max-clk-turbo =   <320000000>;
 	};
 
 	sound {

--- a/arch/arm/mach-msm/sony_gpiomux.c
+++ b/arch/arm/mach-msm/sony_gpiomux.c
@@ -135,6 +135,11 @@ int __init sony_init_gpiomux(struct msm_gpiomux_config *configs,
 			gpiomux_merge_setting(c, s);
 	}
 
+	if (of_machine_is_compatible("somc,honami-row") ||
+	    of_machine_is_compatible("somc,togari-row") ||
+	    of_machine_is_compatible("somc,amami-row"))
+		msm_tlmm_misc_reg_write(TLMM_SPARE_REG, 0x5);
+
 	/* Install product-all merged configuration */
 	msm_gpiomux_install(configs, nconfigs);
 


### PR DESCRIPTION
Enable 8MHz clock source in pinmux, use correct nodes and
properties, add required clocks to 8974 ispif node.
