### PR TITLE
[1.1] power: qpnp-smbcharger_extension: Use pr_debug for charger type read …

### DIFF
--- a/drivers/power/qpnp-smbcharger_extension.c
+++ b/drivers/power/qpnp-smbcharger_extension.c
@@ -460,7 +460,7 @@ static bool somc_chg_is_charger_type_same(const char *type)
 		rc = chg_params->usb_psy->get_property(chg_params->usb_psy,
 			POWER_SUPPLY_PROP_CHARGER_TYPE, &prop);
 		if (rc < 0)
-			pr_err("Couldn't read charger type: %d\n", rc);
+			pr_debug("Couldn't read charger type: %d\n", rc);
 		else if (strcmp(prop.strval, type) == 0)
 			ret = true;
 	}


### PR DESCRIPTION
…error

STFU way: 1.1 has broken support for Sony USB Extensions, which is
meant for newer kernels.
This commit solves the kmsg spam by this driver.
