### PR TITLE
[1.3.3] Fix race condition for rfkill clock voting

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2373,23 +2373,6 @@ void msm_hs_request_clock_on(struct uart_port *uport)
 }
 EXPORT_SYMBOL(msm_hs_request_clock_on);
 
-void msm_hs_set_clock(int port_index, int on)
-{
-	struct uart_port *uport = msm_hs_get_uart_port(port_index);
-
-	pr_debug("%s /dev/ttyHS%d clock: %s\n", __func__,
-		port_index, on ? "ON" : "OFF");
-
-	if (on) {
-		msm_hs_request_clock_on(uport);
-		msm_hs_set_mctrl(uport, TIOCM_RTS);
-	} else {
-		msm_hs_set_mctrl(uport, 0);
-		msm_hs_request_clock_off(uport);
-	}
-}
-EXPORT_SYMBOL(msm_hs_set_clock);
-
 #ifdef SONY_SHINANO_LOIRE
 static irqreturn_t msm_hs_wakeup_isr(int irq, void *dev)
 {

--- a/include/linux/platform_data/msm_serial_hs.h
+++ b/include/linux/platform_data/msm_serial_hs.h
@@ -61,5 +61,4 @@ void msm_hs_request_clock_on(struct uart_port *uport);
 struct uart_port *msm_hs_get_uart_port(int port_index);
 void msm_hs_set_mctrl(struct uart_port *uport,
 				    unsigned int mctrl);
-void msm_hs_set_clock(int port_index, int on);
 #endif


### PR DESCRIPTION
Fix unbalanced rfkill clock voting and revert unused msm_serial implementation.
