### PR TITLE
arm: DT: shinano: leo: Fix Sharp Novatek panel

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-leo.dtsi
@@ -325,22 +325,22 @@
 			0xFF 0x00 0x00 0x3B 0x00 0x3B 0x8000 0x8000 0x8000>;
 	};
 
-	dsi_novatek_sharp_1080_cmd: somc,novatek_sharp_1080p_cmd_panel {
-		qcom,mdss-dsi-panel-name = "sharp novatek 1080p cmd";
+	dsi_novatek_sharp_1080_video: somc,novatek_sharp_1080p_vid_panel {
+		qcom,mdss-dsi-panel-name = "sharp novatek 1080p vid";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
-		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-panel-width = <1080>;
 		qcom,mdss-dsi-panel-height = <1920>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-front-porch = <136>;
+		qcom,mdss-dsi-h-back-porch = <20>;
+		qcom,mdss-dsi-h-pulse-width = <60>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-front-porch = <233>;
+		qcom,mdss-dsi-v-back-porch = <3>;
+		qcom,mdss-dsi-v-front-porch = <4>;
 		qcom,mdss-dsi-v-pulse-width = <2>;
 		qcom,mdss-dsi-h-left-border = <0>;
 		qcom,mdss-dsi-h-right-border = <0>;
@@ -349,50 +349,19 @@
 		qcom,mdss-dsi-bpp = <24>;
 		qcom,mdss-dsi-underflow-color = <0x0>;
 		qcom,mdss-dsi-border-color = <0>;
-		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 10
+		somc,mdss-dsi-init-command = [15 01 00 00 00 00 02 BB 03
+				39 01 00 00 00 00 06 3B 03 05 04 50 88
 				15 01 00 00 00 00 02 FF 24
 				15 01 00 00 00 00 02 FB 01
 				15 01 00 00 00 00 02 C4 9A
-				15 01 00 00 00 00 02 85 05
-				15 01 00 00 00 00 02 93 02
-				15 01 00 00 00 00 02 94 08
-				15 01 00 00 00 00 02 92 95
-				15 01 00 00 00 00 02 FF 10
-				15 01 00 00 00 00 02 FF 20
-				15 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 58 82
-				15 01 00 00 00 00 02 59 02
-				15 01 00 00 00 00 02 5A 02
-				15 01 00 00 00 00 02 5B 02
-				15 01 00 00 00 00 02 5C 83
-				15 01 00 00 00 00 02 5D 83
-				15 01 00 00 00 00 02 5E 03
-				15 01 00 00 00 00 02 5F 03
-				15 01 00 00 00 00 02 6D 55
-				15 01 00 00 00 00 02 FF 10
-				15 01 00 00 00 00 02 FF 24
-				15 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 C4 02
-				15 01 00 00 00 00 02 FF 10
-				15 01 00 00 00 00 02 35 00
-				39 01 00 00 00 00 03 44 03 00
-				15 01 00 00 00 00 02 FF E0
-				15 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 B5 86
-				15 01 00 00 00 00 02 B6 77
-				15 01 00 00 00 00 02 B8 AD
-				15 01 00 00 00 00 02 FF 20
-				15 01 00 00 00 00 02 FB 01
-				15 01 00 00 00 00 02 10 04
-				15 01 00 00 00 00 02 FF 10
-				05 01 00 00 1E 00 01 11];
-		qcom,mdss-dsi-on-command = [05 01 00 00 28 00 01 29];
+				15 01 00 00 00 00 02 FF 10];
+		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
+				05 01 00 00 28 00 01 29];
 		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
 				05 01 00 00 14 00 01 28
 				05 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
 		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
-
 		qcom,mdss-dsi-h-sync-pulse = <1>;
 		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
 		qcom,mdss-dsi-bllp-eof-power-mode;
@@ -401,15 +370,9 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-te-pin-select = <1>;
-		qcom,mdss-dsi-wr-mem-start = <0x2c>;
-		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
-		qcom,mdss-dsi-te-dcs-command = <1>;
-		qcom,mdss-dsi-te-check-enable;
-		qcom,mdss-dsi-te-using-te-pin;
 		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
 		qcom,mdss-dsi-lp11-init;
-		qcom,mdss-dsi-t-clk-post = <0x21>;
+		qcom,mdss-dsi-t-clk-post = <0x02>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -431,12 +394,12 @@
 				00 c2 ef 00 00 00 00 01 ff
 				00 c2 ef 00 00 00 00 01 ff
 				00 02 45 00 00 00 00 01 97];
-		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-disp-on-in-hs = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
 		somc,lcd-id = <1>;
 		somc,lcd-id-adc = <0 57000>;
-		somc,disp-en-on-pre = <10>;
-		somc,disp-en-on-post = <20>;
+		somc,disp-en-on-pre = <200>;
+		somc,disp-en-on-post = <10>;
 		somc,pw-on-rst-seq = <1 1>, <0 1>, <1 20>;
 		somc,disp-en-off-post = <200>;
 		somc,pw-off-rst-seq = <0 5>;
@@ -673,25 +636,6 @@
 			0x00 0xDF 0x04 0x07 0x00 0x03 0x8000 0x5a00 0x5200
 			0x00 0xE0 0x00 0x03 0x00 0x03 0x8000 0x5400 0x4d00
 			0xFF 0x00 0x00 0x3B 0x00 0x3B 0x8000 0x8000 0x8000>;
-
-		somc,change-fps-command = [15 01 00 00 00 00 02 FF 24
-				15 01 00 00 00 00 02 92 95
-				15 01 00 00 00 00 02 FF 10
-				39 01 00 00 00 00 03 44 03 00];
-		somc,display-clock = <17330000>;
-		somc,driver-ic-vbp = <8>;
-		somc,driver-ic-vfp = <2>;
-
-		somc,change-fps-rtn-pos = <1 1>;
-		somc,change-wait-on = <40 60>;
-		somc,change-wait-off = <80 90>;
-		somc,change-wait-cmds-num = <0 2>;
-		somc,fps-threshold = <47400>;
-		somc,te-c-update = <1>;
-		somc,te-c-mode-60fps = <0x03 0x00>;
-		somc,te-c-mode-45fps = <0x04 0xFF>;
-		somc,te-c-cmds-num = <3>;
-		somc,te-c-payload-num = <1>;
 	};
 
 	dsi_novatek_jdi_1080_vid: somc,novatek_jdi_1080p_video_panel {


### PR DESCRIPTION
Some leo's panels implementation was referring to Sharp Novatek CMD mode panels,
but we don't want to always use CMD mode for various reasons, such as
performance degradation and driver problems.

Refactor the panel timings and initialization to allow video mode
to be used with those ones, also solving the pixels corruption
issue.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ibda3013febc33b2b0dbac2974b25a528d3c86fcc
