### PR TITLE
usb: dwc3: dwc3-msm: Fix header inclusion

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -52,6 +52,9 @@
 #include <linux/gpio.h>
 #include <linux/of_gpio.h>
 #include <asm/setup.h>
+ #ifdef CONFIG_QPNP_SMBCHARGER_EXTENSION
+ #include <linux/qpnp/qpnp-smbcharger_extension.h>
+ #endif
 #endif
 
 #include "dwc3_otg.h"


### PR DESCRIPTION
In case of SONY smbcharger extension, we need to include its header.
