### PR TITLE
[1.2.2] drivers: dma: Fix gcc warnings

### DIFF
--- a/drivers/dma/qcom-sps-dma.c
+++ b/drivers/dma/qcom-sps-dma.c
@@ -207,7 +207,7 @@ static struct dma_chan *qbam_dma_xlate(struct of_phandle_args *dma_spec,
 	/* allocate a channel */
 	qbam_chan = kzalloc(sizeof(*qbam_chan), GFP_KERNEL);
 	if (!qbam_chan) {
-		qbam_err(qbam_dev, "error kmalloc(size:%lu) faild\n",
+		qbam_err(qbam_dev, "error kmalloc(size:%zu) faild\n",
 			 sizeof(*qbam_chan));
 		return NULL;
 	}
@@ -442,7 +442,7 @@ static int qbam_slave_cfg(struct qbam_channel *qbam_chan,
 						  GFP_KERNEL);
 	if (!pipe_cfg->desc.base) {
 		qbam_err(qbam_dev,
-			"error dma_alloc_coherent(desc-sz:%lu * n-descs:%d)\n",
+			"error dma_alloc_coherent(desc-sz:%zu * n-descs:%d)\n",
 			sizeof(struct sps_iovec),
 			qbam_chan->bam_pipe.num_descriptors);
 		return -ENOMEM;
@@ -635,7 +635,7 @@ static int qbam_probe(struct platform_device *pdev)
 
 	qbam_dev = devm_kzalloc(&pdev->dev, sizeof(*qbam_dev), GFP_KERNEL);
 	if (!qbam_dev) {
-		qbam_err(qbam_dev, "error kmalloc(size:%lu) faild",
+		qbam_err(qbam_dev, "error kmalloc(size:%zu) faild",
 			 sizeof(*qbam_dev));
 		return -ENOMEM;
 	}


### PR DESCRIPTION
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c: In function 'qbam_dma_xlate':
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c:210:3: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'unsigned int' [-Wformat=]
   qbam_err(qbam_dev, "error kmalloc(size:%lu) faild\n",
   ^
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c: In function 'qbam_slave_cfg':
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c:446:18: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'unsigned int' [-Wformat=]
    sizeof(struct sps_iovec),
                  ^
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c:123:68: note: in definition of macro 'qbam_err'
 #define qbam_err(qbam_dev, fmt ...) dev_err(qbam_dev->dma_dev.dev, fmt)
                                                                    ^
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c: In function 'qbam_probe':
../../../../../../kernel/sony/msm/drivers/dma/qcom-sps-dma.c:638:3: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'unsigned int' [-Wformat=]
   qbam_err(qbam_dev, "error kmalloc(size:%lu) faild",
   ^
Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I85baae066dc2e2e778ba0aa4586e7558efec814d
