### PR TITLE
arm: DT: MSM8974: fix clocks CSID for camera

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
@@ -83,17 +83,16 @@
 		qcom,mipi-csi-vdd-supply = <&pm8941_l12>;
 		clocks = <&clock_mmss clk_camss_top_ahb_clk>,
 			<&clock_mmss clk_camss_ispif_ahb_clk>,
+			<&clock_mmss clk_camss_csi0_ahb_clk>,
 			<&clock_mmss clk_csi0_clk_src>,
 			<&clock_mmss clk_camss_csi0_clk>,
-			<&clock_mmss clk_camss_csi0_ahb_clk>,
-			<&clock_mmss clk_camss_csi0rdi_clk>,
+			<&clock_mmss clk_camss_csi0phy_clk>,
 			<&clock_mmss clk_camss_csi0pix_clk>,
-			<&clock_mmss clk_camss_csi0phy_clk>;
-		clock-names = "camss_top_ahb_clk",
-			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
-			"csi_src_clk", "csi_rdi_clk",
-			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+			<&clock_mmss clk_camss_csi0rdi_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csi_ahb_clk", "csi_src_clk", "csi_clk",
+			"csi_phy_clk", "csi_pix_clk", "csi_rdi_clk";
+		qcom,clock-rates = <0 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,csid@fda08400 {
@@ -107,17 +106,16 @@
 		qcom,mipi-csi-vdd-supply = <&pm8941_l12>;
 		clocks = <&clock_mmss clk_camss_top_ahb_clk>,
 			<&clock_mmss clk_camss_ispif_ahb_clk>,
+			<&clock_mmss clk_camss_csi1_ahb_clk>,
 			<&clock_mmss clk_csi1_clk_src>,
 			<&clock_mmss clk_camss_csi1_clk>,
-			<&clock_mmss clk_camss_csi1_ahb_clk>,
-			<&clock_mmss clk_camss_csi1rdi_clk>,
+			<&clock_mmss clk_camss_csi1phy_clk>,
 			<&clock_mmss clk_camss_csi1pix_clk>,
-			<&clock_mmss clk_camss_csi1phy_clk>;
-		clock-names = "camss_top_ahb_clk",
-			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
-			"csi_src_clk", "csi_rdi_clk",
-			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+			<&clock_mmss clk_camss_csi1rdi_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csi_ahb_clk", "csi_src_clk", "csi_clk",
+			"csi_phy_clk", "csi_pix_clk", "csi_rdi_clk";
+		qcom,clock-rates = <0 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,csid@fda08800 {
@@ -131,17 +129,16 @@
 		qcom,mipi-csi-vdd-supply = <&pm8941_l12>;
 		clocks = <&clock_mmss clk_camss_top_ahb_clk>,
 			<&clock_mmss clk_camss_ispif_ahb_clk>,
+			<&clock_mmss clk_camss_csi2_ahb_clk>,
 			<&clock_mmss clk_csi2_clk_src>,
 			<&clock_mmss clk_camss_csi2_clk>,
-			<&clock_mmss clk_camss_csi2_ahb_clk>,
-			<&clock_mmss clk_camss_csi2rdi_clk>,
+			<&clock_mmss clk_camss_csi2phy_clk>,
 			<&clock_mmss clk_camss_csi2pix_clk>,
-			<&clock_mmss clk_camss_csi2phy_clk>;
-		clock-names = "camss_top_ahb_clk",
-			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
-			"csi_src_clk", "csi_rdi_clk",
-			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+			<&clock_mmss clk_camss_csi2rdi_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csi_ahb_clk", "csi_src_clk", "csi_clk",
+			"csi_phy_clk", "csi_pix_clk", "csi_rdi_clk";
+		qcom,clock-rates = <0 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,csid@fda08C00 {
@@ -155,17 +152,16 @@
 		qcom,mipi-csi-vdd-supply = <&pm8941_l12>;
 		clocks = <&clock_mmss clk_camss_top_ahb_clk>,
 			<&clock_mmss clk_camss_ispif_ahb_clk>,
+			<&clock_mmss clk_camss_csi3_ahb_clk>,
 			<&clock_mmss clk_csi3_clk_src>,
 			<&clock_mmss clk_camss_csi3_clk>,
-			<&clock_mmss clk_camss_csi3_ahb_clk>,
-			<&clock_mmss clk_camss_csi3rdi_clk>,
+			<&clock_mmss clk_camss_csi3phy_clk>,
 			<&clock_mmss clk_camss_csi3pix_clk>,
-			<&clock_mmss clk_camss_csi3phy_clk>;
-		clock-names = "camss_top_ahb_clk",
-			"ispif_ahb_clk", "csi_clk", "csi_ahb_clk",
-			"csi_src_clk", "csi_rdi_clk",
-			 "csi_pix_clk", "csi_phy_clk";
-		qcom,clock-rates = <0 0 0 0 200000000 0 0 0>;
+			<&clock_mmss clk_camss_csi3rdi_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csi_ahb_clk", "csi_src_clk", "csi_clk",
+			"csi_phy_clk", "csi_pix_clk", "csi_rdi_clk";
+		qcom,clock-rates = <0 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,ispif@fda0A000 {


### PR DESCRIPTION
Following DOCUMENTATION and kernel 1.2.2

https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/Documentation/devicetree/bindings/media/video/msm-csid.txt
https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BF64.1.2.2_rb4.7/arch/arm/boot/dts/qcom/msm8974-camera.dtsi

FIXES
http://hastebin.com/ozidohukoq.xml

Signed-off-by: David Viteri davidteri91@gmail.com
