### PR TITLE
[1.2.2] kitakami: karin: Fix brightness

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
@@ -127,12 +127,12 @@
 			compatible = "ti,lp8557";
 			reg = <0x2c>;
 			status = "ok";
-			linux,name = "lp8557";
+			linux,name = "wled:backlight";
 			linux,default-trigger = "bkl-trigger";
 			mode = "register based";
 			chip_name = "lp8557";
-			max_br = <0xFF>;
-			init_br = <0x83>;
+			max_br = <0x0FF>;
+			init_br = <0x66>;
 			somc-s1,br-power-save = <0x83>;
 			slope_reg = <0x00>;
 			dev-ctrl = <0x01>;

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
@@ -127,12 +127,12 @@
 			compatible = "ti,lp8557";
 			reg = <0x2c>;
 			status = "ok";
-			linux,name = "wled:backlight";
+			linux,name = "lp8557";
 			linux,default-trigger = "bkl-trigger";
 			mode = "register based";
 			chip_name = "lp8557";
-			max_br = <0x0FF>;
-			init_br = <0x66>;
+			max_br = <0x0FFF>;
+			init_br = <0x666>;
 			somc-s1,br-power-save = <0x83>;
 			slope_reg = <0x00>;
 			dev-ctrl = <0x01>;

--- a/drivers/leds/leds-lp855x.c
+++ b/drivers/leds/leds-lp855x.c
@@ -198,7 +198,6 @@ struct lp855x_device_config {
 	u8 reg_slope_mask;
 	u8 reg_devicectrl;
 	u8 reg_devicectrl_mask;
-	u8 reg_brt;
 	int (*pre_init_device)(struct lp855x *);
 	int (*post_init_device)(struct lp855x *);
 	int (*resume_init)(struct lp855x *);
@@ -249,7 +248,7 @@ static int lp855x_write_brightness(struct lp855x *lp,
 		brightness = (brightness * lp->bl_scale) / 100;
 	if (is_8bit) {
 		ret = lp855x_write_byte(lp,
-			lp->cfg->reg_brt, (u8)brightness);
+			LP855X_BRIGHTNESS_CTRL, (u8)brightness);
 	} else {
 		val = (u8)((brightness << LP8557_BRTLO_SHFT)
 			& LP8557_BRTLO_MASK);
@@ -614,19 +613,17 @@ static struct lp855x_device_config lp855x_dev_cfg = {
 	.reg_slope_mask = SLOPE_FILTER_MASK,
 	.reg_devicectrl = LP855X_DEVICE_CTRL,
 	.reg_devicectrl_mask = BL_CTL_MASK,
-	.reg_brt = LP855X_BRIGHTNESS_CTRL,
 	.pre_init_device = lp855x_bl_off,
 	.post_init_device = lp855x_bl_on,
 	.resume_init = lp855x_resume_init,
 };
 
 static struct lp855x_device_config lp8557_dev_cfg = {
-	.is_8bit_brightness = true,
+	.is_8bit_brightness = false,
 	.reg_slope = STEP_CTRL,
 	.reg_slope_mask = STEP_SLOPE_FILTER_MASK,
 	.reg_devicectrl = LP8557_BL_CMD,
 	.reg_devicectrl_mask = LP8557_BL_MASK,
-	.reg_brt = LP8557_BRTHI,
 	.pre_init_device = lp8557_bl_off,
 	.post_init_device = lp8557_bl_on,
 	.resume_init = NULL,


### PR DESCRIPTION
Light HAL unification requires same levels on all devices.
Those reverts bring back max brightness to 4095 for lp8557x driver
