### PR TITLE
arm: DT: Sony: Load modem on PIL on Yukon, Rhine, Shinano

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
@@ -377,6 +377,10 @@
                        <0xfe05300c 0x4>;
                reg-names = "avtimer_lsb_addr", "avtimer_msb_addr";
        };
+
+	qcom,mss@fc880000 {
+		qcom,mba-load-to-phys;
+	};
 };
 
 &rpm_bus {

--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -348,6 +348,10 @@
 	qcom,msm-thermal {
 		qcom,pmic-sw-mode-regs = "vdd_dig";
 	};
+
+	qcom,mss@fc880000 {
+		qcom,mba-load-to-phys;
+	};
 };
 
 &peripheral_mem {

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
@@ -195,6 +195,7 @@
 
 	qcom,mss@fc880000 {
 		/delete-property/ linux,contiguous-region;
+		qcom,mba-load-to-phys;
 	};
 
 	nxp,tfa98xx-codec {


### PR DESCRIPTION
On Rhine, Shinano and Yukon (8974 and 8226) platforms,
we can load modem using only kernel drivers, without using
any userspace helper daemon.
Add qcom,mba-load-to-phys to the corresponding MSS node.
