### PR TITLE
(fix for arm64) readahead: fault retry breaks mmap file read random d…

### DIFF
--- a/arch/arm64/mm/fault.c
+++ b/arch/arm64/mm/fault.c
@@ -282,6 +282,7 @@ retry:
 			 * starvation.
 			 */
 			mm_flags &= ~FAULT_FLAG_ALLOW_RETRY;
+			mm_flags |= FAULT_FLAG_TRIED;
 			goto retry;
 		}
 	}


### PR DESCRIPTION
…etection

.fault now can retry.  The retry can break state machine of .fault.  In
filemap_fault, if page is miss, ra->mmap_miss is increased.  In the second
try, since the page is in page cache now, ra->mmap_miss is decreased.  And
these are done in one fault, so we can't detect random mmap file access.

Add a new flag to indicate .fault is tried once.  In the second try, skip
ra->mmap_miss decreasing.  The filemap_fault state machine is ok with it.

I only tested x86, didn't test other archs, but looks the change for other
archs is obvious, but who knows :)

Change-Id: Ib0d911c27f2347b2f1fa56231ff9ad518adf5988
Signed-off-by: Shaohua Li shaohua.li@fusionio.com
Cc: Rik van Riel riel@redhat.com
Cc: Wu Fengguang fengguang.wu@intel.com
Signed-off-by: Andrew Morton akpm@linux-foundation.org
Signed-off-by: Linus Torvalds torvalds@linux-foundation.org
