### PR TITLE
wlan: Address buffer overflow due to invalid length

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -6895,6 +6895,9 @@ int wlan_hdd_set_filter(hdd_context_t *pHddCtx, tpPacketFilterCfg pRequest,
 
                 hddLog(VOS_TRACE_LEVEL_INFO, "Data Offset %d Data Len %d",
                         pRequest->paramsData[i].dataOffset, pRequest->paramsData[i].dataLength);
+                if ((sizeof(packetFilterSetReq.paramsData[i].compareData)) <
+                    (pRequest->paramsData[i].dataLength))
+                    return -EINVAL;
 
                 memcpy(&packetFilterSetReq.paramsData[i].compareData,
                         pRequest->paramsData[i].compareData, pRequest->paramsData[i].dataLength);


### PR DESCRIPTION
https://www.codeaurora.org/cgit/quic/la/platform/vendor/qcom-opensource/wlan/prima/commit/CORE/HDD/src/wlan_hdd_wext.c?h=caf-wlan/master&id=4b91219ada9e73c897da2e0ae7bf2ff043dde950

Change-Id: Ib04308c814d8400d8924bab7e0d33535df7820e9
