### PR TITLE
flamingo: DT: merge typo fix

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -131,6 +131,19 @@
 		qcom,has-autodetect-xo;
 		qcom,wcnss-adc_tm = <&pm8226_adc_tm>;
 	};
+
+	i2c@f9925000 {
+		qcom,master-id = <86>;
+	};
+
+	i2c@f9926000 {
+		qcom,i2c-src-freq = <19200000>;
+		qcom,master-id = <86>;
+	};
+
+	i2c@f9927000 {
+		qcom,master-id = <86>;
+	};
 };
 
 &modem_mem {
@@ -175,15 +188,6 @@
 			/delete-property/ qcom,mode;
 		};
         };
-
-	i2c@f9926000 {
-		qcom,i2c-src-freq = <19200000>;
-		qcom,master-id = <86>;
-	};
-
-	i2c@f9927000 {
-		qcom,master-id = <86>;
-	};
 };
 
 &pm8226_gpios {


### PR DESCRIPTION
fix i2c@9925000/9926000 and 9927000 as sub node &soc {}

without the fix, the following err kmesg was seen flamingo:
qup_i2c f9925000.i2c: Missing 'qcom,master-id' DT entry
qup_i2c f9927000.i2c: Missing 'qcom,master-id' DT entry
