### PR TITLE
[1.3.3] arm: DT: Kitakami: Fix scale function choice in VADC channels

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -3275,10 +3275,10 @@
 		qcom,fast-avg-setup = <0>;
 	};
 	chan@73 { /* msm_therm */
-		qcom,scale-function = <13>;
+		qcom,scale-function = <18>; /* 100K_PULLUP_DECI */
 	};
 	chan@74 { /* emmc_therm */
-		qcom,scale-function = <13>;
+		qcom,scale-function = <18>; /* 100K_PULLUP_DECI */
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_r2_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_r2_common.dtsi
@@ -297,19 +297,19 @@
 		qcom,decimation = <0>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <15>;
+		qcom,scale-function = <18>; /* THERM_100K_PULLUP_DECI */
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;
 	};
 
 	chan@78 { /* quiet_therm */
-		qcom,scale-function = <15>;
+		qcom,scale-function = <18>; /* THERM_100K_PULLUP_DECI */
 	};
 };
 
 &pm8994_adc_tm {
 	chan@78 { /* quiet_therm */
-		qcom,scale-function = <8>;
+		qcom,scale-function = <8>; /* SCALE_SMB_BATT_THERM */
 	};
 };


### PR DESCRIPTION
Some VADC channels are connected to the 100K pullup thermistor.
The qcom,scale-function number got off-phase after some kernel
drivers update from copyleft releases.

Fix the scale function configuration in DT for global Kitakami
and write small but effective documentation for the values.
