### PR TITLE
[1.3.3] Sanify code, fix warnings and memory leaks

### DIFF
--- a/drivers/gpu/msm/adreno_iommu.c
+++ b/drivers/gpu/msm/adreno_iommu.c
@@ -331,6 +331,7 @@ static inline int _adreno_iommu_add_idle_indirect_cmds(
  *
  * Returns number of commands added.
  */
+#ifndef CONFIG_MSM_ADRENO_USES_OLD_FIRMWARE
 static unsigned int _adreno_mmu_set_pt_update_condition(
 			struct adreno_ringbuffer *rb,
 			unsigned int *cmds, unsigned int ptname)
@@ -484,6 +485,7 @@ static unsigned int _adreno_iommu_pt_update_pid_to_mem(
 
 	return cmds - cmds_orig;
 }
+#endif /* CONFIG_MSM_ADRENO_USES_OLD_FIRMWARE */
 
 static unsigned int _adreno_iommu_set_pt_v1(struct adreno_ringbuffer *rb,
 					unsigned int *cmds_orig,
@@ -497,6 +499,8 @@ static unsigned int _adreno_iommu_set_pt_v1(struct adreno_ringbuffer *rb,
 	unsigned int *cond_exec_ptr;
 
 	cmds += _adreno_iommu_add_idle_cmds(adreno_dev, cmds);
+
+	cond_exec_ptr = cmds;
 
 #ifndef CONFIG_MSM_ADRENO_USES_OLD_FIRMWARE
 	/* set flag that indicates whether pt switch is required*/

--- a/drivers/input/touchscreen/clearpad_core.c
+++ b/drivers/input/touchscreen/clearpad_core.c
@@ -3555,7 +3555,7 @@ static int clearpad_command_open(struct clearpad_t *this,
 	} else {
 		this->flash.buffer_size = image_size;
 		dev_info(&this->pdev->dev,
-			"prepared buffer size=%u\n", this->flash.buffer_size);
+			"prepared buffer size=%zu\n", this->flash.buffer_size);
 	}
 	UNLOCK(this);
 	return rc;
@@ -3602,7 +3602,7 @@ static ssize_t clearpad_fwdata_write(struct file *file,
 				"config_size=%d\n",
 				this->flash.config_size);
 		dev_info(&this->pdev->dev,
-				"image_size=%d\n", image_size);
+				"image_size=%zu\n", image_size);
 		rc = clearpad_command_open(this, image_size);
 		if (rc) {
 			size = -EINVAL;
@@ -3621,7 +3621,7 @@ static ssize_t clearpad_fwdata_write(struct file *file,
 	memcpy(this->flash.image + this->flash.size, buf, size);
 	this->flash.size += size;
 	dev_info(&this->pdev->dev,
-		"got %d bytes, total %d bytes\n", size, this->flash.size);
+		"got %zu bytes, total %zu bytes\n", size, this->flash.size);
 	UNLOCK(this);
 exit:
 	return size;
@@ -4063,7 +4063,7 @@ static ssize_t clearpad_pca_store(struct device *dev,
 	if (size > SYN_PCA_ACCESS_MAX_WRITE_SIZE) {
 		rc = -EINVAL;
 		dev_err(&this->pdev->dev,
-		       "Input data size is large (size = %d)\n", size);
+		       "Input data size is large (size = %zu)\n", size);
 		goto err_unlock;
 	}
 
@@ -4091,8 +4091,8 @@ static ssize_t clearpad_pca_store(struct device *dev,
 	if (size % block_size) {
 		rc = -EINVAL;
 		dev_err(&this->pdev->dev,
-		       "Writed data size is not multiples of block_size" \
-			"(size = %d, block_size = %d)\n", size, block_size);
+		       "Written data size is not multiples of block_size" \
+			"(size = %zu, block_size = %d)\n", size, block_size);
 		goto err_unlock;
 	}
 
@@ -5319,7 +5319,7 @@ err_retrun:
 	return;
 }
 
-static ssize_t clearpad_debug_hwtest_open(struct inode *inode,
+static int clearpad_debug_hwtest_open(struct inode *inode,
 		struct file *file)
 {
 	file->private_data = inode->i_private;
@@ -5801,8 +5801,8 @@ static void clearpad_debug_init(struct clearpad_t *this)
 	dent = debugfs_create_dir("clearpad", 0);
 	if (!dent || IS_ERR(dent)) {
 		dev_err(&this->pdev->dev,
-			"%s: debugfs_create_dir error: dent=0x%x\n",
-			__func__, (unsigned)dent);
+			"%s: debugfs_create_dir error: dent=0x%lx\n",
+			__func__, PTR_ERR(dent));
 		goto exit;
 	}
 
@@ -5813,8 +5813,8 @@ static void clearpad_debug_init(struct clearpad_t *this)
 				&clearpad_debug_hwtest_fops);
 	if (!dent || IS_ERR(dent)) {
 		dev_err(&this->pdev->dev,
-			"%s: debugfs_create_file error: dent=0x%x\n",
-			__func__, (unsigned)dent);
+			"%s: debugfs_create_file error: dent=0x%lx\n",
+			__func__, PTR_ERR(dent));
 		goto error;
 	}
 

--- a/drivers/media/platform/msm/vidc/msm_venc.c
+++ b/drivers/media/platform/msm/vidc/msm_venc.c
@@ -3323,7 +3323,6 @@ int msm_venc_set_csc(struct msm_vidc_inst *inst)
 int msm_venc_s_fmt(struct msm_vidc_inst *inst, struct v4l2_format *f)
 {
 	struct msm_vidc_format *fmt = NULL;
-	struct hal_frame_size frame_sz = {0};
 	int rc = 0;
 	int i;
 	struct hfi_device *hdev;
@@ -3364,7 +3363,6 @@ int msm_venc_s_fmt(struct msm_vidc_inst *inst, struct v4l2_format *f)
 			goto exit;
 		}
 	} else if (f->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
-		struct hal_uncompressed_format_select hal_fmt = {0};
 		struct hal_frame_size frame_sz;
 		struct hal_video_signal_info signal_info = {0};
 

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -242,10 +242,6 @@ static int mdss_dsi_regulator_init(struct platform_device *pdev,
 		struct dsi_shared_data *sdata)
 {
 	int rc = 0, i = 0, j = 0;
-#if defined (CONFIG_REGULATOR_QPNP_LABIBB_SOMC) && \
-    defined (CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)
-	struct mdss_dsi_ctrl_pdata *ctrl = NULL;
-#endif
 
 	if (!pdev || !sdata) {
 		pr_err("%s: invalid input\n", __func__);

--- a/scripts/sortextable.c
+++ b/scripts/sortextable.c
@@ -64,14 +64,6 @@ fail_file(void)
 	longjmp(jmpenv, SJ_FAIL);
 }
 
-static void __attribute__((noreturn))
-succeed_file(void)
-{
-	cleanup();
-	longjmp(jmpenv, SJ_SUCCEED);
-}
-
-
 /*
  * Get the whole file as a programming convenience in order to avoid
  * malloc+lseek+read+free of many pieces.  If successful, then mmap

--- a/scripts/sortextable.h
+++ b/scripts/sortextable.h
@@ -101,7 +101,7 @@ do_func(Elf_Ehdr *ehdr, char const *const fname, table_sort_t custom_sort)
 	Elf_Sym *sort_needed_sym;
 	Elf_Shdr *sort_needed_sec;
 	Elf_Rel *relocs = NULL;
-	int relocs_size;
+	int relocs_size = 0;
 	uint32_t *sort_done_location;
 	const char *secstrtab;
 	const char *strtab;

--- a/sound/soc/codecs/wcd9xxx-mbhc.c
+++ b/sound/soc/codecs/wcd9xxx-mbhc.c
@@ -5299,7 +5299,6 @@ static int wcd9xxx_detect_impedance(struct wcd9xxx_mbhc *mbhc, uint32_t *zl,
 				    uint32_t *zr)
 {
 	int i;
-	int ret = 0;
 	int valid_z = 0;
 	u8 micb_mbhc_val;
 	s16 l[3], r[3];


### PR DESCRIPTION
Fix various warnings across the tree, fix possible memory leaks (in vidc venc).

Sanification run done compiling 8974 targets.
