### PR TITLE
remove questionable vddio node from mdss dsi panel DT

### DIFF
--- a/arch/arm/boot/dts/qcom/apq8084-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8084-mdss.dtsi
@@ -207,16 +207,6 @@
 				qcom,supply-enable-load = <100000>;
 				qcom,supply-disable-load = <100>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
@@ -173,15 +173,6 @@
 				qcom,supply-disable-load = <100>;
 				qcom,supply-post-on-sleep = <20>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8610-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8610-mdss.dtsi
@@ -62,15 +62,6 @@
 				qcom,supply-post-on-sleep = <20>;
 				qcom,supply-post-off-sleep = <20>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
@@ -268,16 +268,6 @@
 				qcom,supply-enable-load = <100000>;
 				qcom,supply-disable-load = <100>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_ivy_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_ivy_common.dtsi
@@ -30,6 +30,7 @@
 			qcom,high-threshold-uamp = <1500000>;
 			qcom,soc-low-threshold = <5>;
 		};
+	};
 };
 
 &pm8994_gpios {


### PR DESCRIPTION
refer to
Documentation/devicetree/bindings/fb/mdss-dsi-ctrl.txt
