### PR TITLE
arm: DT: Kitakami: Karin: Correct backlight name and levels

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
@@ -127,12 +127,12 @@
 			compatible = "ti,lp8557";
 			reg = <0x2c>;
 			status = "ok";
-			linux,name = "wled:backlight";
+			linux,name = "lp8557";
 			linux,default-trigger = "bkl-trigger";
 			mode = "register based";
 			chip_name = "lp8557";
-			max_br = <0x0FF>;
-			init_br = <0x66>;
+			max_br = <0xFF>;
+			init_br = <0x83>;
 			somc-s1,br-power-save = <0x83>;
 			slope_reg = <0x00>;
 			dev-ctrl = <0x01>;


### PR DESCRIPTION
This commit is a partial revert of 5fc2d22 by @humberos.
The backlight shall be registered as lp8557 because we have to
update its level differently.

We are allowed to use the Linux trigger "bkl-trigger" for this,
otherwise we can access it directly from (discouraged) its
directory in class sysfs.

On Qualcomm platforms, we can update it through MDSS backlight
triggers: this will allow display correction algorithms to adjust
the displayed image's RGB levels considering the current backlight
level while calculating the color deltas.
