### PR TITLE
yukon: camera: fix clocks

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226-yukon_common.dtsi
@@ -116,11 +116,10 @@
 			"csi0_pix_clk", "csi0_rdi_clk",
 			"csi1_src_clk", "csi1_clk",
 			"csi1_pix_clk", "csi1_rdi_clk",
-			"vfe0_clk_src", "camss_vfe_vfe0_clk", "camss_csi_vfe0_clk";
+			"vfe_clk_src", "camss_vfe_vfe_clk", "camss_csi_vfe_clk";
 		qcom,clock-rates = <0
 			200000000 0 0 0
 			200000000 0 0 0
-			266670000 0 0
 			266670000 0 0>;
 	};
 

--- a/arch/arm/mach-msm/clock-8226.c
+++ b/arch/arm/mach-msm/clock-8226.c
@@ -3486,6 +3486,8 @@ static struct clk_lookup msm_clocks_8226[] = {
 					"fda0a000.qcom,ispif"),
 	CLK_LOOKUP("csi1_rdi_clk", camss_csi1rdi_clk.c,
 					"fda0a000.qcom,ispif"),
+        CLK_LOOKUP("vfe_clk_src", vfe0_clk_src.c,
+		"fda0a000.qcom,ispif"),
 	CLK_LOOKUP("camss_vfe_vfe_clk", camss_vfe_vfe0_clk.c,
 		"fda0a000.qcom,ispif"),
 	CLK_LOOKUP("camss_csi_vfe_clk", camss_csi_vfe0_clk.c,


### PR DESCRIPTION
In previous yukon camera commit I obviously forgot to hire an accountant to count the correct number of clocks in DT.
Also correct clocknames in DT to match cameradriver and add absent clocksetting to clocks-8226.c

@kholk can you please be so kind to double check this?
