### PR TITLE
tulip: fix smb1360-charger-fg compile

### DIFF
--- a/drivers/power/smb1360-charger-fg.c
+++ b/drivers/power/smb1360-charger-fg.c
@@ -1002,6 +1002,22 @@ static int smb1360_get_prop_batt_status(struct smb1360_chip *chip)
 		return POWER_SUPPLY_STATUS_CHARGING;
 }
 
+#ifdef CONFIG_MACH_SONY_TULIP
+static int smb1360_get_prop_charging_status(struct smb1360_chip *chip)
+{
+	int rc;
+	u8 reg = 0;
+
+	rc = smb1360_read(chip, STATUS_3_REG, &reg);
+	if (rc) {
+		pr_err("Couldn't read STATUS_3_REG rc=%d\n", rc);
+		return 0;
+	}
+
+	return (reg & CHG_EN_BIT) ? 1 : 0;
+}
+#endif
+
 static int smb1360_get_prop_charge_type(struct smb1360_chip *chip)
 {
 	int rc;
@@ -1825,9 +1841,15 @@ static int smb1360_battery_get_property(struct power_supply *psy,
 	case POWER_SUPPLY_PROP_STATUS:
 		val->intval = smb1360_get_prop_batt_status(chip);
 		break;
+#ifndef CONFIG_MACH_SONY_TULIP
 	case POWER_SUPPLY_PROP_CHARGING_ENABLED:
 		val->intval = !chip->charging_disabled_status;
 		break;
+#else
+	case POWER_SUPPLY_PROP_CHARGING_ENABLED:
+		val->intval = smb1360_get_prop_charging_status(chip);
+		break;
+#endif
 	case POWER_SUPPLY_PROP_CHARGE_TYPE:
 		val->intval = smb1360_get_prop_charge_type(chip);
 		break;
@@ -2580,7 +2602,9 @@ static struct irq_handler_info handlers[] = {
 			},
 			{
 				.name		= "aicl_done",
+#ifndef CONFIG_MACH_SONY_TULIP
 				.smb_irq	= aicl_done_handler,
+#endif
 			},
 			{
 				.name		= "battery_ov",


### PR DESCRIPTION
fixes

../../../../../../kernel/sony/msm/drivers/power/smb1360-charger-fg.c:2583:16: error: 'aicl_done_handler' undeclared here (not in a function)
     .smb_irq = aicl_done_handler,
                ^
../../../../../../kernel/sony/msm/drivers/power/smb1360-charger-fg.c: In function 'brain_work':
../../../../../../kernel/sony/msm/drivers/power/smb1360-charger-fg.c:4825:2: error: implicit declaration of function 'smb1360_get_prop_charging_status' [-Werror=implicit-function-declaration]
  int en = smb1360_get_prop_charging_status(chip);
  ^
cc1: some warnings being treated as errors
