### PR TITLE
[1.2.2] arm: irq: Fix logspam by removing harmless irq messages

### DIFF
--- a/arch/arm/kernel/irq.c
+++ b/arch/arm/kernel/irq.c
@@ -193,7 +193,7 @@ void migrate_irqs(void)
 		raw_spin_unlock(&desc->lock);
 
 		if (affinity_broken && printk_ratelimit())
-			pr_warning("IRQ%u no longer affine to CPU%u\n", i,
+			pr_debug("IRQ%u no longer affine to CPU%u\n", i,
 				smp_processor_id());
 	}
 


### PR DESCRIPTION
These kernel messages are harmless so do not populate dmesg with them

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ia2a4af1ac9d55db50df63266ea4b12d93f14f77c
