### PR TITLE
[1.3.3] karin: scale backlight to 12bit

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-karin.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-karin.dtsi
@@ -82,7 +82,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -190,7 +190,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -535,7 +535,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -660,7 +660,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -990,7 +990,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1086,7 +1086,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1183,7 +1183,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
@@ -1273,7 +1273,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x1B>;
 		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-bl-min-level = <1>;
-		qcom,mdss-dsi-bl-max-level = <255>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi
@@ -131,8 +131,8 @@
 			linux,default-trigger = "bkl-trigger";
 			mode = "register based";
 			chip_name = "lp8557";
-			max_br = <0xFF>;
-			init_br = <0x83>;
+			max_br = <0xFFF>;
+			init_br = <0x666>;
 			somc-s1,br-power-save = <0x83>;
 			slope_reg = <0x00>;
 			dev-ctrl = <0x01>;

--- a/drivers/leds/leds-lp855x.c
+++ b/drivers/leds/leds-lp855x.c
@@ -198,7 +198,6 @@ struct lp855x_device_config {
 	u8 reg_slope_mask;
 	u8 reg_devicectrl;
 	u8 reg_devicectrl_mask;
-	u8 reg_brt;
 	int (*pre_init_device)(struct lp855x *);
 	int (*post_init_device)(struct lp855x *);
 	int (*resume_init)(struct lp855x *);
@@ -249,7 +248,7 @@ static int lp855x_write_brightness(struct lp855x *lp,
 		brightness = (brightness * lp->bl_scale) / 100;
 	if (is_8bit) {
 		ret = lp855x_write_byte(lp,
-			lp->cfg->reg_brt, (u8)brightness);
+			LP855X_BRIGHTNESS_CTRL, (u8)brightness);
 	} else {
 		val = (u8)((brightness << LP8557_BRTLO_SHFT)
 			& LP8557_BRTLO_MASK);
@@ -614,19 +613,17 @@ static struct lp855x_device_config lp855x_dev_cfg = {
 	.reg_slope_mask = SLOPE_FILTER_MASK,
 	.reg_devicectrl = LP855X_DEVICE_CTRL,
 	.reg_devicectrl_mask = BL_CTL_MASK,
-	.reg_brt = LP855X_BRIGHTNESS_CTRL,
 	.pre_init_device = lp855x_bl_off,
 	.post_init_device = lp855x_bl_on,
 	.resume_init = lp855x_resume_init,
 };
 
 static struct lp855x_device_config lp8557_dev_cfg = {
-	.is_8bit_brightness = true,
+	.is_8bit_brightness = false,
 	.reg_slope = STEP_CTRL,
 	.reg_slope_mask = STEP_SLOPE_FILTER_MASK,
 	.reg_devicectrl = LP8557_BL_CMD,
 	.reg_devicectrl_mask = LP8557_BL_MASK,
-	.reg_brt = LP8557_BRTHI,
 	.pre_init_device = lp8557_bl_off,
 	.post_init_device = lp8557_bl_on,
 	.resume_init = NULL,


### PR DESCRIPTION
- Revert "leds: lp855x: Change LP8557's brightness sensitivity to 8bit"

This reverts commit dabb804a284fa1df3609b9d4a12c5d2cec23f19b.
- arm64: DT: karin: scale backlight to 12bit

Android uses 8bit (256 values) but on some devices the backlight
needs 12bit (4096 values). The display driver automatically scales
android's 8bit value to a 12bit value with transition.

Just following the same logic here:
https://github.com/sonyxperiadev/kernel/commit/3c5d381f75471682bb799a23b1adeba098fd63a2

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Icca082116a4368cc0364f3d200152904e3c31b98
