### PR TITLE
ASoC: msm: Add Buffer overflow check

### DIFF
--- a/drivers/misc/qcom/qdsp6v2/audio_utils.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_utils.c
@@ -24,6 +24,12 @@
 #include <asm/ioctls.h>
 #include "audio_utils.h"
 
+#define MIN_FRAME_SIZE  1536
+#define NUM_FRAMES	5
+#define META_SIZE	(sizeof(struct meta_out_dsp))
+#define FRAME_SIZE	(1 + ((MIN_FRAME_SIZE + META_SIZE) * NUM_FRAMES))
+
+
 static int audio_in_pause(struct q6audio_in  *audio)
 {
 	int rc;
@@ -326,6 +332,11 @@ long audio_in_ioctl(struct file *file,
 		if ((cfg.buffer_size < (audio->min_frame_size+ \
 			sizeof(struct meta_out_dsp))) ||
 			(cfg.buffer_count < FRAME_NUM)) {
+			rc = -EINVAL;
+			break;
+		}
+		if ((cfg.buffer_size > FRAME_SIZE) ||
+			(cfg.buffer_count != FRAME_NUM)) {
 			rc = -EINVAL;
 			break;
 		}

--- a/sound/soc/msm/qdsp6v2/q6asm.c
+++ b/sound/soc/msm/qdsp6v2/q6asm.c
@@ -51,6 +51,8 @@ enum {
 	ASM_MAX_CAL_TYPES
 };
 
+#define FRAME_NUM   (8)
+
 /* TODO, combine them together */
 static DEFINE_MUTEX(session_lock);
 struct asm_mmap {
@@ -1177,6 +1179,8 @@ int q6asm_audio_client_buf_alloc(unsigned int dir,
 			pr_debug("%s: buffer already allocated\n", __func__);
 			return 0;
 		}
+		if (bufcnt != FRAME_NUM)
+			goto fail;
 		mutex_lock(&ac->cmd_lock);
 		if (bufcnt > (LONG_MAX/sizeof(struct audio_buffer))) {
 			pr_err("%s: Buffer size overflows", __func__);


### PR DESCRIPTION
The overflow check is required to ensure that user space data
in kernel may not go beyond buffer boundary.

Change-Id: Ia0c785b8c895c317e9f904bc738df5217b837191
CRs-Fixed: 563086
Signed-off-by: Asish Bhattacharya asishb@codeaurora.org
Signed-off-by: Mohammad Johny Shaik mjshai@codeaurora.org
Signed-off-by: Ajay Dudani adudani@codeaurora.org

Conflicts:
    sound/soc/msm/qdsp6v2/q6asm.c
