### PR TITLE
[1.2.2] Satsuki 4K awesomeness

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.h
+++ b/drivers/video/msm/mdss/mdss_dsi.h
@@ -513,6 +513,8 @@ struct mdss_dsi_ctrl_pdata {
 
 	struct dsi_panel_cmds cabc_off_cmds;
 	struct dsi_panel_cmds cabc_late_off_cmds;
+	struct dsi_panel_cmds lock_cmds;
+	struct dsi_panel_cmds unlock_cmds;
 #endif
 
 	struct dcs_cmd_list cmdlist;

--- a/drivers/video/msm/mdss/mdss_dsi_cmd.c
+++ b/drivers/video/msm/mdss/mdss_dsi_cmd.c
@@ -665,6 +665,47 @@ struct dcs_cmd_req *mdss_dsi_cmdlist_get(struct mdss_dsi_ctrl_pdata *ctrl)
 	return req;
 }
 
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+#define __UNLOCK 0
+#define __LOCK   1
+static int mdss_dsi_cmd_lock(struct mdss_dsi_ctrl_pdata *ctrl,
+			     struct dcs_cmd_list *clist,
+			     int lock)
+{
+	struct dcs_cmd_req cmdreq;
+	struct dcs_cmd_req *req;
+	int ret = 0;
+
+	if (!ctrl->lock_cmds.cmd_cnt)
+		goto out;
+
+	if (lock) {
+		cmdreq.cmds = ctrl->lock_cmds.cmds;
+		cmdreq.cmds_cnt = ctrl->lock_cmds.cmd_cnt;
+	} else {
+		cmdreq.cmds = ctrl->unlock_cmds.cmds;
+		cmdreq.cmds_cnt = ctrl->unlock_cmds.cmd_cnt;
+	}
+	cmdreq.flags = CMD_REQ_COMMIT;
+	cmdreq.rlen = 0;
+	cmdreq.cb = NULL;
+
+	req = &clist->list[clist->put];
+	*req = cmdreq;
+	clist->put++;
+	clist->put %= CMD_REQ_MAX;
+	clist->tot++;
+
+	pr_debug("%s: tot=%d put=%d get=%d lock=%d\n", __func__,
+		 clist->tot, clist->put, clist->get, lock);
+
+	ret = ctrl->cmdlist_commit(ctrl, 0);
+
+out:
+	return ret;
+}
+#endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
+
 int mdss_dsi_cmdlist_put(struct mdss_dsi_ctrl_pdata *ctrl,
 				struct dcs_cmd_req *cmdreq)
 {
@@ -674,6 +715,11 @@ int mdss_dsi_cmdlist_put(struct mdss_dsi_ctrl_pdata *ctrl,
 
 	mutex_lock(&ctrl->cmd_mutex);
 	clist = &ctrl->cmdlist;
+
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	mdss_dsi_cmd_lock(ctrl, clist, __UNLOCK);
+#endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
+
 	req = &clist->list[clist->put];
 	*req = *cmdreq;
 	clist->put++;
@@ -697,6 +743,11 @@ int mdss_dsi_cmdlist_put(struct mdss_dsi_ctrl_pdata *ctrl,
 		else
 			ret = ctrl->cmdlist_commit(ctrl, 0);
 	}
+
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	mdss_dsi_cmd_lock(ctrl, clist, __LOCK);
+#endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
+
 	mutex_unlock(&ctrl->cmd_mutex);
 
 	return ret;

--- a/drivers/video/msm/mdss/mdss_dsi_cmd.h
+++ b/drivers/video/msm/mdss/mdss_dsi_cmd.h
@@ -94,7 +94,7 @@ struct dsi_cmd_desc {
 	char *payload;
 };
 
-#define CMD_REQ_MAX     4
+#define CMD_REQ_MAX     6
 #define CMD_REQ_RX      0x0001
 #define CMD_REQ_COMMIT  0x0002
 #define CMD_CLK_CTRL    0x0004


### PR DESCRIPTION
video: mdss: Add logic to reset dual-display panels (4K awesomeness)

On dual-display panels (read: 4K displays found in satsuki) we
need to reset ONLY the MASTER one and NEVER the SLAVE.

Dual display is only an hack for panels that needs to be connected
to TWO DSI channels because of bandwidth issues.
