### PR TITLE
arm: DT: MSM8974: add missing clocks for WCNSS node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2214,6 +2214,13 @@
 		qcom,pronto-vddpx-current = <0>;
 
 		gpios = <&msmgpio 36 0>, <&msmgpio 37 0>, <&msmgpio 38 0>, <&msmgpio 39 0>, <&msmgpio 40 0>;
+
+		clocks = <&clock_rpm clk_cxo_wlan_clk>,
+			 <&clock_rpm clk_cxo_a2>,
+			 <&clock_gcc clk_gcc_debug_mux>,
+			 <&clock_gcc clk_wcnss_m_clk>;
+		clock-names = "xo", "rf_clk", "measure", "wcnss_debug";
+
 		qcom,has-48mhz-xo;
 		qcom,has-pronto-hw;
 		qcom,wcnss-pm = <11 19 1200 1 1 6>;


### PR DESCRIPTION
Signed-off-by: David Viteri davidteri91@gmail.com
