### PR TITLE
ARM: dt: msm8226: Add AV timer specific data

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8226.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8226.dtsi
@@ -703,6 +703,13 @@
 		qcom,msm-auxpcm-interface = "primary";
 	};
 
+	qcom,avtimer@fe053000 {
+		compatible = "qcom,avtimer";
+		reg = <0xfe053008 0x4>,
+			<0xfe05300c 0x4>;
+		reg-names = "avtimer_lsb_addr", "avtimer_msb_addr";
+	};
+
 	qcom,wcnss-wlan@fb000000 {
 		compatible = "qcom,wcnss_wlan";
 		reg = <0xfb000000 0x280000>,


### PR DESCRIPTION
LPASS exposes registers from which timestamp can be
read by clients for audio & video synchronization.
Change adds the register address of AV timer in LPASS.

CRs-fixed: 677082
Change-Id: I4677a745a48913d53d91e7bdeb62ad3ee5358cb3
Signed-off-by: Laxminath Kasam lkasam@codeaurora.org
Signed-off-by: Shreyas Nagasandra Chandrasekhar snagas@codeaurora.org
