### PR TITLE
[1.3.3] arm: DT: MSM8939: Fix VFE nodes for camera

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-camera.dtsi
@@ -178,48 +178,55 @@
 		qcom,clock-rates = <80000000 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>;
 	};
 
-	qcom,vfe@1b10000 {
-		cell-index = <0>;
-		compatible = "qcom,vfe40";
-		reg = <0x1b10000 0x1000>,
-			<0x1b40000 0x200>;
-		reg-names = "vfe", "vfe_vbif";
-		interrupts = <0 57 0>;
-		interrupt-names = "vfe";
-		vdd-supply = <&gdsc_vfe>;
-		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
-			<&clock_gcc clk_vfe0_clk_src>,
-			<&clock_gcc clk_gcc_camss_vfe0_clk>,
-			<&clock_gcc clk_gcc_camss_csi_vfe0_clk>,
-			<&clock_gcc clk_gcc_camss_vfe_ahb_clk>,
-			<&clock_gcc clk_gcc_camss_vfe_axi_clk>,
-			<&clock_gcc clk_gcc_camss_ahb_clk>,
-			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>;
-		clock-names = "camss_top_ahb_clk", "vfe_clk_src",
-			"camss_vfe_vfe_clk", "camss_csi_vfe_clk", "iface_clk",
-			"bus_clk", "camss_ahb_clk", "ispif_ahb_clk";
-		qcom,clock-rates = <0 266670000 0 0 0 0 0 80000000>;
-		qos-entries = <8>;
-		qos-regs = <0x2C4 0x2C8 0x2CC 0x2D0 0x2D4 0x2D8
-				0x2DC 0x2E0>;
-		qos-settings = <0xAAA5AAA5 0xAAA5AAA5 0xAAA5AAA5
-				0xAAA5AAA5 0xAAA5AAA5 0xAAA5AAA5
-				0xAAA5AAA5 0x0001AAA5>;
-		vbif-entries = <2>;
-		vbif-regs = <0x30 0x34>;
-		vbif-settings = <0x00000fff 0x00555000>;
-		ds-entries = <17>;
-		ds-regs = <0x988 0x98C 0x990 0x994 0x998
-			0x99C 0x9A0 0x9A4 0x9A8 0x9AC 0x9B0
-			0x9B4 0x9B8 0x9BC 0x9C0 0x9C4 0x9C8>;
-		ds-settings = <0xCCCC1111 0xCCCC1111 0xCCCC1111
-				0xCCCC1111 0xCCCC1111 0xCCCC1111
-				0xCCCC1111 0xCCCC1111 0xCCCC1111
-				0xCCCC1111 0xCCCC1111 0xCCCC1111
-				0xCCCC1111 0xCCCC1111 0xCCCC1111
-				0xCCCC1111 0x00000103>;
-		max-clk-nominal = <320000000>;
-		max-clk-turbo = <432000000>;
+	qcom,vfe {
+		compatible = "qcom,vfe";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		vfe0: qcom,vfe@1b10000 {
+			cell-index = <0>;
+			compatible = "qcom,vfe40";
+			reg = <0x1b10000 0x1000>,
+				<0x1b40000 0x200>;
+			reg-names = "vfe", "vfe_vbif";
+			interrupts = <0 57 0>;
+			interrupt-names = "vfe";
+			vdd-supply = <&gdsc_vfe>;
+			clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+				<&clock_gcc clk_vfe0_clk_src>,
+				<&clock_gcc clk_gcc_camss_vfe0_clk>,
+				<&clock_gcc clk_gcc_camss_csi_vfe0_clk>,
+				<&clock_gcc clk_gcc_camss_vfe_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_vfe_axi_clk>,
+				<&clock_gcc clk_gcc_camss_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_ispif_ahb_clk>;
+			clock-names = "camss_top_ahb_clk", "vfe_clk_src",
+				"camss_vfe_vfe_clk", "camss_csi_vfe_clk", "iface_clk",
+				"bus_clk", "camss_ahb_clk", "ispif_ahb_clk";
+			qcom,clock-rates = <0 266670000 0 0 0 0 0 80000000>;
+			qos-entries = <8>;
+			qos-regs = <0x2C4 0x2C8 0x2CC 0x2D0 0x2D4 0x2D8
+					0x2DC 0x2E0>;
+			qos-settings = <0xAAA5AAA5 0xAAA5AAA5 0xAAA5AAA5
+					0xAAA5AAA5 0xAAA5AAA5 0xAAA5AAA5
+					0xAAA5AAA5 0x0001AAA5>;
+			vbif-entries = <2>;
+			vbif-regs = <0x30 0x34>;
+			vbif-settings = <0x00000fff 0x00555000>;
+			ds-entries = <17>;
+			ds-regs = <0x988 0x98C 0x990 0x994 0x998
+				0x99C 0x9A0 0x9A4 0x9A8 0x9AC 0x9B0
+				0x9B4 0x9B8 0x9BC 0x9C0 0x9C4 0x9C8>;
+			ds-settings = <0xCCCC1111 0xCCCC1111 0xCCCC1111
+					0xCCCC1111 0xCCCC1111 0xCCCC1111
+					0xCCCC1111 0xCCCC1111 0xCCCC1111
+					0xCCCC1111 0xCCCC1111 0xCCCC1111
+					0xCCCC1111 0xCCCC1111 0xCCCC1111
+					0xCCCC1111 0x00000103>;
+			max-clk-nominal = <320000000>;
+			max-clk-turbo = <432000000>;
+		};
 	};
 
 	qcom,cam_smmu {


### PR DESCRIPTION
New drivers in 1.3.3 3.10 and new 3.18 kernel require vfe40
devices to be subnodes of the main vfe driver.
