### PR TITLE
dt: amami dsi panel: add somc,panel-id-read-cmds

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-amami.dtsi
@@ -480,6 +480,7 @@
 
 		somc,panel-detect = <1>;
 		somc,driver-ic = <4>;
+		somc,panel-id-read-cmds;
 		qcom,mdss-pan-physical-width-dimension = <53>;
 		qcom,mdss-pan-physical-height-dimension = <94>;
 		somc,mdss-phy-size-mm = <53 94>;


### PR DESCRIPTION
panel-id-read-cmds fixes panel detection on future panelchanges (or makes it more simple) and does not affect panel detection on current paneldriver
