### PR TITLE
[1.2.2] arm: DT: mdss updates

### DIFF
--- a/arch/arm/boot/dts/qcom/apq8084-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8084-mdss.dtsi
@@ -207,16 +207,6 @@
 				qcom,supply-enable-load = <100000>;
 				qcom,supply-disable-load = <100>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-mdss.dtsi
@@ -169,15 +169,6 @@
 				qcom,supply-disable-load = <100>;
 				qcom,supply-post-on-sleep = <20>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8610-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8610-mdss.dtsi
@@ -62,15 +62,6 @@
 				qcom,supply-post-on-sleep = <20>;
 				qcom,supply-post-off-sleep = <20>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
@@ -274,16 +274,6 @@
 				qcom,supply-enable-load = <100000>;
 				qcom,supply-disable-load = <100>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
 		};
 
 		qcom,panel-supply-entries {

--- a/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
@@ -179,16 +179,6 @@
 				qcom,supply-enable-load = <100000>;
 				qcom,supply-disable-load = <100>;
 			};
-
-			qcom,ctrl-supply-entry@1 {
-				reg = <1>;
-				qcom,supply-name = "vddio";
-				qcom,supply-min-voltage = <1800000>;
-				qcom,supply-max-voltage = <1800000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
 		};
 
 		qcom,panel-supply-entries {


### PR DESCRIPTION
Remove vddio node

[    0.568566] WARNING: at ../../../../../../kernel/sony/msm/fs/sysfs/dir.c:530 sysfs_add_one+0x7c/0x9c()
[    0.568571] sysfs: cannot create duplicate filename '/devices/qcom,rpm-smd.72/rpm-regulator-ldoa12.117/regulator-l12.156/regulator/regulator.24/fd922800.qcom,mdss_dsi-vddio'
