### PR TITLE
aosp pstore

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-rhine_common.dtsi
@@ -25,7 +25,14 @@
 			reg = <0 0x03400000 0 0x2200000>;
 			label = "cont_splash_mem";
 		};
-        };
+		ramoops_mem: ramoops_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			reg = <0x3e8e0000 0x200000>;
+			linux,remove-completely;
+			label = "ramoops_mem";
+		};
+	};
 };
 
 &soc {
@@ -33,15 +40,17 @@
 		compatible = "ramoops";
 		status = "ok";
 
-		android,ramoops-buffer-start = <0x7fe00000>;
-		android,ramoops-buffer-size = <0x100000>;
-		android,ramoops-console-size = <0x80000>;
-		android,ramoops-record-size = <0x7F800>;
-		android,ramoops-annotate-size = <0x800>;
+		android,ramoops-buffer-start = <0x3e8e0000>;
+		android,ramoops-buffer-size = <0x200000>;
+		android,ramoops-console-size = <0x100000>;
+		android,ramoops-record-size = <0x10000>;
+		android,ramoops-ftrace-size = <0x10000>;
+		android,ramoops-pmsg-size = <0x80000>;
 		android,ramoops-dump-oops = <0x1>;
+		linux,contiguous-region = <&ramoops_mem>;
 		android,ramoops-hole {
-			 compatible = "qcom,msm-contig-mem";
-			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
+			compatible = "qcom,msm-contig-mem";
+			qcom,memblock-reserve = <0x3e8e0000 0x200000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
@@ -26,23 +26,32 @@
 			reg = <0 0x03400000 0 0x2200000>;
 			label = "cont_splash_mem";
 		};
-        };
+		ramoops_mem: ramoops_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			reg = <0x3e8e0000 0x200000>;
+			linux,remove-completely;
+			label = "ramoops_mem";
+		};
+	};
 };
 
 &soc {
 	ramoops {
 		compatible = "ramoops";
-		status = "disable";
+		status = "ok";
 
-		android,ramoops-buffer-start = <0x7fe00000>;
-		android,ramoops-buffer-size = <0x100000>;
-		android,ramoops-console-size = <0x80000>;
-		android,ramoops-record-size = <0x7F800>;
-		android,ramoops-annotate-size = <0x800>;
+		android,ramoops-buffer-start = <0x3e8e0000>;
+		android,ramoops-buffer-size = <0x200000>;
+		android,ramoops-console-size = <0x100000>;
+		android,ramoops-record-size = <0x10000>;
+		android,ramoops-ftrace-size = <0x10000>;
+		android,ramoops-pmsg-size = <0x80000>;
 		android,ramoops-dump-oops = <0x1>;
+		linux,contiguous-region = <&ramoops_mem>;
 		android,ramoops-hole {
-			 compatible = "qcom,msm-contig-mem";
-			 qcom,memblock-reserve = <0x3e9e0000 0x100000>;
+			compatible = "qcom,msm-contig-mem";
+			qcom,memblock-reserve = <0x3e8e0000 0x200000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
@@ -13,10 +13,6 @@
  */
 
 &soc {
-        ramoops {
-                android,ramoops-buffer-start = <0xdff00000>;
-        };
-
 	/* I2C : BLSP8 */
 	i2c@f9964000 {
 		synaptics_clearpad@2c {

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
@@ -13,10 +13,6 @@
  */
 
 &soc {
-        ramoops {
-                android,ramoops-buffer-start = <0xdff00000>;
-        };
-
 	/* I2C : BLSP8 */
 	i2c@f9964000 {
 		synaptics_clearpad@2c {

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -30,6 +30,14 @@
 			reg = <0 0x40000000 0 0x1000000>;
 			label = "fb_mem";
 		};
+
+		ramoops_mem: ramoops_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			reg = <0 0x1fe00000 0 0x00200000>;
+			linux,remove-completely;
+			label = "ramoops_mem";
+		};
 	};
 };
 
@@ -48,6 +56,24 @@
 };
 
 &soc {
+	ramoops {
+		compatible = "ramoops";
+		status = "ok";
+
+		android,ramoops-buffer-start = <0x1fe00000>;
+		android,ramoops-buffer-size = <0x200000>;
+		android,ramoops-console-size = <0x100000>;
+		android,ramoops-record-size = <0x10000>;
+		android,ramoops-ftrace-size = <0x10000>;
+		android,ramoops-pmsg-size = <0x80000>;
+		android,ramoops-dump-oops = <0x1>;
+		linux,contiguous-region = <&ramoops_mem>;
+		android,ramoops-hole {
+			compatible = "qcom,msm-contig-mem";
+			qcom,memblock-reserve = <0x1fe00000 0x00200000>;
+		};
+	};
+
 	/* UART: BLSP2 */
 	serial@f991e000 {
 		pinctrl-0 = <&msm_gpio_4_sus &msm_gpio_5_sus>;

--- a/fs/pstore/inode.c
+++ b/fs/pstore/inode.c
@@ -320,10 +320,10 @@ int pstore_mkfile(enum pstore_type_id type, char *psname, u64 id, int count,
 			  psname, id);
 		break;
 	case PSTORE_TYPE_CONSOLE:
-		scnprintf(name, sizeof(name), "console-%s-%lld", psname, id);
+		scnprintf(name, sizeof(name), "console-%s", psname);
 		break;
 	case PSTORE_TYPE_FTRACE:
-		scnprintf(name, sizeof(name), "ftrace-%s-%lld", psname, id);
+		scnprintf(name, sizeof(name), "ftrace-%s", psname);
 		break;
 	case PSTORE_TYPE_MCE:
 		scnprintf(name, sizeof(name), "mce-%s-%lld", psname, id);

--- a/fs/pstore/ram.c
+++ b/fs/pstore/ram.c
@@ -520,11 +520,11 @@ static int ramoops_probe(struct platform_device *pdev)
 		goto fail_out;
 	}
 
-	if (!is_power_of_2(pdata->record_size))
+	if (pdata->record_size && !is_power_of_2(pdata->record_size))
 		pdata->record_size = rounddown_pow_of_two(pdata->record_size);
-	if (!is_power_of_2(pdata->console_size))
+	if (pdata->console_size && !is_power_of_2(pdata->console_size))
 		pdata->console_size = rounddown_pow_of_two(pdata->console_size);
-	if (!is_power_of_2(pdata->ftrace_size))
+	if (pdata->ftrace_size && !is_power_of_2(pdata->ftrace_size))
 		pdata->ftrace_size = rounddown_pow_of_two(pdata->ftrace_size);
 	if (pdata->pmsg_size && !is_power_of_2(pdata->pmsg_size))
 		pdata->pmsg_size = rounddown_pow_of_two(pdata->pmsg_size);

--- a/fs/pstore/ram.c
+++ b/fs/pstore/ram.c
@@ -432,7 +432,8 @@ static void  ramoops_of_init(struct platform_device *pdev)
 	const struct device *dev = &pdev->dev;
 	struct ramoops_platform_data *pdata;
 	struct device_node *np = pdev->dev.of_node;
-	u32 start, size, console;
+	u32 start = 0, size = 0, console = 0, pmsg = 0;
+	u32 record = 0, oops = 0;
 	int ret;
 
 	pdata = dev_get_drvdata(dev);
@@ -455,9 +456,27 @@ static void  ramoops_of_init(struct platform_device *pdev)
 	if (ret)
 		return;
 
+	ret = of_property_read_u32(np, "android,ramoops-pmsg-size",
+				&pmsg);
+	if (ret)
+		pr_info("pmsg buffer not configured");
+
+	ret = of_property_read_u32(np, "android,ramoops-record-size",
+				&record);
+	if (ret)
+		pr_info("record buffer not configured");
+
+	ret = of_property_read_u32(np, "android,ramoops-dump-oops",
+				&oops);
+	if (ret)
+		pr_info("oops not configured");
+
 	pdata->mem_address = start;
 	pdata->mem_size = size;
 	pdata->console_size = console;
+	pdata->pmsg_size = pmsg;
+	pdata->record_size = record;
+	pdata->dump_oops = (int)oops;
 }
 #else
 static inline void ramoops_of_init(struct platform_device *pdev)

--- a/fs/pstore/ram.c
+++ b/fs/pstore/ram.c
@@ -34,6 +34,7 @@
 #include <linux/slab.h>
 #include <linux/compiler.h>
 #include <linux/pstore_ram.h>
+#include <linux/of.h>
 
 #define RAMOOPS_KERNMSG_HDR "===="
 #define MIN_MEM_SIZE 4096UL
@@ -419,14 +420,73 @@ void notrace ramoops_console_write_buf(const char *buf, size_t size)
 	persistent_ram_write(cxt->cprz, buf, size);
 }
 
+#ifdef CONFIG_OF
+static struct of_device_id ramoops_of_match[] = {
+	{ .compatible = "ramoops", },
+	{ },
+};
+
+MODULE_DEVICE_TABLE(of, ramoops_of_match);
+static void  ramoops_of_init(struct platform_device *pdev)
+{
+	const struct device *dev = &pdev->dev;
+	struct ramoops_platform_data *pdata;
+	struct device_node *np = pdev->dev.of_node;
+	u32 start, size, console;
+	int ret;
+
+	pdata = dev_get_drvdata(dev);
+	if (!pdata) {
+		pr_err("private data is empty!\n");
+		return;
+	}
+	ret = of_property_read_u32(np, "android,ramoops-buffer-start",
+				&start);
+	if (ret)
+		return;
+
+	ret = of_property_read_u32(np, "android,ramoops-buffer-size",
+				&size);
+	if (ret)
+		return;
+
+	ret = of_property_read_u32(np, "android,ramoops-console-size",
+				&console);
+	if (ret)
+		return;
+
+	pdata->mem_address = start;
+	pdata->mem_size = size;
+	pdata->console_size = console;
+}
+#else
+static inline void ramoops_of_init(struct platform_device *pdev)
+{
+	return;
+}
+#endif
+
 static int ramoops_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct ramoops_platform_data *pdata = pdev->dev.platform_data;
+	struct ramoops_platform_data *pdata;
 	struct ramoops_context *cxt = &oops_cxt;
 	size_t dump_mem_sz;
 	phys_addr_t paddr;
 	int err = -EINVAL;
+
+	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
+	if (!pdata) {
+		pr_err("could not allocate ramoops_platform_data\n");
+		return -ENOMEM;
+	}
+
+	err = dev_set_drvdata(dev, pdata);
+	if (err)
+		goto fail_out;
+
+	if (pdev->dev.of_node)
+		ramoops_of_init(pdev);
 
 	/* Only a single ramoops area allowed at a time, so fail extra
 	 * probes.
@@ -565,6 +625,7 @@ static struct platform_driver ramoops_driver = {
 	.remove		= __exit_p(ramoops_remove),
 	.driver		= {
 		.name	= "ramoops",
+		.of_match_table = of_match_ptr(ramoops_of_match),
 		.owner	= THIS_MODULE,
 	},
 };

--- a/fs/pstore/ram.c
+++ b/fs/pstore/ram.c
@@ -593,6 +593,9 @@ static int ramoops_probe(struct platform_device *pdev)
 	mem_address = pdata->mem_address;
 	record_size = pdata->record_size;
 	dump_oops = pdata->dump_oops;
+	ramoops_console_size = pdata->console_size;
+	ramoops_pmsg_size = pdata->pmsg_size;
+	ramoops_ftrace_size = pdata->ftrace_size;
 
 	pr_info("attached 0x%lx@0x%llx, ecc: %d/%d\n",
 		cxt->size, (unsigned long long)cxt->phys_addr,

--- a/fs/pstore/ram.c
+++ b/fs/pstore/ram.c
@@ -520,8 +520,6 @@ static int ramoops_probe(struct platform_device *pdev)
 		goto fail_out;
 	}
 
-	if (!is_power_of_2(pdata->mem_size))
-		pdata->mem_size = rounddown_pow_of_two(pdata->mem_size);
 	if (!is_power_of_2(pdata->record_size))
 		pdata->record_size = rounddown_pow_of_two(pdata->record_size);
 	if (!is_power_of_2(pdata->console_size))

--- a/fs/pstore/ram_core.c
+++ b/fs/pstore/ram_core.c
@@ -54,7 +54,7 @@ static size_t buffer_start_add_atomic(struct persistent_ram_zone *prz, size_t a)
 	do {
 		old = atomic_read(&prz->buffer->start);
 		new = old + a;
-		while (unlikely(new > prz->buffer_size))
+		while (unlikely(new >= prz->buffer_size))
 			new -= prz->buffer_size;
 	} while (atomic_cmpxchg(&prz->buffer->start, old, new) != old);
 
@@ -91,7 +91,7 @@ static size_t buffer_start_add_locked(struct persistent_ram_zone *prz, size_t a)
 
 	old = atomic_read(&prz->buffer->start);
 	new = old + a;
-	while (unlikely(new > prz->buffer_size))
+	while (unlikely(new >= prz->buffer_size))
 		new -= prz->buffer_size;
 	atomic_set(&prz->buffer->start, new);
 


### PR DESCRIPTION
pstore allow to store kernel output on crash on /sys/fs/pstore/

tested on Z2, z3c, z4t wifi, probably Z1 family is ok but need to be tested on all device 
