### PR TITLE
qseecom: Update key id strings for full disk encryption

### DIFF
--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -245,6 +245,14 @@ static struct qseecom_key_id_usage_desc key_id_array[] = {
 	{
 		.desc = "Per File Encryption",
 	},
+
+	{
+		.desc = "UFS ICE Full Disk Encryption",
+	},
+
+	{
+		.desc = "SDCC ICE Full Disk Encryption",
+	},
 };
 
 /* Function proto types */


### PR DESCRIPTION
key id string for certain use cases are not updated which
uses garbage value as key id while generating the keys.
From functional point of view these string should be
common between builds which needs an kernel update with
full disk encryption is enabled.
