### PR TITLE
drivers: video: mdss: Fix gpio handler for kitakami karin

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -324,14 +324,6 @@ static int mdss_dsi_request_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 {
 	int rc = 0;
 
-	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio)) {
-		rc = gpio_request(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio,
-						"disp_dcdc_en_gpio");
-		if (rc) {
-			pr_err("request disp_dcdc_en gpio failed, rc=%d\n", rc);
-			goto disp_dcdc_en_gpio_err;
-		}
-	}
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio)) {
 		rc = gpio_request(ctrl_pdata->disp_en_gpio,
 						"disp_enable");
@@ -375,9 +367,6 @@ rst_gpio_err:
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio))
 		gpio_free(ctrl_pdata->disp_en_gpio);
 disp_en_gpio_err:
-	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio))
-		gpio_free(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio);
-disp_dcdc_en_gpio_err:
 	return rc;
 }
 
@@ -394,9 +383,6 @@ static void mdss_dsi_free_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 
 	if (gpio_is_valid(ctrl_pdata->mode_gpio))
 		gpio_free(ctrl_pdata->mode_gpio);
-
-	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio))
-		gpio_free(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio);
 }
 
 static void mdss_dsi_panel_set_gpio_seq(
@@ -2581,20 +2567,6 @@ int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 
 	pw_seq = (enable) ? &spec_pdata->on_seq : &spec_pdata->off_seq;
 
-	if (gpio_is_valid(spec_pdata->disp_dcdc_en_gpio)) {
-		if (enable) {
-			if (pw_seq->disp_dcdc_en_pre)
-				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
-					pw_seq->disp_dcdc_en_pre * 1000 + 100);
-
-			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
-
-			if (pw_seq->disp_dcdc_en_post)
-				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
-					pw_seq->disp_dcdc_en_post * 1000 + 100);
-		}
-	}
-
 	if (pw_seq->disp_en_pre)
 		usleep_range(pw_seq->disp_en_pre * 1000,
 				pw_seq->disp_en_pre * 1000 + 100);
@@ -2615,20 +2587,6 @@ int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 	if (pw_seq->disp_en_post)
 		usleep_range(pw_seq->disp_en_post * 1000,
 				pw_seq->disp_en_post * 1000 + 100);
-
-	if (gpio_is_valid(spec_pdata->disp_dcdc_en_gpio)) {
-		if (!enable) {
-			if (pw_seq->disp_dcdc_en_pre)
-				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
-					pw_seq->disp_dcdc_en_pre * 1000 + 100);
-
-			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
-
-			if (pw_seq->disp_dcdc_en_post)
-				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
-					pw_seq->disp_dcdc_en_post * 1000 + 100);
-		}
-	}
 
 	return 0;
 }

--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -75,6 +75,7 @@ static int lcd_id;
 static int vsn_gpio, vsp_gpio;
 static uint32_t lcdid_adc;
 static bool adc_det;
+static bool gpio_req;
 static bool display_on_in_boot;
 static bool display_onoff_state;
 static unsigned char panel_id[1];
@@ -323,6 +324,14 @@ static int mdss_dsi_request_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 {
 	int rc = 0;
 
+	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio)) {
+		rc = gpio_request(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio,
+						"disp_dcdc_en_gpio");
+		if (rc) {
+			pr_err("request disp_dcdc_en gpio failed, rc=%d\n", rc);
+			goto disp_dcdc_en_gpio_err;
+		}
+	}
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio)) {
 		rc = gpio_request(ctrl_pdata->disp_en_gpio,
 						"disp_enable");
@@ -366,6 +375,9 @@ rst_gpio_err:
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio))
 		gpio_free(ctrl_pdata->disp_en_gpio);
 disp_en_gpio_err:
+	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio))
+		gpio_free(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio);
+disp_dcdc_en_gpio_err:
 	return rc;
 }
 
@@ -382,6 +394,9 @@ static void mdss_dsi_free_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 
 	if (gpio_is_valid(ctrl_pdata->mode_gpio))
 		gpio_free(ctrl_pdata->mode_gpio);
+
+	if (gpio_is_valid(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio))
+		gpio_free(ctrl_pdata->spec_pdata->disp_dcdc_en_gpio);
 }
 
 static void mdss_dsi_panel_set_gpio_seq(
@@ -399,6 +414,7 @@ static void mdss_dsi_panel_set_gpio_seq(
 
 static int mdss_dsi_panel_reset_seq(struct mdss_panel_data *pdata, int enable)
 {
+	int rc;
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
 	struct mdss_panel_info *pinfo;
@@ -427,7 +443,14 @@ static int mdss_dsi_panel_reset_seq(struct mdss_panel_data *pdata, int enable)
 	pr_debug("%s: enable=%d\n", __func__, enable);
 	pinfo = &ctrl_pdata->panel_data.panel_info;
 
-	mdss_dsi_request_gpios(ctrl_pdata);
+	if (!gpio_req) {
+		rc = mdss_dsi_request_gpios(ctrl_pdata);
+		if (rc) {
+			pr_err("gpio request failed\n");
+			return rc;
+		}
+		gpio_req = true;
+	}
 
 	pw_seq = (enable) ? &ctrl_pdata->spec_pdata->on_seq :
 				&ctrl_pdata->spec_pdata->off_seq;
@@ -2547,11 +2570,30 @@ int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 
 	pr_info("%s: enable = %d\n", __func__, enable);
 
-	rc = mdss_dsi_request_gpios(ctrl_pdata);
-	if (rc)
-		pr_err("gpio request failed\n");
+	if (!gpio_req) {
+		rc = mdss_dsi_request_gpios(ctrl_pdata);
+		if (rc) {
+			pr_err("gpio request failed\n");
+			return rc;
+		}
+		gpio_req = true;
+	}
 
 	pw_seq = (enable) ? &spec_pdata->on_seq : &spec_pdata->off_seq;
+
+	if (gpio_is_valid(spec_pdata->disp_dcdc_en_gpio)) {
+		if (enable) {
+			if (pw_seq->disp_dcdc_en_pre)
+				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
+					pw_seq->disp_dcdc_en_pre * 1000 + 100);
+
+			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
+
+			if (pw_seq->disp_dcdc_en_post)
+				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
+					pw_seq->disp_dcdc_en_post * 1000 + 100);
+		}
+	}
 
 	if (pw_seq->disp_en_pre)
 		usleep_range(pw_seq->disp_en_pre * 1000,
@@ -2573,6 +2615,20 @@ int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 	if (pw_seq->disp_en_post)
 		usleep_range(pw_seq->disp_en_post * 1000,
 				pw_seq->disp_en_post * 1000 + 100);
+
+	if (gpio_is_valid(spec_pdata->disp_dcdc_en_gpio)) {
+		if (!enable) {
+			if (pw_seq->disp_dcdc_en_pre)
+				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
+					pw_seq->disp_dcdc_en_pre * 1000 + 100);
+
+			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
+
+			if (pw_seq->disp_dcdc_en_post)
+				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
+					pw_seq->disp_dcdc_en_post * 1000 + 100);
+		}
+	}
 
 	return 0;
 }


### PR DESCRIPTION
[   16.386442] ------------[ cut here ]------------
[   16.386454] WARNING: at ../../../../../../kernel/sony/msm/drivers/gpio/gpiolib.c:126 gpio_to_desc+0x2c/0x50()
[   16.386455] invalid GPIO -2
[   16.386461] CPU: 1 PID: 678 Comm: mdss_fb0 Tainted: G        W    3.10.84-perf-gf27d248-00381-g5bf33af #4
[   16.386463] Call trace:
[   16.386470] [<ffffffc000206b20>] dump_backtrace+0x0/0x270
[   16.386473] [<ffffffc000206da0>] show_stack+0x10/0x1c
[   16.386479] [<ffffffc000cde0cc>] dump_stack+0x1c/0x28
[   16.386484] [<ffffffc00021c39c>] warn_slowpath_common+0x70/0x9c
[   16.386487] [<ffffffc00021c440>] warn_slowpath_fmt+0x4c/0x58
[   16.386490] [<ffffffc00045c67c>] gpio_to_desc+0x28/0x50
[   16.386494] [<ffffffc00045f318>] gpio_request+0xc/0x20
[   16.386498] [<ffffffc0004fd564>] mdss_dsi_request_gpios+0x54/0x118
[   16.386501] [<ffffffc0004fd7dc>] mdss_dsi_panel_reset_seq+0x104/0x348
[   16.386505] [<ffffffc000500df0>] mdss_dsi_panel_reset+0x8/0x14
[   16.386510] [<ffffffc0004f3638>] mdss_dsi_on+0x1d0/0x2c4
[   16.386514] [<ffffffc0004f3978>] mdss_dsi_event_handler+0x10c/0x7e0
[   16.386518] [<ffffffc0004c0c90>] mdss_mdp_ctl_intf_event+0x7c/0xa4
[   16.386521] [<ffffffc0004dbb74>] mdss_mdp_cmd_panel_on+0x60/0x188
[   16.386524] [<ffffffc0004dd264>] mdss_mdp_cmd_kickoff+0xd8/0x540
[   16.386529] [<ffffffc0004c3be8>] mdss_mdp_display_commit+0xa30/0xbbc
[   16.386532] [<ffffffc0004e68b4>] mdss_mdp_overlay_kickoff+0x9e8/0x10cc
[   16.386538] [<ffffffc00052321c>] __mdss_fb_display_thread+0x224/0x428
[   16.386543] [<ffffffc00023d328>] kthread+0xac/0xb8
[   16.386545] ---[ end trace cdbbdccf423660b7 ]---
[   16.386547] gpiod_request: invalid GPIO
[   16.386548] request reset gpio failed, rc=-22

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I4d120c8a9c0018f3d5d83760c189c68813217baa
