### PR TITLE
arm: DT: MSM8974: fix typos for venus clocks

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974.dtsi
@@ -2337,10 +2337,10 @@
 			<&clock_mmss clk_venus0_ahb_clk>,
 			<&clock_mmss clk_venus0_axi_clk>,
 			<&clock_mmss clk_venus0_ocmemnoc_clk>,
-			<&clock_rpm clk_gcc_ce1_clk>,
-			<&clock_rpm clk_gcc_ce1_ahb_clk>,
-			<&clock_rpm clk_gcc_ce1_axi_clk>,
-			<&clock_rpm clk_ce1_clk_src>;
+			<&clock_gcc clk_gcc_ce1_clk>,
+			<&clock_gcc clk_gcc_ce1_ahb_clk>,
+			<&clock_gcc clk_gcc_ce1_axi_clk>,
+			<&clock_gcc clk_ce1_clk_src>;
 		clock-names = "core_clk", "iface_clk", "bus_clk", "mem_clk",
 				"scm_core_clk", "scm_iface_clk", "scm_bus_clk",
 				"scm_core_clk_src";


### PR DESCRIPTION
https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/arch/arm/mach-msm/clock-gcc-8974.c#L2491

Signed-off-by: David Viteri davidteri91@gmail.com
