### PR TITLE
Revert "kitakami: update touchpad wake code"

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -221,12 +221,12 @@
 					};
 					event_01 {
 						type = <1>; /* KEY */
-						code = <116>; /* KEY_POWER */
+						code = <531>; /* TOUCHPAD_ON */
 						down = <1>;
 					};
 					event_02 {
 						type = <1>; /* KEY */
-						code = <116>; /* KEY_POWER */
+						code = <531>; /* TOUCHPAD_ON */
 						down = <0>;
 					};
 					event_03 {


### PR DESCRIPTION
This reverts commit 17576a2c2ab38956292ba449529efa199375e6db.

This change broke waking up the device via Double-Tap-2-Wake,

the double-tap would still be registered (as seen from output in dmesg), but the device wouldn't turn the screen on - making the function a worthless feature.

Confirmed for Sumire + Satsuki.
