### PR TITLE
kitakami: scale backlight to 12bit on devices that need it

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-ivy.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-ivy.dtsi
@@ -93,7 +93,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -433,7 +433,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -778,7 +778,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1132,7 +1132,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1232,7 +1232,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1330,7 +1330,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x21>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";

--- a/arch/arm/boot/dts/qcom/dsi-panel-satsuki.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-satsuki.dtsi
@@ -138,7 +138,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -234,7 +234,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-fbc-enable;
@@ -385,7 +385,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -481,7 +481,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-fbc-enable;
@@ -559,7 +559,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -1071,7 +1071,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		somc,platform-regulator-settings = [03 03 03 00 20 00 01];
@@ -1192,7 +1192,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -1444,7 +1444,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		somc,platform-regulator-settings = [03 03 03 00 20 00 01];
@@ -1565,7 +1565,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -2049,7 +2049,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		somc,platform-regulator-settings = [03 03 03 00 20 00 01];
@@ -2170,7 +2170,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -2633,7 +2633,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		somc,platform-regulator-settings = [03 03 03 00 20 00 01];
@@ -2754,7 +2754,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -3191,7 +3191,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		somc,platform-regulator-settings = [03 03 03 00 20 00 01];
@@ -3337,7 +3337,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -3438,7 +3438,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-fbc-enable;
@@ -3541,7 +3541,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
@@ -3642,7 +3642,7 @@
 		qcom,qpnp-ibb-limit-maximum-current = <900>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-fbc-enable;

--- a/arch/arm/boot/dts/qcom/dsi-panel-sumire.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-sumire.dtsi
@@ -93,7 +93,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -448,7 +448,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -803,7 +803,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -1515,7 +1515,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -1872,7 +1872,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -2229,7 +2229,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -2327,7 +2327,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;

--- a/arch/arm/boot/dts/qcom/dsi-panel-suzuran.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-suzuran.dtsi
@@ -87,7 +87,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -429,7 +429,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -757,7 +757,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;
@@ -841,7 +841,7 @@
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,qpnp-lab-limit-maximum-current = <200>;


### PR DESCRIPTION
Android uses 8bit (256 values) but on some devices the backlight
needs 12bit (4096 values). The display driver automatically scales
android's 8bit value to a 12bit value with transition.

Signed-off-by: Adam Farden adam@farden.cz
