### PR TITLE
[1.2.2] Revert "qcom: rpm-smd: Add NULL check for input data variable"

### DIFF
--- a/drivers/soc/qcom/rpm-smd.c
+++ b/drivers/soc/qcom/rpm-smd.c
@@ -524,8 +524,8 @@ static int msm_rpm_add_kvp_data_common(struct msm_rpm_request *handle,
 	if (probe_status)
 		return probe_status;
 
-	if (!handle || !data) {
-		pr_err("%s(): Invalid handle/data\n", __func__);
+	if (!handle) {
+		pr_err("%s(): Invalid handle\n", __func__);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
This patch is causing lags on msm8974 devices and also it is breaking kexec.

This reverts commit 2ce9ed3d321c01e3eb2b5d6e3619d1e3c62e084d.

Change-Id: I595b56bcbca41d3722414c4d831510960d6d955e
