### PR TITLE
[1.2.2] drivers: mmc: Fix mmc block deferred resume

### DIFF
--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -2805,13 +2805,14 @@ static int mmc_blk_issue_rq(struct mmc_queue *mq, struct request *req)
 		mmc_rpm_hold(host, &card->dev);
 		/* claim host only for the first request */
 		mmc_claim_host(card->host);
+		if (mmc_card_get_bkops_en_manual(card))
+			mmc_stop_bkops(card);
+	}
+
 #ifdef CONFIG_MMC_BLOCK_DEFERRED_RESUME
 	if (mmc_bus_needs_resume(card->host))
 		mmc_resume_bus(card->host);
 #endif
-		if (mmc_card_get_bkops_en_manual(card))
-			mmc_stop_bkops(card);
-	}
 
 	ret = mmc_blk_part_switch(card, md);
 	if (ret) {
@@ -3322,7 +3323,8 @@ static int mmc_blk_probe(struct mmc_card *card)
 	mmc_fixup_device(card, blk_fixups);
 
 #ifdef CONFIG_MMC_BLOCK_DEFERRED_RESUME
-	mmc_set_bus_resume_policy(card->host, 1);
+	if (mmc_card_sd(card))
+		mmc_set_bus_resume_policy(card->host, 1);
 #endif
 	if (mmc_add_disk(md))
 		goto out;

--- a/drivers/mmc/core/bus.c
+++ b/drivers/mmc/core/bus.c
@@ -26,7 +26,11 @@
 #include "bus.h"
 
 #define to_mmc_driver(d)	container_of(d, struct mmc_driver, drv)
+
+/* Default idle timeout for MMC devices: 10 seconds. */
 #define RUNTIME_SUSPEND_DELAY_MS 10000
+/* Default idle timeout for SD cards: 5 minutes. */
+#define RUNTIME_SDCARD_SUSPEND_DELAY_MS 300000
 
 static ssize_t mmc_type_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
@@ -451,8 +455,10 @@ int mmc_add_card(struct mmc_card *card)
 		if (ret)
 			pr_err("%s: %s: creating runtime pm sysfs entry: failed: %d\n",
 			       mmc_hostname(card->host), __func__, ret);
-		/* Default timeout is 10 seconds */
-		card->idle_timeout = RUNTIME_SUSPEND_DELAY_MS;
+		if (mmc_card_sd(card))
+			card->idle_timeout = RUNTIME_SDCARD_SUSPEND_DELAY_MS;
+		else
+			card->idle_timeout = RUNTIME_SUSPEND_DELAY_MS;
 	}
 
 	mmc_card_set_present(card);

--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -29,6 +29,11 @@
 #include "sdio_ops.h"
 #include "sdio_cis.h"
 
+// Sony Kitakami R2
+#if defined(CONFIG_MACH_SONY_SUZURAN) || defined(CONFIG_MACH_SONY_SUMIRE) || defined(CONFIG_MACH_SONY_SATSUKI)
+#define SELECT_LOW_VOLTAGE
+#endif
+
 #ifdef CONFIG_MMC_EMBEDDED_SDIO
 #include <linux/mmc/sdio_ids.h>
 #endif
@@ -1048,7 +1053,7 @@ static int mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 {
 	int ret = 0;
 
-#ifdef CONFIG_MACH_SONY_SUZURAN
+#if defined(SELECT_LOW_VOLTAGE)
 	if ((host->ocr_avail == MMC_VDD_165_195) && mmc_host_uhs(host) &&
 		((ocr & host->ocr_avail) == 0)) {
 		/* lowest voltage can be selected in mmc_power_cycle */
@@ -1113,11 +1118,11 @@ static int mmc_sdio_power_restore(struct mmc_host *host)
 		/* to query card if 1.8V signalling is supported */
 		host->ocr |= R4_18V_PRESENT;
 
+#if defined(SELECT_LOW_VOLTAGE)
 	ret = mmc_sdio_init_card(host, host->ocr, host->card,
-#ifdef CONFIG_MACH_SONY_SHINANO
-		0);
+				mmc_card_keep_power(host));
 #else
-		mmc_card_keep_power(host));
+	ret = mmc_sdio_init_card(host, host->ocr, host->card, 0);
 #endif
 	if (!ret && host->sdio_irqs)
 		mmc_signal_sdio_irq(host);


### PR DESCRIPTION
Fix the logic for mmc block requesting process.
The logic was extracted from 32.1.F.0.x.

The patch fixes this BUG:

<4>[   52.765552] IRQ39 no longer affine to CPU1
<2>[   54.071351] EXT4-fs error (device mmcblk0p25): ext4_lookup:1437: inode #147305: comm SharedPreferenc: deleted inode referenced: 147159
<3>[   54.082730] Aborting journal on device mmcblk0p25-8.
<0>[   54.092589] Kernel panic - not syncing: EXT4-fs (device mmcblk0p25): panic forced after error
