### PR TITLE
[1.2.2] drivers: mdss: Remove duplicate property check

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -3673,6 +3673,8 @@ int mdss_panel_parse_dt(struct device_node *np,
 		pinfo->mode_gpio_state = MODE_GPIO_NOT_VALID;
 	}
 
+	pinfo->mipi.input_fpks = pinfo->mipi.frame_rate * 1000;
+
 	rc = of_property_read_u32(np, "qcom,mdss-mdp-transfer-time-us", &tmp);
 	pinfo->mdp_transfer_time_us = (!rc ? tmp : DEFAULT_MDP_TRANSFER_TIME);
 
@@ -3681,15 +3683,6 @@ int mdss_panel_parse_dt(struct device_node *np,
 	rc = of_property_read_u32(np, "qcom,mdss-dsi-init-delay-us",
 			&tmp);
 	pinfo->mipi.init_delay = (!rc ? tmp : 0);
-
-	rc = of_property_read_u32(np,
-		"qcom,mdss-dsi-panel-framerate", &tmp);
-	pinfo->mipi.frame_rate = !rc ? tmp : 60;
-	pinfo->mipi.input_fpks = pinfo->mipi.frame_rate * 1000;
-
-	rc = of_property_read_u32(np,
-		"qcom,mdss-dsi-panel-clockrate", &tmp);
-	pinfo->clk_rate = !rc ? tmp : 0;
 
 	data = of_get_property(np,
 		"somc,platform-regulator-settings", &len);
@@ -3721,13 +3714,6 @@ int mdss_panel_parse_dt(struct device_node *np,
 		"qcom,mdss-dsi-dma-trigger");
 
 	mdss_dsi_parse_lane_swap(np, &(pinfo->mipi.dlane_swap));
-
-	rc = of_property_read_u32(np,
-		"qcom,mdss-dsi-t-clk-pre", &tmp);
-	pinfo->mipi.t_clk_pre = !rc ? tmp : 0x24;
-	rc = of_property_read_u32(np,
-		"qcom,mdss-dsi-t-clk-post", &tmp);
-	pinfo->mipi.t_clk_post = !rc ? tmp : 0x03;
 
 	mdss_dsi_parse_reset_seq(np, pinfo->rst_seq,
 		&(pinfo->rst_seq_len),


### PR DESCRIPTION
1. qcom,mdss-dsi-panel-framerate
2. qcom,mdss-dsi-panel-clockrate
3. qcom,mdss-dsi-t-clk-pre
4. qcom,mdss-dsi-t-clk-post

Those entries are present in mdss_dsi_panel_timing_from_dt function
so it is not necessary to check them again.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I66fa77ee91617e4b068bde724e8f93029322dee3
