### PR TITLE
flamingo: DT: cleanup useless entires

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -175,15 +175,6 @@
 			/delete-property/ qcom,mode;
 		};
         };
-
-	i2c@f9926000 {
-		qcom,i2c-src-freq = <19200000>;
-		qcom,master-id = <86>;
-	};
-
-	i2c@f9927000 {
-		qcom,master-id = <86>;
-	};
 };
 
 &pm8226_gpios {

--- a/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_flamingo-mtp.dtsi
@@ -279,19 +279,4 @@
 
 &mdss_dsi0 {
 	qcom,dsi-pref-prim-pan = <&dsi_truly_hx8379c_fwvga_vid>;
-	vdddsi-supply = <&pm8226_lvs1>;
-	qcom,panel-supply-entries {
-		qcom,panel-supply-entry@2 {
-			reg = <2>;
-			qcom,supply-name = "vdddsi";
-			qcom,supply-min-voltage = <1800000>;
-			qcom,supply-max-voltage = <1800000>;
-			qcom,supply-enable-load = <100000>;
-			qcom,supply-disable-load = <100>;
-			qcom,supply-pre-on-sleep = <0>;
-			qcom,supply-post-on-sleep = <0>;
-			qcom,supply-pre-off-sleep = <0>;
-			qcom,supply-post-off-sleep = <0>;
-		};
-	};
 };


### PR DESCRIPTION
first of all, the removed lines are in wrong position,
because i2c@9925000/9926000 and 9927000 should be sub node &soc {}
seems to be a merge typo here.   so, removing wrong lines brings no impact.

secondly, i can't find similar lines in CAF reference, lines should be useless. 
so i deleted them instead of moving them into &soc{}
