### PR TITLE
msm: camera: KW fixes to avoid null pointer dereference

### DIFF
--- a/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1655,6 +1655,10 @@ static int32_t msm_actuator_config(struct msm_actuator_ctrl_t *a_ctrl,
 	struct msm_actuator_cfg_data *cdata =
 		(struct msm_actuator_cfg_data *)argp;
 	int32_t rc = 0;
+	if (a_ctrl == NULL) {
+		pr_err("ERROR: a_ctrl is NULL");
+		return -EFAULT;
+	}
 	mutex_lock(a_ctrl->actuator_mutex);
 	CDBG("Enter\n");
 	CDBG("%s type %d\n", __func__, cdata->cfgtype);

--- a/drivers/media/platform/msm/camera_v2/sensor/ov7695.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/ov7695.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -293,10 +293,11 @@ MODULE_DEVICE_TABLE(of, ov7695_dt_match);
 
 static int32_t ov7695_platform_probe(struct platform_device *pdev)
 {
-	int32_t rc;
-	const struct of_device_id *match;
+	int32_t rc = -EFAULT;
+	const struct of_device_id *match = NULL;
 	match = of_match_device(ov7695_dt_match, &pdev->dev);
-	rc = msm_sensor_platform_probe(pdev, match->data);
+	if (match)
+		rc = msm_sensor_platform_probe(pdev, match->data);
 	return rc;
 }
 


### PR DESCRIPTION
Adding null checks on few pointers to avoid null
pointer dereferencing.

Change-Id: I2d78b64f898d60248ca61c0eef23155246d00375
Signed-off-by: Vijay kumar Tumati vtumati@codeaurora.org
