### PR TITLE
[DO NOT MERGE] drivers: clearpad: Workaround for suzu touchscreen

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -164,7 +164,7 @@
 			interrupts = <65 0x2>;
 			synaptics,irq_gpio = <&msm_gpio 65 0x00>;
 			chip_id = <0x40>;
-			post_probe_start = <0>;
+			post_probe_start = <1>;
 			synaptics,firmware_name = "touch_module_id_0x%02x.img";
 			flash_on_post_probe = <0>;
 			flip_config = <0>;
@@ -180,7 +180,7 @@
 			preset_x_max = <1079>;
 			preset_y_max = <1919>;
 			preset_n_fingers = <10>;
-			wakeup_gesture_supported = <1>;
+			wakeup_gesture_supported = <0>;
 			wakeup_gesture_lpm_disabled = <1>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {

--- a/drivers/video/msm/mdss/somc_panel/panel_incell.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_incell.c
@@ -44,6 +44,7 @@
 
 struct incell_ctrl *incell = NULL;
 struct incell_ctrl incell_buf;
+static bool sp_panel_forced = false;
 
 static void incell_panel_power_worker_canceling(struct incell_ctrl *incell);
 
@@ -580,6 +581,7 @@ void incell_state_change_off(struct incell_ctrl *incell)
 		break;
 	}
 
+	sp_panel_forced = false;
 	pr_debug("%s: ---> status:%d\n", __func__, ((int)(*state)));
 }
 
@@ -1637,6 +1639,11 @@ int incell_power_lock_ctrl(incell_pw_lock lock,
 	incell->incell_intf_operation = INCELL_TOUCH_RUN;
 
 	pr_debug("%s: status:%d --->\n", __func__, ((int)(incell->state)));
+
+	if (incell->state == INCELL_STATE_SLE000_P0 && !sp_panel_forced) {
+		incell_force_sp_on();
+		sp_panel_forced = true;
+	}
 
 	if (lock == INCELL_DISPLAY_POWER_LOCK)
 		ret = incell_power_lock(&(incell->state));


### PR DESCRIPTION
This patch disables wakeup gesture and force incell panel as SP mode
during initialization.

Wakeup gesture feature uses EWU as panel mode which is broken
during suspend/resume.

Also, it moves clearpad hacks to mdss incell driver.

although the panel and touch are not fixed totally but seems
this patch improves the touchscreem functionality a lot.

Signed-off-by: Humberto Borba humberos@gmail.com
