### PR TITLE
[TEST][1.3.3] MSM8974: Second qcrypto engine

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2487,6 +2487,14 @@
 		      <0xfd444000 0x1b000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
+
+		clock-names = "core_clk", "iface_clk", "bus_clk",
+				"core_clk_src";
+		clocks = <&clock_gcc clk_gcc_ce2_clk>,
+			 <&clock_gcc clk_gcc_ce2_ahb_clk>,
+			 <&clock_gcc clk_gcc_ce2_axi_clk>,
+			 <&clock_gcc clk_ce2_clk_src>;
+
 		qcom,bam-pipe-pair = <0>;
 		qcom,ce-hw-instance = <1>;
 		qcom,ce-device = <1>;

--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2426,7 +2426,7 @@
 		qcom,memory-reservation-size = <0x280000>; /* 2.5M EBI1 buffer */
 	};
 
-        qcom,qcedev@fd440000 {
+	qcom_cedev: qcom,qcedev@fd440000 {
 		compatible = "qcom,qcedev";
 		reg = <0xfd440000 0x20000>,
 		      <0xfd444000 0x1b000>;
@@ -2451,7 +2451,7 @@
 		qcom,ce-opp-freq = <100000000>;
 	};
 
-        qcom,qcrypto@fd440000 {
+	qcom_crypto: qcom,qcrypto@fd440000 {
 		compatible = "qcom,qcrypto";
 		reg = <0xfd440000 0x20000>,
 		      <0xfd444000 0x1b000>;
@@ -2481,7 +2481,7 @@
 		qcom,ce-opp-freq = <100000000>;
 	};
 
-	qcom,qcrypto1@fd440000 {
+	qcom_crypto1: qcom,qcrypto1@fd440000 {
 		compatible = "qcom,qcrypto";
 		reg = <0xfd440000 0x20000>,
 		      <0xfd444000 0x1b000>;

--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2429,7 +2429,7 @@
         qcom,qcedev@fd440000 {
 		compatible = "qcom,qcedev";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x8000>;
+		      <0xfd444000 0x1b000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 		clock-names = "core_clk", "iface_clk", "bus_clk",
@@ -2451,10 +2451,10 @@
 		qcom,ce-opp-freq = <100000000>;
 	};
 
-        qcom,qcrypto@fd444000 {
+        qcom,qcrypto@fd440000 {
 		compatible = "qcom,qcrypto";
 		reg = <0xfd440000 0x20000>,
-		      <0xfd444000 0x8000>;
+		      <0xfd444000 0x1b000>;
 		reg-names = "crypto-base","crypto-bam-base";
 		interrupts = <0 236 0>;
 
@@ -2470,6 +2470,28 @@
 		qcom,ce-device = <0>;
 		qcom,clk-mgmt-sus-res;
                 qcom,msm-bus,name = "qcrypto-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,use-sw-aes-cbc-ecb-ctr-algo;
+		qcom,use-sw-aes-xts-algo;
+		qcom,use-sw-ahash-algo;
+		qcom,msm-bus,vectors-KBps =
+				<56 512 0 0>,
+				<56 512 3936000 393600>;
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom,qcrypto1@fd440000 {
+		compatible = "qcom,qcrypto";
+		reg = <0xfd440000 0x20000>,
+		      <0xfd444000 0x1b000>;
+		reg-names = "crypto-base","crypto-bam-base";
+		interrupts = <0 236 0>;
+		qcom,bam-pipe-pair = <0>;
+		qcom,ce-hw-instance = <1>;
+		qcom,ce-device = <1>;
+		qcom,clk-mgmt-sus-res;
+		qcom,msm-bus,name = "qcrypto-noc";
 		qcom,msm-bus,num-cases = <2>;
 		qcom,msm-bus,num-paths = <1>;
 		qcom,use-sw-aes-cbc-ecb-ctr-algo;

--- a/arch/arm/mach-msm/board-8974.c
+++ b/arch/arm/mach-msm/board-8974.c
@@ -101,8 +101,6 @@ static struct of_dev_auxdata msm8974_auxdata_lookup[] __initdata = {
 			"msm-tsens", NULL),
 	OF_DEV_AUXDATA("qcom,qcedev", 0xFD440000, \
 			"qcedev.0", NULL),
-	OF_DEV_AUXDATA("qcom,qcrypto", 0xFD440000, \
-			"qcrypto.0", NULL),
 	OF_DEV_AUXDATA("qcom,hsic-host", 0xF9A00000, \
 			"msm_hsic_host", NULL),
 	OF_DEV_AUXDATA("qcom,hsic-smsc-hub", 0, "msm_smsc_hub",

--- a/arch/arm/mach-msm/clock-gcc-8974.c
+++ b/arch/arm/mach-msm/clock-gcc-8974.c
@@ -2446,11 +2446,6 @@ static struct clk_lookup msm_clocks_gcc_8974[] = {
 	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcedev.0"),
 	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcedev.0"),
 
-	CLK_LOOKUP_OF("core_clk",     gcc_ce2_clk,         "qcrypto.0"),
-	CLK_LOOKUP_OF("iface_clk",    gcc_ce2_ahb_clk,     "qcrypto.0"),
-	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcrypto.0"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcrypto.0"),
-
 	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto"),
 	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto"),
 	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto"),

--- a/arch/arm/mach-msm/clock-gcc-8974.c
+++ b/arch/arm/mach-msm/clock-gcc-8974.c
@@ -2446,15 +2446,15 @@ static struct clk_lookup msm_clocks_gcc_8974[] = {
 	CLK_LOOKUP_OF("bus_clk",      gcc_ce2_axi_clk,     "qcedev.0"),
 	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src,         "qcedev.0"),
 
-	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcom,qcrypto"),
+	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcrypto"),
+	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcrypto"),
+	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcrypto"),
+	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcrypto"),
 
-	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcom,qcrypto1"),
-	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcom,qcrypto1"),
+	CLK_LOOKUP_OF("core_clk", gcc_ce2_clk, "fd440000.qcrypto1"),
+	CLK_LOOKUP_OF("iface_clk", gcc_ce2_ahb_clk, "fd440000.qcrypto1"),
+	CLK_LOOKUP_OF("bus_clk", gcc_ce2_axi_clk, "fd440000.qcrypto1"),
+	CLK_LOOKUP_OF("core_clk_src", ce2_clk_src, "fd440000.qcrypto1"),
 
 	CLK_LOOKUP_OF("core_clk",     gcc_ce1_clk,         "qseecom"),
 	CLK_LOOKUP_OF("iface_clk",    gcc_ce1_ahb_clk,     "qseecom"),


### PR DESCRIPTION
[    4.387660] qcrypto fd440000.qcom,qcrypto: Qualcomm Crypto 5.1.0 device found @0xfd440000
[    4.395284] qcrypto fd440000.qcom,qcrypto: CE device = 0x0
[    4.428236] qcrypto fd440000.qcom,qcrypto: qcrypto-ecb-aes
[    4.433619] qcrypto fd440000.qcom,qcrypto: qcrypto-cbc-aes
[    4.439035] qcrypto fd440000.qcom,qcrypto: qcrypto-ctr-aes
[    4.444528] qcrypto fd440000.qcom,qcrypto: qcrypto-ecb-des
[    4.449968] qcrypto fd440000.qcom,qcrypto: qcrypto-cbc-des
[    4.455466] qcrypto fd440000.qcom,qcrypto: qcrypto-ecb-3des
[    4.460993] qcrypto fd440000.qcom,qcrypto: qcrypto-cbc-3des
[    4.466594] qcrypto fd440000.qcom,qcrypto: qcrypto-xts-aes
[    4.472042] qcrypto fd440000.qcom,qcrypto: qcrypto-sha1
[    4.477231] qcrypto fd440000.qcom,qcrypto: qcrypto-sha256
[    4.482631] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha1-cbc-aes
[    4.489374] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha1-cbc-des
[    4.496216] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha1-cbc-3des
[    4.503034] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha256-cbc-aes
[    4.509946] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha256-cbc-des
[    4.516917] qcrypto fd440000.qcom,qcrypto: qcrypto-aead-hmac-sha256-cbc-3des
[    4.523937] qcrypto fd440000.qcom,qcrypto: qcrypto-hmac-sha1
[    4.529560] qcrypto fd440000.qcom,qcrypto: qcrypto-hmac-sha256
[    4.535400] qcrypto fd440000.qcom,qcrypto: qcrypto-aes-ccm
[    4.540847] qcrypto fd440000.qcom,qcrypto: qcrypto-rfc4309-aes-ccm
[    4.546927] qcrypto: FIPS140-2 Known Answer Tests: Skipped
[    4.561694] qcrypto fd440000.qcom,qcrypto1: Qualcomm Crypto 5.1.0 device found @0xfd440000
[    4.569303] qcrypto fd440000.qcom,qcrypto1: CE device = 0x1
