### PR TITLE
net: wireless: bcmdhd: Set random MAC generation for Kitakami devices…

### DIFF
--- a/arch/arm/vfp/vfpmodule.c
+++ b/arch/arm/vfp/vfpmodule.c
@@ -731,9 +731,6 @@ static int __init vfp_init(void)
 {
 	unsigned int vfpsid;
 	unsigned int cpu_arch = cpu_architecture();
-#ifdef CONFIG_PROC_FS
-	static struct proc_dir_entry *procfs_entry;
-#endif
 	if (cpu_arch >= CPU_ARCH_ARMv6)
 		on_each_cpu(vfp_enable, NULL, 1);
 
@@ -807,8 +804,13 @@ static int __init vfp_init(void)
 #endif
 		}
 	}
+	return 0;
+}
 
+static int __init vfp_init_rootfs(void)
+{
 #ifdef CONFIG_PROC_FS
+	static struct proc_dir_entry *procfs_entry;
 	procfs_entry = proc_create("cpu/vfp_bounce", S_IRUGO, NULL,
 			&vfp_bounce_fops);
 	if (!procfs_entry)
@@ -819,3 +821,4 @@ static int __init vfp_init(void)
 }
 
 core_initcall(vfp_init);
+rootfs_initcall(vfp_init_rootfs);


### PR DESCRIPTION
… as default

This change fixes MAC address generation for all Kitakami devices that aren't
using /sys/devices/platform/bcmdhd_wlan/macaddr (wlan sysfs path).

Also avoid this error during initalization:
<3>[    9.260469] somc_wifi_get_mac_addr: Failed to get information from file /sys/devices/platform/bcmdhd_wlan/macaddr (-2)

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I50412a74cf3565cbc02772416c0603c025c8d48b
