### PR TITLE
drivers: mdss: Use correct flag

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -731,7 +731,7 @@ static int mdss_mdp_cmd_wait4pingpong(struct mdss_mdp_ctl *ctl, void *arg)
 			rc, ctl->num, ctx->pp_timeout_report_cnt);
 		if (ctx->pp_timeout_report_cnt == 0) {
 			MDSS_XLOG_TOUT_HANDLER("mdp", "dsi0_ctrl", "dsi0_phy",
-#ifdef CONFIG_FB_MDSS_SPECIFIC_PANEL
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
 				"dsi1_ctrl", "dsi1_phy");
 #else
 				"dsi1_ctrl", "dsi1_phy", "panic");


### PR DESCRIPTION
Accordingly 32.1.F.0.x the corret flag is:
CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I1ae1fbdea3fd7dbd2ed49ab1b70c9689ce55f338
