### PR TITLE
arm:dt:msm8994 Correct regulator timming

### DIFF
--- a/arch/arm/boot/dts/qcom/msm-pmi8994.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-pmi8994.dtsi
@@ -470,7 +470,7 @@
 
 				qcom,qpnp-ibb-min-voltage = <1400000>;
 				qcom,qpnp-ibb-step-size = <100000>;
-				qcom,qpnp-ibb-slew-rate = <2000000>;
+				qcom,qpnp-ibb-slew-rate = <2000>;
 				qcom,qpnp-ibb-use-default-voltage;
 				qcom,qpnp-ibb-init-voltage = <5500000>;
 				qcom,qpnp-ibb-init-amoled-voltage = <4000000>;


### PR DESCRIPTION
Documentation describe slew-rate as "time in us it takes for the regulator to change votlage value in one step".
2s seems a lot and qpnp-lab-slew-rate is only 5000us.
So correct it as if a 1000 factor was added.

This reduce the kernel boot time of the karin windy by 80s
Tested on karin windy only

Signed-off-by: Mathieu Maret mmaret@genymobile.com
