### PR TITLE
net: wireless: bcmdhd: Fix wifi for scorpion

### DIFF
--- a/drivers/net/wireless/bcmdhd/dhd_linux.c
+++ b/drivers/net/wireless/bcmdhd/dhd_linux.c
@@ -6065,8 +6065,7 @@ dhd_preinit_ioctls(dhd_pub_t *dhd)
 			kfree(eventmask_msg);
 			goto done;
 		}
-#if !defined(CONFIG_MACH_SONY_SCORPION) || \
-		!defined(CONFIG_MACH_SONY_SCORPION_WINDY)
+#ifndef CONFIG_MACH_SONY_SCORPION
 	} else if (ret2 < 0 && ret2 != BCME_UNSUPPORTED) {
 		DHD_ERROR(("%s read event mask ext failed %d\n", __FUNCTION__, ret2));
 		kfree(eventmask_msg);


### PR DESCRIPTION
commit ec3bcce2afb7771a94f849a4ed1d06b4ed41310c
"net: wireless: bcmdhd: Fix older firmwares support for BCM4354"
removed this check for scorpion or scorpion_windy, but now
that those two are unified as scorpion, the check failed.
Remove the windy check to fix wifi.

Change-Id: I01823a2eceec8f301ee8958873594ce9c1b7a463
