### PR TITLE
drivers: mdss: Fix logspam

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -2061,7 +2061,7 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 		pr_err("%s: Cannot configure picadj: %d\n",
 			__func__, ret);
 
-	pr_info("%s (%d):sat=%d hue=%d val=%d cont=%d",
+	pr_debug("%s (%d):sat=%d hue=%d val=%d cont=%d\n",
 		__func__, __LINE__, padata->global_sat_adj,
 		padata->global_hue_adj, padata->global_val_adj,
 		padata->global_cont_adj);


### PR DESCRIPTION
Remove unused panel logs about its saturation/brightness variation.

Signed-off-by: Humberto Borba humberos@gmail.com
