### PR TITLE
net: ipc_router: Bind only a client port as control port

### DIFF
--- a/net/ipc_router/ipc_router_core.c
+++ b/net/ipc_router/ipc_router_core.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -3450,7 +3450,7 @@ int msm_ipc_router_get_curr_pkt_size(struct msm_ipc_port *port_ptr)
 
 int msm_ipc_router_bind_control_port(struct msm_ipc_port *port_ptr)
 {
-	if (!port_ptr)
+	if (unlikely(!port_ptr || port_ptr->type != CLIENT_PORT))
 		return -EINVAL;
 
 	down_write(&local_ports_lock_lhc2);


### PR DESCRIPTION
IPC Router binds any port as a control port and moves it from the client
port list to control port list. Misbehaving clients can exploit this
incorrect behavior.

IPC Router to check if the port is a client port before binding it as a
control port.

CRs-Fixed: 974577
Change-Id: I9f189b76967d5f85750218a7cb6537d187a69663
Signed-off-by: Karthikeyan Ramasubramanian kramasub@codeaurora.org
