### PR TITLE
drivers: mmc: Fix shinano card initialization

### DIFF
--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1113,7 +1113,12 @@ static int mmc_sdio_power_restore(struct mmc_host *host)
 		/* to query card if 1.8V signalling is supported */
 		host->ocr |= R4_18V_PRESENT;
 
-	ret = mmc_sdio_init_card(host, host->ocr, host->card, mmc_card_keep_power(host));
+	ret = mmc_sdio_init_card(host, host->ocr, host->card,
+#ifdef CONFIG_MACH_SONY_SHINANO
+		0);
+#else
+		mmc_card_keep_power(host));
+#endif
 	if (!ret && host->sdio_irqs)
 		mmc_signal_sdio_irq(host);
 


### PR DESCRIPTION
Shinano card is broken after abf348b86b9cc9d7584211235805c67ecb8503b6
This patch fixes it.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I6c1daf433eb7c115d6591037debdc17a2a5affe8
