### PR TITLE
ASoC: msm8974: Fix audio in notif/alarms

### DIFF
--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -2169,21 +2169,6 @@ static struct snd_soc_dai_link msm8974_common_dai_links[] = {
 		.be_id = MSM_FRONTEND_DAI_VOIP,
 	},
 	{
-		.name = "MSM8974 LPA",
-		.stream_name = "LPA",
-		.cpu_dai_name	= "MultiMedia3",
-		.platform_name  = "msm-pcm-lpa",
-		.dynamic = 1,
-		.trigger = {SND_SOC_DPCM_TRIGGER_POST,
-			SND_SOC_DPCM_TRIGGER_POST},
-		.codec_dai_name = "snd-soc-dummy-dai",
-		.codec_name = "snd-soc-dummy",
-		.ignore_suspend = 1,
-		/* this dainlink has playback support */
-		.ignore_pmdown_time = 1,
-		.be_id = MSM_FRONTEND_DAI_MULTIMEDIA3,
-	},
-	{
 		.name = "MSM8974 ULL",
 		.stream_name = "MultiMedia3",
 		.cpu_dai_name	= "MultiMedia3",


### PR DESCRIPTION
LPA & ULL can't use multimedia3 it causes a bug with audio in notifications and alarms

Signed-off-by: David Viteri davidteri91@gmail.com
