### PR TITLE
arm: DT: MSM8994: Raise allocatable amount of memory for modem

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994.dtsi
@@ -319,7 +319,7 @@
 			linux,reserve-contiguous-region;
 			linux,reserve-region;
 			linux,remove-completely;
-			reg = <0 0x07000000 0 0x5800000>;
+			reg = <0 0x07000000 0 0x5a00000>;
 			label = "modem_mem";
 		};
 	};


### PR DESCRIPTION
This is necessary for newest modem firmwares.
