### PR TITLE
[1.3.3] arm64: DT: Loire: Disable wakeup gesture for now

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -180,7 +180,7 @@
 			preset_x_max = <1079>;
 			preset_y_max = <1919>;
 			preset_n_fingers = <10>;
-			wakeup_gesture_supported = <1>;
+			wakeup_gesture_supported = <0>;
 			wakeup_gesture_lpm_disabled = <1>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {


### PR DESCRIPTION
This feature is causing suspend/resume problems for touchscreen.

So, this patch removes it for now and fix touchscreen issue while we
haven't the proper fix.

Signed-off-by: Humberto Borba humberos@gmail.com
