### PR TITLE
Revert "mm: Increase MIN and MAX default readahead sizes"

### DIFF
--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -1624,8 +1624,8 @@ int write_one_page(struct page *page, int wait);
 void task_dirty_inc(struct task_struct *tsk);
 
 /* readahead.c */
-#define VM_MAX_READAHEAD	1536	/* kbytes */
-#define VM_MIN_READAHEAD	32	/* kbytes (includes current page) */
+#define VM_MAX_READAHEAD	512	/* kbytes */
+#define VM_MIN_READAHEAD	16	/* kbytes (includes current page) */
 
 int force_page_cache_readahead(struct address_space *mapping, struct file *filp,
 			pgoff_t offset, unsigned long nr_to_read);


### PR DESCRIPTION
imho, this must be set for device in userspace
