### PR TITLE
[1.3.3] drivers: mdss: Call panel post on from specific driver data

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -1417,10 +1417,6 @@ static int mdss_dsi_post_panel_on(struct mdss_panel_data *pdata)
 		mdss_dsi_panel_cmds_send(ctrl, on_cmds);
 	}
 
-#ifdef CONFIG_SOMC_PANEL_INCELL
-	incell_driver_post_power_on(pdata);
-#endif
-
 	/* NOTE: Any debugging message must be shown from specific function. */
 	if (specific->panel_post_on) {
 		rc = specific->panel_post_on(pdata);

--- a/drivers/video/msm/mdss/somc_panel/panel_incell.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_incell.c
@@ -1883,6 +1883,7 @@ int incell_panel_driver_init(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 
 	spec_pdata->panel_power_off = incell_dsi_panel_power_off_ex;
 	spec_pdata->panel_power_on = incell_dsi_panel_power_on_ex;
+	spec_pdata->panel_post_on = incell_driver_post_power_on;
 	spec_pdata->dsi_panel_off_ex = incell_dsi_panel_off_ex;
 	spec_pdata->dsi_request_gpios = incell_panel_request_gpios;
 	spec_pdata->parse_specific_dt = incell_parse_dt;


### PR DESCRIPTION
Just reduce the use of #ifdef in panel_driver.

Signed-off-by: Humberto Borba humberos@gmail.com
