### PR TITLE
togari: fix camera 1 mount angle

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
@@ -61,7 +61,7 @@
 		reg = <0x1>;
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
-		qcom,mount-angle = <90>;
+		qcom,mount-angle = <270>;
 		cam_vdig-supply = <&pm8941_l3>;
 		cam_vana-supply = <&pm8941_l17>;
 		cam_vio-supply = <&pm8941_lvs2>;


### PR DESCRIPTION
initial values were wrong and selfie camera was upside down

Signed-off-by: Alin Jerpelea alin.jerpelea@sonymobile.com
