### PR TITLE
[1.3.3] mmc: host: sdhci-msm: Disable BKOPS for Rhine

### DIFF
--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -3845,11 +3845,14 @@ static int sdhci_msm_probe(struct platform_device *pdev)
 				MMC_CAP2_DETECT_ON_ERR);
 	msm_host->mmc->caps2 |= MMC_CAP2_CACHE_CTRL;
 	msm_host->mmc->caps2 |= MMC_CAP2_STOP_REQUEST;
-	msm_host->mmc->caps2 |= MMC_CAP2_INIT_BKOPS;
 	msm_host->mmc->caps2 |= MMC_CAP2_ASYNC_SDIO_IRQ_4BIT_MODE;
 	msm_host->mmc->pm_caps |= MMC_PM_KEEP_POWER | MMC_PM_WAKE_SDIO_IRQ;
 	msm_host->mmc->caps2 |= MMC_CAP2_CORE_PM;
 	msm_host->mmc->caps2 |= MMC_CAP2_SANITIZE;
+
+#ifndef CONFIG_MACH_SONY_RHINE
+	msm_host->mmc->caps2 |= MMC_CAP2_INIT_BKOPS;
+#endif
 
 #ifdef CONFIG_MACH_SONY_SUZU
 	msm_host->mmc->caps2 |= MMC_CAP2_AWAKE_SUPP;


### PR DESCRIPTION
This is not a really important feature. Since the card already
supports BKOPS (bit has been burnt), disabling this flag will
disable automatic scheduling (by eMMC firmware) of background
operations and will let the Linux MMC drivers to manually
schedule them on-need.
