### PR TITLE
ASoC: wcd9330: avoid hardcoding values in tomtom_codec_mclk_enable

### DIFF
--- a/sound/soc/codecs/wcd9330.c
+++ b/sound/soc/codecs/wcd9330.c
@@ -3006,7 +3006,7 @@ int tomtom_codec_mclk_enable(struct snd_soc_codec *codec,
 			__func__, enable, dapm);
 		return __tomtom_mclk_enable(tomtom, enable);
 	} else if (tomtom->codec_ext_clk_en_cb)
-		return tomtom_codec_ext_clk_en(codec, true, false);
+		return tomtom_codec_ext_clk_en(codec, enable, dapm);
 	else {
 		dev_err(codec->dev,
 			"%s: Cannot turn on MCLK\n",


### PR DESCRIPTION
<del>the functions tomtom_codec_mclk_enable() and
tomtom_codec_get_ext_clk_users() were introduced when adding
support to tasha. These calls break sound on kitakami, so ifdef them to
fix the problem.</del>
the values for the fallback to tomtom_codec_ext_clk_en() were hardcoded.
Pass over enable and dapm to avoid that.
