### PR TITLE
arm: DT: Loire: Fix pinctrl and GPIOs declarations for bluesleep

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -126,20 +126,22 @@
 		compatible = "qcom,bluesleep";
 		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
 		bt_ext_wake = <&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
+		bt_reg_on = <&msm_gpio 91 0x00>; /* BT_REG_ON */
 		interrupt-parent = <&msm_gpio>;
 		interrupts = <17 0>;
 		interrupt-names = "host_wake";
-		pinctrl-names = "wake_irq_active", "wake_irq_suspend";
-		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_18_def>;
-		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_18_def>;
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&msm_gpio_19_def &msm_gpio_17_act &msm_gpio_18_def>;
+		pinctrl-1 = <&msm_gpio_19_def &msm_gpio_17_sus &msm_gpio_18_def>;
 	};
 
 	bcm43xx {
 		compatible = "bcm,bcm43xx";
-		bcm,reg-on-gpio = <&msm_gpio 19 0x00>; /* BT_REG_ON */
+		gpios = <&msm_gpio 91 0x00>, /* BT_REG_ON */
+			<&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_19_def>;
-		pinctrl-1 = <&msm_gpio_19_def>;
+		pinctrl-0 = <&msm_gpio_19_def &msm_gpio_18_def>;
+		pinctrl-1 = <&msm_gpio_19_def &msm_gpio_18_def>;
 	};
 
 	/* SPI : BLSP3 */


### PR DESCRIPTION
Our bluesleep driver requires different pinctrl names
and needs us to specify the bt_reg_on GPIO explicitly
in DT because there's no bcm43xx driver helping it.

While at it, fix the bcm43xx driver DT node to keep
it consistent with the other platforms, even if we
aren't really using it in this moment.
In the future, we may think about using it!
