### PR TITLE
[1.2.2] drivers: video: mdss: Fix backlight during initialization

### DIFF
--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -211,7 +211,7 @@ static void mdss_ensure_kworker_done(struct workqueue_struct *wq)
 	}
 }
 
-static struct input_handler mds_input_handler = {
+static struct input_handler mdss_input_handler = {
 	.event		= mdss_input_event,
 	.connect	= mdss_input_connect,
 	.disconnect	= mdss_input_disconnect,
@@ -4529,7 +4529,7 @@ int __init mdss_fb_init(void)
 		return rc;
 
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	if (input_register_handler(&mds_input_handler))
+	if (input_register_handler(&mdss_input_handler))
 		return rc;
 #endif
 

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1330,6 +1330,11 @@ static int mdss_fb_suspend_sub(struct msm_fb_data_type *mfd)
 		mfd->op_enable = false;
 		fb_set_suspend(mfd->fbi, FBINFO_STATE_SUSPENDED);
 	}
+
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	pwr_pressed = false;
+#endif
+
 exit:
 	return ret;
 }
@@ -1623,9 +1628,6 @@ void mdss_fb_set_backlight(struct msm_fb_data_type *mfd, u32 bkl_lvl)
 			mfd->bl_level = bkl_lvl;
 			mfd->bl_level_scaled = temp;
 		}
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-		bl_before = temp;
-#endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 
 		if (ad_bl_notify_needed)
 			mdss_fb_bl_update_notify(mfd,
@@ -1634,6 +1636,9 @@ void mdss_fb_set_backlight(struct msm_fb_data_type *mfd, u32 bkl_lvl)
 			mdss_fb_bl_update_notify(mfd,
 					NOTIFY_TYPE_BL_UPDATE);
 	}
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	bl_before = temp;
+#endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 }
 
 void mdss_fb_update_backlight(struct msm_fb_data_type *mfd)
@@ -3655,10 +3660,6 @@ static int mdss_fb_check_var(struct fb_var_screeninfo *var,
 			return rc;
 		mfd->panel_reconfig = rc;
 	}
-
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	pwr_pressed = false;
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
This patch uses 32.0.A.6.xxx tree as reference.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I6338e6bf655f1e13946387be6a29106db516cef6
