### PR TITLE
 [1.3.3] arm: DT: Satsuki: Fix IMX300 camera mount angle

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_satsuki_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_satsuki_camera.dtsi
@@ -17,7 +17,7 @@
 		reg = <0x0>;
 		qcom,csiphy-sd-index = <0>;
 		qcom,csid-sd-index = <0>;
-		qcom,mount-angle = <270>;
+		qcom,mount-angle = <90>;
 		qcom,actuator-src = <&actuator0>;
 		qcom,led-flash-src = <&led_flash0>;
 		cam_vdig-supply = <&pm8994_l3>;


### PR DESCRIPTION
Change IMX300 (rear) camera mount angle to match userspace orientation.
