### PR TITLE
[1.3.3] Revert "clearpad: update incell driver from x-performance"

### DIFF
--- a/drivers/input/touchscreen/clearpad_i2c.c
+++ b/drivers/input/touchscreen/clearpad_i2c.c
@@ -1,16 +1,11 @@
 /* linux/drivers/input/touchscreen/clearpad_i2c.c
  *
+ * Copyright (C) 2011 Sony Ericsson Mobile Communications AB.
  * Copyright (c) 2011 Synaptics Incorporated
  * Copyright (c) 2011 Unixphere
+ * Copyright (C) 2012 Sony Mobile Communications AB.
  *
  * Author: Yusuke Yoshimura <Yusuke.Yoshimura@sonyericsson.com>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2, as
- * published by the Free Software Foundation.
- */
-/*
- * Copyright (C) 2015 Sony Mobile Communications Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2, as
@@ -263,7 +258,7 @@ static int clearpad_i2c_probe(struct i2c_client *client,
 	if (rc)
 		goto err_device_put;
 
-	dev_info(&client->dev, "%s: success\n", __func__);
+	dev_info(&client->dev, "%s: sucess\n", __func__);
 	goto exit;
 
 err_device_put:

--- a/drivers/input/touchscreen/clearpad_rmi_dev.c
+++ b/drivers/input/touchscreen/clearpad_rmi_dev.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2011 Synaptics Incorporated
+ * Copyright (C) 2012 Sony Ericsson Mobile Communications AB.
+ * Copyright (C) 2012-2013 Sony Mobile Communications AB.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,13 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- */
-/*
- * Copyright (C) 2015 Sony Mobile Communications Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2, as
- * published by the Free Software Foundation.
  */
 
 #include <linux/module.h>

--- a/include/linux/clearpad.h
+++ b/include/linux/clearpad.h
@@ -1,5 +1,7 @@
 /* include/linux/clearpad.h
  *
+ * Copyright (C) 2013 Sony Mobile Communications Inc.
+ *
  * Author: Courtney Cavin <courtney.cavin@sonyericsson.com>
  *         Yusuke Yoshimura <Yusuke.Yoshimura@sonymobile.com>
  *
@@ -7,13 +9,6 @@
  * it under the terms of the GNU General Public License version 2, as
  * published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- */
-/*
- * Copyright (C) 2015 Sony Mobile Communications Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2, as
- * published by the Free Software Foundation.
  */
 
 #ifndef __LINUX_CLEARPAD_H
@@ -27,8 +22,7 @@
 #define CLEARPADI2C_NAME "clearpad-i2c"
 #define CLEARPAD_RMI_DEV_NAME "clearpad-rmi-dev"
 
-#define SYN_PCA_BLOCK_SIZE		16
-#define SYN_PCA_BLOCK_NUMBER_MAX	31
+#define SYN_PCA_BLOCK_SIZE	16
 
 enum clearpad_funcarea_kind_e {
 	SYN_FUNCAREA_INSENSIBLE,
@@ -42,18 +36,6 @@ enum clearpad_flip_config_e {
 	SYN_FLIP_X,
 	SYN_FLIP_Y,
 	SYN_FLIP_XY,
-};
-
-enum clearpad_infomation_attribute_kind_e {
-	PCA_DATA			= 0x00,
-	PCA_IC				= 0x01,
-	PCA_CHIP			= 0x03,
-	PCA_MODULE			= 0x05,
-};
-
-enum clearpad_infomation_kind_e {
-	PCA_NO_USE			= 0x00,
-	PCA_FW_INFO			= 0x02,
 };
 
 struct clearpad_area_t {


### PR DESCRIPTION
For some reason clearpad driver has not been initialized
then device requires a reboot.

Also, the touch is broken on recovery mode (i.e. TWRP).

This reverts commit a65470bbc726fdae789fb870c926ffd69088bd18.
