### PR TITLE
[1.3.3] arm64: DT: suzu: Add missed batterydata entry

### DIFF
--- a/arch/arm/boot/dts/qcom/batterydata-loire-suzu-send.dtsi
+++ b/arch/arm/boot/dts/qcom/batterydata-loire-suzu-send.dtsi
@@ -18,6 +18,7 @@
  */
 
 qcom,loire-suzu-send {
+	qcom,max-voltage-uv = <4350000>;
 	qcom,batt-id-kohm = <330>;
 	qcom,battery-type = "1299-8167";
 	qcom,chg-rslow-comp-c1 = <2571531>;


### PR DESCRIPTION
Add DT entry based on Z5 battery value.

```
qcom,max-voltage-uv = <4350000>;
```

Fix kernel warning:

```
FG: fg_batt_profile_init: couldn't find battery max voltage
```

Signed-off-by: Humberto Borba humberos@gmail.com
