### PR TITLE
[1.2.2] drivers: spmi: Fix gcc warning

### DIFF
--- a/drivers/spmi/spmi.c
+++ b/drivers/spmi/spmi.c
@@ -237,7 +237,7 @@ int spmi_add_device(struct spmi_device *spmidev)
 
 	/* Set the device name */
 	if (spmidev->res.resource)
-		dev_set_name(dev, "%02x-%s-%04x", spmidev->sid, spmidev->dev.of_node->name, spmidev->res.resource[0].start);
+		dev_set_name(dev, "%02x-%s-%pa", spmidev->sid, spmidev->dev.of_node->name, &spmidev->res.resource[0].start);
 	else
 		dev_set_name(dev, "%02x-%s", spmidev->sid, spmidev->dev.of_node->name);
 


### PR DESCRIPTION
kernel/sony/msm/drivers/spmi/spmi.c: In function 'spmi_add_device':
kernel/sony/msm/drivers/spmi/spmi.c:240:3: warning: format '%x' expects argument of type 'unsigned int', but argument 5 has type 'resource_size_t' [-Wformat=]
   dev_set_name(dev, "%02x-%s-%04x", spmidev->sid, spmidev->dev.of_node->name, spmidev->res.resource[0].start);
   ^

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ie0a54ee15c6008e0d5ea0a34653e0d922dc4a0f2
