### PR TITLE
arm: MSM8974-camera: DTS: fix cpp for smmu dts node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974-camera.dtsi
@@ -368,7 +368,7 @@
 
 		msm_cam_smmu_cb3: msm_cam_smmu_cb3 {
 			compatible = "qcom,qsmmu-cam-cb";
-			iommus = <&cpp_iommu 2>;
+			iommus = <&vfe_iommu 2>;
 			label = "cpp";
 		};
 


### PR DESCRIPTION
CPP is a part of label = vfe_iommu;

CPP_0/1/2 are part of label = cpp_iommu;

this is a part of commit: 918e71d4ea4e8b0688e3695e5be2cc29e384d877

Signed-off-by: David Viteri davidteri91@gmail.com
