### PR TITLE
[1.3.3] Consolidate MDSS and DRS feature

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-satsuki.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-satsuki.dtsi
@@ -144,6 +144,7 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -240,6 +241,7 @@
 		qcom,mdss-brightness-max-level = <4095>;
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -393,6 +395,7 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -489,6 +492,7 @@
 		qcom,mdss-brightness-max-level = <4095>;
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -1012,6 +1016,7 @@
 					"dsi_lp_mode";
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -1131,6 +1136,7 @@
 				qcom,mdss-dsi-t-clk-pre = <0x2B>;
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -1387,6 +1393,7 @@
 					"dsi_lp_mode";
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -1506,6 +1513,7 @@
 				qcom,mdss-dsi-t-clk-pre = <0x2B>;
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -1994,6 +2002,7 @@
 					"dsi_lp_mode";
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -2113,6 +2122,7 @@
 				qcom,mdss-dsi-t-clk-pre = <0x2B>;
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -2580,6 +2590,7 @@
 					"dsi_lp_mode";
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -2699,6 +2710,7 @@
 				qcom,mdss-dsi-t-clk-pre = <0x2B>;
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -3140,6 +3152,7 @@
 					"dsi_lp_mode";
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -3259,6 +3272,7 @@
 				qcom,mdss-dsi-t-clk-pre = <0x2B>;
 
 				qcom,mdss-dsi-compression = "fbc";
+				qcom,mdss-dsi-fbc-enable;
 				qcom,mdss-dsi-fbc-ver2-mode;
 				qcom,mdss-dsi-fbc-bpp = <8>;
 				qcom,mdss-dsi-fbc-packing = <1>;
@@ -3357,6 +3371,7 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -3458,6 +3473,7 @@
 		qcom,mdss-brightness-max-level = <4095>;
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -3563,6 +3579,7 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;
@@ -3664,6 +3681,7 @@
 		qcom,mdss-brightness-max-level = <4095>;
 
 		qcom,mdss-dsi-compression = "fbc";
+		qcom,mdss-dsi-fbc-enable;
 		qcom,mdss-dsi-fbc-ver2-mode;
 		qcom,mdss-dsi-fbc-bpp = <8>;
 		qcom,mdss-dsi-fbc-packing = <1>;

--- a/drivers/clk/qcom/mdss/mdss-dsi-20nm-pll-util.c
+++ b/drivers/clk/qcom/mdss/mdss-dsi-20nm-pll-util.c
@@ -955,6 +955,8 @@ void pll_20nm_vco_unprepare(struct clk *c)
 
 static void pll_20nm_config_resetsm(void __iomem *pll_base)
 {
+	MDSS_PLL_REG_W(pll_base, MMSS_DSI_PHY_PLL_KVCO_CODE, 0x00);
+	MDSS_PLL_REG_W(pll_base, MMSS_DSI_PHY_PLL_PLL_VCO_TUNE, 0x00);
 	MDSS_PLL_REG_W(pll_base, MMSS_DSI_PHY_PLL_RESETSM_CNTRL, 0x24);
 	MDSS_PLL_REG_W(pll_base, MMSS_DSI_PHY_PLL_RESETSM_CNTRL2, 0x07);
 }

--- a/drivers/clk/qcom/mdss/mdss-pll-util.c
+++ b/drivers/clk/qcom/mdss/mdss-pll-util.c
@@ -40,6 +40,7 @@ int mdss_pll_util_resource_init(struct platform_device *pdev,
 		goto clk_err;
 	}
 
+	mutex_init(&pll_res->res_lock);
 	return rc;
 
 clk_err:
@@ -90,6 +91,8 @@ void mdss_pll_util_resource_deinit(struct platform_device *pdev,
 	msm_dss_put_clk(mp->clk_config, mp->num_clk);
 
 	msm_dss_config_vreg(&pdev->dev, mp->vreg_config, mp->num_vreg, 0);
+
+	mutex_destroy(&pll_res->res_lock);
 }
 
 void mdss_pll_util_resource_release(struct platform_device *pdev,

--- a/drivers/clk/qcom/mdss/mdss-pll.c
+++ b/drivers/clk/qcom/mdss/mdss-pll.c
@@ -45,6 +45,7 @@ int mdss_pll_resource_enable(struct mdss_pll_resources *pll_res, bool enable)
 		return rc;
 	}
 
+	mutex_lock(&pll_res->res_lock);
 	if (enable) {
 		if (pll_res->resource_ref_cnt == 0)
 			changed++;
@@ -67,6 +68,7 @@ int mdss_pll_resource_enable(struct mdss_pll_resources *pll_res, bool enable)
 			pll_res->resource_enable = enable;
 	}
 
+	mutex_unlock(&pll_res->res_lock);
 	return rc;
 }
 

--- a/drivers/clk/qcom/mdss/mdss-pll.h
+++ b/drivers/clk/qcom/mdss/mdss-pll.h
@@ -161,6 +161,11 @@ struct mdss_pll_resources {
 	 */
 	uint32_t index;
 
+	/*
+	 * Mutex to handle pll resource access
+	 */
+	struct mutex res_lock;
+
 	struct dfps_info *dfps;
 };
 

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -1183,6 +1183,7 @@ int mdss_dsi_switch_mode(struct mdss_panel_data *pdata, int mode)
 	}
 
 	mdss_dsi_clk_ctrl(ctrl_pdata, DSI_ALL_CLKS, 1);
+	mdss_dsi_ctrl_setup(ctrl_pdata);
 	ctrl_pdata->switch_mode(pdata, mode);
 	mdss_dsi_clk_ctrl(ctrl_pdata, DSI_ALL_CLKS, 0);
 

--- a/drivers/video/msm/mdss/mdss_dsi_host.c
+++ b/drivers/video/msm/mdss/mdss_dsi_host.c
@@ -1966,28 +1966,27 @@ static int mdss_dsi_cmd_dma_tx(struct mdss_dsi_ctrl_pdata *ctrl,
 
 	ret = wait_for_completion_timeout(&ctrl->dma_comp,
 				msecs_to_jiffies(DMA_TX_TIMEOUT));
-
-	if (ret <= 0) {
-		u32 reg_val, status, mask;
+	if (ret == 0) {
+		u32 reg_val, status;
 
 		reg_val = MIPI_INP(ctrl->ctrl_base + 0x0110);/* DSI_INTR_CTRL */
-		mask = reg_val & DSI_INTR_CMD_DMA_DONE_MASK;
-		status = mask & reg_val;
+		status = reg_val & DSI_INTR_CMD_DMA_DONE;
 		if (status) {
-			pr_warn("dma tx done but irq not triggered\n");
 			reg_val &= DSI_INTR_MASK_ALL;
 			/* clear CMD DMA isr only */
 			reg_val |= DSI_INTR_CMD_DMA_DONE;
 			MIPI_OUTP(ctrl->ctrl_base + 0x0110, reg_val);
-			mdss_dsi_disable_irq_nosync(ctrl, DSI_MDP_TERM);
+			mdss_dsi_disable_irq_nosync(ctrl, DSI_CMD_TERM);
 			complete(&ctrl->dma_comp);
-			ret = 1;
+
+			pr_warn("%s: dma tx done but irq not triggered\n",
+				__func__);
+		} else {
+			ret = -ETIMEDOUT;
 		}
 	}
 
-	if (ret == 0)
-		ret = -ETIMEDOUT;
-	else
+	if (!IS_ERR_VALUE(ret))
 		ret = tp->len;
 
 	if (mctrl && mctrl->dma_addr) {

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -3691,13 +3691,6 @@ static int mdss_fb_check_var(struct fb_var_screeninfo *var,
 	if ((var->xres_virtual <= 0) || (var->yres_virtual <= 0))
 		return -EINVAL;
 
-	if (info->fix.smem_start) {
-		u32 len = var->xres_virtual * var->yres_virtual *
-			(var->bits_per_pixel / 8);
-		if (len > info->fix.smem_len)
-			return -EINVAL;
-	}
-
 	if ((var->xres == 0) || (var->yres == 0))
 		return -EINVAL;
 
@@ -3864,8 +3857,10 @@ static int mdss_fb_set_par(struct fb_info *info)
 	else
 		mfd->fbi->fix.line_length = var->xres * var->bits_per_pixel / 8;
 
-	mfd->fbi->fix.smem_len = PAGE_ALIGN(mfd->fbi->fix.line_length *
-					mfd->fbi->var.yres) * mfd->fb_page;
+	/* if memory is not allocated yet, change memory size for fb */
+	if (!info->fix.smem_start)
+		mfd->fbi->fix.smem_len = PAGE_ALIGN(mfd->fbi->fix.line_length *
+				mfd->fbi->var.yres) * mfd->fb_page;
 
 	if (mfd->panel_reconfig || (mfd->fb_imgType != old_imgType)) {
 		mdss_fb_blank_sub(FB_BLANK_POWERDOWN, info, mfd->op_enable);

--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -145,6 +145,9 @@ static int mdss_mdp_tearcheck_enable(struct mdss_mdp_ctl *ctl, bool enable)
 
 	sctl = mdss_mdp_get_split_ctl(ctl);
 	te = &ctl->panel_data->panel_info.te;
+
+	pr_debug("%s: enable=%d\n", __func__, enable);
+
 	mdss_mdp_pingpong_write(mixer->pingpong_base,
 		MDSS_MDP_REG_PP_TEAR_CHECK_EN,
 		(te ? te->tear_check_en : 0) && enable);
@@ -174,7 +177,7 @@ static int mdss_mdp_tearcheck_enable(struct mdss_mdp_ctl *ctl, bool enable)
 }
 
 static int mdss_mdp_cmd_tearcheck_cfg(struct mdss_mdp_mixer *mixer,
-		struct mdss_mdp_cmd_ctx *ctx, bool enable)
+		struct mdss_mdp_cmd_ctx *ctx)
 {
 	struct mdss_mdp_pp_tear_check *te = NULL;
 	struct mdss_panel_info *pinfo;
@@ -189,49 +192,48 @@ static int mdss_mdp_cmd_tearcheck_cfg(struct mdss_mdp_mixer *mixer,
 		return -ENODEV;
 	}
 
-	if (enable) {
-		pinfo = &ctl->panel_data->panel_info;
-		te = &ctl->panel_data->panel_info.te;
+	pinfo = &ctl->panel_data->panel_info;
+	te = &ctl->panel_data->panel_info.te;
 
-		mdss_mdp_vsync_clk_enable(1);
+	mdss_mdp_vsync_clk_enable(1);
 
-		vsync_clk_speed_hz =
-			mdss_mdp_get_clk_rate(MDSS_CLK_MDP_VSYNC);
+	vsync_clk_speed_hz =
+		mdss_mdp_get_clk_rate(MDSS_CLK_MDP_VSYNC);
 
-		total_lines = mdss_panel_get_vtotal(pinfo);
+	total_lines = mdss_panel_get_vtotal(pinfo);
 
-		total_lines *= pinfo->mipi.frame_rate;
+	total_lines *= pinfo->mipi.frame_rate;
 
-		vclks_line = (total_lines) ? vsync_clk_speed_hz/total_lines : 0;
+	vclks_line = (total_lines) ? vsync_clk_speed_hz/total_lines : 0;
 
-		cfg = BIT(19);
-		if (pinfo->mipi.hw_vsync_mode)
-			cfg |= BIT(20);
+	cfg = BIT(19);
+	if (pinfo->mipi.hw_vsync_mode)
+		cfg |= BIT(20);
 
-		if (te->refx100)
-			vclks_line = vclks_line * pinfo->mipi.frame_rate *
-				100 / te->refx100;
-		else {
-			pr_warn("refx100 cannot be zero! Use 6000 as default\n");
-			vclks_line = vclks_line * pinfo->mipi.frame_rate *
-				100 / 6000;
-		}
+	if (te->refx100)
+		vclks_line = vclks_line * pinfo->mipi.frame_rate *
+			100 / te->refx100;
+	else {
+		pr_warn("refx100 cannot be zero! Use 6000 as default\n");
+		vclks_line = vclks_line * pinfo->mipi.frame_rate *
+			100 / 6000;
+	}
 
-		cfg |= vclks_line;
+	cfg |= vclks_line;
 
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-		vporch = pinfo->lcdc.v_back_porch +
-			 pinfo->lcdc.v_front_porch +
-			 pinfo->lcdc.v_pulse_width;
+	vporch = pinfo->lcdc.v_back_porch +
+		 pinfo->lcdc.v_front_porch +
+		 pinfo->lcdc.v_pulse_width;
 
-		height = (pinfo->yres + vporch) * 2;
+	height = (pinfo->yres + vporch) * 2;
 #endif
-		pr_debug("%s: yres=%d vclks=%x height=%d init=%d rd=%d start=%d\n",
-			__func__, pinfo->yres, vclks_line, te->sync_cfg_height,
-			 te->vsync_init_val, te->rd_ptr_irq, te->start_pos);
-		pr_debug("thrd_start =%d thrd_cont=%d\n",
-			te->sync_threshold_start, te->sync_threshold_continue);
-	}
+	pr_debug("%s: yres=%d vclks=%x height=%d init=%d rd=%d start=%d\n",
+		__func__, pinfo->yres, vclks_line, te->sync_cfg_height,
+		 te->vsync_init_val, te->rd_ptr_irq, te->start_pos);
+	pr_debug("thrd_start =%d thrd_cont=%d\n",
+		te->sync_threshold_start, te->sync_threshold_continue);
+
 
 	pingpong_base = mixer->pingpong_base;
 
@@ -262,8 +264,7 @@ static int mdss_mdp_cmd_tearcheck_cfg(struct mdss_mdp_mixer *mixer,
 	return 0;
 }
 
-static int mdss_mdp_cmd_tearcheck_setup(struct mdss_mdp_cmd_ctx *ctx,
-		bool enable)
+static int mdss_mdp_cmd_tearcheck_setup(struct mdss_mdp_cmd_ctx *ctx)
 {
 	int rc = 0;
 	struct mdss_mdp_mixer *mixer;
@@ -272,7 +273,7 @@ static int mdss_mdp_cmd_tearcheck_setup(struct mdss_mdp_cmd_ctx *ctx,
 
 	mixer = mdss_mdp_mixer_get(ctl, MDSS_MDP_MIXER_MUX_LEFT);
 	if (mixer) {
-		rc = mdss_mdp_cmd_tearcheck_cfg(mixer, ctx, enable);
+		rc = mdss_mdp_cmd_tearcheck_cfg(mixer, ctx);
 		if (rc)
 			goto err;
 	}
@@ -281,7 +282,7 @@ static int mdss_mdp_cmd_tearcheck_setup(struct mdss_mdp_cmd_ctx *ctx,
 	    !is_dsc_compression(pinfo)) {
 		mixer = mdss_mdp_mixer_get(ctl, MDSS_MDP_MIXER_MUX_RIGHT);
 		if (mixer)
-			rc = mdss_mdp_cmd_tearcheck_cfg(mixer, ctx, enable);
+			rc = mdss_mdp_cmd_tearcheck_cfg(mixer, ctx);
 	}
 err:
 	return rc;
@@ -1133,7 +1134,7 @@ int mdss_mdp_cmd_restore(struct mdss_mdp_ctl *ctl)
 {
 	pr_debug("%s: called for ctl%d\n", __func__, ctl->num);
 	mdss_mdp_clk_ctrl(MDP_BLOCK_POWER_ON);
-	if (mdss_mdp_cmd_tearcheck_setup(ctl->intf_ctx[MASTER_CTX], true))
+	if (mdss_mdp_cmd_tearcheck_setup(ctl->intf_ctx[MASTER_CTX]))
 		pr_warn("%s: tearcheck setup failed\n", __func__);
 	else
 		mdss_mdp_tearcheck_enable(ctl, true);
@@ -1200,7 +1201,6 @@ int mdss_mdp_cmd_ctx_stop(struct mdss_mdp_ctl *ctl,
 
 	mdss_mdp_cmd_clk_off(ctx);
 	flush_work(&ctx->pp_done_work);
-	mdss_mdp_cmd_tearcheck_setup(ctx, false);
 	mdss_mdp_tearcheck_enable(ctl, false);
 
 	if (mdss_panel_is_power_on(panel_power_state)) {
@@ -1449,7 +1449,7 @@ static int mdss_mdp_cmd_ctx_setup(struct mdss_mdp_ctl *ctl,
 	mdss_mdp_set_intr_callback(MDSS_MDP_IRQ_PING_PONG_COMP, ctx->pp_num,
 				   mdss_mdp_cmd_pingpong_done, ctl);
 
-	ret = mdss_mdp_cmd_tearcheck_setup(ctx, true);
+	ret = mdss_mdp_cmd_tearcheck_setup(ctx);
 	if (ret)
 		pr_err("tearcheck setup failed\n");
 

--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -561,11 +561,14 @@ static int mdss_mdp_cmd_add_vsync_handler(struct mdss_mdp_ctl *ctl,
 	struct mdss_mdp_cmd_ctx *ctx, *sctx = NULL;
 	unsigned long flags;
 	bool enable_rdptr = false;
+	int ret = 0;
 
+	mutex_unlock(&ctl->offlock);
 	ctx = (struct mdss_mdp_cmd_ctx *) ctl->intf_ctx[MASTER_CTX];
 	if (!ctx) {
 		pr_err("%s: invalid ctx\n", __func__);
-		return -ENODEV;
+		ret = -ENODEV;
+		goto done;
 	}
 
 	MDSS_XLOG(ctl->num, atomic_read(&ctx->koff_cnt), ctx->clk_enabled,
@@ -600,7 +603,10 @@ static int mdss_mdp_cmd_add_vsync_handler(struct mdss_mdp_ctl *ctl,
 			mutex_unlock(&cmd_clk_mtx);
 	}
 
-	return 0;
+done:
+	mutex_unlock(&ctl->offlock);
+
+	return ret;
 }
 
 static int mdss_mdp_cmd_remove_vsync_handler(struct mdss_mdp_ctl *ctl,

--- a/drivers/video/msm/mdss/mdss_mdp_pp.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pp.c
@@ -5296,9 +5296,11 @@ static int mdss_mdp_ad_setup(struct msm_fb_data_type *mfd)
 	int ret = 0;
 	struct mdss_ad_info *ad;
 	struct mdss_mdp_ctl *ctl = mfd_to_ctl(mfd);
+	struct mdss_mdp_ctl *sctl = mdss_mdp_get_split_ctl(ctl);
 	struct msm_fb_data_type *bl_mfd;
 	struct mdss_data_type *mdata;
 	u32 bypass = MDSS_PP_AD_BYPASS_DEF, bl;
+	u32 width;
 
 	ret = mdss_mdp_get_ad(mfd, &ad);
 	if (ret) {
@@ -5378,15 +5380,18 @@ static int mdss_mdp_ad_setup(struct msm_fb_data_type *mfd)
 		}
 	}
 
+	width = ctl->width;
+	if (sctl)
+		width += sctl->width;
+
 	/* update ad screen size if it has changed since last configuration */
-	if (mfd->panel_info->type == WRITEBACK_PANEL &&
-		(ad->init.frame_w != ctl->width ||
-			ad->init.frame_h != ctl->height)) {
+	if ((ad->init.frame_w != width) ||
+			(ad->init.frame_h != ctl->height)) {
 		pr_debug("changing from %dx%d to %dx%d\n", ad->init.frame_w,
 							ad->init.frame_h,
-							ctl->width,
+							width,
 							ctl->height);
-		ad->init.frame_w = ctl->width;
+		ad->init.frame_w = width;
 		ad->init.frame_h = ctl->height;
 		ad->reg_sts |= PP_AD_STS_DIRTY_INIT;
 	}


### PR DESCRIPTION
This is touching generic Dynamic Resolution Switch feature, other than MSM8994 PLL and Satsuki specific things.
Other than DRS, the commits are also fixing random (and rare) MDSS freezes, resulting in black display and non-responding device until manual hard reboot on ALL MSM8994 SoC devices.
