### PR TITLE
[1.2.2] arm: DT: mdss: msm8974: Remove unused node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-mdss.dtsi
@@ -187,16 +187,6 @@
 
 			qcom,panel-supply-entry@0 {
 				reg = <0>;
-				qcom,supply-name = "vdd";
-				qcom,supply-min-voltage = <3000000>;
-				qcom,supply-max-voltage = <3000000>;
-				qcom,supply-enable-load = <100000>;
-				qcom,supply-disable-load = <100>;
-				qcom,supply-post-on-sleep = <20>;
-			};
-
-			qcom,panel-supply-entry@1 {
-				reg = <1>;
 				qcom,supply-name = "vddio";
 				qcom,supply-min-voltage = <1800000>;
 				qcom,supply-max-voltage = <1800000>;


### PR DESCRIPTION
This patch uses 1.2.1 kernel tree as reference.

Fix warning:
[ 0.441916] sysfs: cannot create duplicate filename '/devices/qcom,rpm-smd.72/rpm-regulator-ldoa12.117/regulator-l12.156/regulator/regulator.24/fd922800.qcom,mdss_dsi-vddio'

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ib9594daa5025bb7b8f3434ca097d17f18f637aff
