### PR TITLE
[1.2.2] Seagull - Bosch Sensortec BMA250 driver FIX

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-720p-mtp.dtsi
@@ -57,10 +57,9 @@
 		bosch@10 {
 			compatible = "bosch,bma2x2";
 			reg = <0x10>;
-			bosch,int_pin = <&msmgpio 63 0x00>;
-			bosch,layout=<0x0>;
-			bmavdd-supply = <&pm8226_l19>;
-			bosch,vdd-current-level = <1 210>;
+			vdd-supply = <&pm8226_l19>;
+			bosch,gpio-int1 = <&msmgpio 63 0>;
+			bosch,place = <0>;
 		};
 
 		bosch@12 {

--- a/drivers/input/misc/bma2x2.c
+++ b/drivers/input/misc/bma2x2.c
@@ -7598,12 +7598,10 @@ static int bma2x2_probe(struct i2c_client *client,
 	}
 
 	err = bma2x2_pinctrl_init(data);
-	if (err) {
+	if (err)
 		dev_err(&client->dev,
 			"Failed to init pinctrl err=%d\n", err);
-		err = -EINVAL;
-		goto disable_power_exit;
-	}
+
 	if (pdata->int_en) {
 		/* check interrupt feature enable state */
 		if ((pdata->use_int2 && (!BMA2x2_IS_INT2_ENABLED())) ||


### PR DESCRIPTION
Old driver had a bad commit by QC that removed support for pinmux devices.
Restore the support and fix Seagull DT for it.
