### PR TITLE
video: msm: mdss: Fix unused function warning

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -126,7 +126,7 @@ static int mdss_dsi_labibb_vreg_init(struct platform_device *pdev)
 	return 0;
 }
 
-static int mdss_dsi_labibb_vreg_ctrl(struct mdss_dsi_ctrl_pdata *ctrl,
+int mdss_dsi_labibb_vreg_ctrl(struct mdss_dsi_ctrl_pdata *ctrl,
 							int enable)
 {
 	int rc;


### PR DESCRIPTION
drivers/video/msm/mdss/mdss_dsi.c:129:12: warning: 'mdss_dsi_labibb_vreg_ctrl' defined but not used [-Wunused-function]
 static int mdss_dsi_labibb_vreg_ctrl(struct mdss_dsi_ctrl_pdata *ctrl,
            ^
