### PR TITLE
arm: DT: ehci-host: fix clock

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -1761,6 +1761,7 @@
 		compatible = "qcom,usb-dbm-1p4";
 		reg = <0xf92f8000 0x1000>;
 	};
+
 	ehci: qcom,ehci-host@f9a55000 {
 		compatible = "qcom,ehci-host";
 		status = "disabled";
@@ -1775,8 +1776,8 @@
 
 		clocks = <&clock_gcc clk_gcc_usb_hs_system_clk>,
 			 <&clock_gcc clk_gcc_usb_hs_ahb_clk>,
-			 <&clock_rpm clk_gcc_usb2b_phy_sleep_clk>;
-		clock-names = "core_clk", "iface_clk", "sleep_clk";
+			 <&clock_rpm clk_cxo_ehci_host_clk>;
+		clock-names = "core_clk", "iface_clk", "xo";
 	};
 
 	gdsc_oxili_gx: qcom,gdsc@fd8c4024 {


### PR DESCRIPTION
cxo_ehci_host_clk (xo) is used by clock-rpm-8974 for ehci-host

Signed-off-by: David Viteri davidteri91@gmail.com
