### PR TITLE
Improvements MarshMallow

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -73,8 +73,8 @@ static const unsigned freqs[] = { 400000, 300000, 200000, 100000 };
  * performance cost, and for other reasons may not always be desired.
  * So we allow it it to be disabled.
  */
-bool use_spi_crc = 1;
-module_param(use_spi_crc, bool, 0);
+bool use_spi_crc = 0;
+module_param(use_spi_crc, bool, 0644);
 
 /*
  * We normally treat cards as removed during suspend if they are not

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -475,7 +475,7 @@ struct request_queue {
 #define QUEUE_FLAG_DEFAULT	((1 << QUEUE_FLAG_IO_STAT) |		\
 				 (1 << QUEUE_FLAG_STACKABLE)	|	\
 				 (1 << QUEUE_FLAG_SAME_COMP)	|	\
-				 (1 << QUEUE_FLAG_ADD_RANDOM))
+				 (0 << QUEUE_FLAG_ADD_RANDOM))
 
 static inline void queue_lockdep_assert_held(struct request_queue *q)
 {


### PR DESCRIPTION
- CRC is disable by default to save 30% performance cost. It's possible back to default setting with any kernel app twaeker like Kernel Adiutor
- Add_Random is designed for old HDD so bye bye

Tested with my Z3
