### PR TITLE
[1.2.2 STABILITY] msm: mdss: release the mutex on rotator kickoff failure

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_rotator.c
+++ b/drivers/video/msm/mdss/mdss_mdp_rotator.c
@@ -605,6 +605,10 @@ static int mdss_mdp_rotator_queue_sub(struct mdss_mdp_rotator_session *rot,
 	ATRACE_BEGIN("rotator_kickoff");
 	ret = mdss_mdp_rotator_kickoff(rot_ctl, rot, dst_data);
 	ATRACE_END("rotator_kickoff");
+	if (ret) {
+		pr_err("mdss_mdp_rotator_kickoff error : %d\n", ret);
+		goto error;
+	}
 
 	return ret;
 error:


### PR DESCRIPTION
Rotator shared lock is released on the rotator completion, but when
rotator kickoff fails as completion wont happen lock is not released.
Handle the failure case gracefully.

Change-Id: I2973a1eec617b36c7af8e7c3f250baefe9f245cf
Signed-off-by: Kalyan Thota kalyant@codeaurora.org
