### PR TITLE
msm: mdss: dsi: Fix warnings

### DIFF
--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -129,6 +129,8 @@ static int mdss_dsi_labibb_vreg_init(struct platform_device *pdev)
 	return 0;
 }
 
+#if !defined (CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL) || \
+     defined (CONFIG_REGULATOR_QPNP_LABIBB_SOMC)
 static int mdss_dsi_labibb_vreg_ctrl(struct mdss_dsi_ctrl_pdata *ctrl,
 							int enable)
 {
@@ -172,6 +174,7 @@ static int mdss_dsi_labibb_vreg_ctrl(struct mdss_dsi_ctrl_pdata *ctrl,
 
 	return 0;
 }
+#endif
 
 static int mdss_dsi_regulator_init(struct platform_device *pdev)
 {


### PR DESCRIPTION
drivers/video/msm/mdss/mdss_dsi.c:132:12: warning: 'mdss_dsi_labibb_vreg_ctrl' defined but not used [-Wunused-function]
