### PR TITLE
mmc: Fix for bkops-status read fail on Castor

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -1519,6 +1519,10 @@ int mmc_read_bkops_status(struct mmc_card *card)
 	}
 
 	mmc_claim_host(card->host);
+	
+#ifdef CONFIG_MACH_SONY_CASTOR
+	err = mmc_send_ext_csd(card, ext_csd);
+#else	
 	if (mmc_card_cmdq(card))
 		err = mmc_cmdq_halt_on_empty_queue(card->host);
 
@@ -1528,6 +1532,7 @@ int mmc_read_bkops_status(struct mmc_card *card)
 		if (mmc_card_cmdq(card))
 			mmc_cmdq_halt(card->host, false);
 	}
+#endif
 	mmc_release_host(card->host);
 	if (err)
 		goto out;


### PR DESCRIPTION
This fixes mmc1: mmc_start_bkops: Failed to read bkops status: 1
