### PR TITLE
ARM: dts: msm: Update adsp heap memory size

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -79,7 +79,7 @@
 
 		adsp_mem: adsp_region@0 {
 			linux,reserve-contiguous-region;
-			reg = <0 0x3F00000>;
+			reg = <0 0x4100000>;
 			label = "adsp_mem";
 		};
 


### PR DESCRIPTION
Adding 2M additional to adsp heap size to support
hevc adaptive playback cases. Otherwise, adaptive CTS
test cases can lead to ADSP crash.

Change-Id: I89d9597852cbdc6efce56814752302ba9af0e98f
Signed-off-by: Balamurugan Alagarsamy balaga@codeaurora.org
