### PR TITLE
[1.2.2] qseecom: Use correct flag for 64bits targets

### DIFF
--- a/include/uapi/linux/qseecom.h
+++ b/include/uapi/linux/qseecom.h
@@ -5,7 +5,7 @@
 #include <linux/ioctl.h>
 
 #define MAX_ION_FD  4
-#ifdef CONFIG_ARCH_MSM8994
+#if defined(CONFIG_ARM64) || defined(CONFIG_64BIT)
 #define MAX_APP_NAME_SIZE  64
 #else
 #define MAX_APP_NAME_SIZE  32


### PR DESCRIPTION
Use the correct flags for 64bits targets
and don't use it only for 8994 devices like I did here:
https://github.com/sonyxperiadev/kernel/commit/e174bee0c8a1824ca923c4e9c3d3ef852da13b0e

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Iec6812aeaf1fef32f376e6c1c8e152e0c27ce6fb
