### PR TITLE
bug #1181606: set the correct screen dimensions

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
@@ -480,6 +480,8 @@
 
 		somc,panel-detect = <1>;
 		somc,driver-ic = <4>;
+		qcom,mdss-pan-physical-width-dimension = <53>;
+		qcom,mdss-pan-physical-height-dimension = <94>;
 		somc,mdss-phy-size-mm = <53 94>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -958,6 +960,8 @@
 		somc,pw-off-rst-seq = <0 10>;
 
 		somc,driver-ic = <4>;
+		qcom,mdss-pan-physical-width-dimension = <53>;
+		qcom,mdss-pan-physical-height-dimension = <94>;
 		somc,mdss-phy-size-mm = <53 94>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -1573,6 +1577,8 @@
 		somc,pw-off-rst-seq = <0 10>;
 
 		somc,driver-ic = <4>;
+		qcom,mdss-pan-physical-width-dimension = <53>;
+		qcom,mdss-pan-physical-height-dimension = <94>;
 		somc,mdss-phy-size-mm = <53 94>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -2188,6 +2194,8 @@
 		somc,pw-off-rst-seq = <0 10>;
 
 		somc,driver-ic = <4>;
+		qcom,mdss-pan-physical-width-dimension = <53>;
+		qcom,mdss-pan-physical-height-dimension = <94>;
 		somc,mdss-phy-size-mm = <53 94>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75

--- a/arch/arm/boot/dts/qcom/dsi-panel-aries.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-aries.dtsi
@@ -86,6 +86,8 @@
 
 		somc,driver-ic = <1>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <56>;
+		qcom,mdss-pan-physical-height-dimension = <100>;
 		somc,mdss-phy-size-mm = <56 100>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -412,6 +414,8 @@
 
 		somc,driver-ic = <1>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <56>;
+		qcom,mdss-pan-physical-height-dimension = <100>;
 		somc,mdss-phy-size-mm = <56 100>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -737,6 +741,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <56>;
+		qcom,mdss-pan-physical-height-dimension = <100>;
 		somc,mdss-phy-size-mm = <56 100>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -827,6 +833,8 @@
 
 		somc,driver-ic = <1>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <56>;
+		qcom,mdss-pan-physical-height-dimension = <100>;
 		somc,mdss-phy-size-mm = <56 100>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff

--- a/arch/arm/boot/dts/qcom/dsi-panel-castor.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-castor.dtsi
@@ -58,6 +58,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <3>;
+		qcom,mdss-pan-physical-width-dimension = <217>;
+		qcom,mdss-pan-physical-height-dimension = <135>;
 		somc,mdss-phy-size-mm = <217 135>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 			00 c2 ef 00 00 00 00 01 ff
@@ -119,6 +121,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <3>;
+		qcom,mdss-pan-physical-width-dimension = <217>;
+		qcom,mdss-pan-physical-height-dimension = <135>;
 		somc,mdss-phy-size-mm = <217 135>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 			00 c2 ef 00 00 00 00 01 ff
@@ -183,6 +187,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <3>;
+		qcom,mdss-pan-physical-width-dimension = <217>;
+		qcom,mdss-pan-physical-height-dimension = <135>;
 		somc,mdss-phy-size-mm = <217 136>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 			00 c2 ef 00 00 00 00 01 75
@@ -244,6 +250,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <3>;
+		qcom,mdss-pan-physical-width-dimension = <217>;
+		qcom,mdss-pan-physical-height-dimension = <135>;
 		somc,mdss-phy-size-mm = <217 135>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 			00 c2 ef 00 00 00 00 01 75
@@ -305,6 +313,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <3>;
+		qcom,mdss-pan-physical-width-dimension = <217>;
+		qcom,mdss-pan-physical-height-dimension = <135>;
 		somc,mdss-phy-size-mm = <217 135>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 			00 c2 ef 00 00 00 00 01 75

--- a/arch/arm/boot/dts/qcom/dsi-panel-honami.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-honami.dtsi
@@ -109,6 +109,8 @@
 		somc,driver-ic = <0>;
 		somc,panel-id-read-cmds;
 		somc,dsi-restart-hack;
+		qcom,mdss-pan-physical-width-dimension = <62>;
+		qcom,mdss-pan-physical-height-dimension = <110>;
 		somc,mdss-phy-size-mm = <62 110>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -222,6 +224,8 @@
 
 		somc,panel-id = [ff ff ff 63];
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <62>;
+		qcom,mdss-pan-physical-height-dimension = <110>;
 		somc,mdss-phy-size-mm = <62 110>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -416,6 +420,8 @@
 
 		somc,panel-id = [ff ff ff 62];
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <62>;
+		qcom,mdss-pan-physical-height-dimension = <110>;
 		somc,mdss-phy-size-mm = <62 110>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -981,6 +987,8 @@
 		somc,panel-detect = <1>;
 		somc,driver-ic = <1>;
 		somc,panel-id-read-cmds;
+		qcom,mdss-pan-physical-width-dimension = <62>;
+		qcom,mdss-pan-physical-height-dimension = <110>;
 		somc,mdss-phy-size-mm = <62 110>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75
@@ -1467,6 +1475,8 @@
 
 		somc,panel-id = [12 72 08 62];
 		somc,driver-ic = <1>;
+		qcom,mdss-pan-physical-width-dimension = <62>;
+		qcom,mdss-pan-physical-height-dimension = <110>;
 		somc,mdss-phy-size-mm = <62 110>;
 		somc,mdss-dsi-lane-config = [00 c2 45 00 00 00 00 01 75
 				00 c2 45 00 00 00 00 01 75

--- a/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
@@ -73,6 +73,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -421,6 +423,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -751,6 +755,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -1061,6 +1067,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -1384,6 +1392,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -1694,6 +1704,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -1773,6 +1785,8 @@
 
 		somc,driver-ic = <0>;
 		somc,touch-reset-gpio = <&msmgpio 85 0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff

--- a/arch/arm/boot/dts/qcom/dsi-panel-scorpion.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-scorpion.dtsi
@@ -78,6 +78,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <108>;
+		qcom,mdss-pan-physical-height-dimension = <172>;
 		somc,mdss-phy-size-mm = <108 172>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
@@ -392,6 +394,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <108>;
+		qcom,mdss-pan-physical-height-dimension = <172>;
 		somc,mdss-phy-size-mm = <108 172>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff

--- a/arch/arm/boot/dts/qcom/dsi-panel-sirius.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-sirius.dtsi
@@ -89,6 +89,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -241,6 +243,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -404,6 +408,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -953,6 +959,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <1>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -1498,6 +1506,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <1>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -1681,6 +1691,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <1>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -1853,6 +1865,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -1946,6 +1960,8 @@
 		qcom,cont-splash-enabled;
 
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
 		somc,mdss-phy-size-mm = <64 114>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75

--- a/arch/arm/boot/dts/qcom/dsi-panel-togari.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-togari.dtsi
@@ -145,6 +145,8 @@
 		somc,pw-on-rst-seq = <0 10>, <1 10>;
 		somc,pw-off-rst-seq = <0 10>;
 		somc,driver-ic = <0>;
+		qcom,mdss-pan-physical-width-dimension = <80>;
+		qcom,mdss-pan-physical-height-dimension = <143>;
 		somc,mdss-phy-size-mm = <80 143>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -286,6 +288,8 @@
 		somc,disp-en-on-pre = <25>;
 		somc,pw-on-rst-seq = <0 10>, <1 10>;
 		somc,pw-off-rst-seq = <0 10>;
+		qcom,mdss-pan-physical-width-dimension = <80>;
+		qcom,mdss-pan-physical-height-dimension = <143>;
 		somc,mdss-phy-size-mm = <80 143>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -486,6 +490,8 @@
 		somc,disp-en-on-pre = <25>;
 		somc,pw-on-rst-seq = <0 10>, <1 10>;
 		somc,pw-off-rst-seq = <0 10>;
+		qcom,mdss-pan-physical-width-dimension = <80>;
+		qcom,mdss-pan-physical-height-dimension = <143>;
 		somc,mdss-phy-size-mm = <80 143>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 75
 				00 c2 ef 00 00 00 00 01 75
@@ -1026,6 +1032,8 @@
 
 		qcom,mdss-brightness-max-level = <255>;
 		somc,driver-ic = <1>;
+		qcom,mdss-pan-physical-width-dimension = <80>;
+		qcom,mdss-pan-physical-height-dimension = <143>;
 		somc,mdss-phy-size-mm = <80 143>;
 		somc,mdss-dsi-lane-config = [00 02 ef 00 00 00 00 01 ff
 				00 02 ef 00 00 00 00 01 ff
@@ -1502,6 +1510,8 @@
 		somc,disp-en-on-post = <10>;
 		somc,pw-on-rst-seq = <1 10>, <0 10>, <1 25>;
 		somc,pw-off-rst-seq = <0 10>;
+		qcom,mdss-pan-physical-width-dimension = <80>;
+		qcom,mdss-pan-physical-height-dimension = <143>;
 		somc,mdss-phy-size-mm = <80 143>;
 		somc,mdss-dsi-lane-config = [00 02 ef 00 00 00 00 01 ff
 				00 02 ef 00 00 00 00 01 ff


### PR DESCRIPTION
all Rhine and Shinano devices are now up-to-date

Signed-off-by: Adam Farden adam@farden.cz
