### PR TITLE
kernel: Fix libelf path

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -127,7 +127,7 @@ define clean-module-folder
 endef
 
 ifeq ($(HOST_OS),darwin)
-  MAKE_FLAGS += C_INCLUDE_PATH=$(ANDROID_BUILD_TOP)/external/elfutils/0.153/libelf/
+  MAKE_FLAGS += C_INCLUDE_PATH=$(ANDROID_BUILD_TOP)/external/elfutils/src/libelf/
 endif
 
 ifeq ($(TARGET_KERNEL_MODULES),)


### PR DESCRIPTION
https://android.googlesource.com/platform/external/elfutils/+/android-6.0.1_r43/src/libelf/

Signed-off-by: David Viteri davidteri91@gmail.com
