### PR TITLE
arm: DT: MSM8974: add missing clocks in PRONTO node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2130,6 +2130,11 @@
 		vdd_pronto_pll-supply = <&pm8941_l12>;
 		qcom,proxy-reg-names = "vdd_pronto_pll";
 		qcom,vdd_pronto_pll-uV-uA = <1800000 18000>;
+		clocks = <&clock_rpm clk_cxo_pil_pronto_clk>,
+			 <&clock_gcc clk_gcc_ce1_clk>,
+			 <&clock_gcc clk_gcc_ce1_ahb_clk>,
+			 <&clock_gcc clk_gcc_ce1_axi_clk>,
+			 <&clock_gcc clk_ce1_clk_src>;
 
 		clock-names = "xo", "scm_core_clk", "scm_iface_clk",
 					"scm_bus_clk", "scm_core_clk_src";


### PR DESCRIPTION
Signed-off-by: David Viteri davidteri91@gmail.com
