### PR TITLE
drivers: mdss: Fix tearcheck for cmd mode

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -225,7 +225,7 @@ static int mdss_mdp_cmd_tearcheck_cfg(struct mdss_mdp_mixer *mixer,
 		 pinfo->lcdc.v_front_porch +
 		 pinfo->lcdc.v_pulse_width;
 
-	height = (pinfo->yres + vporch) * 2;
+	height = (pinfo->yres + vporch);
 
 	pr_debug("%s: yres=%d vclks=%x height=%d init=%d rd=%d start=%d\n",
 		__func__, pinfo->yres, vclks_line, te->sync_cfg_height,


### PR DESCRIPTION
From stock kernel we have te->sync_cfg_height = 0xfff0;
This value is used for tearcheck on stock version.
But it is too high for current panel driver and
it is affecting panel performance during its synchronization.

After mdss unified driver change ( 49dc51608ea0ed20d54b60ed47b06956ac59a4ba )
the te->sync_cfg_height was updated to "height" variable as following:

```
vporch = pinfo->lcdc.v_back_porch +
     pinfo->lcdc.v_front_porch +
     pinfo->lcdc.v_pulse_width;

height = (pinfo->yres + vporch) * 2;
```

This patch reduces "height" variable (which is a composition of vporch
values + y_res) by removing (*2) factor. It seems to working better
for panel synchronization then performance is improved.

This patch was tested on Kitakami Karin (10.1 Tablet).

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I33b278143c884fb0828f1a169e2cd3e2c1ffbb5a
