### PR TITLE
arm: DT: MSM8974: fix clocks CSID for camera

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
@@ -93,7 +93,7 @@
 			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
 			"csi_src_clk", "csi_rdi_clk",
 			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+		qcom,clock-rates = <0 0 200000000 0 0 0 0 0>;
 	};
 
 	qcom,csid@fda08400 {
@@ -117,7 +117,7 @@
 			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
 			"csi_src_clk", "csi_rdi_clk",
 			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+		qcom,clock-rates = <0 0 200000000 0 0 0 0 0>;
 	};
 
 	qcom,csid@fda08800 {
@@ -141,7 +141,7 @@
 			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
 			"csi_src_clk", "csi_rdi_clk",
 			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+		qcom,clock-rates = <0 0 200000000 0 0 0 0 0>;
 	};
 
 	qcom,csid@fda08C00 {
@@ -165,7 +165,7 @@
 			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
 			"csi_src_clk", "csi_rdi_clk",
 			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+		qcom,clock-rates = <0 0 200000000 0 0 0 0 0>;
 	};
 
 	qcom,ispif@fda0A000 {


### PR DESCRIPTION
Following DOCUMENTATION and kernel 1.2.2

https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/Documentation/devicetree/bindings/media/video/msm-csid.txt
https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BF64.1.2.2_rb4.7/arch/arm/boot/dts/qcom/msm8974-camera.dtsi

FIXES
http://hastebin.com/ozidohukoq.xml

Signed-off-by: David Viteri davidteri91@gmail.com
