### PR TITLE
arm: vfp: Fix create procfs node for VFP bounce

### DIFF
--- a/arch/arm/vfp/vfpmodule.c
+++ b/arch/arm/vfp/vfpmodule.c
@@ -731,9 +731,6 @@ static int __init vfp_init(void)
 {
 	unsigned int vfpsid;
 	unsigned int cpu_arch = cpu_architecture();
-#ifdef CONFIG_PROC_FS
-	static struct proc_dir_entry *procfs_entry;
-#endif
 	if (cpu_arch >= CPU_ARCH_ARMv6)
 		on_each_cpu(vfp_enable, NULL, 1);
 
@@ -807,8 +804,13 @@ static int __init vfp_init(void)
 #endif
 		}
 	}
+	return 0;
+}
 
+static int __init vfp_init_rootfs(void)
+{
 #ifdef CONFIG_PROC_FS
+	static struct proc_dir_entry *procfs_entry;
 	procfs_entry = proc_create("cpu/vfp_bounce", S_IRUGO, NULL,
 			&vfp_bounce_fops);
 	if (!procfs_entry)
@@ -819,3 +821,4 @@ static int __init vfp_init(void)
 }
 
 core_initcall(vfp_init);
+rootfs_initcall(vfp_init_rootfs);


### PR DESCRIPTION
[    0.091834] VFP support v0.3: implementor 51 architecture 64 part 6f variant 2 rev 1
[    0.091855] ------------[ cut here ]------------
[    0.091874] WARNING: at ../../../../../../kernel/sony/msm/fs/proc/generic.c:101 __xlate_proc_name+0xa0/0xb4()
[    0.091882] name 'cpu/vfp_bounce'
[    0.091894] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 3.10.84-gf27d248-00444-g6185dc0 #2
[    0.091921] [<c010b7d0>](unwind_backtrace+0x0/0x11c) from [<c0109aac>](show_stack+0x10/0x14)
[    0.091944] [<c0109aac>](show_stack+0x10/0x14) from [<c012be1c>](warn_slowpath_common+0x48/0x68)
[    0.091963] [<c012be1c>](warn_slowpath_common+0x48/0x68) from [<c012be94>](warn_slowpath_fmt+0x2c/0x3c)
[    0.091981] [<c012be94>](warn_slowpath_fmt+0x2c/0x3c) from [<c023e860>](__xlate_proc_name+0xa0/0xb4)
[    0.091998] [<c023e860>](__xlate_proc_name+0xa0/0xb4) from [<c023e8c0>](__proc_create+0x4c/0xdc)
[    0.092013] [<c023e8c0>](__proc_create+0x4c/0xdc) from [<c023eda8>](proc_create_data+0x58/0x98)
[    0.092031] [<c023eda8>](proc_create_data+0x58/0x98) from [<c1002f50>](vfp_init+0x16c/0x1d8)
[    0.092049] [<c1002f50>](vfp_init+0x16c/0x1d8) from [<c1000b04>](do_one_initcall+0xb8/0x160)
[    0.092065] [<c1000b04>](do_one_initcall+0xb8/0x160) from [<c1000cb4>](kernel_init_freeable+0x108/0x1cc)
[    0.092087] [<c1000cb4>](kernel_init_freeable+0x108/0x1cc) from [<c0a8ec24>](kernel_init+0xc/0xe4)
[    0.092110] [<c0a8ec24>](kernel_init+0xc/0xe4) from [<c0106260>](ret_from_fork+0x14/0x34)
[    0.092141] ---[ end trace da227214a82491b7 ]---
[    0.092150] Failed to create procfs node for VFP bounce reporting

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ia0b98c80483fb5646a21eea28f45d396c4ea3e30
