### PR TITLE
arm: msm8974pro: Remove modem_mem memory node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974pro.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro.dtsi
@@ -1652,10 +1652,6 @@
 		linux,contiguous-region = <&alt_peripheral_mem>;
 	};
 
-	qcom,mss@fc880000 {
-		linux,contiguous-region = <&modem_mem>;
-	};
-
 	qcom,venus@fdce0000 {
 		linux,contiguous-region = <&alt_peripheral_mem>;
 	};


### PR DESCRIPTION
It's not necessary and this is only giving problems to us...for now.
Fall back to standard 8974 peripheral_mem for allocating memory
for loading MBA OS to MBA HW.
