### PR TITLE
[1.3.3] arm: msm: clocks: adapt to actual qcrypto needed clocks

### DIFF
--- a/arch/arm/mach-msm/clock-gcc-8974.c
+++ b/arch/arm/mach-msm/clock-gcc-8974.c
@@ -2446,11 +2446,6 @@ static struct clk_lookup msm_clocks_gcc_8974[] = {
 	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcedev.0"),
 	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcedev.0"),
 
-	CLK_LOOKUP_OF("core_clk",     gcc_ce2_clk,         "qcrypto.0"),
-	CLK_LOOKUP_OF("iface_clk",    gcc_ce2_ahb_clk,     "qcrypto.0"),
-	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcrypto.0"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcrypto.0"),
-
 	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto"),
 	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto"),
 	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto"),

--- a/arch/arm/mach-msm/clock-gcc-8974.c
+++ b/arch/arm/mach-msm/clock-gcc-8974.c
@@ -2446,15 +2446,10 @@ static struct clk_lookup msm_clocks_gcc_8974[] = {
 	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcedev.0"),
 	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcedev.0"),
 
-	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcom,qcrypto"),
-
-	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcom,qcrypto1"),
+	CLK_LOOKUP_OF("core_clk",     gcc_ce2_clk,     "qcrypto.0"),
+	CLK_LOOKUP_OF("iface_clk",    gcc_ce2_ahb_clk, "qcrypto.0"),
+	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk, "qcrypto.0"),
+	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,     "qcrypto.0"),
 
 	CLK_LOOKUP_OF("core_clk",     gcc_ce1_clk,         "qseecom"),
 	CLK_LOOKUP_OF("iface_clk",    gcc_ce1_ahb_clk,     "qseecom"),


### PR DESCRIPTION
since we are using just one instance for qcrypto there is not reason for have extra clocks 
