### PR TITLE
[1.3.3]clearpad: update incell driver from x-performance

### DIFF
--- a/drivers/input/touchscreen/clearpad_i2c.c
+++ b/drivers/input/touchscreen/clearpad_i2c.c
@@ -1,11 +1,16 @@
 /* linux/drivers/input/touchscreen/clearpad_i2c.c
  *
- * Copyright (C) 2011 Sony Ericsson Mobile Communications AB.
  * Copyright (c) 2011 Synaptics Incorporated
  * Copyright (c) 2011 Unixphere
- * Copyright (C) 2012 Sony Mobile Communications AB.
  *
  * Author: Yusuke Yoshimura <Yusuke.Yoshimura@sonyericsson.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2015 Sony Mobile Communications Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2, as
@@ -258,7 +263,7 @@ static int clearpad_i2c_probe(struct i2c_client *client,
 	if (rc)
 		goto err_device_put;
 
-	dev_info(&client->dev, "%s: sucess\n", __func__);
+	dev_info(&client->dev, "%s: success\n", __func__);
 	goto exit;
 
 err_device_put:

--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -44,8 +44,6 @@
 #include <asm/mach-types.h>
 #endif
 
-#define SYN_PCA_BLOCK_NUMBER_MAX	31
-
 #define SYN_CLEARPAD_VENDOR		0x1
 #define SYN_MAX_N_FINGERS		10
 #define SYN_DEVICE_STATUS		0x13
@@ -299,7 +297,7 @@ BIT_DEF(CALIBRATION_STATE_CALIBRATION_CRC,		0x02, 1);
 	HWLOG(this, format, ## __VA_ARGS__);	\
 })
 #define HWLOGD(this, format, ...) HWLOGx(LOGD, this, format, ## __VA_ARGS__)
-#define HWLOGI(this, format, ...) HWLOGx(LOGD, this, format, ## __VA_ARGS__)
+#define HWLOGI(this, format, ...) HWLOGx(LOGI, this, format, ## __VA_ARGS__)
 #define HWLOGE(this, format, ...) HWLOGx(LOGE, this, format, ## __VA_ARGS__)
 #define HWLOGW(this, format, ...) HWLOGx(LOGW, this, format, ## __VA_ARGS__)
 
@@ -349,18 +347,6 @@ BIT_DEF(CALIBRATION_STATE_CALIBRATION_CRC,		0x02, 1);
 /*
  * Types
  */
-
-enum clearpad_infomation_attribute_kind_e {
-	PCA_DATA			= 0x00,
-	PCA_IC				= 0x01,
-	PCA_CHIP			= 0x03,
-	PCA_MODULE			= 0x05,
-};
-
-enum clearpad_infomation_kind_e {
-	PCA_NO_USE			= 0x00,
-	PCA_FW_INFO			= 0x02,
-};
 
 enum clearpad_state_e {
 	SYN_STATE_INIT,
@@ -933,11 +919,6 @@ static void clearpad_debug_info(struct clearpad_t *this);
 #endif
 
 /*
- * Global variables
- */
-static bool first_blank_done = false;
-
-/*
  * Functions
  */
 
@@ -1331,10 +1312,8 @@ static int clearpad_ctrl_session_begin(struct clearpad_t *this,
 	touchctrl->session = session;
 
 	LOCK(&this->lock);
-
 	/* keep touch power for this session */
-	rc = touchctrl_lock_power(this, session, true, false);
-	if (unlikely(!rc) && unlikely(first_blank_done)) {
+	if (!touchctrl_lock_power(this, session, true, false)) {
 		LOGE(this, "failed to lock power\n");
 		rc = -EAGAIN;
 		goto err_in_lock_power;
@@ -5903,9 +5882,6 @@ end:
 
 static void clearpad_fb_powerdown_handler(struct clearpad_t *this)
 {
-	if (unlikely(!first_blank_done))
-		first_blank_done = true;
-
 	LOCK(&this->lock);
 	if (this->wakeup_gesture.enabled)
 		clearpad_powerdown_core(this, "POWERDOWN");
@@ -5946,7 +5922,6 @@ static void clearpad_fb_unblank_handler(struct clearpad_t *this)
 	       ts.tv_sec, ts.tv_nsec);
 
 	LOCK(&this->lock);
-
 	if (!this->post_probe.done) {
 		HWLOGI(this, "ignore UNBLANK event before post probe\n");
 		if (this->post_probe.start) {
@@ -7908,8 +7883,6 @@ static int clearpad_probe(struct platform_device *pdev)
 		}
 	}
 
-	this->post_probe.start = true;
-
 	spin_lock_init(&this->noise_det.slock);
 #ifdef CONFIG_TOUCHSCREEN_CLEARPAD_RMI_DEV
 	if (!cdata->rmi_dev) {
@@ -8029,7 +8002,7 @@ static int clearpad_probe(struct platform_device *pdev)
 		goto err_in_create_link;
 	}
 
-	if (likely(this->post_probe.start)) {
+	if (this->post_probe.start) {
 		HWLOGI(this, "schedule post probe\n");
 		schedule_delayed_work(&this->post_probe.work, 0);
 	} else {
@@ -8103,15 +8076,14 @@ static void clearpad_post_probe_work(struct work_struct *work)
 	get_monotonic_boottime(&ts);
 	HWLOGI(this, "start post probe @ %ld.%06ld\n", ts.tv_sec, ts.tv_nsec);
 
-//	if (unlikely(!first_blank_done))
-//		incell_force_sp_on();
-
 	rc = clearpad_ctrl_session_begin(this, session);
 	if (rc) {
 		HWLOGE(this, "failed to begin post probe session\n");
 		do_reschedule = true;
 		goto err_in_ctrl_session_begin;
 	}
+
+	WARN_ON(!touchctrl_is_display_powered(this));
 
 	LOCK(&this->lock);
 	if (!this->dev_active) {

--- a/drivers/input/touchscreen/clearpad_rmi_dev.c
+++ b/drivers/input/touchscreen/clearpad_rmi_dev.c
@@ -1,7 +1,5 @@
 /*
  * Copyright (c) 2011 Synaptics Incorporated
- * Copyright (C) 2012 Sony Ericsson Mobile Communications AB.
- * Copyright (C) 2012-2013 Sony Mobile Communications AB.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +14,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+/*
+ * Copyright (C) 2015 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
  */
 
 #include <linux/module.h>

--- a/include/linux/clearpad.h
+++ b/include/linux/clearpad.h
@@ -1,7 +1,5 @@
 /* include/linux/clearpad.h
  *
- * Copyright (C) 2013 Sony Mobile Communications Inc.
- *
  * Author: Courtney Cavin <courtney.cavin@sonyericsson.com>
  *         Yusuke Yoshimura <Yusuke.Yoshimura@sonymobile.com>
  *
@@ -9,6 +7,13 @@
  * it under the terms of the GNU General Public License version 2, as
  * published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
+ */
+/*
+ * Copyright (C) 2015 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
  */
 
 #ifndef __LINUX_CLEARPAD_H
@@ -22,7 +27,8 @@
 #define CLEARPADI2C_NAME "clearpad-i2c"
 #define CLEARPAD_RMI_DEV_NAME "clearpad-rmi-dev"
 
-#define SYN_PCA_BLOCK_SIZE	16
+#define SYN_PCA_BLOCK_SIZE		16
+#define SYN_PCA_BLOCK_NUMBER_MAX	31
 
 enum clearpad_funcarea_kind_e {
 	SYN_FUNCAREA_INSENSIBLE,
@@ -36,6 +42,18 @@ enum clearpad_flip_config_e {
 	SYN_FLIP_X,
 	SYN_FLIP_Y,
 	SYN_FLIP_XY,
+};
+
+enum clearpad_infomation_attribute_kind_e {
+	PCA_DATA			= 0x00,
+	PCA_IC				= 0x01,
+	PCA_CHIP			= 0x03,
+	PCA_MODULE			= 0x05,
+};
+
+enum clearpad_infomation_kind_e {
+	PCA_NO_USE			= 0x00,
+	PCA_FW_INFO			= 0x02,
 };
 
 struct clearpad_area_t {


### PR DESCRIPTION
taken from 35.0.D.362 kerneldrop. Did not re-apply the (first) blank code, as it seems to be working fine on suzu here in combination with https://github.com/sonyxperiadev/kernel/pull/851

ping @humberos @kholk 
