### PR TITLE
arm64: kitakami: use another code for clearpad wakeup gesture

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -221,12 +221,12 @@
 					};
 					event_01 {
 						type = <1>; /* KEY */
-						code = <116>; /* KEY_POWER */
+						code = <531>; /* TOUCHPAD_ON */
 						down = <1>;
 					};
 					event_02 {
 						type = <1>; /* KEY */
-						code = <116>; /* KEY_POWER */
+						code = <531>; /* TOUCHPAD_ON */
 						down = <0>;
 					};
 					event_03 {


### PR DESCRIPTION
double tap to wakeup wasn't working with KEY_POWER code. Switching to 531 makes dt2w work.
according to
https://github.com/sonyxperiadev/device-sony-kitakami/blob/master/rootdir/system/usr/keylayout/clearpad.kl#L1
531 should be the correct code for wakeup.
This is also the same value that karin uses:
https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/arch/arm/boot/dts/qcom/msm8994-kitakami_karin_common.dtsi#L107
