### PR TITLE
[1.3.3] arm64: DT: loire: Fix BT gpio entry

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -126,7 +126,7 @@
 		compatible = "qcom,bluesleep";
 		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
 		bt_ext_wake = <&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
-		bt_reg_on = <&msm_gpio 91 0x00>; /* BT_REG_ON */
+		bt_reg_on = <&msm_gpio 19 0x00>; /* BT_REG_ON */
 		interrupt-parent = <&msm_gpio>;
 		interrupts = <17 0>;
 		interrupt-names = "host_wake";
@@ -137,7 +137,7 @@
 
 	bcm43xx {
 		compatible = "bcm,bcm43xx";
-		gpios = <&msm_gpio 91 0x00>, /* BT_REG_ON */
+		gpios = <&msm_gpio 19 0x00>, /* BT_REG_ON */
 			<&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
 		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&msm_gpio_19_def &msm_gpio_18_def>;


### PR DESCRIPTION
It is required BT (bt_reg_on) gpio.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I5a53eddd1883e528ee8494fece72880132ffbb40
