### PR TITLE
[1.3.3] drivers: input: misc: Update bu520x1nvx driver

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_castor_common.dtsi
@@ -171,7 +171,13 @@
 
 	bu520x1nvx {
 		compatible = "rohm,bu520x1nvx";
-		gpios = <&pm8941_gpios 36 0x1>;
+
+		acc_cover {
+			label = "lid";
+			gpios = <&pm8941_gpios 36 0x1>;
+			lid-pin = <1>;
+			debounce-interval = <50>;
+		};
 	};
 
 	nxp,tfa98xx-codec {

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_aries.dtsi
@@ -102,7 +102,13 @@
 
 	bu520x1nvx {
 		compatible = "rohm,bu520x1nvx";
-		gpios = <&pm8941_gpios 36 0x1>;
+
+		acc_cover {
+			label = "lid";
+			gpios = <&pm8941_gpios 36 0x1>;
+			lid-pin = <1>;
+			debounce-interval = <50>;
+		};
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_leo.dtsi
@@ -98,7 +98,13 @@
 
 	bu520x1nvx {
 		compatible = "rohm,bu520x1nvx";
-		gpios = <&pm8941_gpios 36 0x1>;
+
+		acc_cover {
+			label = "lid";
+			gpios = <&pm8941_gpios 36 0x1>;
+			lid-pin = <1>;
+			debounce-interval = <50>;
+		};
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ac-shinano_scorpion_common.dtsi
@@ -183,7 +183,14 @@
 
 	bu520x1nvx {
 		compatible = "rohm,bu520x1nvx";
-		gpios = <&pm8941_gpios 36 0x1>;
+
+		acc_cover {
+			label = "lid";
+			gpios = <&pm8941_gpios 36 0x1>;
+			lid-pin = <1>;
+			debounce-interval = <50>;
+		};
+
 	};
 };
 

--- a/include/linux/input/bu520x1nvx.h
+++ b/include/linux/input/bu520x1nvx.h
@@ -1,0 +1,37 @@
+/* include/linux/input/bu520x1nvx.h
+ *
+ * Author: Atsushi Iyogi <atsushi.x.iyogi@sonymobile.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+/*
+ * Copyright (C) 2014 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef _LINUX_INPUT_BU520X1NVX_H
+#define _LINUX_INPUT_BU520X1NVX_H
+
+struct device;
+
+struct bu520x1nvx_gpio_event {
+	bool lid_pin;
+	int gpio;
+	int active_low;
+	const char *desc;
+	int debounce_interval;
+	unsigned int irq;
+};
+
+struct bu520x1nvx_platform_data {
+	int n_events;
+	struct bu520x1nvx_gpio_event *events;
+};
+
+#endif


### PR DESCRIPTION
Update bu520x1nvx driver from 32.1.F.0.x

Fix:
[ 4.433626] input: bu520x1nvx as /devices/virtual/input/input1
[ 4.433881] genirq: Threaded irq requested with handler=NULL and !ONESHOT for irq 477
[ 4.433931] bu520x1nvx bu520x1nvx.93: failed to request irq (bu520x1nvx_probe)

Also, update DT entries for shinano devices.
