### PR TITLE
Device tree: minor modifications about charging for kitakami

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -3311,7 +3311,7 @@
 
 &pmi8994_charger {
 	/delete-property/ qcom,parallel-usb-min-current-ma;
-	/delete-property/ qcom,parallel-9v-usb-min-current-ma;
+	/delete-property/ qcom,parallel-usb-9v-min-current-ma;
 	qcom,bmd-pin-src = "bpd_none";
 	qcom,usb_dp-vadc = <&pmi8994_vadc>;
 	qcom,usb_dm-vadc = <&pmi8994_vadc>;


### PR DESCRIPTION
Some modifications on kitakami DT about charging:
- correct a typo about 9v minimal current
- (add qcom,float-voltage-mv with a value of 4350mV - Removed)
