### PR TITLE
shinano: fix Front camera mount angle

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_camera.dtsi
@@ -65,7 +65,7 @@
 		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <0>;
+		qcom,mount-angle = <180>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_sirius_camera.dtsi
@@ -76,7 +76,7 @@
 		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <90>;
+		qcom,mount-angle = <270>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries_camera.dtsi
@@ -72,7 +72,7 @@
 		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <90>;
+		qcom,mount-angle = <270>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo_camera.dtsi
@@ -76,7 +76,7 @@
 		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <90>;
+		qcom,mount-angle = <270>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_camera.dtsi
@@ -61,7 +61,7 @@
 		reg = <0x2>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <0>;
+		qcom,mount-angle = <180>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;


### PR DESCRIPTION
New camera binaries makes the Z3 front camera upside down.

Signed-off-by: Julien Bolard jbolard@genymobile.com
