### PR TITLE
[1.2.2] drivers: mmc: sdhci: Fix timeout timer

### DIFF
--- a/drivers/mmc/host/sdhci.c
+++ b/drivers/mmc/host/sdhci.c
@@ -2828,10 +2828,13 @@ static void sdhci_timeout_timer(unsigned long data)
 		if (!host->mrq->cmd->ignore_timeout) {
 			pr_err("%s: Timeout waiting for hardware interrupt.\n",
 			       mmc_hostname(host->mmc));
-			if (host->data)
+			if (host->data) {
 				sdhci_show_adma_error(host);
-			else
-				sdhci_dumpregs(host);
+			} else {
+				if (host->mmc->card &&
+						!mmc_card_sdio(host->mmc->card))
+					sdhci_dumpregs(host);
+			}
 		}
 
 		if (host->data) {


### PR DESCRIPTION
Fix timeout timer during sdhci request.
This change check the type of card then set the correct timeout value.

Fix:

[  735.633375] ------------[ cut here ]------------
[  735.637028] WARNING: at ../../../../../../kernel/sony/msm/drivers/mmc/host/sdhci.c:1755 sdhci_request+0x40/0x2b4()
[  735.650451] ---[ end trace 736c1c74e5e12fbb ]---
[  735.654114] ------------[ cut here ]------------
[  735.658673] WARNING: at ../../../../../../kernel/sony/msm/drivers/mmc/host/sdhci.c:1755 sdhci_request+0x40/0x2b4()
[  735.670331] ---[ end trace 736c1c74e5e12fbc ]---
[  735.673992] ------------[ cut here ]------------
[  735.678551] WARNING: at ../../../../../../kernel/sony/msm/drivers/mmc/host/sdhci.c:1755 sdhci_request+0x40/0x2b4()
[  735.690048] ---[ end trace 736c1c74e5e12fbd ]---
[  735.693704] ------------[ cut here ]------------
[  735.698267] WARNING: at ../../../../../../kernel/sony/msm/drivers/mmc/host/sdhci.c:1755 sdhci_request+0x40/0x2b4()
[  735.709562] ---[ end trace 736c1c74e5e12fbe ]---
[  735.719906] mmc2: error -5 during shutdown

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I6a74e2e5d4539e9687c551c4638ab429f8d5d5fd
