### PR TITLE
net: wireless: bcmdhd/somc-wifi-ctrl: Fix random MAC usage ...

### DIFF
--- a/drivers/net/wireless/controlfnc/somc-wifi-ctrl.c
+++ b/drivers/net/wireless/controlfnc/somc-wifi-ctrl.c
@@ -533,6 +533,7 @@ static int somc_wifi_get_mac_addr(unsigned char *buf)
 	}
 
 	readlen = kernel_read(fp, fp->f_pos, macasc, 17); // 17 = 12 + 5
+	filp_close(fp, NULL);
 	if (readlen > 0) {
 		unsigned char* macbin;
 		struct ether_addr* convmac = ether_aton( macasc );
@@ -551,9 +552,10 @@ static int somc_wifi_get_mac_addr(unsigned char *buf)
 				macbin[3], macbin[4], macbin[5]);
 
 		memcpy(buf, macbin, ETHER_ADDR_LEN);
+	} else {
+		goto random_mac;
 	}
 
-	filp_close(fp, NULL);
 	return ret;
 
 random_mac:


### PR DESCRIPTION
... when nothing is written to the macaddr file.

The current check for 'readlen > 0' only accounts for the cases
where something is written to the macaddr file.
If nothing is written at all, the random MAC won't be used either,
and the bcmdhd driver's random MAC setting fails as well, which results
in a MAC of all zeroes, which isn't usable.

While this isn't perfect for normal use cases (as it'll generate a new random
MAC each boot), it's better to have wifi functioning with this rather
than not working at all.

Also sneak in a little change to move the file closing near it's usage.

Change-Id: I27aed88160e735460ba6e76160e6f5660e0bbd39
