### PR TITLE
[1.2.2] video: msm: mdss: panel_driver: Fix lcd-backlight for cmd detected

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel_driver.c
@@ -3497,6 +3497,7 @@ static int mdss_panel_parse_dt(struct device_node *np,
 	static const char *panel_name;
 	struct mdss_panel_info *pinfo = &(ctrl_pdata->panel_data.panel_info);
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
+	bool doing_cmd_detection = false;
 
 	spec_pdata = ctrl_pdata->spec_pdata;
 	if (!spec_pdata) {
@@ -3545,6 +3546,7 @@ static int mdss_panel_parse_dt(struct device_node *np,
 						, "somc,panel-detect", &tmp);
 					spec_pdata->panel_detect =
 							!rc ? tmp : 0;
+					doing_cmd_detection = true;
 				}
 			}
 		} else {
@@ -3683,10 +3685,12 @@ static int mdss_panel_parse_dt(struct device_node *np,
 			"qcom,mdss-dsi-bl-pmic-control-type", NULL);
 		if (data) {
 			if (!strncmp(data, "bl_ctrl_wled", 12)) {
-				led_trigger_register_simple("bkl-trigger",
-					&bl_led_trigger);
-				pr_debug("%s: SUCCESS WLED TRIGGER register\n",
-					__func__);
+				if (!doing_cmd_detection) {
+					led_trigger_register_simple("bkl-trigger",
+						&bl_led_trigger);
+					pr_info("%s: SUCCESS WLED TRIGGER register\n",
+						__func__);
+				}
 				ctrl_pdata->bklt_ctrl = BL_WLED;
 			} else if (!strncmp(data, "bl_ctrl_pwm", 11)) {
 				ctrl_pdata->bklt_ctrl = BL_PWM;


### PR DESCRIPTION
cmd-detected panels were suffering of lcd-backlight registration
issues: it was registering the backlight trigger on the first
panel read for detection kickstart, then failing to re-register
it on the real, detected panel (because of obvious reasons).

Fix the issue by adding detection awareness for backlight LED
trigger registration.
