### PR TITLE
[1.2.2] Seagull Camera configuration

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-camera-sensor.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_seagull-camera-sensor.dtsi
@@ -13,103 +13,22 @@
  */
 
 &cci {
-	actuator2: qcom,actuator@18 {
-		cell-index = <6>;
-		reg = <0x18>;
+	actuator0: qcom,actuator@0 {
+		cell-index = <0>;
+		reg = <0x0>;
 		compatible = "qcom,actuator";
 		qcom,cci-master = <0>;
 	};
 
-	eeprom2: qcom,eeprom@18 {
+	qcom,camera@0 {
 		cell-index = <0>;
-		reg = <0x18 0x0>;
-		qcom,eeprom-name = "imx134_Sony";
-		compatible	= "qcom,eeprom";
-		qcom,slave-addr = <0xa0>;
-		qcom,cci-master = <0>;
-		qcom,num-blocks = <8>;
-
-		qcom,page0	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen0	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr0	=	<0xa0>;
-		qcom,poll0	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem0	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page1	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen1	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr1	=	<0xa2>;
-		qcom,poll1	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem1	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page2	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen2	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr2	=	<0xa4>;
-		qcom,poll2	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem2	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page3	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen3	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr3	=	<0xa6>;
-		qcom,poll3	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem3	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page4	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen4	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr4	=	<0xa8>;
-		qcom,poll4	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem4	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page5	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen5	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr5	=	<0xaa>;
-		qcom,poll5	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem5	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page6	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen6	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr6	=	<0xac>;
-		qcom,poll6	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem6	= <256 0x00 1 0x00 1 0>;
-
-		qcom,page7	=	<0 0x00 1 0x00 1 1>;
-		qcom,pageen7	=	<0 0x00 1 0x01 1 10>;
-		qcom,saddr7	=	<0xae>;
-		qcom,poll7	=	<0 0x00 1 0x01 1 1>;
-		qcom,mem7	= <256 0x00 1 0x00 1 0>;
-
-		cam_vdig-supply 		= <&pm8226_l5>;
-		qcom,cam-vreg-name		= "cam_vdig";
-		qcom,cam-vreg-type		= <0>;
-		qcom,cam-vreg-min-voltage	= <1100000 0>;
-		qcom,cam-vreg-max-voltage	= <1100000 0>;
-		qcom,cam-vreg-op-mode		= <1050000 0>;
-
-		qcom,gpio-no-mux = <0>;
-		gpios = <&msmgpio 112 0>;
-		qcom,gpio-cam-vddio-v1p8 = <0>;
-		qcom,gpio-req-tbl-num = <0>;
-		qcom,gpio-req-tbl-flags = <0>;
-		qcom,gpio-req-tbl-label = "CAM_VDDIO_V1P8";
-
-		qcom,cam-power-seq-type 	= "sensor_gpio";    
-		qcom,cam-power-seq-val		="sensor_gpio_cam_vddio_v1p8";
-		qcom,cam-power-seq-cfg-val	= <1>;
-		qcom,cam-power-seq-delay	= <20>;
-
-		somc,cam-mclk-rate		= <24000000>;
-		};
-
-	qcom,camera@34 {
-		compatible = "sne,imx134";
-		reg = <0x34>;
-		qcom,slave-id = <0x20 0x0016 0x134>;
+		compatible = "qcom,camera";
+		reg = <0x0>;
 		qcom,csiphy-sd-index = <0>;
 		qcom,csid-sd-index = <0>;
-		qcom,actuator-src = <&actuator2>;
-		qcom,eeprom-src = <&eeprom2>;
+		qcom,actuator-src = <&actuator0>;
 		qcom,led-flash-src = <&led_flash0>;
 		qcom,mount-angle = <90>;
-		qcom,sensor-name = "imx134";
 		cam_vdig-supply = <&pm8226_l5>;
 		qcom,cam-vreg-name = "cam_vdig";
 		qcom,cam-vreg-type = <0>;
@@ -123,19 +42,18 @@
 			<&msmgpio 111 0>,
 			<&msmgpio 112 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-cam-vaa-v2p8 = <2>;
-		qcom,gpio-cam-vddaf-v2p8 = <3>;
-		qcom,gpio-cam-vddio-v1p8 = <4>;
-		qcom,gpio-req-tbl-num = <0 1 2 3 4 >;
-		qcom,gpio-req-tbl-flags = <1 0 0 0 0 >;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
-			"CAM_RESET1",
-		    "CAM_VAA_V2P8",
-			"CAM_VDDAF_V2P8",
-			"CAM_VDDIO_V1P8";
+		qcom,gpio-vana = <2>;
+		qcom,gpio-vaf = <3>;
+		qcom,gpio-vio = <4>;
+		qcom,gpio-req-tbl-num = <0 1 2 3 4>;
+		qcom,gpio-req-tbl-flags = <1 0 0 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK0",
+			"CAM_RESET0",
+			"SENSOR_GPIO_VANA",
+			"SENSOR_GPIO_VAF",
+			"SENSOR_GPIO_VIO";
 		qcom,csi-lane-assign = <0x4320>;
 		qcom,csi-lane-mask = <0x1F>;
-		qcom,csi-phy-sel = <0>;
 		qcom,sensor-position = <0>;
 		qcom,sensor-mode = <0>;
 		qcom,sensor-type = <0>;
@@ -143,16 +61,18 @@
 		qcom,actuator-cam-name = <3>;
 		qcom,actuator-vcm-pwd = <111>;
 		qcom,actuator-vcm-enable = <1>;
+
+		status = "ok";
+		clock-names = "cam_src_clk", "cam_clk";
 	};
 
-	qcom,camera@6e {
+	qcom,camera@1 {
+		cell-index = <1>;
 		compatible = "qcom,imx188";
-		reg = <0x6e>;
-		qcom,slave-id = <0x6E 0x0000 0x188>;
+		reg = <0x1>;
 		qcom,csiphy-sd-index = <1>;
 		qcom,csid-sd-index = <1>;
 		qcom,mount-angle = <270>;
-		qcom,sensor-name = "imx188";
 		cam_vdig-supply = <&pm8226_l26>;
 		qcom,cam-vreg-name = "cam_vdig";
 		qcom,cam-vreg-type = <0>;
@@ -161,24 +81,42 @@
 		qcom,cam-vreg-op-mode = <1200000>;
 		qcom,gpio-no-mux = <0>;
 		gpios = <&msmgpio 27 0>,
-			    <&msmgpio 28 0>,
-			    <&msmgpio 69 0>,
-				<&msmgpio 112 0>;
-		qcom,gpio-reset1 = <1>;
-		qcom,gpio-cam-vaa-v2p8 = <2>;
-		qcom,gpio-cam-vddio-v1p8 = <3>;
+			<&msmgpio 28 0>,
+			<&msmgpio 69 0>,
+			<&msmgpio 112 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-vana = <2>;
+		qcom,gpio-vio = <3>;
 		qcom,gpio-req-tbl-num = <0 1 2 3>;
 		qcom,gpio-req-tbl-flags = <1 0 0 0>;
 		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
 				"CAM_RESET",
-				"CAM_VAA_V2P8",
-				"CAM_VDDIO_V1P8";
+				"SENSOR_GPIO_VANA",
+				"SENSOR_GPIO_VIO";
 		qcom,csi-lane-assign = <0x4320>;
 		qcom,csi-lane-mask = <0x3>;
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,sensor-type = <0>;
 		qcom,cci-master = <0>;
-		status = "ok";
+		status = "disabled";
+	};
+
+
+	eeprom1: qcom,eeprom@a1 {
+		status = "disabled";
+	};
+
+	qcom,camera@6c {
+		status = "disabled";
+	};
+
+	/* disable Qualcomm camera sensors */
+	qcom,camera@6e {
+		status = "disabled";
+	};
+
+	qcom,camera@90 {
+		status = "disabled";
 	};
 };

--- a/drivers/media/platform/msm/camera_v2/sensor/cci/msm_cci.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/cci/msm_cci.c
@@ -1394,7 +1394,55 @@ static int msm_cci_get_clk_info(struct cci_device *cci_dev,
 	return 0;
 }
 
+#define CAM_I2C_VTG_MIN_UV	1800000
+#define CAM_I2C_VTG_MAX_UV	1800000
+#define CAM_I2C_LOAD_UA		10000
 
+#define reg_set_optimum_mode_check(reg, load_uA) \
+		((regulator_count_voltages(reg) > 0) ? \
+		 regulator_set_optimum_mode(reg, load_uA) : 0)
+
+static int cci_enable_i2c_vcc(struct platform_device *pdev)
+{
+	struct regulator *vcc_i2c;
+	int rc;
+
+	vcc_i2c = regulator_get(&pdev->dev, "vcc_i2c");
+	if (IS_ERR(vcc_i2c)){
+		pr_err("%s: Failed to get vcc_i2c regulator\n", __func__);
+		/* Don't fail: it's not required on all devices */
+		return 0;
+	}
+
+	if (regulator_count_voltages(vcc_i2c) > 0) {
+		rc = regulator_set_voltage(vcc_i2c,
+				CAM_I2C_VTG_MIN_UV, CAM_I2C_VTG_MAX_UV);
+		if (rc){
+			pr_err("%s: reg set i2c vtg failed retval =%d\n",
+				__func__, rc);
+			regulator_put(vcc_i2c);
+			return rc;
+		}
+	}
+
+	rc = reg_set_optimum_mode_check(vcc_i2c, CAM_I2C_LOAD_UA);
+	if(rc < 0){
+		pr_err("%s: Regulator vcc_i2c set_opt failed rc=%d\n",
+				__func__, rc);
+		return rc;
+	}
+
+	rc = regulator_enable(vcc_i2c);
+	if(rc){
+		pr_err("%s: Regulator vcc_i2c enable failed rc=%d\n",
+				__func__, rc);
+		reg_set_optimum_mode_check(vcc_i2c, 0);
+		return rc;
+	}
+	usleep_range(1000, 2000);
+
+	return 0;
+}
 
 static int msm_cci_probe(struct platform_device *pdev)
 {
@@ -1406,6 +1454,11 @@ static int msm_cci_probe(struct platform_device *pdev)
 		CDBG("%s: no enough memory\n", __func__);
 		return -ENOMEM;
 	}
+
+	rc = cci_enable_i2c_vcc(pdev);
+	if (rc < 0)
+		return rc;
+
 	v4l2_subdev_init(&new_cci_dev->msm_sd.sd, &msm_cci_subdev_ops);
 	new_cci_dev->msm_sd.sd.internal_ops = &msm_cci_internal_ops;
 	snprintf(new_cci_dev->msm_sd.sd.name,


### PR DESCRIPTION
This is enabling camera on Seagull. BACK only. FRONT disabled (wip).
