### PR TITLE
[1.3.3] incell: suzu: fix touchscreen after suspend / resume

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -1417,6 +1417,10 @@ static int mdss_dsi_post_panel_on(struct mdss_panel_data *pdata)
 		mdss_dsi_panel_cmds_send(ctrl, on_cmds);
 	}
 
+#ifdef CONFIG_SOMC_PANEL_INCELL
+	incell_driver_post_power_on(pdata);
+#endif
+
 	/* NOTE: Any debugging message must be shown from specific function. */
 	if (specific->panel_post_on) {
 		rc = specific->panel_post_on(pdata);


### PR DESCRIPTION
on some panels (at least, mine does) touchscreen on suzu does initially work on boot, but after suspend / resume touch functionality is completely absent. This commit fixes that
