### PR TITLE
video: msm: somc_panel: Fix detection fallback for CMD china-panels

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_detect.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_detect.c
@@ -239,7 +239,12 @@ static int cmd_panel_detect(struct mdss_panel_data *pdata)
 		}
 	}
 parse:
-	pr_info("%s: Panel detected!\n", __func__);
+	if (unlikely(rc != len)) {
+		pr_err("%s: WARNING: Cannot detect panel." \
+			" Falling back to the default entry!\n", __func__);
+		next = np;
+	} else
+		pr_info("%s: Panel detected!\n", __func__);
 
 	spec_pdata->detected = true;
 	rc = mdss_panel_parse_dt(next, ctrl_pdata);


### PR DESCRIPTION
Chinese spare parts for various Sony (and other OEMs) devices
will not have an original Sony panel, but something that is
usually compatible with the default panel entry in the DTs.

This is funny, as actually no Sony original panels will use
the default entry! Anyway, CMD panel detection has fallback
problems because of a code logic bug, causing MDSS backlight
to not be registered, but panel working.

Fix the fallback entry by adding an unlikely check on the actual
detection status, instead of stupidly and blindly saying that
we have detected the panel even when we haven't.
