### PR TITLE
wlan: Address buffer overflow due to invalid length

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -6895,6 +6895,9 @@ int wlan_hdd_set_filter(hdd_context_t *pHddCtx, tpPacketFilterCfg pRequest,
 
                 hddLog(VOS_TRACE_LEVEL_INFO, "Data Offset %d Data Len %d",
                         pRequest->paramsData[i].dataOffset, pRequest->paramsData[i].dataLength);
+                if ((sizeof(packetFilterSetReq.paramsData[i].compareData)) <
+                    (pRequest->paramsData[i].dataLength))
+                    return -EINVAL;
 
                 memcpy(&packetFilterSetReq.paramsData[i].compareData,
                         pRequest->paramsData[i].compareData, pRequest->paramsData[i].dataLength);


### PR DESCRIPTION
Check for valid length before copying the packet filter data from
userspace buffer to kernel space buffer to avoid buffer overflow
issue.

Change-Id: I9548727543b903b5eaafa25c6184615d511ca99d
CRs-Fixed: 930533
