### PR TITLE
[1.2.2] asoc: shinano: Remove Add UltraLowLatency

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-v2.2-rhine_common.dtsi
@@ -320,6 +320,13 @@
 		max-clk-turbo =   <320000000>;
 	};
 
+	qcom,msm-pcm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
 	sound {
 		qcom,audio-routing =
 			"RX_BIAS", "MCLK",

--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -1691,13 +1691,6 @@
 		qcom,latency-level = "regular";
 	};
 
-	qcom,msm-pcm-ultra-low-latency {
-		compatible = "qcom,msm-pcm-dsp";
-		qcom,msm-pcm-dsp-id = <2>;
-		qcom,msm-pcm-low-latency;
-		qcom,latency-level = "ultra";
-	};
-
 	qcom,msm-pcm-routing {
 		compatible = "qcom,msm-pcm-routing";
 	};

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -2183,6 +2183,7 @@ static struct snd_soc_dai_link msm8974_common_dai_links[] = {
 		.ignore_pmdown_time = 1,
 		.be_id = MSM_FRONTEND_DAI_MULTIMEDIA3,
 	},
+#ifdef CONFIG_MACH_SONY_RHINE
 	{
 		.name = "MSM8974 ULL",
 		.stream_name = "MultiMedia3",
@@ -2198,6 +2199,7 @@ static struct snd_soc_dai_link msm8974_common_dai_links[] = {
 		.ignore_pmdown_time = 1,
 		.be_id = MSM_FRONTEND_DAI_MULTIMEDIA3,
 	},
+#endif
 	/* Hostless PCM purpose */
 	{
 		.name = "SLIMBUS_0 Hostless",


### PR DESCRIPTION
It is breaking audio for notifications on shinano devices.
So move it to rhine platform which was only the tested target.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I71416d943e9ca016843f9c94f6f13ba35f03af3d
