### PR TITLE
arm64: charger: Hack to set androidboot.mode=charger

### DIFF
--- a/arch/arm64/kernel/setup.c
+++ b/arch/arm64/kernel/setup.c
@@ -375,6 +375,34 @@ u64 __cpu_logical_map[NR_CPUS] = { [0 ... NR_CPUS-1] = INVALID_HWID };
 
 void __init __weak init_random_pool(void) { }
 
+/*
+ * HACK: These two functions sets the androidboot.mode=charger based
+ * on the Sony Mobile parameters startup and warmboot.
+ */
+static unsigned long sony_startup;
+
+static int __init sony_param_startup(char *p)
+{
+	if (kstrtoul(p, 16, &sony_startup))
+		return 1;
+	return 0;
+}
+early_param("startup", sony_param_startup);
+
+static int __init sony_param_warmboot(char *p)
+{
+	unsigned long warmboot;
+
+	if (kstrtoul(p, 16, &warmboot))
+		return 1;
+
+	if (!warmboot && (sony_startup & 0x4004))
+		strlcat(boot_command_line, " androidboot.mode=charger",
+			COMMAND_LINE_SIZE);
+	return 0;
+}
+early_param("warmboot", sony_param_warmboot);
+
 void __init setup_arch(char **cmdline_p)
 {
 	/*


### PR DESCRIPTION
Based on the parameters startup and warmboot we patch the command line
that init will read to determin if the device was powerd on by a
charger.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I5d00cfb4689aef2c94b29de71911102c7637a43e
