### PR TITLE
[1.1] video: msm: mdss_dsi_panel_driver: Fix GPIO requests

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -366,6 +366,7 @@ rst_gpio_err:
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio))
 		gpio_free(ctrl_pdata->disp_en_gpio);
 disp_en_gpio_err:
+	gpio_req = false;
 	return rc;
 }
 
@@ -382,6 +383,8 @@ static void mdss_dsi_free_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 
 	if (gpio_is_valid(ctrl_pdata->mode_gpio))
 		gpio_free(ctrl_pdata->mode_gpio);
+
+	gpio_req = false;
 }
 
 static void mdss_dsi_panel_set_gpio_seq(


### PR DESCRIPTION
Commit 4422ec277fe00a87ac91c3fc55253cac811f0904 was "fixing" the
kernel warnings about GPIO requests for the Sony board Karin,
but its logic was completely broken:
GPIOs were requested at display power-on and freed at power-off,
but the actual boolean for re-requesting the GPIOs was never set
back to good state, hence the driver was never requesting them
anymore.

Fix the logic error by properly setting the gpio_req bool to
false when GPIOs get freed.
