### PR TITLE
soc: qcom: Use specific check for modem fw load address

### DIFF
--- a/drivers/soc/qcom/pil-msa.c
+++ b/drivers/soc/qcom/pil-msa.c
@@ -408,7 +408,7 @@ int pil_mss_reset_load_mba(struct pil_desc *pil)
 	int ret, count;
 	const u8 *data;
 
-	mbadev = drv->non_elf_image ? pil->dev : &md->mba_mem_dev;
+	mbadev = drv->load_to_phys ? pil->dev : &md->mba_mem_dev;
 
 	fw_name_p = drv->non_elf_image ? fw_name_legacy : fw_name;
 	/* Load and authenticate mba image */
@@ -478,7 +478,7 @@ static int pil_msa_auth_modem_mdt(struct pil_desc *pil, const u8 *metadata,
 	int ret;
 	DEFINE_DMA_ATTRS(attrs);
 
-	mbadev = q6_drv->non_elf_image ? pil->dev : &drv->mba_mem_dev;
+	mbadev = q6_drv->load_to_phys ? pil->dev : &drv->mba_mem_dev;
 
 	drv->mba_mem_dev.coherent_dma_mask =
 		DMA_BIT_MASK(sizeof(dma_addr_t) * 8);
@@ -566,7 +566,7 @@ static int pil_msa_mba_auth(struct pil_desc *pil)
 	int ret;
 	s32 status;
 
-	mbadev = q6_drv->non_elf_image ? pil->dev : &drv->mba_mem_dev;
+	mbadev = q6_drv->load_to_phys ? pil->dev : &drv->mba_mem_dev;
 
 	/* Wait for all segments to be authenticated or an error to occur */
 	ret = readl_poll_timeout(drv->rmb_base + RMB_MBA_STATUS, status,

--- a/drivers/soc/qcom/pil-q6v5.c
+++ b/drivers/soc/qcom/pil-q6v5.c
@@ -484,6 +484,9 @@ struct q6v5_data *pil_q6v5_init(struct platform_device *pdev)
 	drv->non_elf_image = of_property_read_bool(pdev->dev.of_node,
 						"qcom,mba-image-is-not-elf");
 
+	drv->load_to_phys = of_property_read_bool(pdev->dev.of_node,
+						"qcom,mba-load-to-phys");
+
 	drv->override_acc = of_property_read_bool(pdev->dev.of_node,
 						"qcom,override-acc");
 

--- a/drivers/soc/qcom/pil-q6v5.h
+++ b/drivers/soc/qcom/pil-q6v5.h
@@ -53,6 +53,7 @@ struct q6v5_data {
 	bool qdsp6v56;
 	bool qdsp6v56_1_3;
 	bool non_elf_image;
+	bool load_to_phys;
 	bool restart_reg_sec;
 	bool override_acc;
 	bool ahb_clk_vote;


### PR DESCRIPTION
When we want to load a non-ELF image on modem, we can't
assume that we want to load it at its phys address.

Add a new variable to check if we want to load the image
in the modem's CMA region (direct access by phys address)
or using generic, dynamic DMA allocations.
