### PR TITLE
[1.3.3] arm: DT: Rhine: Fix camera clocks for rear sensor on all Rhine

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-amami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-amami_row.dtsi
@@ -64,8 +64,8 @@
 		qcom,cci-master = <0>;
 		status = "ok";
 		clock-names = "cam_src_clk", "cam_clk";
-		clocks = <&clock_mmss clk_mclk0_clk_src>,
-			 <&clock_mmss clk_camss_mclk0_clk>;
+		clocks = <&clock_mmss clk_mmss_gp0_clk_src>,
+			 <&clock_mmss clk_camss_gp0_clk>;
 	};
 
 	qcom,camera@1 {

--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-honami_row.dtsi
@@ -63,8 +63,8 @@
 		qcom,cci-master = <0>;
 		status = "ok";
 		clock-names = "cam_src_clk", "cam_clk";
-		clocks = <&clock_mmss clk_mclk0_clk_src>,
-			 <&clock_mmss clk_camss_mclk0_clk>;
+		clocks = <&clock_mmss clk_mmss_gp0_clk_src>,
+			 <&clock_mmss clk_camss_gp0_clk>;
 	};
 
 	qcom,camera@1 {

--- a/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera-sensor-togari_row.dtsi
@@ -53,8 +53,8 @@
 		qcom,cci-master = <0>;
 		status = "ok";
 		clock-names = "cam_src_clk", "cam_clk";
-		clocks = <&clock_mmss clk_mclk0_clk_src>,
-			 <&clock_mmss clk_camss_mclk0_clk>;
+		clocks = <&clock_mmss clk_mmss_gp0_clk_src>,
+			 <&clock_mmss clk_camss_gp0_clk>;
 	};
 
 	qcom,camera@1 {


### PR DESCRIPTION
Amami, Honami, Togari are based on MSM8974, which camera clocks
are GP and not MCLK, unlike MSM8974PRO.
