### PR TITLE
dts:fix scorpion/scorpion_windy msm-id

### DIFF
--- a/arch/arm/boot/dts/qcom/apq8074pro-ac-shinano_scorpion_windy.dts
+++ b/arch/arm/boot/dts/qcom/apq8074pro-ac-shinano_scorpion_windy.dts
@@ -28,5 +28,9 @@
 / {
 	model = "SoMC Scorpion WINDY";
 	compatible = "somc,scorpion-windy", "qcom,apq8074";
-        qcom,msm-id = <210 9 0x10001>;
+        qcom,board-id = <9 0>;
+        qcom,msm-id = <216 0x10000>,
+                      <213 0x10000>,
+                      <210 0x10000>,
+                      <194 0x10000>;
 };

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion.dts
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion.dts
@@ -27,6 +27,9 @@
 / {
 	model = "SoMC Scorpion ROW";
 	compatible = "somc,scorpion-row", "qcom,msm8974";
-        qcom,msm-id = <210 8 0x10001>;
+        qcom,board-id = <8 0>;
+        qcom,msm-id = <216 0x10000>,
+                      <213 0x10000>,
+                      <210 0x10000>,
+                      <194 0x10000>;
 };
-


### PR DESCRIPTION
root@scorpion:/ # hexdump /proc/device-tree/qcom,msm-id
0000000 0000 c200 0100 0000 0000 d200 0100 0000
0000010 0000 d500 0100 0000 0000 d800 0100 0000
0000020
root@scorpion:/ # hexdump /proc/device-tree/qcom,board-id
0000000 0000 0800 0000 0000
0000008

This is HexDump of msm-id and board-id from my SGP621.
Convert these hex to decimal.
And separate board-id string. It will genarate dtb version 2.

(Scorpion_windy is may-be...)
