### PR TITLE
[1.2.2] drivers: misc: qseecom: Fix app name size

### DIFF
--- a/include/uapi/linux/qseecom.h
+++ b/include/uapi/linux/qseecom.h
@@ -5,7 +5,11 @@
 #include <linux/ioctl.h>
 
 #define MAX_ION_FD  4
+#ifdef CONFIG_ARCH_MSM8994
 #define MAX_APP_NAME_SIZE  64
+#else
+#define MAX_APP_NAME_SIZE  32
+#endif
 #define QSEECOM_HASH_SIZE  32
 /*
  * struct qseecom_register_listener_req -


### PR DESCRIPTION
The app name size should be 32 for non 8994 platforms.
This patch fix keymaster HAL.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ib2afdcc8436468effe622fdf76c37543eb84f398
