### PR TITLE
arm: DT: MSM8974: Fix typo in CPP smmu label

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
@@ -369,7 +369,7 @@
 		msm_cam_smmu_cb3: msm_cam_smmu_cb3 {
 			compatible = "qcom,qsmmu-cam-cb";
 			iommus = <&cpp_iommu 2>;
-			label = "cpp_0";
+			label = "cpp";
 		};
 
 		msm_cam_smmu_cb4: msm_cam_smmu_cb4 {


### PR DESCRIPTION
fixes
      [   13.584286] CAM-SMMU cam_smmu_create_add_handle_in_table:381 Error: Cannot find name cpp or all handle exist!
      [   13.688162] CAM-SMMU cam_smmu_get_handle:650 Error: cpp gets handle fail

after this commit
      [    5.062566] CAM-SMMU cam_populate_smmu_context_banks:996 getting QSMMU ctx : cpp
Now cams can start

Signed-off-by: David Viteri davidteri91@gmail.com
