### PR TITLE
[1.2.2] drivers: mmc: sdhci: Implements mutex for next_data

### DIFF
--- a/include/linux/mmc/sdhci.h
+++ b/include/linux/mmc/sdhci.h
@@ -280,6 +280,7 @@ struct sdhci_host {
 	struct device_attribute pm_qos_tout;
 
 	struct sdhci_next next_data;
+	spinlock_t next_lock;	/* Mutex for next_data */
 	ktime_t data_start_time;
 	struct mutex ios_mutex;
 	enum sdhci_power_policy power_policy;


### PR DESCRIPTION
Implements mutex control for next_data and avoid unbalanced jobs.

This implementation was extracted from stock kernel.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I3eeff8990329eb7cdd7d25e3d03178bbd5ab3bc8
