### PR TITLE
[1.1] usb: dwc3: dwc3-msm: Fix error condition check for devm_regulator_get

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -3936,7 +3936,7 @@ static void dwc3_msm_shutdown(struct platform_device *pdev)
 		struct dwc3 *dwc = platform_get_drvdata(mdwc->dwc3);
 		struct regulator *vbus_rec = devm_regulator_get(
 						dwc->dev->parent, "vbus_rec");
-		if (!vbus_rec) {
+		if (IS_ERR_OR_NULL(vbus_rec)) {
 			dev_err(mdwc->dev, "failed to get vbus_rec\n");
 		} else {
 			int rc;


### PR DESCRIPTION
The function devm_regulator_get can return an error code or can
be NULL. Fix the check.
