### PR TITLE
drivers: video: mdss: Fix backlight during initialization

### DIFF
--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1382,10 +1382,10 @@ void mdss_fb_set_backlight(struct msm_fb_data_type *mfd, u32 bkl_lvl)
 			mfd->bl_level = bkl_lvl;
 			mfd->bl_level_scaled = temp;
 		}
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-		bl_before = temp;
-#endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 	}
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	bl_before = temp;
+#endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 }
 
 void mdss_fb_update_backlight(struct msm_fb_data_type *mfd)


### PR DESCRIPTION
This patch uses 32.0.A.6.xxx tree as reference.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I230c23ebb47b299f4ede43c61e893b7d9930be74
