### PR TITLE
arm: msm: clocks: Fix camera clocks for MSM8974 and cleanup

### DIFF
--- a/arch/arm/mach-msm/clock-gcc-8974.c
+++ b/arch/arm/mach-msm/clock-gcc-8974.c
@@ -2547,16 +2547,8 @@ static struct clk_lookup msm_clocks_gcc_8974[] = {
 
 static struct clk_lookup msm_clocks_gcc_8974_only[] = {
 	/* Camera Sensor clocks */
-	CLK_LOOKUP_OF("cam_src_clk", gp1_clk_src, "2.qcom,camera"),
-	CLK_LOOKUP_OF("cam_clk", gcc_gp1_clk, "2.qcom,camera"),
-	CLK_LOOKUP_OF("cam_src_clk", gp1_clk_src, "6c.qcom,camera"),
-	CLK_LOOKUP_OF("cam_clk", gcc_gp1_clk, "6c.qcom,camera"),
-
-	/* Sony EEPROM */
-	CLK_LOOKUP_OF("cam_src_clk", gp1_clk_src, "a0.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_clk", gcc_gp1_clk, "a0.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_src_clk", gp1_clk_src, "a1.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_clk", gcc_gp1_clk, "a1.qcom,eeprom"),
+	CLK_LOOKUP_OF("cam_src_clk", gp1_clk_src, "1.qcom,camera"),
+	CLK_LOOKUP_OF("cam_clk", gcc_gp1_clk, "1.qcom,camera"),
 };
 
 static struct clk *qup_i2c_clks[][2] = {

--- a/arch/arm/mach-msm/clock-mmss-8974.c
+++ b/arch/arm/mach-msm/clock-mmss-8974.c
@@ -2330,18 +2330,6 @@ static struct clk_lookup msm_camera_clocks_8974_only[] = {
 	CLK_LOOKUP_OF("cam_src_clk", mmss_gp1_clk_src, "1.qcom,camera"),
 	CLK_LOOKUP_OF("cam_clk", camss_gp0_clk, "0.qcom,camera"),
 	CLK_LOOKUP_OF("cam_clk", camss_gp1_clk, "1.qcom,camera"),
-
-	/* Sony Camera */
-	CLK_LOOKUP_OF("cam_src_clk", mclk0_clk_src, "20.qcom,camera"),
-	CLK_LOOKUP_OF("cam_clk", camss_mclk0_clk, "20.qcom,camera"),
-	CLK_LOOKUP_OF("cam_src_clk", mclk2_clk_src, "6c.qcom,camera"),
-	CLK_LOOKUP_OF("cam_clk", camss_mclk2_clk, "6c.qcom,camera"),
-
-	/* Sony EEPROM */
-	CLK_LOOKUP_OF("cam_src_clk", mmss_gp0_clk_src, "a0.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_clk", camss_gp0_clk, "a0.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_src_clk", mmss_gp0_clk_src, "a1.qcom,eeprom"),
-	CLK_LOOKUP_OF("cam_clk", camss_gp0_clk, "a1.qcom,eeprom"),
 };
 
 static struct clk_lookup msm_clocks_mmss_8974[] = {


### PR DESCRIPTION
Remove unneeded clocks which would be used on unexistant DT
camera nodes and fix GCC clock for second (front) camera.
