### PR TITLE
[1.2.2] qcom: rpm-smd: Add NULL check for input data variable

### DIFF
--- a/drivers/soc/qcom/rpm-smd.c
+++ b/drivers/soc/qcom/rpm-smd.c
@@ -524,8 +524,8 @@ static int msm_rpm_add_kvp_data_common(struct msm_rpm_request *handle,
 	if (probe_status)
 		return probe_status;
 
-	if (!handle) {
-		pr_err("%s(): Invalid handle\n", __func__);
+	if (!handle || !data) {
+		pr_err("%s(): Invalid handle/data\n", __func__);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add NULL check to prevent NULL pointer dereference during memcmp.
