### PR TITLE
[1.3.3] kernel: gitignore: Ignore file x509_certificate_list

### DIFF
--- a/kernel/.gitignore
+++ b/kernel/.gitignore
@@ -5,3 +5,4 @@ config_data.h
 config_data.gz
 timeconst.h
 hz.bc
+x509_certificate_list


### PR DESCRIPTION
This file is autogenerated at build time. Ignore it for GIT.
