### PR TITLE
[1.3.3] Broadcom BT/FM Combo chip driver

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -442,6 +442,10 @@
 		/delete-property/ qcom,android-usb-uicc-nluns;
 	};
 
+        bcmbt_ldisc {
+		compatible = "bcmbt_ldisc";
+        };
+
 	sim_detect {
 		compatible = "sim-detect";
 		interrupt-parent = <&msm_gpio>;

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -272,6 +272,14 @@ config MSM_BT_POWER
 	  Provides a parameter to switch on/off power from PMIC
 	  to Bluetooth device.
 
+config BT_BCM_COMBO
+	tristate "Broadcom BT/FM Combo chip driver"
+	help
+	  This enables the Broadcom BT/FM combo chip driver for
+	  certain BCM chips found primarily on various handheld
+	  devices.
+	  If unsure, say N.
+
 source drivers/bluetooth/broadcom/Kconfig
 
 endmenu

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -272,4 +272,6 @@ config MSM_BT_POWER
 	  Provides a parameter to switch on/off power from PMIC
 	  to Bluetooth device.
 
+source drivers/bluetooth/broadcom/Kconfig
+
 endmenu

--- a/drivers/bluetooth/Makefile
+++ b/drivers/bluetooth/Makefile
@@ -35,5 +35,5 @@ hci_uart-$(CONFIG_BT_HCIUART_3WIRE)	+= hci_h5.o
 hci_uart-$(CONFIG_BT_HCIUART_IBS)	+= hci_ibs.o
 hci_uart-objs				:= $(hci_uart-y)
 
-obj-$(CONFIG_ARCH_SONY_KITAKAMI) += broadcom/
+obj-$(CONFIG_BT_BCM_COMBO)		+= broadcom/
 

--- a/drivers/bluetooth/Makefile
+++ b/drivers/bluetooth/Makefile
@@ -34,3 +34,6 @@ hci_uart-$(CONFIG_BT_HCIUART_ATH3K)	+= hci_ath.o
 hci_uart-$(CONFIG_BT_HCIUART_3WIRE)	+= hci_h5.o
 hci_uart-$(CONFIG_BT_HCIUART_IBS)	+= hci_ibs.o
 hci_uart-objs				:= $(hci_uart-y)
+
+obj-$(CONFIG_ARCH_SONY_KITAKAMI) += broadcom/
+

--- a/drivers/bluetooth/broadcom/Kconfig
+++ b/drivers/bluetooth/broadcom/Kconfig
@@ -1,0 +1,16 @@
+menu "BROADCOM V4L2 BT/FM device drivers"
+  depends on BT
+
+config BT_PROTOCOL_DRIVER
+	tristate "BROADCOM BT Protocol Driver"
+	default n
+
+config LINE_DISCIPLINE_DRIVER
+	tristate "BROADCOM Line Discipline Driver"
+	default n
+
+config V4L2_FM_DRIVER
+	tristate "BROADCOM V4L2 FM Driver"
+	default n
+
+endmenu

--- a/drivers/bluetooth/broadcom/Makefile
+++ b/drivers/bluetooth/broadcom/Makefile
@@ -1,0 +1,3 @@
+obj-$(CONFIG_BT_PROTOCOL_DRIVER) += bt_protocol_driver/
+obj-$(CONFIG_LINE_DISCIPLINE_DRIVER) += line_discipline_driver/
+obj-$(CONFIG_V4L2_FM_DRIVER) += v4l2_fm_driver/

--- a/drivers/bluetooth/broadcom/bt_protocol_driver/Makefile
+++ b/drivers/bluetooth/broadcom/bt_protocol_driver/Makefile
@@ -1,0 +1,12 @@
+# Makefile for Bluetooth protocol driver
+
+obj-$(CONFIG_BT_PROTOCOL_DRIVER) := brcm_bt_drv.o
+
+KBUILD_CFLAGS += -w 
+EXTRA_CFLAGS := -I$(PWD)/../include/
+
+#BT_S : [CONBT-2455] LGC_BT_COMMON_IMP_KO_MODULE_LOAD_FAIL_FIX ("Unknown symbol _GLOBAL_OFFSET_TABLE_" Error fix)
+CFLAGS_MODULE = -fno-pic
+#BT_E : [CONBT-2455] LGC_BT_COMMON_IMP_KO_MODULE_LOAD_FAIL_FIX ("Unknown symbol _GLOBAL_OFFSET_TABLE_" Error fix)
+
+ccflags-y := -DVERSION="\"1.2\""

--- a/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.c
+++ b/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.c
@@ -1,0 +1,711 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+*      Module Name : Bluetooth Protocol Driver
+*
+*      Description:     This driver module allows Mini HCI layer in Bluedroid to send/receive
+*                            packets to/from bluetooth chip. This driver registers with
+*                            Line discipline driver to communicate with bluetooth chip.
+*
+*******************************************************************************/
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/kdev_t.h>
+#include <linux/fs.h>
+#include <linux/slab.h>
+#include <linux/device.h>
+#include <linux/cdev.h>
+#include <linux/poll.h>
+#include "../include/v4l2_target.h"
+#include "../include/brcm_ldisc_sh.h"
+#include "../include/v4l2_logs.h"
+#include "brcm_bt_drv.h"
+
+#ifndef BTDRV_DEBUG
+#define BTDRV_DEBUG TRUE
+#endif
+
+/* set this module parameter to enable debug info */
+int bt_dbg_param = 0;
+
+/* Debugging for BT protocol driver */
+#if BTDRV_DEBUG
+#define BT_DRV_DBG(flag, fmt, arg...) \
+        do { \
+            if (bt_dbg_param & flag) \
+                printk(KERN_DEBUG "(btdrv):%s  "fmt"\n" , \
+                                           __func__,## arg); \
+        } while(0)
+#else
+    #define BT_DRV_DBG(flag, fmt, arg...)
+#endif
+
+#define BT_DRV_ERR(fmt, arg...)  printk(KERN_ERR "(btdrv):%s  "fmt"\n" , \
+                                           __func__,## arg)
+
+/* global variables */
+struct brcm_bt_dev *bt_dev_p;        /* allocated in init_module */
+
+static int is_print_reg_error = 1;
+
+/* timers for ldisc to send callback on register complete */
+static unsigned long jiffi1, jiffi2;
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_drv_open
+**
+** Description - Open call to BT protocol driver. Called when user-space program opens fd
+**                    on BT protocol character driver. This function will register BT protocol driver
+**                    to Line discipline driver if not already registered. Receives write function
+**                    pointer from Line discipline driver.
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_bt_drv_open(struct inode *inode, struct file *filp)
+{
+    struct brcm_bt_dev *bt_dev;
+
+    /* register to ldisc driver */
+    int err=0;
+    static struct sh_proto_s brcm_bt_st_proto;
+    unsigned long timeleft;
+    unsigned long diff;
+
+    bt_dev = container_of(inode->i_cdev, struct brcm_bt_dev, c_dev);
+    filp->private_data = bt_dev;
+
+    /* Already registered with Line discipline ST ? */
+    if (test_bit(BT_ST_REGISTERED, &bt_dev->flags)) {
+        BT_DRV_DBG(V4L2_DBG_OPEN, "Registered with ST already,open called again?");
+        return 0;
+    }
+
+    /* Populate BT driver info required by ST */
+    memset(&brcm_bt_st_proto, 0, sizeof(brcm_bt_st_proto));
+
+    /* BT driver ID */
+    brcm_bt_st_proto.type = PROTO_SH_BT;
+
+    /* Receive function which will be called from ST */
+    brcm_bt_st_proto.recv = brcm_bt_st_receive;
+
+    /* Packet match function may used in future */
+    brcm_bt_st_proto.match_packet = NULL;
+
+    /* Callback to be called when registration is pending */
+    brcm_bt_st_proto.reg_complete_cb = brcm_bt_st_registration_completion_cb;
+
+    /* This is write function pointer of ST. BT driver will make use of this
+    * for sending any packets to chip. ST will assign and give to us, so
+    * make it as NULL */
+    brcm_bt_st_proto.write = NULL;
+
+    /* send in the hst to be received at registration complete callback
+    * and during st's receive
+    */
+    brcm_bt_st_proto.priv_data = bt_dev;
+
+    /* Register with ST layer */
+    BT_DRV_DBG(V4L2_DBG_OPEN, "calling ldisc register");
+    err = brcm_sh_ldisc_register(&brcm_bt_st_proto);
+    if (err == -EINPROGRESS) {
+       /* Prepare wait-for-completion handler data structures.
+            * Needed to syncronize this and st_registration_completion_cb()
+            * functions.
+            */
+        init_completion(&bt_dev->wait_for_btdrv_reg_completion);
+
+       /* Reset ST registration callback status flag , this value
+            * will be updated in hci_st_registration_completion_cb()
+            * function whenever it called from ST driver.
+            */
+       bt_dev->streg_cbdata = -EINPROGRESS;
+
+       /* ST is busy with other protocol registration(may be busy with
+            * firmware download).So,Wait till the registration callback
+            * (passed as a argument to st_register() function) getting
+            * called from ST.
+            */
+       BT_DRV_DBG(V4L2_DBG_OPEN, " %s waiting for reg completion signal" \
+                                                       "from ST", __func__);
+
+       timeleft = wait_for_completion_timeout
+                        (&bt_dev->wait_for_btdrv_reg_completion,
+                                msecs_to_jiffies(BT_REGISTER_TIMEOUT));
+       if (!timeleft) {
+            BT_DRV_ERR("Timeout(%ld sec),didn't get reg"
+                     "completion signal from ST", BT_REGISTER_TIMEOUT / 1000);
+            err = -ETIMEDOUT;
+            BT_DRV_DBG(V4L2_DBG_OPEN, "End ret=%d", err);
+            return err;
+       }
+
+       /* Is ST registration callback called with ERROR value? */
+       if (bt_dev->streg_cbdata != 0) {
+            BT_DRV_ERR("ST reg completion CB called with invalid"
+                "status %d", bt_dev->streg_cbdata);
+            err = -EAGAIN;
+            BT_DRV_DBG(V4L2_DBG_OPEN, "End ret=%d", err);
+            return err;
+       }
+
+       err = 0;
+    }
+    else if (err < 0) {
+        if (is_print_reg_error) {
+            BT_DRV_ERR("st_register failed %d", err);
+            jiffi1 = jiffies;
+            is_print_reg_error = 0;
+        }
+        else {
+            jiffi2 = jiffies;
+            diff = (long)jiffi2 - (long)jiffi1;
+            if ( ((diff *1000)/HZ) >= 1000)
+                is_print_reg_error = 1;
+        }
+        err = -EAGAIN;
+        BT_DRV_DBG(V4L2_DBG_OPEN, "End ret=%d", err);
+        return err;
+    }
+
+    /* Do we have proper ST write function? */
+    if (brcm_bt_st_proto.write != NULL) {
+        /* We need this pointer for sending any Bluetooth pkts */
+        bt_dev->st_write = brcm_bt_st_proto.write;
+    }
+    else {
+        BT_DRV_ERR("failed to get ST write func pointer");
+
+        /* Undo registration with ST */
+        err = brcm_sh_ldisc_unregister(PROTO_SH_BT);
+        if (err < 0)
+            BT_DRV_ERR("st_unregister failed %d", err);
+
+        bt_dev->st_write = NULL;
+        err = -EAGAIN;
+        BT_DRV_DBG(V4L2_DBG_OPEN, "End ret=%d", err);
+        return err;
+    }
+
+    brcm_bt_drv_prepare(bt_dev);
+
+    BT_DRV_DBG(V4L2_DBG_OPEN, "End ret=%d", err);
+    return err;
+
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_drv_prepare
+**
+** Description - Initialized the locks on tx and rx queue. Also initialized wait_queue for
+**                    blocking select-read in user space.
+**
+*****************************************************************************/
+static void brcm_bt_drv_prepare(struct brcm_bt_dev* bt_dev)
+{
+    /* Registration with ST successful */
+    set_bit(BT_ST_REGISTERED, &bt_dev->flags);
+
+    /* Initialize TX queue and TX tasklet */
+    skb_queue_head_init(&bt_dev->tx_q);
+    spin_lock_init(&bt_dev->tx_q_lock);
+
+#ifdef TASKLET_SUPPORT
+    tasklet_init(&bt_dev->tx_task, __send_tasklet, (unsigned long)bt_dev);
+#else
+    INIT_WORK(&bt_dev->tx_workqueue,bt_send_data_ldisc);
+#endif
+
+    /* Initialize RX Queue and RX tasklet */
+    skb_queue_head_init(&bt_dev->rx_q);
+    spin_lock_init(&bt_dev->rx_q_lock);
+
+    atomic_set(&bt_dev->tx_cnt, 0);
+
+    init_waitqueue_head(&bt_dev->inq);
+
+    return;
+
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_drv_close
+**
+** Description - Performs cleanup of BT protocol driver.
+**
+*****************************************************************************/
+static int brcm_bt_drv_close(struct inode *i, struct file *f)
+{
+    int err=0;
+    struct brcm_bt_dev *bt_dev_p = f->private_data;
+
+#ifndef TASKLET_SUPPORT
+    cancel_work_sync(&bt_dev_p->tx_workqueue);
+#endif
+    /* Unregister from ST layer */
+    if (test_and_clear_bit(BT_ST_REGISTERED, &bt_dev_p->flags)) {
+        err = brcm_sh_ldisc_unregister(PROTO_SH_BT);
+        if (err != 0) {
+            BT_DRV_ERR("%s st_unregister failed %d", __func__, err);
+            err = -EBUSY;
+            BT_DRV_DBG(V4L2_DBG_CLOSE, "End ret=%d", err);
+            return err;
+        }
+        else {
+            clear_bit(BT_ST_REGISTERED, &bt_dev_p->flags);
+            BT_DRV_DBG(V4L2_DBG_CLOSE, "st_unregister done");
+        }
+    }
+
+    skb_queue_purge(&bt_dev_p->tx_q);
+    skb_queue_purge(&bt_dev_p->rx_q);
+    atomic_set(&bt_dev_p->tx_cnt, 0);
+    bt_dev_p->st_write = NULL;
+
+    BT_DRV_DBG(V4L2_DBG_CLOSE, "End ret=%d", err);
+    return err;
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_drv_read
+**
+** Description - Called when user-space program tries to read a packet.
+**
+** Returns - Number of bytes in packet.
+*****************************************************************************/
+static ssize_t brcm_bt_drv_read(struct file *f, char __user *buf, size_t
+  len, loff_t *off)
+{
+    struct sk_buff *skb;
+    struct brcm_bt_dev *bt_dev_p = f->private_data;
+    size_t skb_size = 0;
+    unsigned long flags;
+
+    spin_lock_irqsave(&bt_dev_p->rx_q_lock, flags);
+    skb = skb_peek(&bt_dev_p->rx_q);
+
+    if(!skb)
+    {
+        skb_size = 0;
+        BT_DRV_ERR("No skb packet in rx queue. This should " \
+            "not happen as user-space program should poll for data "\
+            "availability before reading");
+        goto exit;
+    }
+    else {
+        skb_size = skb->len;
+
+         /* copy packet to user-space */
+         if(copy_to_user(buf, skb->data, sizeof(char) * skb_size)){
+            /* free the skb */
+            /*kfree_skb(skb);*/
+            printk("copy to user failed\n");
+            spin_unlock_irqrestore(&bt_dev_p->rx_q_lock, flags);
+            return -EFAULT;
+         }
+         else {
+            /* free the skb after copying to user space. Return the size of skb */
+            skb = skb_dequeue(&bt_dev_p->rx_q);
+            kfree_skb(skb);
+            spin_unlock_irqrestore(&bt_dev_p->rx_q_lock, flags);
+            return skb_size;
+         }
+    }
+
+exit:
+         spin_unlock_irqrestore(&bt_dev_p->rx_q_lock, flags);
+         BT_DRV_DBG(V4L2_DBG_RX, "skb_size=%d", skb_size);
+         return skb_size;
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_write
+**
+** Description - Called when user-space program writes to fd.
+**
+** Returns - Number of bytes written.
+*****************************************************************************/
+static ssize_t brcm_bt_write(struct file *f, const char __user *buf,
+  size_t len, loff_t *off)
+{
+    int ret=0;
+    struct sk_buff *skb;
+    struct brcm_bt_dev *bt_dev;
+    unsigned long flags;
+
+    bt_dev = f->private_data;
+    spin_lock_irqsave(&bt_dev->tx_q_lock, flags);
+
+    if (buf != NULL)
+    {
+        if(!(skb = alloc_skb(len, GFP_ATOMIC)))
+        {
+            BT_DRV_ERR("Error in allocating memory for skb\n");
+            ret=-EFAULT;
+            goto nomem;
+        }
+
+        if(copy_from_user(skb_put(skb, len), buf, len))
+        {
+            BT_DRV_ERR("Error:Could not copy all data bytes from user space\n");
+            ret=-EFAULT;
+            goto nomem;
+        }
+
+    }
+    else {
+        BT_DRV_ERR("Error: Buffer from user space is NULL\n");
+        ret=-EFAULT;
+        goto nomem;
+    }
+
+    /* writing to tx queue should be atomic */
+    skb_queue_tail(&bt_dev->tx_q, skb);
+    spin_unlock_irqrestore(&bt_dev->tx_q_lock, flags);
+
+    atomic_inc(&bt_dev->tx_cnt);
+
+#ifdef TASKLET_SUPPORT
+    tasklet_schedule(&bt_dev->tx_task);
+#else
+    queue_work(bt_dev->tx_wq,&bt_dev->tx_workqueue);
+#endif
+
+    BT_DRV_DBG(V4L2_DBG_TX, "End len=%d", len);
+    return len;
+
+nomem:
+     spin_unlock_irqrestore(&bt_dev->tx_q_lock, flags);
+     BT_DRV_DBG(V4L2_DBG_TX, "End ret=%d", ret);
+     return ret;
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_drv_poll
+**
+** Description - Called by Linux kernel when user-space programs calls select. Kernel system
+*                      calls this function to check for data availability.
+**
+** Returns - Number of bytes written.
+*****************************************************************************/
+static unsigned int brcm_bt_drv_poll(struct file *filp,
+                                         struct poll_table_struct *pwait)
+{
+    int canread;
+    unsigned int mask=0;
+    struct brcm_bt_dev *bt_dev;
+    unsigned long flags;
+
+    bt_dev = filp->private_data;
+
+    poll_wait(filp,&bt_dev->inq, pwait);
+
+    spin_lock_irqsave(&bt_dev->rx_q_lock, flags);
+    if(skb_queue_len(&bt_dev->rx_q) > 0) {
+        canread = 1;
+    }
+    else {
+        canread = 0;
+    }
+    spin_unlock_irqrestore(&bt_dev->rx_q_lock, flags);
+    BT_DRV_DBG(V4L2_DBG_RX, "canread = %d", canread);
+
+    if (canread) mask |= POLLIN | POLLRDNORM;
+
+    BT_DRV_DBG(V4L2_DBG_RX, "mask=%d", mask);
+    return mask;
+}
+
+
+
+/*****************************************************************************
+**
+** Function - __send_tasklet
+**
+** Description - Called by write function to initiate a send tasklet. This tasklet will send
+**                    the packet to Line discipline driver.
+**
+*****************************************************************************/
+#ifdef TASKLET_SUPPORT
+static void __send_tasklet(unsigned long arg)
+{
+    struct brcm_bt_dev *bt_dev_p = (struct brcm_bt_dev *)arg;
+#else
+static void bt_send_data_ldisc(struct work_struct *w)
+{
+    struct  brcm_bt_dev *bt_dev_p = container_of(w, struct brcm_bt_dev,
+                                                                tx_workqueue);
+#endif
+
+    struct sk_buff *skb;
+    int len = 0;
+    unsigned long flags;
+
+    BT_DRV_DBG(V4L2_DBG_TX, "sending data to ldisc");
+
+    if (atomic_read(&bt_dev_p->tx_cnt))
+    {
+        spin_lock_irqsave(&bt_dev_p->tx_q_lock, flags);
+        skb = skb_dequeue(&bt_dev_p->tx_q);
+        spin_unlock_irqrestore(&bt_dev_p->tx_q_lock, flags);
+        if (skb)
+        {
+            sh_ldisc_cb(skb)->pkt_type = skb->data[0];
+
+            if(bt_dev_p->st_write != NULL){
+                len = bt_dev_p->st_write(skb);
+            }
+            else
+            {
+                BT_DRV_ERR("%s Error!!! bt_dev_p->st_write is NULL", __func__);
+            }
+
+            if(len < 0)
+            {
+                kfree_skb(skb);
+                BT_DRV_ERR("Error!!! sending skb to ldisc_write from \
+                    send_tasklet. Packet dropped");
+                atomic_set(&bt_dev_p->tx_cnt, 0);
+            }
+            else
+            {
+                atomic_dec(&bt_dev_p->tx_cnt);
+            }
+        }
+    }
+}
+
+
+/*  File operations which can be performed on this driver  */
+static struct file_operations brcm_bt_drv_fops =
+{
+  .owner = THIS_MODULE,
+  .open = brcm_bt_drv_open,
+  .release = brcm_bt_drv_close,
+  .read = brcm_bt_drv_read,
+  .write = brcm_bt_write,
+  .poll = brcm_bt_drv_poll
+};
+
+
+/* ------- Interfaces to Line discipline driver  ------ */
+
+/*****************************************************************************
+**
+** Function - brcm_bt_st_registration_completion_cb
+**
+** Description - Called by Line discipline driver to indicate protocol registration completion
+**                    status. open() function will wait for signal from this function
+**                    when registration function with ldisc returns ST_PENDING.
+**
+*****************************************************************************/
+static void brcm_bt_st_registration_completion_cb(void *priv_data,
+                char data)
+{
+    struct brcm_bt_dev *bt_dev_p = (struct brcm_bt_dev *)priv_data;
+
+    /* hci_st_open() function needs value of 'data' to know
+    * the registration status(success/fail),So have a back
+    * up of it.
+    */
+    bt_dev_p->streg_cbdata = data;
+
+    set_bit(BT_ST_REGISTERED, &bt_dev_p->flags);
+    BT_DRV_DBG(V4L2_DBG_OPEN, "registration to ldisc cb received");
+}
+
+
+/*****************************************************************************
+**
+** Function - brcm_bt_st_registration_completion_cb
+**
+** Description - Called by Line discipline driver when receive data is available.
+**
+*****************************************************************************/
+static long brcm_bt_st_receive(void *priv_data, struct sk_buff *skb)
+{
+    int err = 0;
+    unsigned long flags;
+
+    struct brcm_bt_dev *brcm_bt_dev_p= (struct brcm_bt_dev *)priv_data;
+
+    if (skb == NULL)
+    {
+        BT_DRV_ERR("Invalid SKB received from ST");
+        err = -EFAULT;
+        return err;
+    }
+    if (!brcm_bt_dev_p)
+    {
+        BT_DRV_ERR("Invalid hci_st memory,freeing SKB");
+        err = -EFAULT;
+        return err;
+    }
+    if (!test_bit(BT_DRV_RUNNING, &brcm_bt_dev_p->flags))
+    {
+        BT_DRV_ERR("Device is not running,freeing SKB");
+        err = -EINVAL;
+        return err;
+    }
+
+    spin_lock_irqsave(&brcm_bt_dev_p->rx_q_lock, flags);
+    skb_queue_tail(&brcm_bt_dev_p->rx_q, skb);
+    spin_unlock_irqrestore(&brcm_bt_dev_p->rx_q_lock, flags);
+
+    wake_up_interruptible(&brcm_bt_dev_p->inq);
+
+    BT_DRV_DBG(V4L2_DBG_RX, "rx_q len = %d",skb_queue_len(&brcm_bt_dev_p->rx_q));
+    if (!skb_queue_empty(&brcm_bt_dev_p->tx_q)){
+#ifdef TASKLET_SUPPORT
+     tasklet_schedule(&brcm_bt_dev_p->tx_task);
+#else
+     queue_work(brcm_bt_dev_p->tx_wq,&brcm_bt_dev_p->tx_workqueue);
+#endif
+    }
+
+    return err;
+}
+
+
+/* Global static variables */
+
+static dev_t dev; /* Global variable for dev device number */
+
+
+/* Driver module initialization and cleanup functions */
+static int __init brcm_bt_drv_init(void) /* Constructor */
+{
+    int err=0;
+
+    if ((err = alloc_chrdev_region(&dev, 0, 1, "brcm_bt_drv")) < 0)
+    {
+        BT_DRV_ERR("alloc_chrdev_region FAILED");
+        return err;
+    }
+    BT_DRV_DBG(V4L2_DBG_INIT, "<Major, Minor>: <%d, %d>\n", MAJOR(dev), MINOR(dev));
+
+    bt_dev_p = kmalloc(sizeof(struct brcm_bt_dev), GFP_KERNEL);
+
+    if (!bt_dev_p)
+    {
+        err = -ENOMEM;
+        BT_DRV_ERR("kmalloc FAILED");
+        return err;
+    }
+
+    memset(bt_dev_p, 0, sizeof(struct brcm_bt_dev));
+
+    if ((bt_dev_p->cl \
+           = (struct class *)class_create(THIS_MODULE, "brcm_bt_drv")) == NULL)
+    {
+        err = -1;
+        BT_DRV_ERR("class_create FAILED");
+        unregister_chrdev_region(dev, 1);
+        return err;
+    }
+
+    if (device_create(bt_dev_p->cl, NULL, dev, NULL, "brcm_bt_drv") \
+            == NULL)
+    {
+        BT_DRV_ERR("device_create FAILED");
+        class_destroy(bt_dev_p->cl);
+        unregister_chrdev_region(dev, 1);
+        err = -1;
+        return err;
+    }
+
+    cdev_init(&bt_dev_p->c_dev, &brcm_bt_drv_fops);
+    if ((err = cdev_add(&bt_dev_p->c_dev, dev, 1)) == -1)
+    {
+        BT_DRV_ERR("cdev_add FAILED");
+        device_destroy(bt_dev_p->cl, dev);
+        class_destroy(bt_dev_p->cl);
+        unregister_chrdev_region(dev, 1);
+        return err;
+    }
+#ifndef TASKLET_SUPPORT
+    bt_dev_p->tx_wq= create_workqueue("bt_drv");
+    if (!bt_dev_p->tx_wq) {
+        BT_DRV_ERR("%s(): Unable to create workqueue bt_drv\n", __func__);
+        return err;
+    }
+#endif
+    set_bit(BT_DRV_RUNNING, &bt_dev_p->flags);
+
+    return err;
+
+}
+
+
+static void __exit brcm_bt_drv_exit(void) /* Destructor */
+{
+#ifndef TASKLET_SUPPORT
+    destroy_workqueue(bt_dev_p->tx_wq);
+#endif
+    if (test_and_clear_bit(BT_DRV_RUNNING, &bt_dev_p->flags))
+    {
+        cdev_del(&bt_dev_p->c_dev);
+        device_destroy(bt_dev_p->cl, dev);
+        class_destroy(bt_dev_p->cl);
+        unregister_chrdev_region(dev, 1);
+        BT_DRV_DBG(V4L2_DBG_INIT, "Unregistering driver done");
+    }
+
+    if(bt_dev_p)
+    {
+        kfree(bt_dev_p);
+        BT_DRV_DBG(V4L2_DBG_INIT, "Driver memory deallocated");
+    }
+
+    BT_DRV_DBG(V4L2_DBG_INIT, "BT_protocol driver exited");
+}
+
+module_init(brcm_bt_drv_init);
+module_exit(brcm_bt_drv_exit);
+
+module_param(bt_dbg_param, int, S_IRUGO);
+MODULE_PARM_DESC(ldisc_dbg_param, \
+               "Set to integer value from 1 to 31 for enabling/disabling" \
+               " specific categories of logs");
+
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Broadcom");
+MODULE_VERSION(VERSION); /* defined in makefile */
+MODULE_DESCRIPTION("Bluetooth driver for Bluedroid. \
+ Integrates with Line discipline driver (Shared Transport)");
+
+
+

--- a/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.h
+++ b/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.h
@@ -76,12 +76,10 @@ struct brcm_bt_dev {
     spinlock_t rx_q_lock;                /* Rx queue lock */
 
     struct sk_buff_head tx_q;            /* TX queue */
-#ifdef TASKLET_SUPPORT
-    struct tasklet_struct tx_task;       /* TX Tasklet */
-#else
+
     struct workqueue_struct *tx_wq;     /* Fm drv workqueue */
     struct work_struct tx_workqueue;    /* Tx work queue */
-#endif
+
     spinlock_t tx_q_lock;                /* Tx queue lock */
 
     unsigned long last_tx_jiffies;       /* Timestamp of last pkt sent */
@@ -111,11 +109,9 @@ static void brcm_bt_st_registration_completion_cb(void *priv_data,
     char data);
 
 static long brcm_bt_st_receive(void *priv_data, struct sk_buff *skb);
-#ifdef TASKLET_SUPPORT
-static void __send_tasklet(unsigned long arg);
-#else
+
 static void bt_send_data_ldisc(struct work_struct *work);
-#endif
+
 
 
 #endif

--- a/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.h
+++ b/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.h
@@ -1,0 +1,122 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************
+**
+**  Name:           brcm_bt_drv.h
+**
+**  Description:    This is the header file for.Bluetooth protocol driver
+**
+*****************************************************************************/
+
+
+#ifndef _BT_DRV_H
+#define _BT_DRV_H
+#include <net/bluetooth/bluetooth.h>
+#include <linux/interrupt.h>
+
+#define TRUE   1
+#define FALSE  0
+
+#define WORKER_QUEUE TRUE
+
+/* Defines number of seconds to wait for reg completion
+ * callback getting called from ST (in case,registration
+ * with ST returns PENDING status)
+ */
+#define BT_REGISTER_TIMEOUT   msecs_to_jiffies(6000)    /* 6 sec */
+
+/* BT driver's local status */
+#define BT_DRV_RUNNING     0
+#define BT_ST_REGISTERED   1
+#define BT_TX_Q_EMPTY      2
+#define BT_RX_Q_EMPTY      3
+
+
+#define BRCM_BT_DEV_MAJOR 0
+
+struct brcm_bt_dev {
+    /*register device to linux system*/
+    struct cdev c_dev;
+    struct class *cl;
+
+    /* used locally,to maintain various BT driver status */
+    unsigned long flags;
+
+    /* to hold ST registration callback  status */
+    char streg_cbdata;
+
+    /* write function pointer of Line discipline driver */
+    long (*st_write) (struct sk_buff *);
+
+    /* Wait on comepletion handler needed to synchronize
+        * hci_st_open() and hci_st_registration_completion_cb()
+        * functions.*/
+    struct completion wait_for_btdrv_reg_completion;
+
+
+    long flag;                           /*  BT driver state machine info */
+    struct sk_buff_head rx_q;            /* RX queue */
+    spinlock_t rx_q_lock;                /* Rx queue lock */
+
+    struct sk_buff_head tx_q;            /* TX queue */
+#ifdef TASKLET_SUPPORT
+    struct tasklet_struct tx_task;       /* TX Tasklet */
+#else
+    struct workqueue_struct *tx_wq;     /* Fm drv workqueue */
+    struct work_struct tx_workqueue;    /* Tx work queue */
+#endif
+    spinlock_t tx_q_lock;                /* Tx queue lock */
+
+    unsigned long last_tx_jiffies;       /* Timestamp of last pkt sent */
+    atomic_t tx_cnt;                     /* Number of packets in tx queue */
+
+    /* queue for polling table */
+    wait_queue_head_t inq;
+
+};
+
+
+
+/* declare functions used in brcm_bt_drv */
+static int brcm_bt_drv_open(struct inode *inode, struct file *filp);
+
+static int brcm_bt_drv_close(struct inode *i, struct file *f);
+
+static void brcm_bt_drv_prepare(struct brcm_bt_dev* bt_dev);
+
+static ssize_t brcm_bt_drv_read(struct file *f, char __user *buf, size_t
+  len, loff_t *off);
+
+static ssize_t brcm_bt_write(struct file *f, const char __user *buf,
+  size_t len, loff_t *off);
+
+static void brcm_bt_st_registration_completion_cb(void *priv_data,
+    char data);
+
+static long brcm_bt_st_receive(void *priv_data, struct sk_buff *skb);
+#ifdef TASKLET_SUPPORT
+static void __send_tasklet(unsigned long arg);
+#else
+static void bt_send_data_ldisc(struct work_struct *work);
+#endif
+
+
+#endif
+

--- a/drivers/bluetooth/broadcom/include/ant.h
+++ b/drivers/bluetooth/broadcom/include/ant.h
@@ -1,0 +1,38 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************
+**
+**  Name:           ant.h
+**
+**  Description:    ant+ common header file between ldisc and protocol FM drivers
+**
+*****************************************************************************/
+#ifndef _ANT_H
+#define _ANT_H
+
+struct ant_event_hdr {
+    unsigned char event;
+    unsigned char plen;
+} __attribute__ ((packed));
+
+#define ANT_MAX_FRAME_SIZE 0xFF
+#define ANT_EVENT_HDR_SIZE 2
+#define ANT_PKT 0x0f
+#endif

--- a/drivers/bluetooth/broadcom/include/brcm_ldisc_sh.h
+++ b/drivers/bluetooth/broadcom/include/brcm_ldisc_sh.h
@@ -1,0 +1,122 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*******************************************************************************
+ *
+ *  Filename:      brcm_ldisc_sh.h
+ *
+ *  Description:   Shared Transport Header file
+ *   To be included by the protocol stack drivers for
+ *   Broadcom BT,FM and GPS combo chip drivers
+ *
+ ******************************************************************************/
+
+#ifndef LDISC_SH_H
+#define LDISC_SH_H
+
+#include <linux/skbuff.h>
+#define CONFIG_BT_HCIUART_BRCM
+
+/*******************************************************************************
+**  Constants
+*******************************************************************************/
+/* install sysfs entry values */
+#define V4L2_STATUS_ERR '2'  // error occured in BT application (HCI command timeout or HW error)
+#define V4L2_STATUS_ON  '1'  // Atleast one procol driver is registered
+#define V4L2_STATUS_OFF '0'  // No procol drivers registered
+
+/* BT err flag values (bt_err) */
+#define  V4L2_ERR_FLAG_RESET '0'
+#define  V4L2_ERR_FLAG_SET   '1'
+
+/*
+ * enum proto-type - The protocol on chips which share a
+ *  common physical interface like UART.
+ */
+enum proto_type {
+    PROTO_SH_BT,
+    PROTO_SH_FM,
+    PROTO_SH_GPS,
+    PROTO_SH_ANT,
+    PROTO_SH_MAX,
+};
+
+/*
+ * enum sleep-type - Sleep control is board specific
+ */
+enum sleep_type {
+    SLEEP_DEFAULT,
+    SLEEP_BLUESLEEP,
+};
+
+
+void brcm_btsleep_wake( enum sleep_type type);
+void brcm_btsleep_start(enum sleep_type type);
+void brcm_btsleep_stop(enum sleep_type type);
+
+
+#define sh_ldisc_cb(skb) ((struct sh_ldisc_skb_cb *)((skb)->cb))
+
+/*******************************************************************************
+**  Type definitions
+*******************************************************************************/
+
+/*
+ * Skb helpers
+ */
+struct sh_ldisc_skb_cb {
+    __u8 pkt_type;
+    __u32 lparam;
+};
+
+/**
+ * struct sh_proto_s - Per Protocol structure from BT/FM/GPS to shared ldisc
+ * @type: type of the protocol being registered among the
+ *  available proto_type(BT, FM, GPS the protocol which share TTY).
+ * @recv: the receiver callback pointing to a function in the
+ *  protocol drivers called by the shared ldisc driver upon receiving
+ *  relevant data.
+ * @match_packet: reserved for future use, to make ST more generic
+ * @reg_complete_cb: callback handler pointing to a function in protocol
+ *  handler called by shared ldisc when the pending registrations are complete.
+ *  The registrations are marked pending, in situations when fw
+ *  download is in progress.
+ * @write: pointer to function in shared ldisc provided to protocol drivers,
+ *  to be made use when protocol drivers have data to send to TTY.
+ * @priv_data: privdate data holder for the protocol drivers, sent
+ *  from the protocol drivers during registration, and sent back on
+ *  reg_complete_cb and recv.
+ */
+struct sh_proto_s {
+    enum proto_type type;
+    long (*recv) (void *, struct sk_buff *);
+    unsigned char (*match_packet) (const unsigned char *data);
+    void (*reg_complete_cb) (void *, char data);
+    long (*write) (struct sk_buff *skb);
+    void *priv_data;
+};
+
+/*******************************************************************************
+**  Extern variables and functions
+*******************************************************************************/
+
+extern long brcm_sh_ldisc_register(struct sh_proto_s *);
+extern long brcm_sh_ldisc_unregister(enum proto_type);
+
+#endif /* LDISC_H */

--- a/drivers/bluetooth/broadcom/include/fm.h
+++ b/drivers/bluetooth/broadcom/include/fm.h
@@ -1,0 +1,39 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************
+**
+**  Name:           fm.h
+**
+**  Description:    FM common header file between ldisc and protocol FM drivers
+**
+*****************************************************************************/
+#ifndef _FM_H
+#define _FM_H
+
+struct fm_event_hdr {
+    unsigned char event;
+    unsigned char plen;
+} __attribute__ ((packed));
+
+#define FM_MAX_FRAME_SIZE 0xFF
+#define FM_EVENT_HDR_SIZE 2
+#define FM_CH8_PKT 0x8
+
+#endif

--- a/drivers/bluetooth/broadcom/include/v4l2_logs.h
+++ b/drivers/bluetooth/broadcom/include/v4l2_logs.h
@@ -1,0 +1,41 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************/
+
+/*******************************************************************************
+ *
+ *  Filename:      v4l2_logs.h
+ *
+ *  Description:   defines flags which enable various types of logs.
+ *
+ ******************************************************************************/
+
+
+#define TRUE 1
+#define FALSE 0
+
+#define V4L2_DBG_INIT     (1 << 0) /* enable logs for init and release in drivers */
+#define V4L2_DBG_OPEN     (1 << 1) /* enable logs for open call to drivers */
+#define V4L2_DBG_CLOSE    (1 << 2) /* enable logs for close call to drivers */
+#define V4L2_DBG_TX       (1 << 3) /* enable logs for tx in drivers */
+#define V4L2_DBG_RX       (1 << 4) /* enable logs for rx in drivers */
+
+
+

--- a/drivers/bluetooth/broadcom/include/v4l2_target.h
+++ b/drivers/bluetooth/broadcom/include/v4l2_target.h
@@ -1,0 +1,59 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************/
+
+/*******************************************************************************
+ *
+ *  Filename:      v4l2_target.h
+ *
+ *  Description:   defines macros to enable/disable the following
+ *                      [1] dynamic logging
+ *                      [2] HCI snooping
+ *
+ ******************************************************************************/
+
+
+ /* Macros to enable/disable debugging. This will overried debug macros in each of
+   * V4L2 drivers. Set these to false for production release.*/
+#ifndef BTDRV_DEBUG
+#define BTDRV_DEBUG FALSE
+#endif
+
+#ifndef BTLDISC_DEBUG
+#define BTLDISC_DEBUG FALSE
+#endif
+
+#ifndef V4L2_FM_DEBUG
+#define V4L2_FM_DEBUG FALSE
+#endif
+
+/* set this to FALSE to disable HCI snooping for production release */
+#ifndef V4L2_SNOOP_ENABLE
+#define V4L2_SNOOP_ENABLE TRUE
+#endif
+
+#ifndef V4L2_ANT
+#define V4L2_ANT TRUE
+#endif
+
+#ifndef V4L2_ANT_DEBUG
+#define V4L2_ANT_DEBUG FALSE
+#endif
+

--- a/drivers/bluetooth/broadcom/line_discipline_driver/Makefile
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/Makefile
@@ -1,0 +1,10 @@
+# Makefile for Line discipline driver
+
+brcm_hci_ldisc-objs := brcm_hci.o brcm_sh_ldisc.o brcm_bluesleep.o
+obj-$(CONFIG_LINE_DISCIPLINE_DRIVER) := brcm_hci_ldisc.o
+
+KBUILD_CFLAGS += -w
+EXTRA_CFLAGS := -I$(PWD)/../include/
+
+ccflags-y += -w -DVERSION="\"1.2\""
+#ccflags-y += -DLPM_BLUESLEEP

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
@@ -1,0 +1,80 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+*
+*  Filename:      brcm_bluesleep.c
+*
+*  Description:   Interface Module for sleep control.Sleep control is board dependant.
+*                 Based on the config entry different sleep controls are selected for
+*                 different platforms
+*
+*******************************************************************************/
+#include "../include/brcm_ldisc_sh.h"
+
+#ifdef LPM_BLUESLEEP
+    extern void bluesleep_outgoing_data(void);
+    extern int bluesleep_start(void);
+    extern void bluesleep_stop(void);
+#endif
+
+/**
+ * Handles proper timer action when outgoing data is delivered to the
+ * HCI line discipline and wake the chip from sleep.
+ **/
+void brcm_btsleep_wake( enum sleep_type type)
+{
+#ifdef LPM_BLUESLEEP
+    if(type == SLEEP_BLUESLEEP)
+         bluesleep_outgoing_data();
+#endif
+}
+
+/**
+ * Starts the Sleep-Mode Protocol on the Host.
+**/
+void brcm_btsleep_start(enum sleep_type type)
+{
+#ifdef LPM_BLUESLEEP
+    if(type == SLEEP_BLUESLEEP)
+        bluesleep_start();
+#endif
+}
+/**
+ * Stops the Sleep-Mode Protocol on the Host.
+ */
+void brcm_btsleep_stop(enum sleep_type type)
+{
+#ifdef LPM_BLUESLEEP
+    if(type == SLEEP_BLUESLEEP)
+        bluesleep_stop();
+#endif
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci.c
@@ -1,0 +1,701 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************
+*
+*  Filename:      brcm_hci.c
+*
+*  Description:   Broadcom Bluetooth Low Power UART protocol
+*
+*****************************************************************************/
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+#include <linux/init.h>
+#include <linux/sched.h>
+#include <linux/types.h>
+#include <linux/fcntl.h>
+#include <linux/interrupt.h>
+#include <linux/ptrace.h>
+#include <linux/poll.h>
+#include <linux/timer.h>
+/*#include <asm/gpio.h>*/
+
+#include <linux/slab.h>
+#include <linux/tty.h>
+#include <linux/errno.h>
+#include <linux/string.h>
+#include <linux/signal.h>
+#include <linux/ioctl.h>
+#include <linux/skbuff.h>
+#include <linux/serial_core.h>
+
+#include <net/bluetooth/bluetooth.h>
+#include <net/bluetooth/hci_core.h>
+
+#include "brcm_hci_uart.h"
+#include "../include/v4l2_target.h"
+#include "../include/fm.h"
+#include "../include/ant.h"
+#include "../include/v4l2_logs.h"
+
+
+/*****************************************************************************
+**  Constants & Macros for dynamic logging
+*****************************************************************************/
+#ifndef BTLDISC_DEBUG
+#define BTLDISC_DEBUG TRUE
+#endif
+
+/* set this module parameter to enable debug info */
+extern int ldisc_dbg_param;
+extern struct sock *nl_sk_hcisnoop;
+
+#if (BTLDISC_DEBUG)
+#define BRCM_HCI_DBG(flag, fmt, arg...) \
+            do { \
+                            if (ldisc_dbg_param & flag) \
+                    printk(KERN_DEBUG "(brcmhci):%s:%d  "fmt"\n" , \
+                                               __func__, __LINE__, ## arg); \
+            } while(0)
+#else
+#define BRCM_HCI_DBG(flag,fmt, arg...)
+#endif
+
+#define BRCM_HCI_ERR(fmt, arg...)  printk(KERN_ERR "(brcmhci):%s:%d  "fmt"\n" , \
+                                           __func__, __LINE__,## arg)
+
+
+#if V4L2_SNOOP_ENABLE
+/* parameter to enable HCI snooping */
+extern int ldisc_snoop_enable_param;
+#endif
+
+
+/*****************************************************************************
+**  Constants & Macros
+*****************************************************************************/
+
+/* HCIBRCM commands */
+#define HCIBRCM_GO_TO_SLEEP_IND    0x30
+#define HCIBRCM_GO_TO_SLEEP_ACK    0x31
+#define HCIBRCM_WAKE_UP_IND    0x32
+#define HCIBRCM_WAKE_UP_ACK    0x33
+
+/* HCIBRCM receiver States */
+#define HCIBRCM_W4_PACKET_TYPE 0
+#define HCIBRCM_W4_EVENT_HDR   1
+#define HCIBRCM_W4_ACL_HDR     2
+#define HCIBRCM_W4_SCO_HDR     3
+#define HCIBRCM_W4_DATA        4
+#define FMBRCM_W4_EVENT_HDR    5
+#define ANTBRCM_W4_EVENT_HDR   6
+
+#define TIMER_PERIOD 100    /* 100 ms */
+#define HOST_CONTROLLER_IDLE_TSH 4000  /* 4 s */
+
+#define RESP_BUFF_SIZE 30
+
+#define BT_WAKE  22
+
+
+/* Message event ID passed from Host/Controller lib to stack */
+#define MSG_HC_TO_STACK_HCI_ERR        0x1300 /* eq. BT_EVT_TO_BTU_HCIT_ERR */
+#define MSG_HC_TO_STACK_HCI_ACL        0x1100 /* eq. BT_EVT_TO_BTU_HCI_ACL */
+#define MSG_HC_TO_STACK_HCI_SCO        0x1200 /* eq. BT_EVT_TO_BTU_HCI_SCO */
+#define MSG_HC_TO_STACK_HCI_EVT        0x1000 /* eq. BT_EVT_TO_BTU_HCI_EVT */
+#define MSG_HC_TO_FM_HCI_EVT           0x3000 /* Response code for FM HCI event */
+#define MSG_HC_TO_STACK_L2C_SEG_XMIT   0x1900 /*eq. BT_EVT_TO_BTU_L2C_SEG_XMIT*/
+
+#undef CONFIG_SERIAL_MSM_HS
+
+/* HCIBRCM states */
+enum hcibrcm_states_e {
+    HCIBRCM_ASLEEP,
+    HCIBRCM_ASLEEP_TO_AWAKE,
+    HCIBRCM_AWAKE,
+    HCIBRCM_AWAKE_TO_ASLEEP
+};
+
+/* Function forward declarations */
+static int brcm_open(struct hci_uart *hu);
+static int brcm_close(struct hci_uart *hu);
+static int brcm_recv(struct hci_uart *hu, void *data, int count);
+static int brcm_recv_int(struct hci_uart *hu, void *data, int count);
+static int brcm_enqueue(struct hci_uart *hu, struct sk_buff *skb);
+static struct sk_buff *brcm_dequeue(struct hci_uart *hu);
+static int brcm_flush(struct hci_uart *hu);
+
+struct hci_uart_proto brcmp = {
+    .id      = HCI_UART_BRCM,
+    .open    = brcm_open,
+    .close   = brcm_close,
+    .recv    = brcm_recv,
+    .recv_int= brcm_recv_int,
+    .enqueue = brcm_enqueue,
+    .dequeue = brcm_dequeue,
+    .flush   = brcm_flush,
+};
+
+
+/* External functions */
+int brcm_hci_snoop(struct hci_uart *hu, void* data, unsigned int count);
+
+/*****************************************************************************
+**  Static functions
+*****************************************************************************/
+
+/*
+ * Function to check data length
+ */
+static inline int brcm_check_data_len(struct brcm_struct *brcm,
+                    struct hci_uart *hu, int protoid,int len)
+{
+    register int room = skb_tailroom(brcm->rx_skb);
+
+    BRCM_HCI_DBG(V4L2_DBG_RX, "len %d room %d", len, room);
+
+    if (!len) {
+       brcm_hci_uart_route_frame(protoid, hu, brcm->rx_skb);
+    } else if (len > room) {
+        BT_ERR("brcm_check_data_len Data length is too large kfree_skb %p",brcm->rx_skb);
+        kfree_skb(brcm->rx_skb);
+    } else {
+        brcm->rx_state = HCIBRCM_W4_DATA;
+        brcm->rx_count = len;
+        return len;
+    }
+
+    brcm->rx_state = HCIBRCM_W4_PACKET_TYPE;
+    brcm->rx_skb   = NULL;
+    brcm->rx_count = 0;
+
+    return 0;
+}
+
+
+void brcm_hci_process_frametype( register int frame_type,
+                               struct hci_uart*hu,struct sk_buff *skb,int count)
+{
+    hc_bt_hdr *hci_hdr;
+
+    hci_hdr = hu->hdr_data;
+
+    hci_hdr->offset = 0;
+    hci_hdr->layer_specific = 0;
+    hci_hdr->len = skb->len;
+
+    BRCM_HCI_DBG(V4L2_DBG_RX, "%s frame_type = 0x%x hci_hdr->len %d", __func__,
+                                                       frame_type,hci_hdr->len);
+
+    switch(frame_type)
+    {
+    case HCI_EVENT_PKT:
+        hci_hdr->event = MSG_HC_TO_STACK_HCI_EVT;
+        break;
+    case HCI_ACLDATA_PKT:
+        hci_hdr->event = MSG_HC_TO_STACK_HCI_ACL;
+        break;
+    case HCI_SCODATA_PKT:
+        hci_hdr->event = MSG_HC_TO_STACK_HCI_SCO;
+        break;
+    default:
+        BRCM_HCI_DBG(V4L2_DBG_RX, "%s received frame_type UNKNOWN", __func__);
+        hci_hdr->event = MSG_HC_TO_STACK_HCI_ERR;
+    };
+
+    memcpy(skb_push(skb, sizeof(hc_bt_hdr)), hci_hdr,
+                                                    sizeof(hc_bt_hdr) );
+}
+
+
+/*****************************************************************************
+**   UART API calls - Start
+*****************************************************************************/
+
+/*****************************************************************************
+**
+** Function - brcm_open()
+**
+** Description - Initialize protocol
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_open(struct hci_uart *hu)
+{
+    struct brcm_struct *brcm;
+
+#if (!V4L2_SNOOP_ENABLE)
+    hc_bt_hdr *hci_hdr;
+    hci_hdr = kzalloc(sizeof(*hci_hdr), GFP_ATOMIC);
+
+    if (!hci_hdr)
+        return -ENOMEM;
+
+    hu->hdr_data = hci_hdr;
+#endif
+
+    brcm = kzalloc(sizeof(*brcm), GFP_ATOMIC);
+    if (!brcm)
+        return -ENOMEM;
+
+    BRCM_HCI_DBG(V4L2_DBG_INIT, "hu %p", hu);
+
+    skb_queue_head_init(&brcm->txq);
+    skb_queue_head_init(&brcm->tx_wait_q);
+    spin_lock_init(&brcm->hcibrcm_lock);
+
+    brcm->hcibrcm_state = HCIBRCM_AWAKE;
+    brcm->is_there_activity = 0;
+    hu->priv = brcm;
+
+    BRCM_HCI_DBG(V4L2_DBG_INIT, "hu %p", hu);
+    BRCM_HCI_DBG(V4L2_DBG_INIT, "sizeof(hu->hdr_data) = %d", sizeof(hu->hdr_data));
+    return 0;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_flush()
+**
+** Description - Flush protocol data
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_flush(struct hci_uart *hu)
+{
+    struct brcm_struct *brcm = hu->priv;
+
+    BRCM_HCI_DBG(V4L2_DBG_INIT, "hu %p", hu);
+
+    if (!skb_queue_empty(&brcm->tx_wait_q))
+        skb_queue_purge(&brcm->tx_wait_q);
+    if (!skb_queue_empty(&brcm->txq))
+        skb_queue_purge(&brcm->txq);
+
+    return 0;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_close()
+**
+** Description - Close protocol
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_close(struct hci_uart *hu)
+{
+    struct brcm_struct *brcm = hu->priv;
+
+    BRCM_HCI_DBG(V4L2_DBG_INIT, "hu %p", hu);
+
+    if (!skb_queue_empty(&brcm->tx_wait_q))
+        skb_queue_purge(&brcm->tx_wait_q);
+    if (!skb_queue_empty(&brcm->txq))
+        skb_queue_purge(&brcm->txq);
+
+    if (brcm->rx_skb) {
+        kfree_skb(brcm->rx_skb);
+    }
+
+    if(hu->hdr_data) {
+        kfree(hu->hdr_data);
+        hu->hdr_data = NULL;
+    }
+    hu->priv = NULL;
+    kfree(brcm);
+
+    return 0;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_enqueue()
+**
+** Description - Enqueue frame for transmittion (padding, crc, etc).
+**               May be cabrcmed from two simultaneous tasklets
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_enqueue(struct hci_uart *hu, struct sk_buff *skb)
+{
+    struct brcm_struct *brcm = hu->priv;
+    unsigned long lock_flags;
+    BRCM_HCI_DBG(V4L2_DBG_TX, "hu %p skb %p", hu, skb);
+
+    spin_lock_irqsave(&hu->lock, lock_flags);
+    skb_queue_tail(&brcm->txq, skb);
+    spin_unlock_irqrestore(&hu->lock, lock_flags);
+    return 0;
+}
+/*****************************************************************************
+**
+** Function - brcm_recv_int()
+**
+** Description - Recv data before protocol registration
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_recv_int(struct hci_uart *hu, void *data, int count)
+{
+    register char *ptr;
+    ptr = (char *)data;
+
+    BRCM_HCI_DBG(V4L2_DBG_RX, "%s hu = %p hu->cmd_rcvd = %p count =%d",__func__,hu,
+                                                         &hu->cmd_rcvd, count);
+
+    if (ptr!= NULL && (count>2) && ptr[0]==0x04 && ptr[1]==0x0E) {
+        BRCM_HCI_DBG(V4L2_DBG_RX, "brcm_recv_int, sending cmd_rcvd");
+        memcpy(hu->priv->resp_buffer, ptr,
+                   (count<RESP_BUFF_SIZE)?count:RESP_BUFF_SIZE);
+        complete_all(&hu->cmd_rcvd);
+#if V4L2_SNOOP_ENABLE
+        if(nl_sk_hcisnoop)
+        {
+            /* forward to hcisnoop */
+            BRCM_HCI_DBG(V4L2_DBG_RX, "capturing internal command response");
+            brcm_hci_snoop(hu, data, count);
+        }
+#endif
+        return 0;
+    }
+
+    return -1;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_recv()
+**
+** Description - Recv data
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static int brcm_recv(struct hci_uart *hu, void *data, int count)
+{
+    struct brcm_struct *brcm = hu->priv;
+    register char *ptr;
+    struct hci_event_hdr *eh;
+    struct hci_acl_hdr   *ah;
+    struct hci_sco_hdr   *sh;
+    struct fm_event_hdr *fm;
+    hc_bt_hdr *hci_hdr;
+    register int len, type, dlen ,received_bytes;
+    static enum proto_type protoid = PROTO_SH_MAX;
+    received_bytes = 0;
+
+    BRCM_HCI_DBG(V4L2_DBG_RX, "hu %p count %d rx_state %ld rx_count %ld", hu,
+                       count, brcm->rx_state, brcm->rx_count);
+
+    ptr = (char *)data;
+    while (count) {
+        if (brcm->rx_count) {
+            len = min_t(unsigned int, brcm->rx_count, count);
+            memcpy(skb_put(brcm->rx_skb, len), ptr, len);
+            brcm->rx_count -= len; count -= len; ptr += len;
+            received_bytes += len;
+            BRCM_HCI_DBG(V4L2_DBG_RX, "brcm_recv received_bytes= %d\n", \
+                                                                received_bytes);
+            if (brcm->rx_count)
+                continue;
+
+            switch (brcm->rx_state) {
+            case HCIBRCM_W4_DATA:
+                BRCM_HCI_DBG(V4L2_DBG_RX, "Complete data, rx_skb->len:%d", brcm->rx_skb->len);
+                /* route frame as internal command response */
+                if(unlikely(hu->protos_registered == LDISC_EMPTY)) {
+                    memcpy(skb_push(brcm->rx_skb, 1), brcm->rx_skb->cb, 1);
+                    if (unlikely(brcm->rx_skb->data[0]==0x04
+                        && brcm->rx_skb->data[4]==0x09
+                        && brcm->rx_skb->data[5]==0x10 )) {
+                        brcm->resp_buffer[0] = brcm->rx_skb->cb[0];
+                        memcpy(brcm->resp_buffer, brcm->rx_skb->data,
+                                                           RESP_BUFF_SIZE);
+                    }
+                    complete_all(&hu->cmd_rcvd);
+#if V4L2_SNOOP_ENABLE
+                    if(nl_sk_hcisnoop)
+                    {
+                        /* forward internal command response to hcisnoop */
+                        type = sh_ldisc_cb(brcm->rx_skb)->pkt_type;
+                        /* remove the type */
+                        skb_pull(brcm->rx_skb, 1);
+                        hci_hdr = hu->hdr_data;
+                        hci_hdr->offset = 0;
+                        hci_hdr->layer_specific = 0;
+                        hci_hdr->event = MSG_HC_TO_STACK_HCI_EVT;
+                        hci_hdr->len = brcm->rx_skb->len;
+                        memcpy(skb_push(brcm->rx_skb, sizeof(hc_bt_hdr))
+                            , hci_hdr, sizeof(hc_bt_hdr));
+                        BRCM_HCI_DBG(V4L2_DBG_RX,"forwarding internal command"\
+                            " response to snoop with type=0x%02X", type);
+                        brcm_hci_snoop(hu, brcm->rx_skb->data, brcm->rx_skb->len);
+                    }
+#endif
+                    kfree_skb(brcm->rx_skb);
+                }
+                else { /* route frame to registered protocol driver */
+                    /*In normal case all the HCI events gets routed to BT protocol driver*/
+                    /*But in this case opcode FC61 sent by FM driver hence the response*/
+                    /* has to go to FM driver so modifying the  type and protoid*/
+                    if (hu->is_registered[PROTO_SH_FM]  && ((brcm->rx_skb->data[0]==0x0e
+                        && (brcm->rx_skb->data[3]==0x61 || brcm->rx_skb->data[3]==0x15)
+                        && brcm->rx_skb->data[4]==0xFC ) ||
+                        (brcm->rx_skb->data[0]==0xFF
+                        && brcm->rx_skb->data[2]==0x08)))
+                    {
+                        type = FM_CH8_PKT;
+                        sh_ldisc_cb(brcm->rx_skb)->pkt_type = type;
+                        protoid = PROTO_SH_FM;
+                    }
+#ifdef V4L2_ANT
+                    else if (unlikely(brcm->rx_skb->data[0]==0x0e
+                        && brcm->rx_skb->data[3]==0xec
+                        && brcm->rx_skb->data[4]==0xFC ))
+                    {
+                        type = ANT_PKT;
+                        sh_ldisc_cb(brcm->rx_skb)->pkt_type = type;
+                        protoid = PROTO_SH_ANT;
+                        BRCM_HCI_DBG(V4L2_DBG_RX, "brcm_recv ANT cmd complete evt");
+                    }
+                    else if (unlikely(brcm->rx_skb->data[0]==0xff
+                        && brcm->rx_skb->data[2]==0x2d ))
+                    {
+                        type = ANT_PKT;
+                        sh_ldisc_cb(brcm->rx_skb)->pkt_type = type;
+                        protoid = PROTO_SH_ANT;
+                        BRCM_HCI_DBG(V4L2_DBG_RX, "brcm_recv ANT evt");
+                    }
+#endif
+                    else
+                    {
+                        type = sh_ldisc_cb(brcm->rx_skb)->pkt_type;
+                        BRCM_HCI_DBG(V4L2_DBG_RX, "brcm_recv type 0x%x",type);
+                    }
+                    /* For BT packet */
+                    if(type == HCI_EVENT_PKT || type == HCI_ACLDATA_PKT ||
+                                                        type == HCI_SCODATA_PKT)
+                    {
+                        /* Add header to frame only in case of BT packet */
+                        brcm_hci_process_frametype(type,hu,brcm->rx_skb,
+                                                                received_bytes);
+
+                    }
+#if V4L2_SNOOP_ENABLE
+                    else { /* For FM packet */
+                        BRCM_HCI_DBG(V4L2_DBG_RX,"FM response event received");
+                        if(nl_sk_hcisnoop && (type != ANT_PKT))
+                        {
+                            /* Add header for sending pkt to snoop. Remove header
+                                                   before sending to fmdrv */
+                            type = sh_ldisc_cb(brcm->rx_skb)->pkt_type;
+                            hci_hdr = hu->hdr_data;
+                            hci_hdr->offset = 0;
+                            hci_hdr->layer_specific = 0;
+                            hci_hdr->len = brcm->rx_skb->len;
+                            hci_hdr->event = MSG_HC_TO_FM_HCI_EVT;
+                            memcpy(skb_push(brcm->rx_skb, sizeof(hc_bt_hdr)),
+                                hci_hdr, sizeof(hc_bt_hdr) );
+                        }
+                    }
+#endif
+                    BRCM_HCI_DBG(V4L2_DBG_RX, "routing frame to registered "\
+                                                                     "driver");
+                    brcm_hci_uart_route_frame(protoid, hu, brcm->rx_skb);
+                }
+                brcm->rx_state = HCIBRCM_W4_PACKET_TYPE;
+                brcm->rx_skb = NULL;
+                protoid = PROTO_SH_MAX;
+                continue;
+
+            case HCIBRCM_W4_EVENT_HDR:
+                eh = hci_event_hdr(brcm->rx_skb);
+                brcm_check_data_len(brcm, hu, protoid, eh->plen);
+                continue;
+
+            case HCIBRCM_W4_ACL_HDR:
+                ah = hci_acl_hdr(brcm->rx_skb);
+                dlen = __le16_to_cpu(ah->dlen);
+                BRCM_HCI_DBG(V4L2_DBG_RX, "ACL header: dlen %d", dlen);
+                brcm_check_data_len(brcm, hu, protoid, dlen);
+                continue;
+
+            case HCIBRCM_W4_SCO_HDR:
+                sh = hci_sco_hdr(brcm->rx_skb);
+                BRCM_HCI_DBG(V4L2_DBG_RX, "SCO header: dlen %d", sh->dlen);
+                brcm_check_data_len(brcm, hu, protoid, sh->dlen);
+                continue;
+
+            case FMBRCM_W4_EVENT_HDR:
+                fm = (struct fm_event_hdr *)brcm->rx_skb->data;
+                BRCM_HCI_DBG(V4L2_DBG_RX, "FM Header: evt 0x%2.2x plen %d",\
+                                                           fm->event, fm->plen);
+                brcm_check_data_len(brcm, hu, PROTO_SH_FM, fm->plen);
+                continue;
+
+            }
+        }
+        BRCM_HCI_DBG(V4L2_DBG_RX, "*ptr =%d",*ptr);
+
+        /* HCIBRCM_W4_PACKET_TYPE */
+        switch (*ptr) {
+        case HCI_EVENT_PKT:
+            BRCM_HCI_DBG(V4L2_DBG_RX, "Event packet");
+            brcm->rx_state = HCIBRCM_W4_EVENT_HDR;
+            brcm->rx_count = HCI_EVENT_HDR_SIZE;
+            type = HCI_EVENT_PKT;
+            protoid = PROTO_SH_BT;
+            break;
+
+        case HCI_ACLDATA_PKT:
+            BRCM_HCI_DBG(V4L2_DBG_RX, "ACL packet");
+            brcm->rx_state = HCIBRCM_W4_ACL_HDR;
+            brcm->rx_count = HCI_ACL_HDR_SIZE;
+            type = HCI_ACLDATA_PKT;
+            protoid = PROTO_SH_BT;
+            break;
+
+        case HCI_SCODATA_PKT:
+            BRCM_HCI_DBG(V4L2_DBG_RX, "SCO packet");
+            brcm->rx_state = HCIBRCM_W4_SCO_HDR;
+            brcm->rx_count = HCI_SCO_HDR_SIZE;
+            type = HCI_SCODATA_PKT;
+            protoid = PROTO_SH_BT;
+            break;
+
+        /* Channel 8(FM) packet */
+        case FM_CH8_PKT:
+            BRCM_HCI_DBG(V4L2_DBG_RX,"FM CH8 packet");
+            type = FM_CH8_PKT;
+            brcm->rx_state = FMBRCM_W4_EVENT_HDR;
+            brcm->rx_count = FM_EVENT_HDR_SIZE;
+            protoid = PROTO_SH_FM;
+            break;
+        default:
+            BRCM_HCI_DBG(V4L2_DBG_RX, "Unknown HCI packet type %2.2x",\
+                                                                   (__u8)*ptr);
+            ptr++; count--;
+            continue;
+        };
+
+        ptr++; count--;
+        BRCM_HCI_DBG(V4L2_DBG_RX, "*ptr =%d count %d protoid %d",*ptr,
+                                                              count,protoid);
+
+        switch (protoid)
+        {
+            case PROTO_SH_BT:
+            case PROTO_SH_FM:
+#ifdef V4L2_ANT
+            case PROTO_SH_ANT:
+#endif
+                /* Allocate new packet to hold received data */
+                brcm->rx_skb = alloc_skb(HCI_MAX_FRAME_SIZE, GFP_ATOMIC);
+                if(brcm->rx_skb)
+                    skb_reserve(brcm->rx_skb,8);
+                if (!brcm->rx_skb)
+                {
+                    BRCM_HCI_ERR("Can't allocate mem for new packet");
+                    brcm->rx_state = HCIBRCM_W4_PACKET_TYPE;
+                    brcm->rx_count = 0;
+                    return -ENOMEM;
+                }
+                brcm->rx_skb->dev = (void *) hu->hdev;
+                sh_ldisc_cb(brcm->rx_skb)->pkt_type = type;
+                break;
+            case PROTO_SH_MAX:
+            case PROTO_SH_GPS:
+                break;
+        }
+
+    }
+    BRCM_HCI_DBG(V4L2_DBG_RX, "%s count %d",__func__,count);
+
+    return count;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_dequeue()
+**
+** Description - Dequeue skb from the skb queue
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+static struct sk_buff *brcm_dequeue(struct hci_uart *hu)
+{
+    struct brcm_struct *brcm = hu->priv;
+    return skb_dequeue(&brcm->txq);
+}
+
+/*****************************************************************************
+**   UART API calls - End
+*****************************************************************************/
+
+
+
+/*****************************************************************************
+**
+** Function - brcm_init()
+**
+** Description - Registers the UART function pointers to the Line
+                  discipline driver. Called after the UART driver
+                  is loaded
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+int brcm_init(void)
+{
+    int err = brcm_hci_uart_register_proto(&brcmp);
+
+    if (!err)
+        BRCM_HCI_DBG(V4L2_DBG_INIT, "HCIBRCM protocol initialized");
+    else
+        BRCM_HCI_ERR("HCIBRCM protocol registration failed");
+
+    return err;
+}
+
+/*****************************************************************************
+**
+** Function - brcm_deinit()
+**
+** Description - Unregisters the UART function pointers from the Line
+                  discipline driver
+**
+** Returns - 0 if success; else errno
+**
+*****************************************************************************/
+
+int brcm_deinit(void)
+{
+    return brcm_hci_uart_unregister_proto(&brcmp);
+}
+
+

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -1,0 +1,239 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/*****************************************************************************
+**
+**  Name:           brcm_hci_uart.h
+**
+**  Description:    This is the header file for.Bluetooth HCI UART driver
+**
+*****************************************************************************/
+
+#ifndef BRCM_HCI_UART_H
+#define BRCM_HCI_UART_H
+
+#include <linux/platform_device.h>
+#include <linux/firmware.h>
+#include "../include/brcm_ldisc_sh.h"
+#include "../include/v4l2_target.h"
+
+#define TRUE 1
+#define FALSE 0
+
+/*****************************************************************************
+**  Constants & Macros
+*****************************************************************************/
+
+#ifndef N_BRCM_HCI
+#define N_BRCM_HCI      26
+#endif
+
+/* Ioctls */
+#define HCIUARTSETPROTO     _IOW('U', 200, int)
+#define HCIUARTGETPROTO     _IOR('U', 201, int)
+#define HCIUARTGETDEVICE    _IOR('U', 202, int)
+
+/* UART protocols */
+#define HCI_UART_MAX_PROTO      5
+
+/* #define HCI_UART_H4    0*/
+#define HCI_UART_BCSP           1
+#define HCI_UART_3WIRE          2
+#define HCI_UART_H4DS           3
+#define HCI_UART_LL             4
+#define HCI_UART_BRCM           0
+
+/* HCI_UART flag bits */
+#define HCI_UART_PROTO_SET      0
+
+/* TX states  */
+#define HCI_UART_SENDING        1
+#define HCI_UART_TX_WAKEUP      2
+
+#define LOCAL_NAME_BUFFER_LEN  32
+#define UART_DEV_NAME_LEN      32
+#define VENDOR_PARAMS_LEN 300
+
+/* time in msec to wait for
+ * line discipline to be installed
+ */
+#define LDISC_TIME             1500
+#define CMD_RESP_TIME          800
+#define CMD_WR_TIME            5000
+#define POR_RETRY_COUNT        5
+
+
+/* states of protocol list */
+#define LDISC_NOTEMPTY          1
+#define LDISC_EMPTY             0
+
+/*
+ * possible st_states
+ */
+#define LDISC_INITIALIZING      1
+#define LDISC_REG_IN_PROGRESS   2
+#define LDISC_REG_PENDING       3
+#define LDISC_WAITING_FOR_RESP  4
+
+/* HCI pkt event and command codes */
+#define HCI_FM_PKT           0x08
+
+/* Max size of HCI packet */
+#define V4L2_HCI_PKT_MAX_SIZE 1050
+
+/* time for workaround in msec to wait for closed tty */
+#define TTY_CLOSE_TIME          20000
+
+struct brcm_struct {
+    unsigned long rx_state;
+    unsigned long rx_count;
+    struct sk_buff *rx_skb;
+    struct sk_buff_head txq;
+    spinlock_t hcibrcm_lock;          /* HCIBRCM state lock */
+    unsigned long hcibrcm_state;      /* HCIBRCM power state */
+    unsigned short is_there_activity;
+    unsigned short inactive_period;
+    struct sk_buff_head tx_wait_q;    /* HCIBRCM wait queue */
+
+    void* hu;
+    char resp_buffer[30];
+};
+
+
+typedef struct hci_uart_proto hci_uart_proto;
+typedef struct hci_uart hci_uart;
+
+struct hci_uart_proto {
+    unsigned int id;
+    int (*open)(struct hci_uart *hu);
+    int (*close)(struct hci_uart *hu);
+    int (*flush)(struct hci_uart *hu);
+    int (*recv)(struct hci_uart *hu, void *data, int len);
+    int (*recv_int)(struct hci_uart *hu, void *data, int len);
+    int (*enqueue)(struct hci_uart *hu, struct sk_buff *skb);
+    struct sk_buff *(*dequeue)(struct hci_uart *hu);
+};
+
+struct hci_uart {
+    struct tty_struct *tty;
+    struct hci_dev *hdev;
+    unsigned long flags;
+
+    struct hci_uart_proto *proto;
+    struct brcm_struct *priv;
+    void *hdr_data;
+
+#if V4L2_SNOOP_ENABLE
+    void *snoop_hdr_data;
+#endif
+
+    struct sk_buff        *tx_skb;
+    unsigned long sh_ldisc_state;
+    unsigned long        tx_state;
+    spinlock_t        rx_lock;
+    struct sh_proto_s *list[PROTO_SH_MAX];
+    bool is_registered[PROTO_SH_MAX];
+    unsigned char    protos_registered;
+    spinlock_t lock;
+
+    struct completion cmd_rcvd, ldisc_installed, ldisc_patchram_complete,
+                uim_baudrate_set_complete;
+    char resp_buffer[30];
+    struct platform_device *brcm_pdev;
+    const struct firmware *fw_entry;
+
+    unsigned char ldisc_install;
+    unsigned char ldisc_bt_err;
+    unsigned char ldisc_fm_err;
+    spinlock_t err_lock;
+
+    //vendor params as comma separated string , read from bt_vendor.conf
+    char vendor_params[VENDOR_PARAMS_LEN];
+
+#if V4L2_SNOOP_ENABLE
+    spinlock_t hcisnoop_lock;
+    spinlock_t hcisnoop_write_lock;
+#endif
+    struct completion tty_close_complete;
+};
+
+typedef struct {
+    unsigned short          event;
+    unsigned short          len;
+    unsigned short          offset;
+    unsigned short          layer_specific;
+} hc_bt_hdr;
+
+
+/*****************************************************************************
+**  Functions
+*****************************************************************************/
+int brcm_init(void);
+int brcm_deinit(void);
+
+/*****************************************************************************
+**  Functions
+*****************************************************************************/
+
+int brcm_hci_uart_register_proto(struct hci_uart_proto *p);
+int brcm_hci_uart_unregister_proto(struct hci_uart_proto *p);
+int brcm_hci_uart_tx_wakeup(struct hci_uart *hu);
+void brcm_hci_uart_route_frame(enum proto_type protoid,
+                                      struct hci_uart *hu, struct sk_buff *skb);
+void brcm_hci_process_frametype( register int frame_type,
+                               struct hci_uart*hu,struct sk_buff *skb,int count);
+
+/**
+ * sh_ldisc_write -
+ * internal write function, passed onto protocol drivers
+ * via the write function ptr of protocol struct
+ */
+long brcm_sh_ldisc_write(struct sk_buff *);
+
+/**
+ * sh_ldisc_init -
+ * internal init function, passed onto protocol drivers
+ * via the init function ptr of protocol struct
+ */
+/* ask for reference from KIM */
+void hu_ref(struct hci_uart **, int);
+long brcm_sh_ldisc_start(struct hci_uart *hu);
+long brcm_sh_ldisc_stop(struct hci_uart *hu);
+
+#ifdef CONFIG_BT_HCIUART_H4
+int h4_init(void);
+int h4_deinit(void);
+#endif
+
+#ifdef CONFIG_BT_HCIUART_BCSP
+int bcsp_init(void);
+int bcsp_deinit(void);
+#endif
+
+#ifdef CONFIG_BT_HCIUART_LL
+int ll_init(void);
+int ll_deinit(void);
+#endif
+
+#ifdef CONFIG_BT_HCIUART_BRCM
+int brcm_init(void);
+int brcm_deinit(void);
+#endif
+
+#endif

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
@@ -1,0 +1,2452 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+*
+*  Filename:      brcm_sh_ldisc.c
+*
+*  Description:   Broadcom HCI Shared line discipline driver implementation
+*
+*******************************************************************************/
+
+#include <linux/module.h>
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/types.h>
+#include <linux/fcntl.h>
+#include <linux/interrupt.h>
+#include <linux/ptrace.h>
+#include <linux/poll.h>
+#include <linux/stat.h>
+#include <linux/moduleparam.h>
+
+#include <linux/slab.h>
+#include <linux/tty.h>
+#include <linux/errno.h>
+#include <linux/string.h>
+#include <linux/signal.h>
+#include <linux/ioctl.h>
+#include <linux/skbuff.h>
+#include <net/sock.h>
+#include <linux/netlink.h>
+#include <linux/semaphore.h>
+#include <linux/version.h>
+
+#include <net/bluetooth/bluetooth.h>
+#include <net/bluetooth/hci_core.h>
+
+#include "brcm_hci_uart.h"
+#include "../include/v4l2_target.h"
+#include "../include/fm.h"
+#include "../include/ant.h"
+#include "../include/v4l2_logs.h"
+
+#include <linux/dirent.h>
+#include <linux/ctype.h>
+#include <linux/tty.h>
+
+#include <linux/time.h>
+
+
+/*****************************************************************************
+**  Constants & Macros for dynamic logging
+*****************************************************************************/
+#ifndef BTLDISC_DEBUG
+#define BTLDISC_DEBUG TRUE
+#endif
+
+/* set this module parameter to enable debug info */
+int ldisc_dbg_param = 0;
+
+#if BTLDISC_DEBUG
+#define BT_LDISC_DBG(flag, fmt, arg...) \
+        do { \
+            if (ldisc_dbg_param & flag) \
+                printk(KERN_DEBUG "(brcmldisc):%s  "fmt"\n" , \
+                                           __func__,## arg); \
+        } while(0)
+#else
+#define BT_LDISC_DBG(flag, fmt, arg...)
+#endif
+
+#define BT_LDISC_ERR(fmt, arg...)  printk(KERN_ERR "(brcmldisc)ERR:%s  "fmt"\n" , \
+                                           __func__,## arg)
+
+#if V4L2_SNOOP_ENABLE
+/* parameter to enable HCI snooping */
+int ldisc_snoop_enable_param = 0;
+#endif
+
+/*******************************************************************************
+**  Constants & Macros
+************************************************************************************/
+
+#undef CONFIG_BT_HCIUART_BCSP
+#undef CONFIG_BT_HCIUART_LL
+#undef CONFIG_BT_HCIUART_H4
+
+
+#define PROTO_ENTRY(type, name) name
+const unsigned char *protocol_strngs[] = {
+    PROTO_ENTRY(ST_BT, "Bluetooth"),
+    PROTO_ENTRY(ST_FM, "FM"),
+    PROTO_ENTRY(ST_GPS, "GPS"),
+};
+/** Bluetooth Address */
+typedef struct {
+    uint8_t address[6];
+} __attribute__((packed))bt_bdaddr_t;
+
+#define RESP_BUFF_SIZE 1024
+
+/* Baudrate threshold to change UART clock rate to 48 MHz */
+#define CLOCK_SET_BAUDRATE 3000000
+
+/* Max length for FW patchfile name */
+#define FW_PATCH_FILENAME_MAXLEN 80
+
+#define BD_ADDR_SIZE 18
+#define LPM_PARAM_SIZE 100
+
+/* HCI HCI_V4L2 message type definitions */
+#define HCI_V4L2_TYPE_COMMAND         1
+#define HCI_V4L2_TYPE_ACL_DATA        2
+#define HCI_V4L2_TYPE_SCO_DATA        3
+#define HCI_V4L2_TYPE_EVENT           4
+#define HCI_V4L2_TYPE_FM_CMD          8
+
+
+/* Message event ID passed from stack to vendor lib */
+#define MSG_STACK_TO_HC_HCI_ACL        0x2100 /* eq. BT_EVT_TO_LM_HCI_ACL */
+#define MSG_STACK_TO_HC_HCI_SCO        0x2200 /* eq. BT_EVT_TO_LM_HCI_SCO */
+#define MSG_STACK_TO_HC_HCI_CMD        0x2000 /* eq. BT_EVT_TO_LM_HCI_CMD */
+#define MSG_FM_TO_HC_HCI_CMD           0x4000
+#define MSG_HC_TO_FM_HCI_EVT           0x3000
+
+/* struct to parse vendor params */
+typedef int (conf_action_t)(char *p_conf_name, char *p_conf_value);
+
+typedef struct {
+    const char *conf_entry;
+    conf_action_t *p_action;
+    long param;
+} conf_entry_t;
+
+/*******************************************************************************
+**  Local type definitions
+*******************************************************************************/
+spinlock_t  reg_lock;
+static int is_print_reg_error = 1;
+static unsigned long jiffi1, jiffi2;
+struct mutex cmd_credit;
+
+/* setting custom baudrate received from UIM */
+struct ktermios ktermios;
+static unsigned char bd_addr_array[6] = {0};
+char bd_addr[BD_ADDR_SIZE] = {0,};
+char fw_name[FW_PATCH_FILENAME_MAXLEN];
+
+#if V4L2_SNOOP_ENABLE
+/* enable/disable HCI snoop logging */
+char snoop_enable[2] = {0, 0};
+#endif
+
+/* module parameters */
+static char lpm_param[LPM_PARAM_SIZE];
+static long int custom_baudrate = 0;
+static int patchram_settlement_delay = 0;
+static int ControllerAddrRead = 0;
+static int LpmUseBluesleep = 0;
+static enum sleep_type sleep = SLEEP_DEFAULT;
+
+#if V4L2_SNOOP_ENABLE
+/* HCI snoop and netlink socket related variables */
+/* Variables for netlink sockets for hcisnoop */
+#define NETLINK_USER 29
+
+struct sock *nl_sk_hcisnoop = NULL;
+static int hcisnoop_client_pid = 0;
+static struct nlmsghdr *nlh;
+static struct sk_buff *hcisnoop_skb_out;
+#endif
+
+
+/*******************************************************************************
+**  Function forward-declarations and Function callback declarations
+*******************************************************************************/
+
+static struct hci_uart_proto *hup[HCI_UART_MAX_PROTO];
+
+#define MAX_BRCM_DEVICES    3   /* Imagine 1 on each UART for now */
+
+static struct platform_device *brcm_plt_devices[MAX_BRCM_DEVICES];
+
+
+/*******************************************************************************
+**  Function forward-declarations and Function callback declarations
+*******************************************************************************/
+/**
+  * internal functions to read chip name and
+ * download patchram file
+ */
+static long download_patchram(struct hci_uart*);
+static struct platform_device *ldisc_get_plat_device(int id);
+static int bcmbt_ldisc_remove(struct platform_device *pdev);
+
+/********************************************************************/
+
+
+/*****************************************************************************
+**  Type definitions
+*****************************************************************************/
+
+/* parsing functions */
+int parse_custom_baudrate(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%ld", &custom_baudrate);
+    return 0;
+}
+
+int parse_patchram_settlement_delay(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%d", &patchram_settlement_delay);
+    return 0;
+}
+
+int parse_LpmUseBluesleep(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%d", &LpmUseBluesleep);
+    if( LpmUseBluesleep )
+        sleep = SLEEP_BLUESLEEP;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%s sleep %d", __func__,sleep);
+    return 0;
+}
+
+int parse_ControllerAddrRead(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%d", &ControllerAddrRead);
+    return 0;
+}
+
+int parse_ldisc_snoop_enable_param(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%d", &ldisc_snoop_enable_param);
+    return 0;
+}
+
+int parse_lpm_param(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s strlen = %d\n", p_conf_name, p_conf_value, strlen(p_conf_value));
+    memset(lpm_param, 0, LPM_PARAM_SIZE);
+    strncpy(lpm_param, p_conf_value, strlen(p_conf_value));
+    pr_info("parse_lpm_param = %s\n", lpm_param);
+    return 0;
+}
+
+int dbg_ldisc_drv(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    sscanf(p_conf_value, "%d", &ldisc_dbg_param);
+    return 0;
+}
+
+int dbg_bt_drv(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    return 0;
+}
+
+int dbg_fm_drv(char *p_conf_name, char *p_conf_value)
+{
+    pr_info("%s = %s\n", p_conf_name, p_conf_value);
+    return 0;
+}
+
+static const conf_entry_t conf_table[] = {
+    {"custom_baudrate", parse_custom_baudrate, 0},
+    {"patchram_settlement_delay", parse_patchram_settlement_delay, 0},
+    {"LpmUseBluesleep", parse_LpmUseBluesleep, 0},
+    {"ControllerAddrRead", parse_ControllerAddrRead, 0},
+    {"ldisc_snoop_enable_param", parse_ldisc_snoop_enable_param, 0},
+    {"lpm_param" , parse_lpm_param, 0},
+    {"ldisc_dbg_param",dbg_ldisc_drv},
+    {"bt_dbg_param",dbg_bt_drv},
+    {"fm_dbg_param",dbg_fm_drv},
+    {(const char *) NULL, NULL, 0}
+};
+
+
+#if V4L2_SNOOP_ENABLE
+/* Function callback for netlink socket */
+static void brcm_hcisnoop_recv_msg(struct sk_buff *skb)
+{
+    struct nlmsghdr *nlh;
+
+    if(skb != NULL)
+    {
+        nlh = (struct nlmsghdr *)skb->data;
+        BT_LDISC_DBG(V4L2_DBG_TX,"hcisnoop: received read command from hcisnoop client: %s",\
+                                                       (char *)nlmsg_data(nlh));
+        hcisnoop_client_pid = nlh->nlmsg_pid; /*pid of sending process */
+        BT_LDISC_DBG(V4L2_DBG_TX,"hcisnoop: accepting request from pid=%d",\
+                                                           hcisnoop_client_pid);
+    }
+    else {
+        BT_LDISC_ERR("skb is NULL");
+    }
+
+    return;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
+struct netlink_kernel_cfg cfg = {
+    .input = brcm_hcisnoop_recv_msg,
+};
+#endif
+
+static int enable_snoop(void)
+{
+    int err;
+    if(ldisc_snoop_enable_param)
+    {
+        /* check whether snoop is enabled */
+        BT_LDISC_DBG(V4L2_DBG_TX, "ldisc_snoop_enable_param = %d",\
+            ldisc_snoop_enable_param);
+
+        /* close previously created socket */
+        if(nl_sk_hcisnoop)
+        {
+            netlink_kernel_release(nl_sk_hcisnoop);
+            nl_sk_hcisnoop = NULL;
+        }
+        /* start hci snoop to hcidump */
+        /* Create socket for hcisnoop */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0)
+        nl_sk_hcisnoop = netlink_kernel_create(&init_net, NETLINK_USER, 0,
+                    brcm_hcisnoop_recv_msg, NULL, THIS_MODULE);
+#else
+        nl_sk_hcisnoop = netlink_kernel_create(&init_net, NETLINK_USER, &cfg);
+#endif
+        if (!nl_sk_hcisnoop)
+        {
+            BT_LDISC_ERR("Error creating netlink socket for HCI snoop");
+            err = -10;
+            return err;
+        }
+        return 0;
+    }
+    else {
+        return 0;
+    }
+}
+
+/* Create netlink socket to snoop Line discipline driver from user space */
+int brcm_hci_snoop(struct hci_uart *hu, void* data, unsigned int count)
+{
+    int err=0;
+    unsigned long flags;
+    BT_LDISC_DBG(V4L2_DBG_TX , "brcm_hci_snoop");
+    /* Snoop and send data to hcidump */
+    if(hcisnoop_client_pid > 0)
+    {
+        spin_lock_irqsave(&hu->hcisnoop_lock, flags);
+        BT_LDISC_DBG(V4L2_DBG_TX , "Routing packet to hcisnoop"\
+            " client pid=%d data_len=%d", hcisnoop_client_pid, count);
+        /* Also route packet to hcisnoop client */
+        hcisnoop_skb_out = nlmsg_new(count, 0);
+
+        if (!hcisnoop_skb_out)
+        {
+            BT_LDISC_ERR("hcisnoop: Failed to allocate new skb");
+            spin_unlock_irqrestore(&hu->hcisnoop_lock, flags);
+            return -1;
+        }
+        nlh = nlmsg_put(hcisnoop_skb_out, 0, 0, NLMSG_DONE, count, 0);
+        NETLINK_CB(hcisnoop_skb_out).dst_group = 0; /* not in mcast group */
+        memcpy(nlmsg_data(nlh), (char *) data, count);
+
+        if(nl_sk_hcisnoop != NULL)
+        {
+            if ((err = nlmsg_unicast(nl_sk_hcisnoop, hcisnoop_skb_out,
+                    hcisnoop_client_pid)) < 0)
+            {
+                BT_LDISC_ERR("Error errcode=%d while sending packet to pid = %d",
+                    err, hcisnoop_client_pid);
+                hcisnoop_client_pid = 0;
+            }
+            else
+                BT_LDISC_DBG(V4L2_DBG_TX , "Forwarded hci packet"\
+                                                         "to hcisnoop client");
+        }
+        else {
+            BT_LDISC_ERR("nl_sk_hcisnoop == NULL");
+        }
+        spin_unlock_irqrestore(&hu->hcisnoop_lock, flags);
+    }
+
+    return 0;
+}
+
+#endif
+
+
+/* Function to abstract tty write. This will help in hci snooping both read and write packets */
+static int brcm_hci_write(struct hci_uart *hu, const unsigned char* data,
+                                                             unsigned int count)
+{
+    int len = 0;
+
+#if V4L2_SNOOP_ENABLE
+    if(nl_sk_hcisnoop)
+    {
+        unsigned long flags = 0;
+
+        hc_bt_hdr *hci_hdr;
+        uint8_t *p;
+
+        /* Snoop and send data to hcidump */
+        /* create header for snooping */
+        hci_hdr = (hc_bt_hdr *) hu->snoop_hdr_data;
+        if(hci_hdr != NULL)
+        {
+            hci_hdr->offset = 0;
+            hci_hdr->layer_specific = 0;
+            hci_hdr->len = count - 1;
+            BT_LDISC_DBG(V4L2_DBG_TX, "written values to hci_hdr");
+        }
+        else {
+            BT_LDISC_ERR("hci_hdr==NULL");
+            return -1;
+        }
+
+        /* write to tty->write for download patchram HCI commands */
+        if(hu->protos_registered == LDISC_EMPTY)
+        {
+            BT_LDISC_DBG(V4L2_DBG_TX, "writing to tty->write and snoop tx during"\
+                "download patchram");
+            spin_lock_irqsave(&hu->hcisnoop_write_lock, flags);
+            len = hu->tty->ops->write(hu->tty, data, count);
+            spin_unlock_irqrestore(&hu->hcisnoop_write_lock, flags);
+        }
+        else
+        {
+            BT_LDISC_DBG(V4L2_DBG_TX,"snoop tx from registered driver");
+        }
+
+        switch(data[0])
+        {
+                /* Construct header for sent packet */
+                case HCI_V4L2_TYPE_COMMAND:
+                    BT_LDISC_DBG(V4L2_DBG_TX, "HCI_V4L2_TYPE_COMMAND");
+                    hci_hdr->event = MSG_STACK_TO_HC_HCI_CMD;
+                    break;
+                case HCI_V4L2_TYPE_ACL_DATA:
+                    BT_LDISC_DBG(V4L2_DBG_TX, "HCI_V4L2_TYPE_ACL_DATA");
+                    hci_hdr->event = MSG_STACK_TO_HC_HCI_ACL;
+                    break;
+                case HCI_V4L2_TYPE_SCO_DATA:
+                    BT_LDISC_DBG(V4L2_DBG_TX, "HCI_V4L2_TYPE_SCO_DATA");
+                    hci_hdr->event = MSG_STACK_TO_HC_HCI_SCO;
+                    break;
+                case HCI_V4L2_TYPE_FM_CMD:
+                    BT_LDISC_DBG(V4L2_DBG_TX, "HCI_V4L2_TYPE_FM_CMD");
+                    hci_hdr->event = MSG_FM_TO_HC_HCI_CMD;
+                    break;
+                default:
+                    BT_LDISC_ERR("Unknown event for received packet event "\
+                        "= 0x%02X", data[0]);
+                    return count;
+                    break;
+        }
+
+        /* Hack to adjust layer_specific. Copy first 2 bytes of payload to layer_specific*/
+        memcpy(&hci_hdr->layer_specific, (uint8_t *)data + 1, 2);
+
+        /* Add HCI header */
+        p = (uint8_t *)(hci_hdr + 1);
+        /* Add payload */
+        memcpy(p, ((unsigned char *)data) + 1, count-1);
+        BT_LDISC_DBG(V4L2_DBG_TX, "Calling brcm_hci_snoop from brcm_hci_write");
+
+        brcm_hci_snoop(hu, hci_hdr, sizeof(hc_bt_hdr) + count - 1);
+    }
+    else
+#endif
+    {
+        len = hu->tty->ops->write(hu->tty, data, count);
+    }
+    return len;
+
+}
+
+/* parse and load vendor params */
+static int parse_vendor_params(void)
+{
+    struct hci_uart *hu;
+    conf_entry_t *p_entry;
+    char *p;
+    char *p_name, *p_value;
+    hu_ref(&hu, 0);
+
+    p = hu->vendor_params;
+    pr_info("parse_vendor_params = %s", hu->vendor_params);
+    while ((p_name = strsep(&p, " ")))
+    {
+        p_entry = (conf_entry_t *)conf_table;
+        while (p_entry->conf_entry != NULL)
+        {
+            if (strncmp(p_entry->conf_entry, (const char *)p_name, \
+                strlen(p_entry->conf_entry)) == 0)
+            {
+                p_value = strsep(&p_name, "=");
+                p_entry->p_action(p_value, p_name);
+                break;
+            }
+            p_entry++;
+        }
+    }
+    return 0;
+}
+
+static ssize_t show_install(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct hci_uart *hu = dev_get_drvdata(dev);
+    memcpy(buf, &hu->ldisc_install, sizeof(unsigned char));
+    return 1;
+}
+
+static ssize_t store_install(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    unsigned long flags = 0;
+    struct hci_uart *hu;
+    hu_ref(&hu, 0);
+
+    // Avoid race condition if all app (BT/FM/Ant) simultaneously try to write to install entry
+    spin_lock_irqsave(&hu->err_lock, flags);
+
+    /* When HCI command timeout or hardware error event occurs in an application,
+    * BT/FM/Ant apps should set a value 0x02 to "install sysfs" entry. Ldisc will set
+    * "bt_err" and "fm_err" for error indication. All applications which use V4L2 solution
+    * should now restart and reset bt_err and fm_err after recovery.
+    * E.g: If fm_err is already set, FM app concludes that BT app has already reported an error.
+    * FM app only needs to restart.
+    */
+    if ((hu->ldisc_install == V4L2_STATUS_ON) && (buf[0] == V4L2_STATUS_ERR) \
+        && ((hu->ldisc_bt_err == V4L2_ERR_FLAG_RESET) \
+        || (hu->ldisc_fm_err == V4L2_ERR_FLAG_RESET)))
+    {
+        hu->ldisc_install = V4L2_STATUS_ERR;
+        hu->ldisc_bt_err = V4L2_ERR_FLAG_SET;
+        hu->ldisc_fm_err = V4L2_ERR_FLAG_SET;
+        sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "install");
+        sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "bt_err");
+        sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "fm_err");
+        BT_LDISC_ERR("Error!: Userspace app has reported error. install = %c",\
+            buf[0]);
+    }
+    spin_unlock_irqrestore(&hu->err_lock, flags);
+    return size;
+}
+
+static ssize_t show_bt_err(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct hci_uart *hu = dev_get_drvdata(dev);
+    memcpy(buf, &hu->ldisc_bt_err, sizeof(unsigned char));
+    return 1;
+}
+
+static ssize_t store_bt_err(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    struct hci_uart *hu;
+    hu_ref(&hu, 0);
+    hu->ldisc_bt_err = buf[0];
+    return size;
+}
+
+static ssize_t show_fm_err(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct hci_uart *hu = dev_get_drvdata(dev);
+    memcpy(buf, &hu->ldisc_fm_err, sizeof(unsigned char));
+    return 1;
+}
+
+static ssize_t store_fm_err(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    struct hci_uart *hu;
+    hu_ref(&hu, 0);
+    hu->ldisc_fm_err = buf[0];
+
+    return size;
+}
+
+static ssize_t show_vendor_params(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct hci_uart *hu = dev_get_drvdata(dev);
+    memcpy(buf, hu->vendor_params, VENDOR_PARAMS_LEN);
+    return VENDOR_PARAMS_LEN;
+}
+
+static ssize_t store_vendor_params(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    struct hci_uart *hu;
+    hu_ref(&hu, 0);
+    memcpy(hu->vendor_params, buf, VENDOR_PARAMS_LEN);
+    parse_vendor_params();
+
+    // enable/disable snoop
+    if(enable_snoop()!=0)
+    {
+        BT_LDISC_ERR("Unable to enable HCI snoop in ldisc");
+    }
+
+    return size;
+}
+
+static ssize_t store_bdaddr(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    sprintf(bd_addr, "%s\n", buf);
+
+    pr_info("store_bdaddr  %s  size %d",bd_addr,size);
+    return size;
+}
+
+/* UIM will read firmware patch filename.
+    From one of the following
+    1. "FwPatchFileName" entry is present in bt_vendor.conf
+                                 OR
+    2. Read chip name through HCI command.and search through the directory
+        to find the exact match.
+    UIM passes the filename to ldisc as sysfs entry */
+static ssize_t store_fw_patchfile(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    sprintf(fw_name, "%s",buf);
+    BT_LDISC_DBG(V4L2_DBG_INIT,"store_fw_patchfile  %s size %d ",fw_name,size);
+    return size;
+}
+
+#if V4L2_SNOOP_ENABLE
+static ssize_t show_snoop_enable(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    return sprintf(buf, "%s", snoop_enable);
+}
+
+static ssize_t store_snoop_enable(struct device *dev,
+        struct device_attribute *attr, char *buf,size_t size)
+{
+    memcpy(&snoop_enable, buf, 1);
+    if(!ldisc_snoop_enable_param) {
+        // enable HCI snoop in line discipline driver
+        if(!strcmp(snoop_enable,"1")) {
+            if(nl_sk_hcisnoop)
+            {
+                netlink_kernel_release(nl_sk_hcisnoop);
+                nl_sk_hcisnoop = NULL;
+            }
+            /* start hci snoop to hcidump */
+            /* Create socket for hcisnoop */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0)
+            nl_sk_hcisnoop = netlink_kernel_create(&init_net, NETLINK_USER, 0,
+                        brcm_hcisnoop_recv_msg, NULL, THIS_MODULE);
+#else
+            nl_sk_hcisnoop = netlink_kernel_create(&init_net, NETLINK_USER, &cfg);
+#endif
+            if (!nl_sk_hcisnoop)
+            {
+                BT_LDISC_ERR("Error creating netlink socket for HCI snoop");
+            }
+            BT_LDISC_DBG(V4L2_DBG_TX, "enabling HCI snoop");
+        }
+        else {
+            /* stop hci snoop to hcidump */
+            if(nl_sk_hcisnoop)
+                netlink_kernel_release(nl_sk_hcisnoop);
+            nl_sk_hcisnoop = NULL;
+            BT_LDISC_DBG(V4L2_DBG_TX, "disabling HCI snoop");
+        }
+    }
+
+    return size;
+}
+#endif
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_bdaddr =
+__ATTR(bdaddr, 0666, NULL,(void *)store_bdaddr);
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_install =
+__ATTR(install, 0666, (void *)show_install, (void *)store_install);
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_vendor_params =
+__ATTR(vendor_params, 0666, (void *)show_vendor_params, (void *)store_vendor_params);
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_bt_err =
+__ATTR(bt_err, 0666, (void *)show_bt_err, (void *)store_bt_err);
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_fm_err =
+__ATTR(fm_err, 0666, (void *)show_fm_err, (void *)store_fm_err);
+
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_fw_patchfile =
+__ATTR(fw_patchfile, 0666, NULL, (void *)store_fw_patchfile);
+
+#if V4L2_SNOOP_ENABLE
+/* structures specific for sysfs entries */
+static struct kobj_attribute ldisc_snoop_enable =
+__ATTR(snoop_enable, 0666, (void *)show_snoop_enable, (void *)store_snoop_enable);
+#endif
+
+static struct attribute *uim_attrs[] = {
+    &ldisc_install.attr,
+    &ldisc_bdaddr.attr,
+    &ldisc_fw_patchfile.attr,
+#if V4L2_SNOOP_ENABLE
+    &ldisc_snoop_enable.attr,
+#endif
+    &ldisc_vendor_params.attr,
+    &ldisc_bt_err.attr,
+    &ldisc_fm_err.attr,
+    NULL,
+};
+
+static struct attribute_group uim_attr_grp = {
+    .attrs = uim_attrs,
+};
+
+
+static void add_channel_to_table(struct hci_uart*hu,
+        struct sh_proto_s *new_proto)
+{
+    BT_LDISC_DBG(V4L2_DBG_INIT, "id %d\n", new_proto->type);
+
+    /* list now has the channel id as index itself */
+    hu->list[new_proto->type] = new_proto;
+    hu->list[new_proto->type]->priv_data = new_proto->priv_data;
+    hu->is_registered[new_proto->type] = true;
+}
+
+static void remove_channel_from_table(struct hci_uart*hu,
+        enum proto_type proto)
+{
+    BT_LDISC_DBG(V4L2_DBG_INIT, "id %d\n", proto);
+    hu->list[proto] = NULL;
+    hu->is_registered[proto] = false;
+}
+
+/* to signal completion of line discipline installation
+ */
+void sh_ldisc_complete(void *sh_data)
+{
+    struct hci_uart*sh_gdata = (struct hci_uart*)sh_data;
+    complete(&sh_gdata->ldisc_installed);
+}
+
+
+/*******************************************************************************
+**  Functions
+*******************************************************************************/
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_register_proto()
+**
+** Description - Used by the lower layer to register UART protocol
+**             which can be H4, LL, BCSP etc
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+int brcm_hci_uart_register_proto(struct hci_uart_proto *p)
+{
+    if (p->id >= HCI_UART_MAX_PROTO)
+        return -EINVAL;
+
+    if (hup[p->id])
+        return -EEXIST;
+
+    hup[p->id] = p;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%p", p);
+
+    return 0;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_unregister_proto()
+**
+** Description - Used by the lower layer to unregister UART protocol
+**             which can be H4, LL, BCSP etc
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+int brcm_hci_uart_unregister_proto(struct hci_uart_proto *p)
+{
+    if (p->id >= HCI_UART_MAX_PROTO)
+        return -EINVAL;
+
+    if (!hup[p->id])
+        return -EINVAL;
+
+    hup[p->id] = NULL;
+
+    return 0;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_route_frame()
+**
+** Description - push the skb received to relevant upper layer
+**             protocol stacks, which could be BT, FM or GPS etc
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+void brcm_hci_uart_route_frame(enum proto_type protoid, struct hci_uart *hu,
+                    struct sk_buff *skb)
+{
+    BT_LDISC_DBG(V4L2_DBG_RX, " (prot:%d) ", protoid);
+
+#if V4L2_SNOOP_ENABLE
+    if(nl_sk_hcisnoop)
+    {
+        if (!(hu->is_registered[PROTO_SH_ANT] || hu->is_registered[PROTO_SH_FM])
+           || (skb->data)[11] != 0x03 || (skb->data)[12] != 0x0c)
+        {
+            /* forward to hcisnoop */
+            BT_LDISC_DBG(V4L2_DBG_RX, "capturing snoop skb->len=%d", skb->len);
+            brcm_hci_snoop(hu, skb->data, skb->len);
+
+            /* Remove hci header used for HCI snoop, before sending to fmdrv */
+            if(protoid == PROTO_SH_FM) {
+                skb_pull(skb, sizeof(hc_bt_hdr));
+            }
+        }
+    }
+#endif
+
+    /* Remove hci header used for HCI snoop, before sending to btdrv */
+    if(protoid == PROTO_SH_BT) {
+        char type = sh_ldisc_cb(skb)->pkt_type;
+        skb_pull(skb, sizeof(hc_bt_hdr));
+        memcpy(skb_push(skb, sizeof(char)),&type, sizeof(char));
+    }
+
+    if(mutex_is_locked(&cmd_credit))
+    {
+        if(protoid == PROTO_SH_BT)
+        {
+            if((skb->data[1]==0x0e && skb->data[3]==0x01) ||  // command_complete evt with hci_credit=1
+               (skb->data[1]==0x0f && skb->data[4]==0x01))    // command_status evt with hci_credit=1
+            {
+                complete_all(&hu->cmd_rcvd);
+            }
+        }
+        else if(protoid == PROTO_SH_FM || protoid == PROTO_SH_ANT)
+        {
+            if((skb->data[0]==0x0e && skb->data[2]==0x01) ||  // command_complete evt with hci_credit=1
+               (skb->data[0]==0x0f && skb->data[3]==0x01))    // command_status evt with hci_credit=1
+            {
+                complete_all(&hu->cmd_rcvd);
+            }
+        }
+    }
+
+    if (unlikely
+            (hu == NULL || skb == NULL
+                || hu->list[protoid] == NULL))
+    {
+        BT_LDISC_ERR("protocol %d not registered, no data to send?",
+                            protoid);
+        if (hu != NULL && skb != NULL)
+            kfree_skb(skb);
+
+        return;
+    }
+  /* this cannot fail. This shouldn't take long. Should be just skb_queue_tail for the
+    *   protocol stack driver
+    */
+    if (likely(hu->list[protoid]->recv != NULL))
+    {
+        if (unlikely
+        (hu->list[protoid]->recv
+        (hu->list[protoid]->priv_data, skb)
+        != 0))
+        {
+            BT_LDISC_ERR(" proto stack %d's ->recv failed", protoid);
+            kfree_skb(skb);
+            return;
+        }
+    }
+    else
+    {
+        BT_LDISC_ERR(" proto stack %d's ->recv null", protoid);
+        kfree_skb(skb);
+    }
+    return;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_get_proto()
+**
+** Description - Function to get the registered UART Protocol
+**             which can be H4, LL, BCSP etc
+**
+** Returns - Pointer to struct hci_uart_proto
+**
+*******************************************************************************/
+static struct hci_uart_proto *brcm_hci_uart_get_proto(unsigned int id)
+{
+    if (id >= HCI_UART_MAX_PROTO)
+        return NULL;
+
+    return hup[id];
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_set_proto()
+**
+** Description - Function to register the UART Protocol
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+static int brcm_hci_uart_set_proto(struct hci_uart *hu, int id)
+{
+    struct hci_uart_proto *p;
+    int err;
+
+    p = brcm_hci_uart_get_proto(id);
+    if (!p)
+        return -EPROTONOSUPPORT;
+
+    err = p->open(hu);
+    if (err)
+        return err;
+
+    hu->proto = p;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%p", p);
+    return 0;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_set_proto()
+**
+** Description - Called upon TX completion, prints packet type for debugging
+**               purposes
+**
+** Returns - void
+**
+*******************************************************************************/
+static inline void brcm_hci_uart_tx_complete(struct hci_uart *hu,
+                                                                   int pkt_type)
+{
+    /* Update HCI stat counters */
+    switch (pkt_type)
+    {
+        case HCI_COMMAND_PKT:
+            BT_LDISC_DBG(V4L2_DBG_TX, "HCI command packet txed");
+            break;
+
+        case HCI_ACLDATA_PKT:
+            BT_LDISC_DBG(V4L2_DBG_TX, "HCI ACL DATA packet txed");
+            break;
+
+        case HCI_SCODATA_PKT:
+            BT_LDISC_DBG(V4L2_DBG_TX ,"HCI SCO DATA packet txed");
+            break;
+    }
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_dequeue()
+**
+** Description - Function to dequeue SKB from the protocol queue
+**
+** Returns - Pointer to struct sk_buff
+**
+*******************************************************************************/
+static inline struct sk_buff *brcm_hci_uart_dequeue(struct hci_uart *hu)
+{
+    struct sk_buff *skb = hu->tx_skb;
+
+    if (!skb)
+        skb = hu->proto->dequeue(hu);
+    else
+        hu->tx_skb = NULL;
+
+    return skb;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_tx_wakeup()
+**
+** Description - Function to dequeue data and write data
+**               to UART driver
+**
+** Returns - Pointer to struct sk_buff
+**
+*******************************************************************************/
+int brcm_hci_uart_tx_wakeup(struct hci_uart *hu)
+{
+    struct tty_struct *tty = hu->tty;
+    struct sk_buff *skb;
+    unsigned long lock_flags;
+    if (test_and_set_bit(HCI_UART_SENDING, &hu->tx_state))
+    {
+        set_bit(HCI_UART_TX_WAKEUP, &hu->tx_state);
+        return 0;
+    }
+
+    BT_LDISC_DBG(V4L2_DBG_TX, "hci_uart_tx_wakeup");
+    brcm_btsleep_wake(sleep);
+
+    do{
+        clear_bit(HCI_UART_TX_WAKEUP, &hu->tx_state);
+
+        while ((skb = brcm_hci_uart_dequeue(hu))) {
+            int len;
+            spin_lock_irqsave(&hu->lock, lock_flags);
+
+            len = tty->ops->write(tty, skb->data, skb->len);
+
+            skb_pull(skb, len);
+            if (skb->len)
+            {
+                hu->tx_skb = skb;
+                set_bit(HCI_UART_TX_WAKEUP, &hu->tx_state);
+                spin_unlock_irqrestore(&hu->lock, lock_flags);
+                break;
+            }
+
+            brcm_hci_uart_tx_complete(hu, sh_ldisc_cb(skb)->pkt_type);
+            kfree_skb(skb);
+            spin_unlock_irqrestore(&hu->lock, lock_flags);
+        }
+    }while(test_bit(HCI_UART_TX_WAKEUP, &hu->tx_state));
+
+    clear_bit(HCI_UART_SENDING, &hu->tx_state);
+    return 0;
+}
+
+
+/*******************************************************************************
+**
+** Function - brcm_sh_ldisc_lpm_disable()
+**
+** Description - disable LPM before turning OFF the chip.
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+
+int brcm_sh_ldisc_lpm_disable(struct hci_uart *hu)
+{
+    const char hci_lpm_disable_cmd[] = {0x01,0x27,0xfc,0x0c,0x00,0x00,0x00,0x00,\
+                                        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
+
+    /* Perform LPM disable  */
+    brcm_hci_write(hu, hci_lpm_disable_cmd, 16);
+    if (!wait_for_completion_timeout
+          (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            BT_LDISC_ERR(" waiting for set LPM disable. Command response timed out");
+            return -ETIMEDOUT;
+    }
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "LPM disabled");
+    return 0;
+}
+
+void resetErrFlags(struct sh_proto_s *new_proto)
+{
+    struct hci_uart *hu;
+    hu_ref(&hu, 0);
+
+    // reset error flags as protocol driver has initiated registration
+    switch(new_proto->type) {
+        case PROTO_SH_BT:
+            hu->ldisc_bt_err = V4L2_ERR_FLAG_RESET;
+            BT_LDISC_DBG(V4L2_DBG_OPEN, "resetting bt_err");
+            sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "bt_err");
+            break;
+        case PROTO_SH_FM:
+            hu->ldisc_fm_err = V4L2_ERR_FLAG_RESET;
+            sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "fm_err");
+            BT_LDISC_DBG(V4L2_DBG_OPEN, "resetting fm_err");
+            break;
+        default:
+            BT_LDISC_ERR("Unknown proto id");
+    }
+
+}
+
+/*******************************************************************************
+**
+** Function - brcm_sh_ldisc_register()
+**
+** Description - Register protocol
+**              called from upper layer protocol stack drivers (BT or FM)
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+long brcm_sh_ldisc_register(struct sh_proto_s *new_proto)
+{
+    long err = 0;
+    unsigned long flags, diff;
+    struct hci_uart *hu;
+
+    hu_ref(&hu, 0);
+    BT_LDISC_DBG(V4L2_DBG_OPEN, "%p",hu);
+
+    if(new_proto->type != 0)
+    {
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "(%d) ", new_proto->type);
+    }
+    spin_lock_irqsave(&reg_lock, flags);
+    if (hu == NULL || /*hu->priv == NULL ||*/
+                new_proto == NULL || new_proto->recv == NULL)
+    {
+        spin_unlock_irqrestore(&reg_lock, flags);
+        if (is_print_reg_error)
+        {
+            BT_LDISC_DBG(V4L2_DBG_OPEN,"%d) ", new_proto->type);
+            pr_err("hu/new_proto/recv or reg_complete_cb not ready");
+            jiffi1 = jiffies;
+            is_print_reg_error = 0;
+        }
+        else
+        {
+            jiffi2 = jiffies;
+            diff = (long)jiffi2 - (long)jiffi1;
+            if ( ((diff *1000)/HZ) >= 1000)
+                is_print_reg_error = 1;
+        }
+        return -1;
+    }
+
+    /* check if received proto is a valid proto */
+    if (new_proto->type < PROTO_SH_BT || new_proto->type >= PROTO_SH_MAX)
+    {
+        spin_unlock_irqrestore(&reg_lock, flags);
+        pr_err("protocol %d not supported", new_proto->type);
+        return -EPROTONOSUPPORT;
+    }
+
+    /* check if protocol already registered */
+    if (hu->list[new_proto->type] != NULL)
+    {
+        spin_unlock_irqrestore(&reg_lock, flags);
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "protocol %d already registered", new_proto->type);
+        return -EALREADY;
+    }
+    if (test_bit(LDISC_REG_IN_PROGRESS, &hu->sh_ldisc_state)) {
+        BT_LDISC_DBG(V4L2_DBG_OPEN, " LDISC_REG_IN_PROGRESS:%d ", new_proto->type);
+        /* fw download in progress */
+
+        add_channel_to_table(hu, new_proto);
+        hu->protos_registered++;
+        new_proto->write = brcm_sh_ldisc_write;
+
+        set_bit(LDISC_REG_PENDING, &hu->sh_ldisc_state);
+        spin_unlock_irqrestore(&reg_lock, flags);
+        return -EINPROGRESS;
+    } else if (hu->protos_registered == LDISC_EMPTY) {
+        BT_LDISC_DBG(V4L2_DBG_OPEN, " chnl_id list empty :%d ", new_proto->type);
+        set_bit(LDISC_REG_IN_PROGRESS, &hu->sh_ldisc_state);
+
+        /* release lock previously held - re-locked below */
+        spin_unlock_irqrestore(&reg_lock, flags);
+
+        err = brcm_sh_ldisc_start(hu);
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "brcm_sh_ldisc_start response = %ld", err);
+        if (err != 0) {
+            clear_bit(LDISC_REG_IN_PROGRESS, &hu->sh_ldisc_state);
+            if ((hu->protos_registered != LDISC_EMPTY) &&
+                (test_bit(LDISC_REG_PENDING, &hu->sh_ldisc_state))) {
+                pr_err(" ldisc registration failed ");
+            }
+            return -EINVAL;
+        }
+
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "clearing flag LDISC_REG_IN_PROGRESS");
+        clear_bit(LDISC_REG_IN_PROGRESS, &hu->sh_ldisc_state);
+
+        BT_LDISC_DBG(V4L2_DBG_OPEN,"clearing flag LDISC_REG_PENDING");
+        clear_bit(LDISC_REG_PENDING, &hu->sh_ldisc_state);
+
+        /* check for already registered once more, since the above check is old */
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "checking already registerd proto");
+        if (hu->is_registered[new_proto->type] == true) {
+            pr_err(" proto %d already registered ",
+                   new_proto->type);
+            return -EALREADY;
+        }
+
+        spin_lock_irqsave(&reg_lock, flags);
+
+        add_channel_to_table(hu, new_proto);
+        hu->protos_registered++;
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "Changed hu->protos_registered = %d",
+                                                      hu->protos_registered);
+        new_proto->write = brcm_sh_ldisc_write;
+        spin_unlock_irqrestore(&reg_lock, flags);
+        resetErrFlags(new_proto);
+
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "exiting %s with err = %ld", __func__, err);
+        return err;
+    }
+    /* if firmware patchram is already downloaded & new protocol driver registers */
+    else {
+        add_channel_to_table(hu, new_proto);
+        hu->protos_registered++;
+        BT_LDISC_DBG(V4L2_DBG_OPEN, "Changed hu->protos_registered = %d",
+                                                      hu->protos_registered);
+        new_proto->write = brcm_sh_ldisc_write;
+        spin_unlock_irqrestore(&reg_lock, flags);
+        resetErrFlags(new_proto);
+        return err;
+    }
+
+    BT_LDISC_DBG(V4L2_DBG_OPEN, "done (%d) ", new_proto->type);
+    return err;
+}
+EXPORT_SYMBOL(brcm_sh_ldisc_register);
+
+
+/*******************************************************************************
+**
+** Function - brcm_sh_ldisc_unregister()
+**
+** Description - UnRegister protocol
+**              called from upper layer protocol stack drivers (BT or FM)
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+long brcm_sh_ldisc_unregister(enum proto_type type)
+{
+    long err = 0;
+    unsigned long flags;
+    struct hci_uart *hu;
+
+    BT_LDISC_DBG(V4L2_DBG_CLOSE,"%d ", type);
+
+    if (type < PROTO_SH_BT || type >= PROTO_SH_MAX)
+    {
+        pr_err(" protocol %d not supported", type);
+        return -EPROTONOSUPPORT;
+    }
+
+    spin_lock_irqsave(&reg_lock, flags);
+    hu_ref(&hu, 0);
+    BT_LDISC_DBG(V4L2_DBG_CLOSE, "%p ", hu);
+
+     if (hu == NULL)
+    {
+        spin_unlock_irqrestore(&reg_lock, flags);
+        pr_err(" protocol %d not registered", type);
+        return -EPROTONOSUPPORT;
+    }
+
+    if(hu->protos_registered > 0)
+        hu->protos_registered--;
+    BT_LDISC_DBG(V4L2_DBG_CLOSE, "Changed hu->protos_registered = %d",hu->protos_registered);
+    remove_channel_from_table(hu,type);
+    spin_unlock_irqrestore(&reg_lock, flags);
+
+    /* Power OFF chip only if no protos are registered.
+       Send notification to UIM to power OFF chip */
+    if ((hu->protos_registered == 0) &&
+        (!test_bit(LDISC_REG_PENDING, &hu->sh_ldisc_state)) &&
+        (!test_bit(LDISC_REG_IN_PROGRESS, &hu->sh_ldisc_state))) {
+
+        BT_LDISC_DBG(V4L2_DBG_CLOSE," all chnl_ids unregistered ");
+
+        /* stop traffic on tty */
+        if (hu->tty){
+            BT_LDISC_DBG(V4L2_DBG_CLOSE," calling tty_ldisc_flush ");
+            tty_ldisc_flush(hu->tty);
+            BT_LDISC_DBG(V4L2_DBG_CLOSE," calling stop_tty ");
+            stop_tty(hu->tty);
+        }
+
+        /* all chnl_ids now unregistered */
+        brcm_sh_ldisc_stop(hu);
+    }
+
+    return err;
+}
+EXPORT_SYMBOL(brcm_sh_ldisc_unregister);
+
+
+
+/*****************************************************************************
+* Function to encode baudrate from int to char sequence
+*****************************************************************************/
+void BRCM_encode_baud_rate(uint baud_rate, unsigned char *encoded_baud)
+{
+    if(baud_rate == 0 || encoded_baud == NULL) {
+        pr_err("Baudrate not supported!");
+        return;
+    }
+
+    encoded_baud[3] = (unsigned char)(baud_rate >> 24);
+    encoded_baud[2] = (unsigned char)(baud_rate >> 16);
+    encoded_baud[1] = (unsigned char)(baud_rate >> 8);
+    encoded_baud[0] = (unsigned char)(baud_rate & 0xFF);
+}
+
+typedef struct {
+    int baud_rate;
+    int termios_value;
+} tBaudRates;
+
+tBaudRates baud_rates[] = {
+    { 115200, B115200 },
+    { 230400, B230400 },
+    { 460800, B460800 },
+    { 500000, B500000 },
+    { 576000, B576000 },
+    { 921600, B921600 },
+    { 1000000, B1000000 },
+    { 1152000, B1152000 },
+    { 1500000, B1500000 },
+    { 2000000, B2000000 },
+    { 2500000, B2500000 },
+    { 3000000, B3000000 },
+	{ 4000000, B4000000 },
+};
+
+/*****************************************************************************
+* Function to lookup baudrate
+*****************************************************************************/
+int
+lookup_baudrate(long int baud_rate)
+{
+    unsigned int i;
+
+    for (i = 0; i < (sizeof(baud_rates) / sizeof(tBaudRates)); i++) {
+        if (baud_rates[i].baud_rate == baud_rate) {
+            return i;
+        }
+    }
+
+    return(-1);
+}
+
+
+/*****************************************************************************
+* Function to encode baudrate from int to char sequence
+*****************************************************************************/
+void
+BRCM_encode_bd_address( unsigned char  *bd_addrr)
+{
+    if(bd_addrr == NULL) {
+        pr_info("%s : BD addr not supported!", __func__);
+        return;
+    }
+
+    bd_addrr[0] = bd_addr_array[5];
+    bd_addrr[1] = bd_addr_array[4];
+    bd_addrr[2] = bd_addr_array[3];
+    bd_addrr[3] = bd_addr_array[2];
+    bd_addrr[4] = bd_addr_array[1];
+    bd_addrr[5] = bd_addr_array[0];
+}
+
+/*****************************************************************************
+* Function to read BD ADDR from bluetooth chip.
+*****************************************************************************/
+static long read_bd_addr(struct hci_uart *hu)
+{
+    long err = 0;
+    long len =0;
+    int i = 0;
+
+    struct tty_struct *tty;
+    const char hci_read_bdaddr[] = { 0x01, 0x09, 0x10, 0x00 };
+    tty = hu->tty;
+
+    init_completion(&hu->cmd_rcvd);
+
+    len = brcm_hci_write(hu, hci_read_bdaddr, 4);
+
+    if(!wait_for_completion_timeout
+            (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            pr_err(" waiting for READ_BD_ADDR command response - timed out ");
+            return -ETIMEDOUT;
+        }
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "read_bd_addr, received wait_completion");
+    for (i=0;i<=5;i++){
+        bd_addr_array[i] = (unsigned char)hu->priv->resp_buffer[7+i];
+    }
+    return err;
+}
+
+int str2bd(char *str, bt_bdaddr_t *addr)
+{
+    int32_t i = 0;
+    for (i = 0; i < 6; i++)
+    {
+        addr->address[i] = (uint8_t)simple_strtoul(str, &str, 16);
+        str++;
+    }
+    return 0;
+}
+
+
+int str2arr(char *str, uint8_t *addr,int len)
+{
+    int32_t i = 0;
+    for (i = 0; i < len; i++)
+    {
+      addr[i] = (uint8_t)simple_strtoul(str, &str, 16);
+       str++;
+    }
+    return 0;
+}
+
+/*****************************************************************************
+* Function to download firmware patchfile to bluetooth chip.
+*****************************************************************************/
+static long download_patchram(struct hci_uart *hu)
+{
+    long err = 0;
+    long len =0;
+    struct tty_struct *tty = hu->tty;
+    uint8_t hci_writesleepmode_cmd[35] = {0};
+    unsigned char *ptr;
+
+    const unsigned char hci_download_minidriver[] = { 0x01, 0x2e, 0xfc, 0x00 };
+    const unsigned char hci_reset_cmd[] = {0x01, 0x03, 0x0C, 0x00};
+    unsigned char hci_update_baud_rate[] = { 0x01, 0x18, 0xFC, 0x06,0x00, \
+                                               0x00,0x00,0x00,0x00,0x00 };
+    unsigned char hci_update_bd_addr[] = { 0x01, 0x01, 0xFC, 0x06,0x00, \
+                                               0x00,0x00,0x00,0x00,0x00 };
+    const char hci_uartclockset_cmd[] = {0x01, 0x45, 0xFC, 0x01, 0x01};
+
+    unsigned char *buf = NULL;
+    struct ktermios ktermios;
+	if (!(buf = kmalloc(RESP_BUFF_SIZE, GFP_KERNEL))) {
+        BT_LDISC_ERR("Unable to allocate memory for buf");
+        err = -ENOMEM;
+        goto error_state;
+    }
+
+    if (unlikely(hu == NULL || hu->tty == NULL)) {
+        err = -EINVAL;
+        goto error_state;
+    }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
+    memcpy(&ktermios, tty->termios, sizeof(ktermios));
+#else
+    memcpy(&ktermios, &(tty->termios), sizeof(ktermios));
+#endif
+    ptr = NULL;
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "tty = %p hu = %p", tty,hu);
+
+    /* request_firmware searches for patchram file. only in /vendor/firmware OR /etc/firmware */
+    BT_LDISC_DBG(V4L2_DBG_INIT, "firmware patchram file: %s", fw_name);
+    err = request_firmware(&hu->fw_entry, fw_name,
+                 &hu->brcm_pdev->dev);
+
+    /* patchram download failure */
+    if ((unlikely((err != 0) || (hu->fw_entry->data == NULL) ||
+         (hu->fw_entry->size == 0)))) {
+         BT_LDISC_ERR("************* ERROR !!! Unable to download patchram \
+            OR file %s not found **************", fw_name);
+    }
+    else {
+        ptr = (void *)hu->fw_entry->data;
+        len = hu->fw_entry->size;
+
+        BT_LDISC_DBG(V4L2_DBG_INIT, " with header patchram data ptr %p, \
+            len %ld ",ptr,len);
+
+        /* write command for hci_download_minidriver. Perform this before patchram download */
+        BT_LDISC_DBG(V4L2_DBG_INIT, "writing hci_download_minidriver");
+        init_completion(&hu->cmd_rcvd);
+
+        brcm_hci_write(hu, hci_download_minidriver, 4);
+
+        /* delay before patchram download */
+        msleep(50);
+
+        /* start downloading firmware */
+        do {
+            buf[0] = 0x01;
+            memcpy(buf+1, ptr, 3);
+            ptr += 3;
+            /* buf[3] holds the len of data to send */
+            memcpy(buf+4, ptr, buf[3]);
+            len -= buf[3] + 3;
+
+            init_completion(&hu->cmd_rcvd);
+            brcm_hci_write(hu, buf, buf[3] + 4);
+
+            ptr += buf[3];
+
+            if (!wait_for_completion_timeout
+              (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+                BT_LDISC_ERR(" waiting for download patchram command response \
+                    - timed out ");
+                return -ETIMEDOUT;
+            }
+        } while(len>0);
+
+        BT_LDISC_DBG(V4L2_DBG_INIT, "fw patchram download complete");
+
+        /* settlement delay */
+        BT_LDISC_DBG(V4L2_DBG_INIT, "patchram_settlement_delay = %d", \
+            patchram_settlement_delay);
+        msleep(patchram_settlement_delay);
+
+        /* firmware patchram download complete */
+        release_firmware(hu->fw_entry);
+
+        /* set baud rate to default */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
+        memcpy(&ktermios, tty->termios, sizeof(ktermios));
+#else
+        memcpy(&ktermios, &(tty->termios), sizeof(ktermios));
+#endif
+        BT_LDISC_DBG(V4L2_DBG_INIT, "before setting baudrate = %d\n",
+                                     (speed_t)(ktermios.c_cflag & CBAUD));
+        ktermios.c_cflag = (ktermios.c_cflag & ~CBAUD) | (B115200 & CBAUD);
+        tty_set_termios(tty, &ktermios);
+
+        msleep(20);
+
+        BT_LDISC_DBG(V4L2_DBG_INIT, "after setting baudrate = %d\n",
+                                           (speed_t)(ktermios.c_cflag & CBAUD));
+    }
+
+    /* Perform HCI Reset */
+    init_completion(&hu->cmd_rcvd);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "Performing HCI Reset");
+    brcm_hci_write(hu, hci_reset_cmd, 4);
+
+    if (!wait_for_completion_timeout
+          (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            pr_err(" waiting for HCI Reset command response - timed out ");
+            err = -ETIMEDOUT;
+            goto error_state;
+    }
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%s HCI Reset complete", __func__);
+
+    /* set UART clock rate to 48 MHz */
+    if( custom_baudrate > CLOCK_SET_BAUDRATE){
+        init_completion(&hu->cmd_rcvd);
+        BT_LDISC_DBG(V4L2_DBG_INIT, "Baudrate > %ld UART clock set to 48 MHz",
+                                                  (unsigned long)CLOCK_SET_BAUDRATE);
+        brcm_hci_write(hu, hci_uartclockset_cmd, 5);
+
+        if (!wait_for_completion_timeout
+               (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            BT_LDISC_ERR(" waiting for UART clock set command response \
+                - timed out");
+            err = -ETIMEDOUT;
+            goto error_state;
+        }
+    }
+
+    /* set baud rate back to custom baudrate */
+    init_completion(&hu->cmd_rcvd);
+    BT_LDISC_DBG(V4L2_DBG_INIT,"set baud rate back to %ld", custom_baudrate);
+
+    BRCM_encode_baud_rate(custom_baudrate, &hci_update_baud_rate[6]);
+
+    brcm_hci_write(hu, hci_update_baud_rate, 10);
+
+    if (!wait_for_completion_timeout
+          (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            pr_err(" waiting for set baud rate back to %ld command response \
+                - timed out", custom_baudrate);
+            err = -ETIMEDOUT;
+            goto error_state;
+    }
+
+    ktermios.c_cflag = (ktermios.c_cflag & ~CBAUD) |
+        (baud_rates[lookup_baudrate(custom_baudrate)].termios_value & CBAUD);
+    tty_set_termios(tty, &ktermios);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "after setting baudrate = %d\n",
+                                          (speed_t)(ktermios.c_cflag & CBAUD));
+
+    if(ControllerAddrRead){
+        /*Read controller address and set*/
+        pr_info("%s Read controller address and set", __func__);
+        err = read_bd_addr(hu);
+        if (err != 0) {
+            pr_err("ldisc: failed to read local name for patchram");
+            goto error_state;
+        }
+    }
+    else
+        str2bd(bd_addr,(bt_bdaddr_t*)bd_addr_array);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "BD ADDRESS going to  set is "\
+        "%02X:%02X:%02X:%02X:%02X:%02X",
+         bd_addr_array[0], bd_addr_array[1], bd_addr_array[2],
+         bd_addr_array[3], bd_addr_array[4], bd_addr_array[5]);
+
+    /* set BD address */
+    init_completion(&hu->cmd_rcvd);
+    BRCM_encode_bd_address(&hci_update_bd_addr[4]);
+
+    brcm_hci_write(hu, hci_update_bd_addr, 10);
+    if (!wait_for_completion_timeout
+          (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            pr_err(" waiting for set bd addr command response \
+                - timed out");
+            err = -ETIMEDOUT;
+            goto error_state;
+    }
+   BT_LDISC_DBG(V4L2_DBG_INIT, "BD ADDRESS set to "\
+        "%02X:%02X:%02X:%02X:%02X:%02X",
+        bd_addr_array[0], bd_addr_array[1], bd_addr_array[2],
+        bd_addr_array[3], bd_addr_array[4], bd_addr_array[5]);
+
+    /* Enable/Disable LPM should be configurable based on the module param */
+    init_completion(&hu->cmd_rcvd);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "lpm param %s", lpm_param);
+    str2arr(lpm_param, (uint8_t*) hci_writesleepmode_cmd, 16);
+
+     BT_LDISC_DBG(V4L2_DBG_INIT,"LPM PARAM set to "\
+        "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:"\
+        "%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+     hci_writesleepmode_cmd[0], hci_writesleepmode_cmd[1], hci_writesleepmode_cmd[2],
+     hci_writesleepmode_cmd[3],hci_writesleepmode_cmd[4], hci_writesleepmode_cmd[5],
+     hci_writesleepmode_cmd[6],hci_writesleepmode_cmd[7], hci_writesleepmode_cmd[8],
+     hci_writesleepmode_cmd[9],hci_writesleepmode_cmd[10], hci_writesleepmode_cmd[11],
+     hci_writesleepmode_cmd[12],hci_writesleepmode_cmd[13],hci_writesleepmode_cmd[14],
+     hci_writesleepmode_cmd[15]);
+
+    brcm_hci_write(hu, hci_writesleepmode_cmd, 16);
+    if (!wait_for_completion_timeout
+          (&hu->cmd_rcvd, msecs_to_jiffies(CMD_RESP_TIME))) {
+            pr_err(" waiting for set LPM command response timed out");
+            err = -ETIMEDOUT;
+            goto error_state;
+    }
+
+    err = 0;
+
+error_state:
+    if (buf != NULL) kfree(buf);
+    return err;
+}
+
+
+/**
+ * brcm_sh_ldisc_stop - called  on the last un-registration */
+
+long brcm_sh_ldisc_stop(struct hci_uart *hu)
+{
+    long err = 0;
+
+    INIT_COMPLETION(hu->ldisc_installed);
+
+    brcm_btsleep_stop(sleep);
+    hu->ldisc_install = V4L2_STATUS_OFF;
+
+    /* send uninstall notification to UIM */
+    sysfs_notify(&hu->brcm_pdev->dev.kobj, NULL, "install");
+
+    /* wait for ldisc to be un-installed */
+    err = wait_for_completion_timeout(&hu->ldisc_installed,
+            msecs_to_jiffies(LDISC_TIME));
+    if (!err) {     /* timeout */
+        BT_LDISC_ERR(" timed out waiting for ldisc to be un-installed");
+        return -ETIMEDOUT;
+    }
+
+    return err;
+}
+
+/**
+ *  This involves  reading the firmware version from chip,
+ *    forming the fw file name
+ *  based on the chip version, requesting the fw, parsing it
+ *  and perform download(send/recv).
+ */
+long brcm_sh_ldisc_start(struct hci_uart *hu)
+{
+    long err = 0;
+    long retry = POR_RETRY_COUNT;
+    long cl_err = 0;
+
+    struct tty_struct *tty = hu->tty;
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, " %p",tty);
+
+    do {
+        brcm_btsleep_start(sleep);
+        INIT_COMPLETION(hu->ldisc_installed);
+        /* send notification to UIM */
+        hu->ldisc_install = V4L2_STATUS_ON;
+        BT_LDISC_DBG(V4L2_DBG_INIT, "ldisc_install = %c",\
+            hu->ldisc_install);
+        sysfs_notify(&hu->brcm_pdev->dev.kobj,
+            NULL, "install");
+
+        /* wait for ldisc to be installed */
+        err = wait_for_completion_timeout(&hu->ldisc_installed,
+                msecs_to_jiffies(LDISC_TIME));
+        if (!err) { /* timeout */
+            pr_err("line disc installation timed out ");
+            INIT_COMPLETION(hu->tty_close_complete);
+            err = brcm_sh_ldisc_stop(hu);
+            cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
+                    msecs_to_jiffies(TTY_CLOSE_TIME));
+            if (!cl_err) { /* timeout */
+                pr_err("tty close timed out");
+                break;
+            }
+            continue;
+        } else {
+            /* ldisc installed now */
+            BT_LDISC_DBG(V4L2_DBG_INIT, " line discipline installed ");
+            err = download_patchram(hu);
+            if (err != 0) {
+                pr_err("patchram download failed");
+                INIT_COMPLETION(hu->tty_close_complete);
+                brcm_sh_ldisc_stop(hu);
+                cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
+                        msecs_to_jiffies(TTY_CLOSE_TIME));
+                if (!cl_err) { /* timeout */
+                    pr_err("tty close timed out");
+                    break;
+                }
+                continue;
+            } else {/* on success don't retry */
+                BT_LDISC_DBG(V4L2_DBG_INIT, "patchram downloaded successfully");
+                // initialize lock for err flags
+                spin_lock_init(&hu->err_lock);
+                break;
+            }
+        }
+    } while (retry--);
+
+    return err;
+}
+
+
+/*******************************************************************************
+**
+** Function - brcm_sh_ldisc_write()
+**
+** Description - Function to write to the shared line discipline driver
+**              called from upper layer protocol stack drivers (BT or FM)
+**              via the write function pointer
+**
+** Returns - 0 if success; errno otherwise
+**
+*******************************************************************************/
+long brcm_sh_ldisc_write(struct sk_buff *skb)
+{
+    enum proto_type protoid = PROTO_SH_MAX;
+    long len;
+    struct brcm_struct *brcm;
+    char ptr[6];
+
+    struct hci_uart *hu;
+    hu_ref(&hu,0);
+
+    brcm = hu->priv;
+
+
+    BT_LDISC_DBG(V4L2_DBG_TX, "%p",hu);
+
+    if (unlikely(skb == NULL))
+    {
+        pr_err("data unavailable to perform write");
+        return -1;
+    }
+
+    if (unlikely(hu == NULL || hu->tty == NULL))
+    {
+        pr_err("tty unavailable to perform write");
+        return -1;
+    }
+
+    switch (sh_ldisc_cb(skb)->pkt_type)
+    {
+        case HCI_COMMAND_PKT:
+        case HCI_ACLDATA_PKT:
+        case HCI_SCODATA_PKT:
+            protoid = PROTO_SH_BT;
+            break;
+#ifdef V4L2_ANT
+       case ANT_PKT:
+            protoid = PROTO_SH_ANT;
+            break;
+#endif
+        case FM_CH8_PKT:
+            protoid = PROTO_SH_FM;
+            break;
+    }
+
+    if (unlikely(hu->list[protoid] == NULL))
+    {
+        pr_err(" protocol %d not registered, and writing? ",
+                            protoid);
+        return -1;
+    }
+
+    len = skb->len;
+
+    if ((hu->is_registered[PROTO_SH_ANT] || hu->is_registered[PROTO_SH_FM])
+            && (skb->data)[1] == 0x03 && (skb->data)[2] == 0x0c)
+    {
+        if (likely(hu->list[PROTO_SH_BT]->recv != NULL))
+        {
+            brcm->rx_skb = alloc_skb(HCI_MAX_FRAME_SIZE, GFP_ATOMIC);
+            if(brcm->rx_skb)
+                skb_reserve(brcm->rx_skb,8);
+
+            brcm->rx_skb->dev = (void *) hu->hdev;
+            sh_ldisc_cb(brcm->rx_skb)->pkt_type = HCI_EVENT_PKT;
+
+            ptr[0] = 0x0e;
+            ptr[1] = 0x04;
+            ptr[2] = 0x01;
+            ptr[3] = 0x03;
+            ptr[4] = 0x0c;
+            ptr[5] = 0x00;
+
+            memcpy(skb_put(brcm->rx_skb, 6), ptr, 6);
+
+            brcm_hci_process_frametype(HCI_EVENT_PKT,hu,brcm->rx_skb, 6);
+            brcm_hci_uart_route_frame(PROTO_SH_BT, hu, brcm->rx_skb);
+        }
+    }
+    else
+    {
+        if (hu->protos_registered > 1 &&
+           (sh_ldisc_cb(skb)->pkt_type == HCI_COMMAND_PKT ||
+            sh_ldisc_cb(skb)->pkt_type == FM_CH8_PKT ||
+            sh_ldisc_cb(skb)->pkt_type == ANT_PKT))
+        {
+            mutex_lock(&cmd_credit);
+            init_completion(&hu->cmd_rcvd);
+
+            hu->proto->enqueue(hu, skb);
+
+            /* forward to snoop */
+#if V4L2_SNOOP_ENABLE
+            if(nl_sk_hcisnoop)
+                brcm_hci_write(hu, skb->data, skb->len);
+#endif
+            brcm_hci_uart_tx_wakeup(hu);
+            if (!wait_for_completion_timeout(&hu->cmd_rcvd, msecs_to_jiffies(5000))) {
+                pr_err(" waiting for command response - timed out");
+                return 0;
+            }
+            mutex_unlock(&cmd_credit);
+        }
+        else
+        {
+            hu->proto->enqueue(hu, skb);
+
+            /* forward to snoop */
+#if V4L2_SNOOP_ENABLE
+            if(nl_sk_hcisnoop)
+                brcm_hci_write(hu, skb->data, skb->len);
+#endif
+            brcm_hci_uart_tx_wakeup(hu);
+        }
+    }
+
+    /* return number of bytes written */
+    return len;
+}
+
+/*****************************************************************************
+**   Shared line discipline driver APIs
+*****************************************************************************/
+/*******************************************************************************
+**
+** Function - hci_uart_tty_open
+**
+** Description - Called when line discipline changed to HCI_UART.
+**
+** Arguments - tty    pointer to tty info structure
+**
+** Returns - 0 if success, otherwise error code
+**
+*******************************************************************************/
+static int brcm_hci_uart_tty_open(struct tty_struct *tty)
+{
+    struct hci_uart *hu;
+    unsigned long flags;
+#if V4L2_SNOOP_ENABLE
+    hc_bt_hdr *snoop_hci_hdr;
+    hc_bt_hdr *snoop_hci_recv_hdr;
+#endif
+    hu_ref(&hu, 0);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "tty open %p hu %p", tty,hu);
+
+    /* don't do an wakeup for now */
+    clear_bit(TTY_DO_WRITE_WAKEUP, &tty->flags);
+
+    tty->disc_data = hu;
+    hu->tty = tty;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "tty open %p hu %p", tty,hu);
+    tty->receive_room = N_TTY_BUF_SIZE;
+
+    spin_lock_irqsave(&reg_lock, flags);
+    spin_unlock_irqrestore(&reg_lock, flags);
+
+    spin_lock_init(&hu->rx_lock);
+    spin_lock_init(&hu->lock);
+
+#if V4L2_SNOOP_ENABLE
+    spin_lock_init(&hu->hcisnoop_lock);
+    spin_lock_init(&hu->hcisnoop_write_lock);
+#endif
+
+    /* Flush any pending characters in the driver and line discipline. */
+    if (tty->ldisc->ops->flush_buffer)
+        tty->ldisc->ops->flush_buffer(tty);
+    tty_driver_flush_buffer(tty);
+
+#if V4L2_SNOOP_ENABLE
+    /* used to create header in snoop */
+    snoop_hci_hdr = kzalloc(V4L2_HCI_PKT_MAX_SIZE, GFP_ATOMIC);
+    if (!snoop_hci_hdr) {
+        BT_LDISC_ERR("could not allocate memory to snoop_hci_hdr");
+        return -ENOMEM;
+    }
+    else {
+        hu->snoop_hdr_data = snoop_hci_hdr;
+    }
+
+    /* used to create header for snoop during internal command response */
+    snoop_hci_recv_hdr = kzalloc(V4L2_HCI_PKT_MAX_SIZE, GFP_ATOMIC);
+    if (!snoop_hci_recv_hdr) {
+        BT_LDISC_ERR("could not allocate memory to snoop_hci_hdr");
+        return -ENOMEM;
+    }
+    else {
+        hu->hdr_data = snoop_hci_recv_hdr;
+    }
+#endif
+
+   /* installation of N_BRCM_HCI ldisc complete */
+    sh_ldisc_complete(hu);
+
+    return 0;
+}
+
+/*******************************************************************************
+**
+** Function - hci_uart_tty_close
+**
+** Description - Called when the line discipline is changed to something
+**              else, the tty is closed, or the tty detects a hangup.
+**
+** Arguments - tty    pointer to associated tty instance data
+**
+** Returns - void
+**
+*******************************************************************************/
+static void brcm_hci_uart_tty_close(struct tty_struct *tty)
+{
+    struct hci_uart *hu = (void *)tty->disc_data; /* assign tty instance to hci_uart */
+    int i;
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "tty= %p", tty);
+
+    /* Detach from the tty */
+    tty->disc_data = NULL;
+
+    tty_ldisc_flush(tty);
+
+    if (tty->ldisc->ops->flush_buffer)
+        tty->ldisc->ops->flush_buffer(tty);
+
+    tty_driver_flush_buffer(tty);
+
+#if V4L2_SNOOP_ENABLE
+    /* release memory allocated for snooping */
+    if(hu->snoop_hdr_data){
+        kfree(hu->snoop_hdr_data);
+        hu->snoop_hdr_data = NULL;
+    }
+    if(hu->hdr_data){
+        kfree(hu->hdr_data);
+        hu->hdr_data = NULL;
+    }
+#endif
+
+    if (hu)
+    {
+        if (test_and_clear_bit(HCI_UART_PROTO_SET, &hu->flags))
+        {
+            hu->proto->close(hu);
+            hu->protos_registered =0;
+            BT_LDISC_DBG(V4L2_DBG_CLOSE, "brcm_hci_uart_tty_close protos_registered = %d",
+                                     hu->protos_registered);
+            for (i = PROTO_SH_BT; i < PROTO_SH_MAX; i++)
+            {
+                if (hu->list[i] != NULL)
+                {
+                    BT_LDISC_ERR("%d not un-registered, unregistering now", i);
+                    remove_channel_from_table(hu,i);
+                }
+            }
+        }
+    }
+    sh_ldisc_complete(hu);
+    hu->tty = 0;
+    complete(&hu->tty_close_complete);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "tty close exit");
+}
+
+/*******************************************************************************
+**
+** Function - hci_uart_tty_wakeup
+**
+** Description - Callback for transmit wakeup. Called when low level
+**              device driver can accept more send data.
+**
+** Arguments - tty    pointer to associated tty instance data
+**
+** Returns - void
+**
+*******************************************************************************/
+static void brcm_hci_uart_tty_wakeup(struct tty_struct *tty)
+{
+    struct hci_uart *hu = (void *)tty->disc_data; /* assign tty instance to hci_uart */
+
+    if (!hu)
+        return;
+
+    if (tty != hu->tty)
+        return;
+
+    clear_bit(TTY_DO_WRITE_WAKEUP, &tty->flags);
+}
+
+/*******************************************************************************
+**
+** Function - hci_uart_tty_receive
+**
+** Description - Called by tty low level driver when receive data is available.
+**
+* Arguments - tty          pointer to tty isntance data
+*             data         pointer to received data
+*             flags        pointer to flags for data
+*             count        count of received data in bytes
+** Returns - void
+**
+*******************************************************************************/
+static void brcm_hci_uart_tty_receive(struct tty_struct *tty,
+                                         const u8 *data, char *flags, int count)
+{
+    struct hci_uart *hu = (void *)tty->disc_data; /* assign tty instance to hci_uart */
+    unsigned long lock_flags;
+
+    if (!hu || tty != hu->tty)
+        return;
+
+    if (!test_bit(HCI_UART_PROTO_SET, &hu->flags))
+        return;
+
+    spin_lock_irqsave(&hu->rx_lock, lock_flags);
+
+    hu->proto->recv(hu, (void *) data, count);
+
+    spin_unlock_irqrestore(&hu->rx_lock, lock_flags);
+
+}
+
+/*******************************************************************************
+**
+** Function - hci_uart_tty_ioctl
+**
+** Description - Process IOCTL system call for the tty device.
+**
+** Arguments - tty  pointer to tty instance data
+**    file          pointer to open file object for device
+**    cmd           IOCTL command code
+**    arg           argument for IOCTL call (cmd dependent)
+*** Returns - 0 if success, otherwise error code
+**
+*******************************************************************************/
+static int brcm_hci_uart_tty_ioctl(struct tty_struct *tty,
+                        struct file * file, unsigned int cmd, unsigned long arg)
+{
+    struct hci_uart *hu = (void *)tty->disc_data; /* assign tty instance to hci_uart */
+    int err = 0;
+
+    BT_LDISC_DBG(V4L2_DBG_INIT,"cmd %d", cmd);
+
+    /* Verify the status of the device */
+    if (!hu)
+        return -EBADF;
+
+    switch (cmd)
+        {
+        case HCIUARTSETPROTO:
+            BT_LDISC_DBG(V4L2_DBG_INIT, "SETPROTO %lu hu %p", arg, hu);
+            if (!test_and_set_bit(HCI_UART_PROTO_SET, &hu->flags))
+            {
+                err = brcm_hci_uart_set_proto(hu, arg);
+                if (err) {
+                    pr_err("error set proto");
+                    clear_bit(HCI_UART_PROTO_SET, &hu->flags);
+                    return err;
+                }
+            } else
+                return -EBUSY;
+            break;
+
+        case HCIUARTGETPROTO:
+            BT_LDISC_DBG(V4L2_DBG_INIT, "GETPROTO");
+            if (test_bit(HCI_UART_PROTO_SET, &hu->flags))
+                return hu->proto->id;
+            return -EUNATCH;
+
+        case HCIUARTGETDEVICE:
+            BT_LDISC_DBG(V4L2_DBG_INIT,"GETDEVICE");
+            if (test_bit(HCI_UART_PROTO_SET, &hu->flags))
+                return hu->hdev->id;
+            return -EUNATCH;
+
+        default:
+            err = n_tty_ioctl_helper(tty, file, cmd, arg);
+            break;
+    }
+
+    return err;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_tty_read
+**
+** Description - Read interface for sh_ldisc driver. Not supported
+**
+*******************************************************************************/
+static ssize_t brcm_hci_uart_tty_read(struct tty_struct *tty,
+       struct file *file, unsigned char __user *buf, size_t nr)
+{
+    BT_LDISC_DBG(V4L2_DBG_RX, "%s", __func__);
+
+return 0;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_tty_read
+**
+** Description - Read interface for sh_ldisc driver. Not supported
+**
+*******************************************************************************/
+static ssize_t brcm_hci_uart_tty_write(struct tty_struct *tty,
+                     struct file *file, const unsigned char *data, size_t count)
+{
+    BT_LDISC_DBG(V4L2_DBG_TX, "%s", __func__);
+
+    return 0;
+}
+
+/*******************************************************************************
+**
+** Function - brcm_hci_uart_tty_read
+**
+** Description - Read interface for sh_ldisc driver. Not supported
+**
+*******************************************************************************/
+static unsigned int brcm_hci_uart_tty_poll(struct tty_struct *tty,
+                    struct file *filp, poll_table *wait)
+{
+    BT_LDISC_DBG(V4L2_DBG_RX, "%s", __func__);
+
+    return 0;
+}
+static void brcm_hci_uart_tty_set_termios(struct tty_struct *tty,
+                                                   struct ktermios *new_termios)
+{
+    struct ktermios *newktermios;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "new_termios->c_ispeed = %d, "\
+        "new_termios->c_ospeed = %d",
+        new_termios->c_ispeed, new_termios->c_ospeed);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0)
+    newktermios =  tty->termios;
+#else
+    newktermios =  &(tty->termios);
+#endif
+    newktermios->c_ispeed= tty_termios_input_baud_rate(newktermios);
+    newktermios->c_ospeed = tty_termios_baud_rate(newktermios);
+}
+
+/*****************************************************************************
+**   Module INIT interface
+*****************************************************************************/
+static int brcm_hci_uart_init( void )
+
+{
+    static struct tty_ldisc_ops hci_uart_ldisc;
+    int err;
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "HCI BRCM UART driver ver %s", VERSION);
+
+    /* Register the tty discipline */
+
+    memset(&hci_uart_ldisc, 0, sizeof (hci_uart_ldisc));
+    hci_uart_ldisc.magic        = TTY_LDISC_MAGIC;
+    hci_uart_ldisc.name     = "n_brcm_hci";
+    hci_uart_ldisc.open     = brcm_hci_uart_tty_open;
+    hci_uart_ldisc.close        = brcm_hci_uart_tty_close;
+    hci_uart_ldisc.read     = brcm_hci_uart_tty_read;
+    hci_uart_ldisc.write        = brcm_hci_uart_tty_write;
+    hci_uart_ldisc.ioctl        = brcm_hci_uart_tty_ioctl;
+    hci_uart_ldisc.poll     = brcm_hci_uart_tty_poll;
+    hci_uart_ldisc.receive_buf  = brcm_hci_uart_tty_receive;
+    hci_uart_ldisc.write_wakeup = brcm_hci_uart_tty_wakeup;
+    hci_uart_ldisc.owner        = THIS_MODULE;
+    hci_uart_ldisc.set_termios = brcm_hci_uart_tty_set_termios;
+
+    if ((err = tty_register_ldisc(N_BRCM_HCI, &hci_uart_ldisc)))
+    {
+        pr_err("HCI line discipline registration failed. (%d)", err);
+        return err;
+    }
+
+#ifdef CONFIG_BT_HCIUART_H4
+    h4_init();
+#endif
+#ifdef CONFIG_BT_HCIUART_BCSP
+    bcsp_init();
+#endif
+#ifdef CONFIG_BT_HCIUART_LL
+    ll_init();
+#endif
+#ifdef CONFIG_BT_HCIUART_BRCM
+    brcm_init();
+#endif
+
+    /* initialize register lock spinlock */
+    spin_lock_init(&reg_lock);
+
+    return 0;
+}
+
+
+/*****************************************************************************
+**   Module EXIT interface
+*****************************************************************************/
+static void brcm_hci_uart_exit(struct hci_uart* hu)
+{
+    int err = 0;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%s", __func__);
+
+#ifdef CONFIG_BT_HCIUART_H4
+    h4_deinit();
+#endif
+#ifdef CONFIG_BT_HCIUART_BCSP
+    bcsp_deinit();
+#endif
+#ifdef CONFIG_BT_HCIUART_LL
+    ll_deinit();
+#endif
+#ifdef CONFIG_BT_HCIUART_BRCM
+    brcm_deinit();
+#endif
+
+    kfree_skb(hu->tx_skb);
+    /* Release tty registration of line discipline */
+    if ((err = tty_unregister_ldisc(N_BRCM_HCI)))
+        BT_LDISC_ERR("Can't unregister HCI line discipline (%d)", err);
+}
+
+/**
+ * ldisc_get_plat_device -
+ *  function which returns the reference to the platform device
+ *  requested by id. As of now only 1 such device exists (id=0)
+ *  the context requesting for reference can get the id to be
+ *  requested by a. The protocol driver which is registering or
+ *  b. the tty device which is opened.
+ */
+static struct platform_device *ldisc_get_plat_device(int id)
+{
+    return brcm_plt_devices[id];
+}
+
+
+/**
+ * hu_ref - reference the core's data
+ *  This references the per-ST platform device in the arch/xx/
+ *  board-xx.c file.
+ *  This would enable multiple such platform devices to exist
+ *  on a given platform
+ */
+void hu_ref(struct hci_uart**priv, int id)
+{
+    struct platform_device  *pdev;
+    struct hci_uart *hu;
+    /* get hu reference from platform device */
+    pdev = ldisc_get_plat_device(id);
+    if (!pdev) {
+        *priv = NULL;
+        return;
+    }
+    hu = dev_get_drvdata(&pdev->dev);
+    *priv = hu;
+}
+
+/**************************************************************
+* bcmbt_ldisc_probe -
+* Used for checking whether specified device hardware exists.
+***************************************************************/
+static int bcmbt_ldisc_probe(struct platform_device *pdev)
+{
+
+    int rc;
+    struct hci_uart *hu;
+    printk("%s\n",  __func__);
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%s", __func__);
+    mutex_init(&cmd_credit);
+
+    if ((pdev->id != -1) && (pdev->id < MAX_BRCM_DEVICES)) {
+        /* multiple devices could exist */
+        brcm_plt_devices[pdev->id] = pdev;
+    } else {
+        /* platform's sure about existence of 1 device */
+        brcm_plt_devices[0] = pdev;
+    }
+
+    hu = kzalloc(sizeof(struct hci_uart), GFP_ATOMIC);
+    memset(hu, 0, sizeof(struct hci_uart));
+    if (!hu) {
+        pr_err("no mem to allocate");
+        return -ENOMEM;
+    }
+    dev_set_drvdata(&pdev->dev, hu);
+
+    BT_LDISC_DBG(V4L2_DBG_INIT, "%s calling brcm_hci_uart_init ", __func__);
+
+    /* register the tty line discipline driver */
+    rc = brcm_hci_uart_init();
+    if (rc) {
+        pr_err("%s: brcm_hci_uart_init failed\n", __func__);
+        return -1;
+    }
+
+    /* get reference of pdev for request_firmware
+     */
+    hu->brcm_pdev = pdev;
+    init_completion(&hu->cmd_rcvd);
+    init_completion(&hu->ldisc_installed);
+    init_completion(&hu->tty_close_complete);
+
+    rc = sysfs_create_group(&pdev->dev.kobj, &uim_attr_grp);
+    if (rc) {
+        pr_err("failed to create sysfs entries");
+        return rc;
+    }
+
+    return 0;
+}
+
+static int bcmbt_ldisc_remove(struct platform_device *pdev)
+{
+    struct hci_uart* hu;
+    BT_LDISC_DBG(V4L2_DBG_INIT, "bcmbt_ldisc_remove() unloading ");
+    mutex_destroy(&cmd_credit);
+#if V4L2_SNOOP_ENABLE
+    if(ldisc_snoop_enable_param)
+    {
+        /* stop hci snoop to hcidump */
+        if(nl_sk_hcisnoop)
+            netlink_kernel_release(nl_sk_hcisnoop);
+    }
+#endif
+    hu = dev_get_drvdata(&pdev->dev);
+    sysfs_remove_group(&pdev->dev.kobj, &uim_attr_grp);
+    brcm_hci_uart_exit(hu);
+    kfree(hu);
+    hu  = NULL;
+    return 0;
+}
+
+static const struct of_device_id bcmbt_ldisc_dt_ids[] = {
+    { .compatible = "bcmbt_ldisc"},
+    {}
+};
+
+/* Sys_fs entry bcm_ldisc. The Line discipline driver sets this to 1 when bluedroid performs open on BT
+  * protocol driver or application performs open on FM v4l2 driver */
+/* Note: This entry is used in bt_hci_bdroid.c (Android source). Also present in
+ *  brcm_sh_ldisc.c (v4l2_drivers) and board specific file (android kernel source) */
+static struct platform_driver bcmbt_ldisc_platform_driver = {
+    .probe = bcmbt_ldisc_probe,
+    .remove = bcmbt_ldisc_remove,
+    .driver = {
+           .name = "bcm_ldisc",
+           .owner = THIS_MODULE,
+           .of_match_table = bcmbt_ldisc_dt_ids,
+           },
+};
+
+module_platform_driver(bcmbt_ldisc_platform_driver);
+
+
+/*****************************************************************************
+**   Module Details
+*****************************************************************************/
+
+MODULE_PARM_DESC(reset, "Send HCI reset command on initialization");
+
+MODULE_AUTHOR("Broadcom");
+MODULE_DESCRIPTION("Line Discipline Driver for Shared Transport" \
+                                                      "over UART ver ");
+MODULE_VERSION(VERSION); /* defined in makefile */
+MODULE_LICENSE("GPL");
+MODULE_ALIAS_LDISC(N_BRCM_HCI);

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/Makefile
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/Makefile
@@ -1,0 +1,10 @@
+# Makefile for V4L2 FM driver
+
+fm_drv-objs := fmdrv_main.o fmdrv_v4l2.o fmdrv_rx.o
+obj-$(CONFIG_V4L2_FM_DRIVER) := fm_drv.o
+
+KBUILD_CFLAGS += -w
+EXTRA_CFLAGS := -I$(PWD)/../include/
+
+ccflags-y += -w -DVERSION="\"1.2\""
+ccflags-y += -DDEF_V4L2_FM_AUDIO_PATH=FM_AUDIO_I2S

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fm_public.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fm_public.h
@@ -1,0 +1,95 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/************************************************************************************
+ *
+ *  Filename:      fm_public.h
+ *
+ *  Description:   FM Driver public header file.
+ *
+ ***********************************************************************************/
+
+#ifndef _FM_PUBLIC_H
+#define _FM_PUBLIC_H
+
+/*******************************************************************************
+**  Constants & Macros
+*******************************************************************************/
+
+#define    FM_REGION_EUR    0x00
+#define    FM_REGION_JP     0x01
+#define    FM_REGION_NA     0x02
+#define    FM_REGION_RUS    0x03
+#define    FM_REGION_CHN    0x04
+#define    FM_REGION_IT     0x05
+
+#define    FM_RDS_BIT       1<<4
+#define    FM_RBDS_BIT      1<<5
+#define    FM_AF_BIT        1<<6
+
+#define     FM_REGION_MAX           FM_REGION_JP
+/* low 3 bits (bit0, 1)of FUNC mask is region code */
+#define     FM_REGION_MASK          (FM_REGION_NA | FM_REGION_EUR)
+
+/* FM audio output mode */
+enum
+{
+    FM_AUTO_MODE = 1,   /* auto blend by default */
+    FM_STEREO_MODE,     /* manual stereo switch */
+    FM_MONO_MODE,       /* manual mono switch */
+    FM_SWITCH_MODE      /* auto stereo, and switch activated */
+};
+
+/* FM audio routing configuration */
+#define FM_AUDIO_NONE       0x00  /* No FM audio output */
+#define FM_AUDIO_DAC        0x01  /* routing FM over analog output */
+#define FM_AUDIO_I2S        0x02  /* routing FM over digital (I2S) output */
+#define FM_AUDIO_BT_MONO    0x04  /* routing FM over SCO */
+#define FM_AUDIO_BT_STEREO  0x08  /* routing FM over BT Stereo */
+
+#define     FM_DEEMPHA_50U      0       /* 6th bit in FM_AUDIO_CTRL0 set to 0, Europe default */
+#define     FM_DEEMPHA_75U      (1<<6)  /* 6th bit in FM_AUDIO_CTRL0 set to 1, US  default */
+
+#define  FM_STEP_50KHZ      0x00
+#define  FM_STEP_100KHZ     0x01
+#define  FM_STEP_200KHZ     0x02
+
+#define  CHL_SPACE_ONE      0x01
+#define  CHL_SPACE_TWO      0x02
+#define  CHL_SPACE_FOUR     0x04
+
+
+
+#define FM_GET_FREQ(x) ((unsigned short) ((x * 10) - 64000))
+#define FM_SET_FREQ(x) ((unsigned int) ((x + 64000)/10))
+enum
+{
+    FM_RDS,
+    FM_RBDS
+};
+
+#ifndef FALSE
+#define FALSE  0
+#endif
+
+#ifndef TRUE
+#define TRUE  1
+#endif
+
+#endif

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
@@ -1,0 +1,260 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+/************************************************************************************
+ *
+ *  Filename:    fmdrv.h
+ *
+ *  Description: Common header for all FM driver sub-modules.
+ *
+ ***********************************************************************************/
+#ifndef _FM_DRV_H
+#define _FM_DRV_H
+
+#include <linux/skbuff.h>
+#include <linux/interrupt.h>
+#include <sound/core.h>
+#include <sound/initval.h>
+#include <linux/timer.h>
+#include <linux/version.h>
+#include <linux/videodev2.h>
+
+/*******************************************************************************
+**  Constants & Macros
+*******************************************************************************/
+
+#define FM_DRV_VERSION            "1.01"
+
+/* Should match with FM_DRV_VERSION */
+#define FM_DRV_RADIO_VERSION      KERNEL_VERSION(1, 0, 1)
+#define FM_DRV_NAME               "brcm_fmdrv"
+#define FM_DRV_CARD_SHORT_NAME    "BRCM FM Radio"
+#define FM_DRV_CARD_LONG_NAME     "Broadcom corporation FM Radio"
+
+/* Flag info */
+#define FM_CORE_READY                 3
+
+#define FM_DRV_TX_TIMEOUT       (5*HZ)  /* 5 sec */
+#define FM_DRV_RX_SEEK_TIMEOUT       (20*HZ)  /* 20 sec */
+
+#define NO_OF_ENTRIES_IN_ARRAY(array) (sizeof(array) / sizeof(array[0]))
+
+/* bits in register FM_RDS_SYS    0x00 */
+#define FM_OFF                     0x00
+#define FM_ON                      0x01
+#define FM_RDS_ON                  0x02
+
+/* bits in register I2C_FM_REG_AUD_CTL0  0x05 */
+#define FM_RF_MUTE                 0x0001    /* bit0 */
+#define FM_MANUAL_MUTE             0x0002    /* bit1 */
+#define FM_Z_MUTE_LEFT_OFF         0x0004    /* bit2 */
+#define FM_Z_MUTE_RITE_OFF         0x0008   /* bit3 */
+#define FM_AUDIO_DAC_ON            0x0010    /* bit4 */
+#define FM_AUDIO_I2S_ON            0x0020    /* bit5 */
+#define FM_DEEMPHA_75_ON           0x0040    /* bit6 */
+#define FM_AUDIO_BAND_WIDTH        0x0080    /* bit7 */
+
+/* bits in register FM_REG_FM_CTRL  0x01 */
+#define FM_BAND_REG_WEST           0x00
+#define FM_BAND_REG_EAST           0x01
+#define FM_STEREO_AUTO             0x02
+#define FM_STEREO_MANUAL           0x04
+#define FM_STEREO_SWITCH           0x08
+#define FM_HI_LO_INJ               0x10
+
+/* bits in register FM_REG_RDS_CTL0  0x02 */
+#define FM_RDS_CTRL_RDS            0x00
+#define FM_RDS_CTRL_RBDS           0x01
+#define FM_RDS_CTRL_FIFO_FLUSH     0x02
+
+/* the highest bit on I2C_FM_REG_PCM_ROUTE register */
+#define FM_PCM_ROUTE_ON_BIT        0x80    /* FM on SCO */
+
+#define FM_STEP_NONE               0xff
+
+/* FM/RDS flag bits */
+#define FM_RDS_FLAG_CLEAN_BIT       0x01 /* clean FM_RDS_FLAG region */
+#define FM_RDS_FLAGSCH_FRZ_BIT          0x02 /* interrupt freeze */
+#define FM_RDS_FLAG_SCH_BIT         0x04 /* Pending search_tune */
+
+/* bits in I2C_FM_REG_FM_RDS_FLAG 0x12 */
+#define I2C_MASK_SRH_TUNE_CMPL_BIT     (0x0001 << 0)    /* FM/RDS register search/tune cmpl bit */
+#define I2C_MASK_SRH_TUNE_FAIL_BIT     (0x0001 << 1)    /* FM/RDS register search/tune fail bit */
+#define I2C_MASK_RSSI_LOW_BIT          (0x0001 << 2)    /* FM/RDS registerRSSI low bit */
+#define I2C_MASK_CARR_HI_ERR_BIT       (0x0001 << 3)    /* FM/RDS register carrier high err bit */
+#define I2C_MASK_AUDIO_PAUSE_BIT       (0x0001 << 4)    /* audio has paused for the specific threshold and duration */
+#define I2C_MASK_STEREO_DETC_BIT       (0x0001 << 5)    /* FM/RDS register search/tune cmpl bit */
+#define I2C_MASK_STEREO_ACTIVE_BIT     (0x0001 << 6)    /* FM/RDS register search/tune fail bit */
+/* second bytes of FM_RDS_FLG 0x13 */
+#define I2C_MASK_RDS_FIFO_WLINE_BIT    (0x0100 << 1)    /* RDS tuples are currently available at
+                                                        a level >= waterline */
+#define I2C_MASK_BB_MATCH_BIT          (0x0100 << 3)    /* PI code match found */
+#define I2C_MASK_SYNC_LOST_BIT         (0x0100 << 4)    /* RDS synchronization was lost */
+#define I2C_MASK_PI_MATCH_BIT          (0x0100 << 5)    /* PI code match found */
+
+/* FM_REG_RDS_DATA 0x80 reading */
+#define FM_RDS_END_TUPLE_1ST_BYTE     0x7c /* 1st byte of a RDS ending tuple */
+#define FM_RDS_END_TUPLE_2ND_BYTE    0xff /* 2nd byte of a RDS ending tuple */
+#define FM_RDS_END_TUPLE_3RD_BYTE    0xff /* 3rd byte of a RDS ending tuple */
+
+/* FM/RDS flag bits used with fm_dev->rx.fm_rds_flag */
+#define     FM_RDS_FLAG_CLEAN_BIT         0x01    /* clean FM_RDS_FLAG register */
+#define     FM_RDS_FLAG_SCH_FRZ_BIT     0x02    /* interrupt freeze */
+#define     FM_RDS_FLAG_SCH_BIT             0x04    /* pending search_tune */
+
+#define     FM_RDS_UPD_TUPLE            64       /* 64 tuples per read(64*3 = 192 bytes),
+                                                    one tuple contains 1 RDS block  */
+
+#define     FM_READ_1_BYTE_DATA     1
+#define     FM_READ_2_BYTE_DATA     2
+
+#define TRUE 1
+#define FALSE 0
+
+#define WORKER_QUEUE TRUE
+
+enum {
+    FM_MODE_OFF,
+    FM_MODE_TX,
+    FM_MODE_RX,
+    FM_MODE_ENTRY_MAX
+};
+
+enum fm_seek_tune_state
+{
+    FM_STATE_NONE,
+    FM_STATE_TUNING,
+    FM_STATE_TUNE_CMPL,
+    FM_STATE_TUNE_ERR,
+    FM_STATE_SEEKING,
+    FM_STATE_SEEK_CMPL,
+    FM_STATE_SEEK_ERR
+};
+
+/*******************************************************************************
+**  Type definitions
+*******************************************************************************/
+
+/* FM region (Europe/US, Japan) info */
+struct region_info {
+    unsigned short  low_bound;   /* lowest frequency boundary */
+    unsigned short  high_bound;     /* highest frequency boundary */
+    unsigned char   deemphasis;     /* FM de-emphasis time constant */
+    unsigned char    scan_step;      /* scanning step */
+    unsigned char    fm_band;
+};
+
+/* RDS info */
+struct fm_rds {
+    unsigned char rds_flag; /* RX RDS on/off status */
+    /* RDS buffer */
+    wait_queue_head_t read_queue;
+    unsigned int buf_size; /* Size is always multiple of 3 */
+    unsigned int wr_index;
+    unsigned int rd_index;
+    unsigned char *cbuffer;
+
+};
+
+/* FM RX mode info */
+struct fm_rx {
+    struct region_info region;      /* Current selected band */
+    unsigned char curr_region;
+    unsigned int curr_freq;         /* Current RX frquency */
+    unsigned char curr_mute_mode;   /* Current mute mode */
+    unsigned short curr_volume;     /* Current volume level */
+    char  curr_snr_threshold;       /* Current SNR threshold level */
+    unsigned char curr_rssi_threshold;  /* Current RSSI threshold value */
+    unsigned char curr_sch_mode;    /* current search mode */
+    unsigned char curr_noise_floor; /* current noise floor estimation */
+    unsigned char rds_mode;         /* RDS operation mode (RDS/RDBS) */
+    unsigned char curr_rssi;        /* Cached value of RSSI for the current frequency */
+    unsigned char audio_mode;
+    unsigned char audio_path;
+    unsigned short aud_ctrl;
+    unsigned char pcm_reg;
+    unsigned char sch_step;
+    unsigned char seek_direction;
+    unsigned char seek_wrap;
+    unsigned char curr_search_state;
+    unsigned short fm_rds_mask;     /* FM/RDS interrupt mask */
+    unsigned short fm_rds_flag;     /* FM/RDS interrupt flag */
+    unsigned char fm_func_mask;
+    struct fm_rds rds;
+
+    u8 af_mode;         /* Alternate frequency on/off */
+    u8 no_of_chans;     /* Number stations found */
+    char current_pins[3]; /*Current pins configuration. either I2S or PCM*/
+};
+
+struct fm_device_info {
+    unsigned int capabilities;       /* Device capabilities */
+    unsigned int tuner_capability;   /* Tuner capability */
+    enum v4l2_tuner_type type;
+    unsigned int rxsubchans;
+    unsigned int aud_mode;
+};
+
+/* FM driver operation structure */
+struct fmdrv_ops {
+    struct video_device *radio_dev;   /* V4L2 video device pointer */
+    spinlock_t resp_skb_lock;         /* To protect access to received SKB */
+    spinlock_t rds_cbuff_lock;        /* To protect access to RDS Circular buffer */
+
+    long flag;                         /*  FM driver state machine info */
+    struct sk_buff_head rx_q;          /* RX queue */
+#ifdef TASKLET_SUPPORT
+    struct tasklet_struct rx_task;  /* RX Tasklet */
+    struct tasklet_struct tx_task;  /* TX Tasklet */
+#else
+    struct workqueue_struct *tx_wq;     /* Fm workqueue */
+    struct work_struct tx_workqueue;    /* Tx work queue */
+    struct workqueue_struct *rx_wq;     /* Fm workqueue */
+    struct work_struct rx_workqueue;    /* Rx work queue */
+#endif
+    struct sk_buff_head tx_q;          /* TX queue */
+
+    unsigned long last_tx_jiffies;  /* Timestamp of last pkt sent */
+    atomic_t tx_cnt;                         /* Number of packets can send at a time */
+
+    struct sk_buff *response_skb;   /* Response from the chip */
+    /* Main task completion handler */
+    struct completion maintask_completion;
+    /* Seek task completion handler */
+    struct completion seektask_completion;
+    /* Opcode of last command sent to the chip */
+    unsigned char last_sent_pkt_opcode;
+    /* Handler used for wakeup when response packet is received */
+    struct completion *response_completion;
+    unsigned char curr_fmmode;   /* Current FM chip mode (TX, RX, OFF) */
+    unsigned char aud_ctrl;     /* Current Audio Control (STEREO/MONO/NONE) */
+    struct fm_rx rx;                         /* FM receiver info */
+    struct fm_device_info device_info; /* FM Device info */
+};
+
+#define GET_PI_CODE     1
+#define GET_TP_CODE     2
+#define GET_PTY_CODE    3
+#define GET_TA_CODE     4
+#define GET_MS_CODE     5
+#define GET_PS_CODE     6
+#define GET_RT_MSG      7
+#define GET_CT_DATA     8
+#define GET_TMC_CHANNEL 9
+
+#endif

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
@@ -218,15 +218,12 @@ struct fmdrv_ops {
 
     long flag;                         /*  FM driver state machine info */
     struct sk_buff_head rx_q;          /* RX queue */
-#ifdef TASKLET_SUPPORT
-    struct tasklet_struct rx_task;  /* RX Tasklet */
-    struct tasklet_struct tx_task;  /* TX Tasklet */
-#else
+
     struct workqueue_struct *tx_wq;     /* Fm workqueue */
     struct work_struct tx_workqueue;    /* Tx work queue */
     struct workqueue_struct *rx_wq;     /* Fm workqueue */
     struct work_struct rx_workqueue;    /* Rx work queue */
-#endif
+
     struct sk_buff_head tx_q;          /* TX queue */
 
     unsigned long last_tx_jiffies;  /* Timestamp of last pkt sent */

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_config.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_config.h
@@ -1,0 +1,97 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+
+/************************************************************************************
+ *
+ *  Filename:      fmdrv_config.h
+ *
+ *  Description:   Configuration file for V4L2 FM driver module.
+ *  Configurations such as World region, Scan step, Audio mode, NFL will be set
+ *  in this file as these params are not defined by the standard V4L2 driver
+ *
+ ***********************************************************************************/
+
+#ifndef _FM_DRV_CONFIG_H
+#define _FM_DRV_CONFIG_H
+
+#include "fm_public.h"
+#include "fmdrv_main.h"
+#include <media/v4l2-common.h>
+
+/*******************************************************************************
+**  Constants & Macros
+*******************************************************************************/
+
+/* Set default World region */
+#define DEF_V4L2_FM_WORLD_REGION FM_REGION_NA
+
+/* Set default Audio mode */
+#define DEF_V4L2_FM_AUDIO_MODE FM_AUTO_MODE
+
+/* Set default Audio path */
+#ifndef DEF_V4L2_FM_AUDIO_PATH
+#define DEF_V4L2_FM_AUDIO_PATH FM_AUDIO_DAC
+#endif
+
+/*Make this TRUE if FM I2S audio to be routed over */
+/*PCM lines in master mode */
+#ifndef ROUTE_FM_I2S_SLAVE_TO_PCM_PINS
+#define ROUTE_FM_I2S_SLAVE_TO_PCM_PINS FALSE
+#endif
+
+#ifndef ROUTE_BT_I2S_MASTER_TO_PCM_PINS
+#define ROUTE_BT_I2S_MASTER_TO_PCM_PINS FALSE
+#endif
+
+/*Make this TRUE if FM I2S audio to be routed over */
+/*PCM lines in slave mode */
+#ifndef ROUTE_FM_I2S_MASTER_TO_PCM_PINS
+#define ROUTE_FM_I2S_MASTER_TO_PCM_PINS FALSE
+#endif
+
+/*Never make both the above macros TRUE*/
+#if (ROUTE_FM_I2S_SLAVE_TO_PCM_PINS) && (ROUTE_FM_I2S_MASTER_TO_PCM_PINS)
+#error "I2S should be either master or slave"
+#endif
+
+/*Whenw e enable FM over PCM, audio path should be I2S*/
+#if (ROUTE_FM_I2S_SLAVE_TO_PCM_PINS) || (ROUTE_FM_I2S_MASTER_TO_PCM_PINS)
+#define DEF_V4L2_FM_AUDIO_PATH FM_AUDIO_I2S
+#endif
+
+/* FM driver debug flag. Set this to FALSE for Production release */
+#ifndef V4L2_FM_DEBUG
+#define V4L2_FM_DEBUG TRUE
+#endif
+
+/* FM enable delay time, default set to 300 millisecond */
+#ifndef V4L2_FM_ENABLE_DELAY
+#define V4L2_FM_ENABLE_DELAY             300
+#endif
+
+/* FM driver RDS debug flag. Set this to FALSE for Production release */
+#define V4L2_RDS_DEBUG TRUE
+
+/* Set default Noise Floor Estimation value */
+#define DEF_V4L2_FM_NFE 93
+#define DEF_V4L2_FM_SIGNAL_STRENGTH 105
+#define DEF_V4L2_FM_RSSI 0x55 /* RSSI threshold value 85 dBm */
+
+#endif
+

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.c
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.c
@@ -1,0 +1,1715 @@
+/*
+ *  FM Driver for Connectivity chip of Broadcom Corporation.
+ *
+ *  This sub-module of FM driver is common for FM RX and TX
+ *  functionality. This module is responsible for:
+ *  1) Forming group of Channel-8 commands to perform particular
+ *     functionality (eg., frequency set require more than
+ *     one Channel-8 command to be sent to the chip).
+ *  2) Sending each Channel-8 command to the chip and reading
+ *     response back over Shared Transport.
+ *  3) Managing TX and RX Queues and Tasklets.
+ *  4) Handling FM Interrupt packet and taking appropriate action.
+ *
+ *  Copyright (C) 2009 Texas Instruments
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+/************************************************************************************
+ *
+ *  Filename:      fmdrv_main.c
+ *
+ *  Description:   Common sub-module for both FM Rx and Tx. Currently, only
+ *                  is supported
+ *
+ ***********************************************************************************/
+
+#include <linux/module.h>
+#include <linux/delay.h>
+#include "fmdrv.h"
+#include "fmdrv_v4l2.h"
+#include "fmdrv_main.h"
+#include "../include/brcm_ldisc_sh.h"
+#include "fmdrv_rx.h"
+#include "fm_public.h"
+#include "fmdrv_config.h"
+#include "../include/v4l2_target.h"
+#include "../include/v4l2_logs.h"
+
+#ifndef V4L2_FM_DEBUG
+#define V4L2_FM_DEBUG TRUE
+#endif
+
+/* set this module parameter to enable debug info */
+int fm_dbg_param = 0;
+
+/* Region info */
+struct region_info region_configs[] = {
+     /* Europe */
+    {
+     .low_bound = FM_GET_FREQ(8750),    /* 87.5 MHz */
+     .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+     .deemphasis = FM_DEEMPHA_50U,
+     .scan_step = 100,
+     .fm_band = 0,
+     },
+
+    /* Japan */
+    {
+     .low_bound = FM_GET_FREQ(7600),    /* 76 MHz */
+     .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+     .deemphasis = FM_DEEMPHA_50U,
+     .scan_step = 100,
+     .fm_band = 1,
+     },
+
+     /* North America */
+     {
+      .low_bound = FM_GET_FREQ(8750),    /* 87.5 MHz */
+      .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+      .deemphasis = FM_DEEMPHA_75U,
+      .scan_step = 200,
+      },
+
+     /* Russia-Ext */
+    {
+     .low_bound = FM_GET_FREQ(6580),    /* 65.8 MHz */
+     .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+     .deemphasis = FM_DEEMPHA_75U,
+     .scan_step = 100,
+    },
+
+    /* China Region */
+    {
+     .low_bound = FM_GET_FREQ(7600),    /* 76 MHz */
+     .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+     .deemphasis = FM_DEEMPHA_75U,
+     .scan_step = 100,
+     },
+
+    /* Italy/Thailand */
+    {
+     .low_bound = FM_GET_FREQ(8750),    /* 87.5 MHz */
+     .high_bound = FM_GET_FREQ(10800),    /* 108 MHz */
+     .deemphasis = FM_DEEMPHA_50U,
+     .scan_step = 50,
+     .fm_band = 0,
+     },
+};
+
+
+#if V4L2_FM_DEBUG
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...) \
+        do { \
+            if (fm_dbg_param & flag) \
+                printk(KERN_DEBUG "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg); \
+        } while(0)
+#else
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...)
+#endif
+#define V4L2_FM_DRV_ERR(fmt, arg...)  printk(KERN_ERR "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg)
+
+/*******************************************************************************
+**  Static Variables
+*******************************************************************************/
+   //#define BTYES_TO_UINT16(u16, lsb, msb) {u16 = (UINT16)(((UINT16)(lsb) << 8) + (UINT16)(msb)); }
+   /* Program Type */
+   static char *pty_str[]= {"None", "News", "Current Affairs",
+                         "Information","Sport", "Education",
+                         "Drama", "Culture","Science",
+                         "Varied Speech", "Pop Music",
+                         "Rock Music","Easy Listening",
+                         "Light Classic Music", "Serious Classics",
+                         "other Music","Weather", "Finance",
+                         "Childrens Progs","Social Affairs",
+                         "Religion", "Phone In", "Travel",
+                         "Leisure & Hobby","Jazz", "Country",
+                         "National Music","Oldies","Folk",
+                         "Documentary", "Alarm Test", "Alarm"};
+
+   /*These are the RDS elements that we are intested to parse*/
+   /*Each variable represents one RDS element*/
+   /*pi_code_b   -Program Identification code*/
+   static __u32 pi_code_b = 1;
+   /* pty  --Program Type, Actually an integer value is transmitted and */
+   /* if we pass the value to pty_str, we get the appropriate string */
+   static __u32 pty =2;
+   /*tp*/
+   static __u32 tp =3;
+   /*ta */
+   static __u32 ta =4;
+   /*ms_code, a bit represneting Music or Speech*/
+   static __u32 ms_code =5;
+   /*rds_psn is the Program name in string format, max length is 8 bytes + null terminate */
+   static char rds_psn[9];
+   /*rds_txt is RDS test message, this could be custom message*/
+   static char rds_txt[65];
+   /*holds the 3 byte RDS tuple data*/
+   static __u8 rds_tupple[3];
+
+   static __u8 psn_const_flags = 0x00;
+   static __u8 skip_flag = 1;
+
+   /*CT is time and date information*/
+   struct ct
+   {
+      __u32 day;
+      __u32 hour;
+      __u32 minute;
+      __u32 second;
+   };
+/*Global to store the CT information after parsing it from RDS stream*/
+   static struct ct current_ct;
+
+/* Band selection */
+static unsigned char default_radio_region;    /* US */
+module_param(default_radio_region, byte, 0);
+MODULE_PARM_DESC(default_radio_region, "Region: 0=US, 1=Europe, 2=Japan");
+
+/* RDS buffer blocks */
+static unsigned int default_rds_buf = 300;
+module_param(default_rds_buf, uint, 0444);
+MODULE_PARM_DESC(rds_buf, "RDS buffer entries");
+
+/* Radio Nr */
+static int radio_nr = -1;
+module_param(radio_nr, int, 0);
+MODULE_PARM_DESC(radio_nr, "Radio Nr");
+
+/*******************************************************************************
+**  Forward function declarations
+*******************************************************************************/
+
+long (*g_bcm_write) (struct sk_buff *skb);
+
+int parse_inrpt_flags(struct fmdrv_ops *fmdev);
+int parse_rds_data(struct fmdrv_ops *fmdev);
+void send_read_intrp_cmd(struct fmdrv_ops *fmdev);
+int read_rds_data(struct fmdrv_ops *);
+
+/*******************************************************************************
+**  Functions
+*******************************************************************************/
+
+#ifdef FM_DUMP_TXRX_PKT
+ /* To dump outgoing FM Channel-8 packets */
+inline void dump_tx_skb_data(struct sk_buff *skb)
+{
+    int len, len_org;
+    char index;
+    struct fm_cmd_msg_hdr *cmd_hdr;
+
+    cmd_hdr = (struct fm_cmd_msg_hdr *)skb->data;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "<<%shdr:%02x len:%02x opcode:%02x type:%s", \
+           fm_cb(skb)->completion ? " " : "*", cmd_hdr->header, \
+           cmd_hdr->len, cmd_hdr->fm_opcode, \
+           cmd_hdr->rd_wr ? "RD" : "WR");
+
+    len_org = skb->len - FM_CMD_MSG_HDR_SIZE;
+    if (len_org > 0)
+    {
+        //V4L2_FM_DRV_DBG("\n   data(%d): ", cmd_hdr->dlen);
+        len = min(len_org, 14);
+        for (index = 0; index < len; index++)
+            V4L2_FM_DRV_DBG(V4L2_DBG_TX, "%x ", \
+                   skb->data[FM_CMD_MSG_HDR_SIZE + index]);
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "%s", (len_org > 14) ? ".." : "");
+    }
+}
+
+ /* To dump incoming FM Channel-8 packets */
+inline void dump_rx_skb_data(struct sk_buff *skb)
+{
+    int len, len_org;
+    char index;
+    struct fm_event_msg_hdr  *evt_hdr;
+
+    evt_hdr = (struct fm_event_msg_hdr *)skb->data;
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, ">> header:%02x event:%02x len:%02x",\
+        evt_hdr->header, evt_hdr->event_id, evt_hdr->len);
+
+    len_org = skb->len - FM_EVT_MSG_HDR_SIZE;
+    if (len_org > 0)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_RX, "   data(%d): ", evt_hdr->len);
+        len = min(len_org, 14);
+        for (index = 0; index < len; index++)
+            V4L2_FM_DRV_DBG(V4L2_DBG_RX, "%x ",\
+                   skb->data[FM_EVT_MSG_HDR_SIZE + index]);
+        V4L2_FM_DRV_DBG(V4L2_DBG_RX, "%s", (len_org > 14) ? ".." : "");
+    }
+}
+
+#endif
+
+/*
+ * Store the currently set region
+ */
+void fmc_update_region_info(struct fmdrv_ops *fmdev,
+                unsigned char region_to_set)
+{
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "fmc_update_region_info");
+    fmdev->rx.curr_region = region_to_set;
+    memcpy(&fmdev->rx.region, &region_configs[region_to_set],
+        sizeof(struct region_info));
+    fmdev->rx.curr_freq = fmdev->rx.region.low_bound;
+    fm_rx_config_deemphasis( fmdev,fmdev->rx.region.deemphasis);
+}
+
+/*
+* FM common sub-module will schedule this tasklet whenever it receives
+* FM packet from ST driver.
+*/
+#ifdef TASKLET_SUPPORT
+static void __recv_tasklet(unsigned long arg)
+{
+    struct fmdrv_ops *fmdev;
+    fmdev = (struct fmdrv_ops *)arg;
+#else
+static void fm_receive_data_ldisc(struct work_struct *w)
+{
+    struct fmdrv_ops *fmdev = container_of(w, struct fmdrv_ops,rx_workqueue);
+#endif
+    //struct fmdrv_ops *fmdev;
+    struct fm_event_msg_hdr *fm_evt_hdr;
+    struct sk_buff *skb;
+    unsigned long flags;
+    unsigned char sub_event, *p;
+
+    /* Process all packets in the RX queue */
+    while ((skb = skb_dequeue(&fmdev->rx_q)))
+    {
+        if (skb->len < sizeof(struct fm_event_msg_hdr))
+        {
+            pr_err("(fmdrv): skb(%p) has only %d bytes"
+                            "atleast need %lu bytes to decode",
+                                        skb, skb->len,
+                                (unsigned long)sizeof(struct fm_event_msg_hdr));
+            kfree_skb(skb);
+            continue;
+        }
+#ifdef FM_DUMP_TXRX_PKT
+        dump_rx_skb_data(skb);
+#endif
+        fm_evt_hdr = (void *)skb->data;
+        if (fm_evt_hdr->event_id == HCI_EV_CMD_COMPLETE)
+        {
+            struct fm_cmd_complete_hdr *cmd_complete_hdr;
+            cmd_complete_hdr = (struct fm_cmd_complete_hdr *) &skb->data [FM_EVT_MSG_HDR_SIZE];
+            /*parsing the Opcode FC61 response since it is sent by */
+            /*FM driver to switch I2S path. Unlike other FM commands*/
+            /*FC61 response comes with HCI event*/
+            if (((unsigned char )skb->data[4] == 0x61) &&
+                ((unsigned char )skb->data[5] == 0xfc) &&
+                (&fmdev->maintask_completion != NULL))
+            {
+                spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+                fmdev->response_skb = skb;
+                spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+                complete(fmdev->response_completion);
+                fmdev->response_completion = NULL;
+                atomic_set(&fmdev->tx_cnt, 1);
+            }
+            /* Anyone waiting for this with completion handler? */
+            else if (cmd_complete_hdr->fm_opcode == fmdev->last_sent_pkt_opcode &&
+                                fmdev->response_completion != NULL)
+            {
+                if (fmdev->response_skb != NULL)
+                    pr_err("(fmdrv): Response SKB ptr not NULL");
+
+                if(cmd_complete_hdr->fm_opcode == FM_REG_FM_RDS_MSK)
+                    fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+
+                spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+                fmdev->response_skb = skb;
+                spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+                complete(fmdev->response_completion);
+
+                fmdev->response_completion = NULL;
+                atomic_set(&fmdev->tx_cnt, 1);
+            }
+            /* This is the VSE interrupt handler case */
+            else if (cmd_complete_hdr->fm_opcode == fmdev->last_sent_pkt_opcode &&
+                                    fmdev->response_completion == NULL)
+            {
+                V4L2_FM_DRV_DBG(V4L2_DBG_RX,"(fmdrv) : VSE interrupt handler case for 0x%x", \
+                                    cmd_complete_hdr->fm_opcode);
+                if (fmdev->response_skb != NULL)
+                    pr_err("(fmdrv): Response SKB ptr not NULL");
+                spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+                fmdev->response_skb = skb;
+                spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+                /* Parse the interrupt flags in 0x12 */
+                if(cmd_complete_hdr->fm_opcode == FM_REG_FM_RDS_FLAG)
+                    parse_inrpt_flags(fmdev);
+                else if(cmd_complete_hdr->fm_opcode == FM_REG_RDS_DATA)
+                    parse_rds_data(fmdev);
+
+                atomic_set(&fmdev->tx_cnt, 1);
+            }
+        }
+        else if(fm_evt_hdr->event_id == BRCM_FM_VS_EVENT) /* Vendor specific Event */
+        {
+            V4L2_FM_DRV_DBG(V4L2_DBG_RX, ": Got Vendor specific Event");
+            p = &skb->data[FM_EVT_MSG_HDR_SIZE];
+
+            /* Check if this is a FM vendor specific event */
+            STREAM_TO_UINT8(sub_event, p);
+            if(sub_event == BRCM_VSE_SUBCODE_FM_INTERRUPT)
+            {
+                V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) VSE Interrupt event for FM received. Calling fmc_send_intrp_cmd().");
+                send_read_intrp_cmd(fmdev);
+            }
+        }
+        else
+        {
+            pr_err("Unhandled packet SKB(%p),purging", skb);
+        }
+        if (!skb_queue_empty(&fmdev->tx_q))
+#ifdef TASKLET_SUPPORT
+        tasklet_schedule(&fmdev->tx_task);
+#else
+        queue_work(fmdev->tx_wq,&fmdev->tx_workqueue);
+#endif
+    }
+}
+
+/*
+* FM send tasklet: is scheduled when
+* FM packet has to be sent to chip */
+#ifdef TASKLET_SUPPORT
+static void __send_tasklet(unsigned long arg)
+{
+    struct fmdrv_ops *fmdev;
+    fmdev = (struct fmdrv_ops *)arg;
+#else
+static void fm_send_data_ldisc(struct work_struct *w)
+{
+    struct fmdrv_ops *fmdev =container_of(w, struct fmdrv_ops,tx_workqueue);
+#endif
+    //struct fmdrv_ops *fmdev;
+    struct sk_buff *skb;
+    int len;
+
+    /* Send queued FM TX packets */
+    if (atomic_read(&fmdev->tx_cnt))
+    {
+        skb = skb_dequeue(&fmdev->tx_q);
+        if (skb)
+        {
+            atomic_dec(&fmdev->tx_cnt);
+            fmdev->last_sent_pkt_opcode = fm_cb(skb)->fm_opcode;
+
+            if (fmdev->response_completion != NULL)
+                    pr_err("(fmdrv): Response completion handler"
+                                "is not NULL");
+
+            fmdev->response_completion = fm_cb(skb)->completion;
+               /* SYED : Hack to set the right packet type for FM */
+            sh_ldisc_cb(skb)->pkt_type = FM_PKT_LOGICAL_CHAN_NUMBER;
+
+        }
+
+            /* Write FM packet to hci shared ldisc driver */
+            len = g_bcm_write(skb);
+            if (len < 0)
+            {
+                kfree_skb(skb);
+                fmdev->response_completion = NULL;
+                pr_err("(fmdrv): TX tasklet failed to send" \
+                                "skb(%p)", skb);
+                atomic_set(&fmdev->tx_cnt, 1);
+            }
+            else {
+                fmdev->last_tx_jiffies = jiffies;
+            }
+        }
+    }
+
+
+/* Queues FM Channel-8 packet to FM TX queue and schedules FM TX tasklet for
+ * transmission */
+static int __fm_send_cmd(struct fmdrv_ops *fmdev, unsigned char fmreg_index,
+                void *payload, int payload_len, unsigned char type,
+                struct completion *wait_completion)
+{
+    struct sk_buff *skb;
+    struct fm_cmd_msg_hdr *cmd_hdr;
+    int size;
+
+    size = FM_CMD_MSG_HDR_SIZE + ((payload == NULL) ? 0 : payload_len);
+    skb = alloc_skb(size, GFP_ATOMIC);
+    if (!skb)
+    {
+        pr_err("(fmdrv): No memory to create new SKB");
+        return -ENOMEM;
+    }
+
+    /* Fill command header info */
+    cmd_hdr =(struct fm_cmd_msg_hdr *)skb_put(skb, FM_CMD_MSG_HDR_SIZE);
+
+    cmd_hdr->header = HCI_COMMAND;    /* 0x01 */
+    /* 3 (cmd, len, fm_opcode,rd_wr) */
+    cmd_hdr->cmd = hci_opcode_pack(HCI_GRP_VENDOR_SPECIFIC, FM_2048_OP_CODE);
+
+    cmd_hdr->len = ((payload == NULL) ? 0 : payload_len) + 2;
+    /* FM opcode */
+    cmd_hdr->fm_opcode = fmreg_index;
+    /* read/write type */
+    cmd_hdr->rd_wr = type;
+
+    fm_cb(skb)->fm_opcode = fmreg_index;
+
+    if (payload != NULL)
+            memcpy(skb_put(skb, payload_len), payload, payload_len);
+
+    fm_cb(skb)->completion = wait_completion;
+
+//    print skb->cb to check pck_type and completion.
+
+    skb_queue_tail(&fmdev->tx_q, skb);
+#ifdef TASKLET_SUPPORT
+     tasklet_schedule(&fmdev->tx_task);
+#else
+     queue_work(fmdev->tx_wq,&fmdev->tx_workqueue);
+#endif
+    return 0;
+}
+
+/* QueuesVSC HCI packet to FM TX queue and schedules FM TX tasklet for
+ * transmission */
+static int __fm_send_vsc_hci_cmd(struct fmdrv_ops *fmdev,__u16 ocf_value,
+                void *payload, int payload_len, struct completion *wait_completion)
+{
+    struct sk_buff *skb;
+    struct fm_cmd_msg_hdr *cmd_hdr;
+    int size;
+    unsigned char *ch  = (unsigned char*)payload;
+
+    size = FM_VSC_HCI_CMD_MSG_HDR_SIZE + ((payload == NULL) ? 0 : payload_len);
+    skb = alloc_skb(size, GFP_ATOMIC);
+    if (!skb)
+    {
+        pr_err("(fmdrv): No memory to create new SKB");
+        return -ENOMEM;
+    }
+
+    /* Fill command header info */
+    cmd_hdr =(struct fm_cmd_msg_hdr *)
+                skb_put(skb, FM_VSC_HCI_CMD_MSG_HDR_SIZE);
+
+    cmd_hdr->header = HCI_COMMAND;    /* 0x01 */
+    /* 3 (cmd, len, fm_opcode,rd_wr) */
+    cmd_hdr->cmd = hci_opcode_pack(HCI_GRP_VENDOR_SPECIFIC, ocf_value);
+
+    cmd_hdr->len = 0x05;  /*Fixed value for FC61 command*/
+
+    if (payload != NULL)
+        memcpy(skb_put(skb, payload_len), ch, payload_len);
+
+    fm_cb(skb)->completion = wait_completion;
+
+    skb_queue_tail(&fmdev->tx_q, skb);
+#ifdef TASKLET_SUPPORT
+    tasklet_schedule(&fmdev->tx_task);
+#else
+    queue_work(fmdev->tx_wq,&fmdev->tx_workqueue);
+#endif
+    return 0;
+}
+
+
+/* Sends FM Channel-8 command to the chip and waits for the reponse */
+int fmc_send_cmd(struct fmdrv_ops *fmdev, unsigned char fmreg_index,
+            void *payload, int payload_len, unsigned char type,
+            struct completion *wait_completion, void *reponse,
+            int *reponse_len)
+{
+    struct sk_buff *skb;
+    struct fm_event_msg_hdr *fm_evt_hdr;
+    struct fm_cmd_complete_hdr *cmd_complete_hdr;
+    unsigned long timeleft;
+    unsigned long flags;
+    int ret;
+
+    //V4L2_FM_DRV_DBG("In fmc_send_cmd");
+
+    init_completion(wait_completion);
+    if(type == VSC_HCI_CMD)
+    {
+        ret = __fm_send_vsc_hci_cmd(fmdev, VSC_HCI_WRITE_PCM_PINS_OCF, payload,
+                            payload_len, wait_completion);
+        if (ret < 0)
+           return ret;
+    }
+    else
+    {
+        ret = __fm_send_cmd(fmdev, fmreg_index, payload, payload_len, type,
+                            wait_completion);
+        if (ret < 0)
+           return ret;
+    }
+
+    timeleft = wait_for_completion_timeout(wait_completion, FM_DRV_TX_TIMEOUT);
+    if (!timeleft)
+    {
+        pr_err("(fmdrv): Timeout(%d sec),didn't get reg"
+                            "completion signal from RX tasklet",
+                                        jiffies_to_msecs(FM_DRV_TX_TIMEOUT) / 1000);
+        return -ETIMEDOUT;
+    }
+    if (!fmdev->response_skb) {
+        pr_err("(fmdrv): Reponse SKB is missing ");
+        return -EFAULT;
+    }
+    spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+    skb = fmdev->response_skb;
+    fmdev->response_skb = NULL;
+    spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+
+    fm_evt_hdr = (void *)skb->data;
+    if (fm_evt_hdr->event_id == HCI_EV_CMD_COMPLETE) /* Vendor specific command response */
+    {
+        cmd_complete_hdr = (struct fm_cmd_complete_hdr *) &skb->data [FM_EVT_MSG_HDR_SIZE];
+        if (cmd_complete_hdr->status != 0)
+        {
+            pr_err("(fmdrv): Reponse status not success ");
+            kfree (skb);
+            return -EFAULT;
+        }
+
+        //V4L2_FM_DRV_DBG("(fmdrv): Reponse status success : %d ", cmd_complete_hdr->status);
+        /* Send reponse data to caller */
+        if (reponse != NULL && reponse_len != NULL && fm_evt_hdr->len) {
+            /* Skip header info and copy only response data */
+            skb_pull(skb, (FM_EVT_MSG_HDR_SIZE + FM_CMD_COMPLETE_HDR_SIZE));
+            memcpy(reponse, skb->data, (fm_evt_hdr->len - FM_CMD_COMPLETE_HDR_SIZE) );
+            *reponse_len = (fm_evt_hdr->len - FM_CMD_COMPLETE_HDR_SIZE) ;
+        }
+        else if (reponse_len != NULL && fm_evt_hdr->len == 0) {
+            *reponse_len = 0;
+        }
+    }
+    else
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Unhandled event ID : %d", fm_evt_hdr->event_id);
+    }
+    kfree_skb(skb);
+    return 0;
+}
+
+/* This function has the necessity of calling when FM station changes.  */
+void reset_rds_parser(void)
+{
+    pi_code_b = 1;
+    pty = 2;
+    tp = 3;
+    ta = 4;
+    ms_code = 5;
+    memset(rds_psn, 0x20, sizeof(rds_psn)-1);
+    memset(rds_txt, 0x20, sizeof(rds_txt)-1);
+    memset(rds_tupple, 0x00, sizeof(rds_tupple));
+
+    psn_const_flags = 0x00;
+    skip_flag = 1;
+}
+
+/* Helper function to parse the interrupt bits
+* in FM_REG_FM_RDS_FLAG (0x12).
+* Called locally by fmdrv_main.c
+*/
+int parse_inrpt_flags(struct fmdrv_ops *fmdev)
+{
+    struct sk_buff *skb;
+    unsigned long flags;
+    unsigned short fm_rds_flag;
+    unsigned char response[2];
+
+    spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+    skb = fmdev->response_skb;
+    fmdev->response_skb = NULL;
+    spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+
+    memcpy(&response, &skb->data[FM_EVT_MSG_HDR_SIZE + FM_CMD_COMPLETE_HDR_SIZE], 2);
+    fm_rds_flag= (unsigned short)response[0] + ((unsigned short)response[1] << 8) ;
+
+    if (fmdev->rx.fm_rds_flag & (FM_RDS_FLAG_SCH_FRZ_BIT|FM_RDS_FLAG_CLEAN_BIT))
+    {
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_CLEAN_BIT;
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) : Clean BIT set. So no processing of the current"\
+            "FM/RDS flag set");
+        kfree_skb(skb);
+        return 0;
+    }
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Processing the interrupt flag. Flag read is 0x%x 0x%x",\
+        response[0], response[1]);
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) : flag register(0x%x)", fm_rds_flag);
+    if(fm_rds_flag & (I2C_MASK_SRH_TUNE_CMPL_BIT|I2C_MASK_SRH_TUNE_FAIL_BIT))
+    {
+        /* reset RDS parser */
+        reset_rds_parser();
+
+        /* remove sch_tune pending bit */
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_BIT;
+
+        if(fm_rds_flag & I2C_MASK_SRH_TUNE_FAIL_BIT)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv) MASK BIT : Search failure");
+            if(fmdev->rx.curr_search_state == FM_STATE_SEEKING)
+            {
+                fmdev->rx.curr_search_state = FM_STATE_SEEK_ERR;
+                complete(&fmdev->seektask_completion);
+            }
+            else if(fmdev->rx.curr_search_state == FM_STATE_TUNING)
+            {
+                fmdev->rx.curr_search_state = FM_STATE_TUNE_ERR;
+                complete(&fmdev->maintask_completion);
+            }
+        }
+        else
+        {
+            V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) MASK BIT : Search success");
+            if(fmdev->rx.curr_search_state == FM_STATE_SEEKING)
+            {
+                fmdev->rx.curr_search_state = FM_STATE_SEEK_CMPL;
+                complete(&fmdev->seektask_completion);
+            }
+            else if(fmdev->rx.curr_search_state == FM_STATE_TUNING)
+            {
+                fmdev->rx.curr_search_state = FM_STATE_TUNE_CMPL;
+                complete(&fmdev->maintask_completion);
+            }
+        }
+    }
+    else if((fm_rds_flag & (I2C_MASK_RDS_FIFO_WLINE_BIT|I2C_MASK_SYNC_LOST_BIT))
+            == I2C_MASK_RDS_FIFO_WLINE_BIT)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Detected WLINE interrupt; Reading RDS.");
+        read_rds_data(fmdev);
+    }
+    kfree_skb(skb);
+    return 0;
+}
+
+void get_rds_element_value(int ioctl_num, char __user *ioctl_value)
+{
+/* Even though the values that are returned from this function are global to this file */
+/* There is no need to lock  Since this is just a read operation */
+/* And we don't maitain the history of any of these values, we just return the */
+/* Current value irrespective of it's previous value */
+   __u8 *current_ct_buf;
+   current_ct_buf = (__u8 *)&current_ct;
+
+   if((ioctl_num > 9) || (ioctl_num <= 0))
+       return;
+
+   switch(ioctl_num)
+   {
+      case GET_PI_CODE:
+         if(copy_to_user(ioctl_value, (char *)&pi_code_b, 4))
+         {
+            V4L2_FM_DRV_ERR("(rds) Failed to copy PI code");
+         }
+         return;
+
+      case GET_TP_CODE:
+        if(copy_to_user(ioctl_value, (char *)&tp, 4))
+        {
+           V4L2_FM_DRV_ERR("(rds) Failed to copy TP code");
+        }
+        return;
+
+      case GET_PTY_CODE:
+        if(copy_to_user(ioctl_value, (char *)&pty, 4))
+        {
+           V4L2_FM_DRV_ERR("(rds) Failed to copy PTY code");
+        }
+        return;
+
+      case GET_TA_CODE:
+        if(copy_to_user(ioctl_value, (char *)&ta, 4))
+        {
+           V4L2_FM_DRV_ERR("(rds) Failed to copy TA code");
+        }
+        return;
+
+      case GET_MS_CODE:
+         if(copy_to_user(ioctl_value, (char *)&ms_code, 4))
+         {
+            V4L2_FM_DRV_ERR("(rds) Failed to copy MS code");
+         }
+         return;
+
+      case GET_PS_CODE:
+         if(copy_to_user(ioctl_value, rds_psn, strlen(rds_psn)+ 1))
+         {
+            V4L2_FM_DRV_ERR("(rds) Failed to copy PS code");
+         }
+         return;
+
+      case GET_RT_MSG:
+         if(copy_to_user(ioctl_value, rds_txt, strlen(rds_txt) + 1))
+         {
+            V4L2_FM_DRV_ERR("(rds) Failed to copy RT Message");
+         }
+         return;
+
+      case GET_CT_DATA:
+          if(copy_to_user(ioctl_value, (char *)current_ct_buf, 16))
+          {
+             V4L2_FM_DRV_ERR("(rds) Failed to copy CT data");
+          }
+          return;
+
+      case GET_TMC_CHANNEL:
+         *(__u32 *)ioctl_value = 4;
+         return;
+   }
+}
+
+/* Each RDS packet is 104bytes = 4*16 bits + 40 bits (10bits error code for each 16bits data)*/
+/* Each RDS packet is devided into 4 blocks of 16bits*/
+/* when we receive RDS packet it is devided into 4 * 3Byts tuples, */
+/*2 bytes of information and 1byte of meta data */
+void parse_rds_tupple(void)
+{
+   int version =0;
+   __u8 byte1, byte2;
+   static __u8 group, spare, blkc_byte1, blkc_byte2, blkb_byte1, blkb_byte2;
+   static __u8 rds_pty;
+   __u32 tmp1;
+   __u32 tmp2;
+   __u8 offset = 0;
+
+   byte1 = rds_tupple[1];
+   byte2 = rds_tupple[0];
+/*tempbuf[2] has meta data */
+   switch ((rds_tupple[2]& 0x07)) {
+      case 0: /* Block A */
+         break;
+
+      case 1: /* Block B */
+         if (rds_tupple[2] & (BRCM_RDS_BIT_6 | BRCM_RDS_BIT_7)) {
+            /* invalid tupple */
+            skip_flag = 1; /* skip Block D decode */
+            break;
+        }
+        skip_flag = 0;
+        V4L2_FM_DRV_DBG(V4L2_DBG_RX, "block B - group=%d%c tp=%d pty=%d spare=%d\n",
+        (byte1 >> 4) & 0x0f,
+        ((byte1 >> 3) & 0x01) + 'A',
+        (byte1 >> 2) & 0x01,
+        ((byte1 << 3) & 0x18) | ((byte2 >> 5) & 0x07),
+                byte2 & 0x1f);
+         blkb_byte1 = byte1;
+         blkb_byte2 = byte2;
+         group = (byte1 >> 3) & 0x1f;
+         spare = byte2 & 0x1f;
+         rds_pty = ((byte1 << 3) & 0x18) | ((byte2 >> 5) & 0x07);
+         ms_code = (byte2 >> 3)& 0x1;
+         tp = (byte1 & (1 << 2));
+         break;
+
+      case 2: /* Block C */
+         if (rds_tupple[2] & (BRCM_RDS_BIT_6 | BRCM_RDS_BIT_7)) {
+            /* invalid tupple */
+            break;
+         }
+         blkc_byte1 = byte1;
+         blkc_byte2 = byte2;
+         break;
+
+      case 3 : /* Block D */
+         if (rds_tupple[2] & (BRCM_RDS_BIT_6 | BRCM_RDS_BIT_7)) {
+            /* invalid tupple */
+            break;
+         }
+         /* Parsing the PI code, PI code will be present in all the Groups in Block-c*/
+         version = (group & 0x01);
+         if(version) {
+            pi_code_b |= (blkc_byte1 << 8) & 0xFF;
+            pi_code_b |= (blkc_byte2 << 16) & 0xFFFF;
+         }
+         if (skip_flag) {
+            /* group and spare was */
+            break;
+         }
+         switch (group) {
+             /*There are 32 Groups in total but we are only interested in the following Groups*/
+            case 0: /* Group 0A */
+            case 1: /* Group 0B */
+               rds_psn[2*(spare & 0x03)+0] = byte1;
+               rds_psn[2*(spare & 0x03)+1] = byte2;
+               psn_const_flags |= 0x01 << (spare & 0x03);
+               if (psn_const_flags == 0x0F) {
+                  V4L2_FM_DRV_DBG(V4L2_DBG_RX, "PSN: %s, PTY: %s, MS: %s\n",rds_psn,
+                                   pty_str[rds_pty],ms_code?"Music":"Speech");
+                  psn_const_flags = 0x00; // reset
+               }
+               ta = blkb_byte2 & (0x01 << 4);
+               break;
+            case 4: /* Group 2A */
+               rds_txt[4*(spare & 0x0f)+0] = blkc_byte1;
+               rds_txt[4*(spare & 0x0f)+1] = blkc_byte2;
+               rds_txt[4*(spare & 0x0f)+2] = byte1;
+               rds_txt[4*(spare & 0x0f)+3] = byte2;
+            /* Display radio text once we get 16 characters */
+            /*        if ((spare & 0x0f) == 0x0f)*/
+                if (spare > 16)
+                {
+                    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "Radio Text: %s\n",rds_txt);
+                }
+                break;
+               /* Parsing  CT information*/
+               case 8: /*Group 4A*/
+                 /* b0-b14@day = b0-b7@bc_1 + b1-b7@bc_2 */
+                 tmp1 = (__u32)((blkc_byte1 << 8) | blkc_byte2);
+                 /* b15,b16@day = b0,b1@bb_2 */
+                 tmp2 = (__u32)(blkb_byte2 & 0x03);
+                 current_ct.day = (tmp2 << 15) | (tmp1 >> 1);
+                 tmp1 = (__u32)(blkc_byte2 & 0x01);/* b4@hour = LSB of bc_2 */
+                 tmp2 = (__u32)(byte1 & 0xf0);/* b0-b3@hour = highest 4 bits of bd_1 */
+                 current_ct.hour = (__u8)((tmp1 << 4) | (tmp2 >> 4));
+                 current_ct.minute = ((byte1 & 0x0f) << 2)|((byte2  & 0xc0) >>6);
+                 current_ct.second = (byte2 & 0x20) >> 5;
+                 offset = byte2  & 0x1f;
+                 V4L2_FM_DRV_DBG(V4L2_DBG_RX, "ct day: %d, hour: %d, minute: %d, sec: %d",
+                           current_ct.day, current_ct.hour, current_ct.minute, current_ct.second);
+                 break;
+                case 15:
+                   ta = blkb_byte2 & (0x01 << 4);
+                }
+                break;
+         default:
+              V4L2_FM_DRV_DBG(V4L2_DBG_RX, "unknown block [%d]\n",rds_tupple[2]);
+         }
+}
+
+/* Helper function to parse the RDS data
+* in FM_REG_FM_RDS_DATA (0x80).
+* Called locally by fmdrv_main.c
+*/
+int parse_rds_data(struct fmdrv_ops *fmdev)
+{
+    unsigned long flags;
+    unsigned char *rds_data;
+    unsigned char type, block_index;
+    tBRCM_RDS_QUALITY qlty_index;
+    int ret, response_len, index=0;
+    struct sk_buff *skb;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds)");
+
+    spin_lock_irqsave(&fmdev->resp_skb_lock, flags);
+    skb = fmdev->response_skb;
+    fmdev->response_skb = NULL;
+    spin_unlock_irqrestore(&fmdev->resp_skb_lock, flags);
+    skb_pull(skb, (sizeof(struct fm_event_msg_hdr) + sizeof(struct fm_cmd_complete_hdr)));
+    rds_data = skb->data;
+    response_len = skb->len;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) RDS length : %d", response_len);
+
+    /* Read RDS data */
+    spin_lock_irqsave(&fmdev->rds_cbuff_lock, flags);
+    while (response_len > 0)
+    {
+        /* Fill RDS buffer as per V4L2 specification.
+     * Store control byte
+     */
+
+        type = (rds_data[0] & BRCM_RDS_GRP_TYPE_MASK);
+        block_index = (type >> 4);
+        if (block_index < V4L2_RDS_BLOCK_A|| block_index >= V4L2_RDS_BLOCK_C_ALT)
+        {
+            V4L2_FM_DRV_ERR("(rds) Block sequence mismatch\n");
+            block_index = V4L2_RDS_BLOCK_INVALID;
+        }
+
+        qlty_index = (tBRCM_RDS_QUALITY)((rds_data[0] & BRCM_RDS_GRP_QLTY_MASK) >> 2);
+
+        rds_tupple[2] = (block_index & V4L2_RDS_BLOCK_MSK);    /* Offset name */
+        rds_tupple[2] |= ((block_index & V4L2_RDS_BLOCK_MSK) << 3);  /* Reserved offset */
+
+        switch(qlty_index)
+        {
+            case BRCM_RDS_NO_ERR:
+                /* Set bits 7 and 8 to 0 to indicate no error / correction*/
+              //  V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) qlty : BRCM_RDS_NO_ERR");
+                break;
+            case BRCM_RDS_2BIT_ERR:
+            case BRCM_RDS_3BIT_ERR:
+                V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) qlty : %s", ((qlty_index==BRCM_RDS_2BIT_ERR)? \
+                    "BRCM_RDS_2BIT_ERR":"BRCM_RDS_3BIT_ERR"));
+                /* Set bit 7 to 1 and bit 8 to 0 indicate no error
+                    but correction made*/
+                rds_tupple[2] |= (BRCM_RDS_BIT_6);
+                rds_tupple[2] &= ~(BRCM_RDS_BIT_7);
+                break;
+
+            case BRCM_RDS_UNRECOVER:
+                V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) qlty : BRCM_RDS_UNRECOVER for data [ 0x%x 0x%x 0x%x]",\
+                    rds_data[0], rds_data[1], rds_data[2]);
+                /* Set bit 7 to 0 and bit 8 to 1 indicate error */
+                rds_tupple[2] |= (BRCM_RDS_BIT_7);
+                rds_tupple[2] &= ~(BRCM_RDS_BIT_6);
+                break;
+             default :
+                V4L2_FM_DRV_ERR("(rds) Unknown quality code");
+                rds_tupple[2] |= (BRCM_RDS_BIT_7);
+                rds_tupple[2] &= ~(BRCM_RDS_BIT_6);
+
+        }
+
+        /* Store data byte. Swap bytes*/
+        rds_tupple[0] = rds_data[2]; /* LSB of V4L2 spec block */
+        rds_tupple[1] = rds_data[1]; /* MSB of V4L2 spec block */
+        parse_rds_tupple();
+        memcpy(&fmdev->rx.rds.cbuffer[fmdev->rx.rds.wr_index], &rds_tupple,
+               FM_RDS_TUPLE_LENGTH);
+        fmdev->rx.rds.wr_index =
+            (fmdev->rx.rds.wr_index +
+             FM_RDS_TUPLE_LENGTH) % fmdev->rx.rds.buf_size;
+
+        /* Check for overflow & start over */
+        if (fmdev->rx.rds.wr_index == fmdev->rx.rds.rd_index) {
+            pr_err("RDS buffer overflow");
+            fmdev->rx.rds.wr_index = 0;
+            fmdev->rx.rds.rd_index = 0;
+            break;
+        }
+
+        /*Check for end of RDS tuple */
+        if ((rds_data + FM_RDS_TUPLE_LENGTH)[FM_RDS_TUPLE_BYTE1] == FM_RDS_END_TUPLE_1ST_BYTE &&
+            (rds_data + FM_RDS_TUPLE_LENGTH)[FM_RDS_TUPLE_BYTE2] == FM_RDS_END_TUPLE_2ND_BYTE &&
+            (rds_data + FM_RDS_TUPLE_LENGTH)[FM_RDS_TUPLE_BYTE3] == FM_RDS_END_TUPLE_3RD_BYTE )
+        {
+            pr_err("(fmdrv) End of RDS tuple reached @ %d index", index);
+            break;
+        }
+        response_len -= FM_RDS_TUPLE_LENGTH;
+        rds_data += FM_RDS_TUPLE_LENGTH;
+        index += FM_RDS_TUPLE_LENGTH;
+    }
+    spin_unlock_irqrestore(&fmdev->rds_cbuff_lock, flags);
+
+     /* Set Tuner RDS capability bit as RDS data has been detected */
+    fmdev->device_info.rxsubchans |= V4L2_TUNER_SUB_RDS;
+
+    /* Wakeup read queue */
+    if (fmdev->rx.rds.wr_index != fmdev->rx.rds.rd_index)
+        wake_up_interruptible(&fmdev->rx.rds.read_queue);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) Now reset the mask");
+
+    fmdev->rx.fm_rds_mask |= I2C_MASK_RDS_FIFO_WLINE_BIT;
+
+    ret = __fm_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &fmdev->rx.fm_rds_mask,
+                            2, REG_WR, NULL);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) Write to FM_REG_FM_RDS_MSK done : %d", ret);
+
+    kfree(skb);
+    return 0;
+}
+
+/*
+ * Read the FM_REG_FM_RDS_FLAG by sending a read command.
+ * Called locally by fmdrv_main.c
+ */
+void send_read_intrp_cmd(struct fmdrv_ops *fmdev)
+{
+    unsigned char read_length;
+    int ret;
+
+    read_length = FM_READ_2_BYTE_DATA;
+    ret = __fm_send_cmd(fmdev, FM_REG_FM_RDS_FLAG, &read_length,
+                            sizeof(read_length), REG_RD, NULL);
+    if(ret < 0)
+    {
+        pr_err("(fmdrv) Error reading FM_REG_FM_RDS_FLAG");
+    }
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Sent read to Interrupt flag FM_REG_FM_RDS_FLAG");
+}
+
+/* Initiate a read to RDS register. Called locally by fmdrv_main.c */
+int read_rds_data(struct fmdrv_ops *fmdev)
+{
+    unsigned char payload;
+    int ret;
+
+    payload = FM_RDS_FIFO_MAX;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) Going to read RDS data from FM_REG_RDS_DATA!!");
+
+    ret = __fm_send_cmd(fmdev, FM_REG_RDS_DATA, &payload, 1, REG_RD, NULL);
+    return 0;
+}
+
+/*
+ * Function to copy RDS data from the FM ring buffer
+ * to the userspace buffer.
+ */
+int fmc_transfer_rds_from_cbuff(struct fmdrv_ops *fmdev, struct file *file,
+                    char __user * buf, size_t count)
+{
+    unsigned int block_count;
+    unsigned long flags;
+    int ret;
+
+    /* Block if no new data available */
+    if (fmdev->rx.rds.wr_index == fmdev->rx.rds.rd_index) {
+        if (file->f_flags & O_NONBLOCK)
+            return -EWOULDBLOCK;
+
+        ret = wait_event_interruptible(fmdev->rx.rds.read_queue,
+                    (fmdev->rx.rds.wr_index != fmdev->rx.rds.rd_index));
+        if (ret) {
+            pr_err("(rds) %s Error : EINTR ", __func__);
+            return -EINTR;
+        }
+    }
+    /* Calculate block count from byte count */
+    count /= 3;
+    block_count = 0;
+    ret = 0;
+
+    spin_lock_irqsave(&fmdev->rds_cbuff_lock, flags);
+
+    /* Copy RDS blocks from the internal buffer and to user buffer */
+    while (block_count < count) {
+        if (fmdev->rx.rds.wr_index == fmdev->rx.rds.rd_index)
+            break;
+
+        /* Always transfer complete RDS blocks */
+        if (copy_to_user
+            (buf, &fmdev->rx.rds.cbuffer[fmdev->rx.rds.rd_index],
+             FM_RDS_BLOCK_SIZE))
+            break;
+
+        /* Increment and wrap the read pointer */
+        fmdev->rx.rds.rd_index += FM_RDS_BLOCK_SIZE;
+
+        /* Wrap read pointer */
+        if (fmdev->rx.rds.rd_index >= fmdev->rx.rds.buf_size)
+            fmdev->rx.rds.rd_index = 0;
+
+        /* Increment counters */
+        block_count++;
+        buf += FM_RDS_BLOCK_SIZE;
+        ret += FM_RDS_BLOCK_SIZE;
+    }
+    spin_unlock_irqrestore(&fmdev->rds_cbuff_lock, flags);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) %s Done copying %d", __func__, ret);
+
+    return ret;
+}
+
+/* Sets the frequency */
+int fmc_set_frequency(struct fmdrv_ops *fmdev, unsigned int freq_to_set)
+{
+    int ret;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "In %s, frequency to set %d", __func__, freq_to_set);
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            ret = fm_rx_set_frequency(fmdev, freq_to_set);
+            if(ret != 0)
+                V4L2_FM_DRV_ERR("Unable to set frequency. ret = %d", ret);
+            break;
+
+        case FM_MODE_TX:
+            /* Currently FM TX is not supported */
+            V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/* Returns the current tuned frequency */
+int fmc_get_frequency(struct fmdrv_ops *fmdev, unsigned int *cur_tuned_frq)
+{
+    int ret = 0;
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            ret = fm_rx_get_frequency(fmdev, cur_tuned_frq);
+            break;
+
+        case FM_MODE_TX:
+        /* Currently FM TX is not supported */
+        V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/* Function to initiate SEEK operation */
+int fmc_seek_station(struct fmdrv_ops *fmdev, unsigned char direction_upward,
+                    unsigned char wrap_around)
+{
+    return fm_rx_seek_station(fmdev, direction_upward, wrap_around);
+}
+
+/* Returns current band index (0-Europe/US; 1-Japan) */
+int fmc_get_region(struct fmdrv_ops *fmdev, unsigned char *region)
+{
+    *region = fmdev->rx.curr_region;
+    return 0;
+}
+
+/* Set the world region */
+int fmc_set_region(struct fmdrv_ops *fmdev, unsigned char region_to_set)
+{
+    int ret;
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            if (region_to_set == fmdev->rx.curr_region)
+            {
+                V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): Already region is set(%d)", region_to_set);
+                return 0;
+            }
+            ret = fm_rx_set_region(fmdev, region_to_set);
+            break;
+
+        case FM_MODE_TX:
+        /* Currently FM TX is not supported */
+        V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/* Sets the audio mode */
+int fmc_set_audio_mode(struct fmdrv_ops *fmdev, unsigned char audio_mode)
+{
+    int ret;
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            ret = fm_rx_set_audio_mode(fmdev, audio_mode);
+            break;
+
+        case FM_MODE_TX:
+            /* Currently FM TX is not supported */
+            V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/* Gets the audio mode */
+int fmc_get_audio_mode(struct fmdrv_ops *fmdev, unsigned char *audio_mode)
+{
+    int ret;
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            ret = fm_rx_get_audio_mode(fmdev, audio_mode);
+            break;
+
+        case FM_MODE_TX:
+            /* Currently FM TX is not supported */
+            V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/* Sets the scan step */
+int fmc_set_scan_step(struct fmdrv_ops *fmdev, unsigned char scan_step)
+{
+    int ret;
+
+    switch (fmdev->curr_fmmode) {
+        case FM_MODE_RX:
+            ret = fm_rx_set_scan_step(fmdev, scan_step);
+            break;
+
+        case FM_MODE_TX:
+            /* Currently FM TX is not supported */
+            V4L2_FM_DRV_ERR("Currently FM TX is not supported");
+
+        default:
+            ret = -EINVAL;
+    }
+    return ret;
+}
+
+/*
+* Resets RDS cache parameters
+*/
+void fmc_reset_rds_cache(struct fmdrv_ops *fmdev)
+{
+    fmdev->rx.rds.rds_flag = FM_RDS_DISABLE;
+    fmdev->rx.rds.wr_index = 0;
+    fmdev->rx.rds.rd_index = 0;
+    fmdev->device_info.rxsubchans &= ~V4L2_TUNER_SUB_RDS;
+}
+
+/*
+ * Turn FM ON by sending FM_REG_RDS_SYS commmand
+ */
+int fmc_turn_fm_on (struct fmdrv_ops *fmdev, unsigned char rds_flag)
+{
+    int ret;
+    unsigned char payload;
+
+    if (rds_flag != FM_RDS_ENABLE && rds_flag != FM_RDS_DISABLE) {
+        pr_err("(fmdrv): Invalid rds option");
+        return -EINVAL;
+    }
+    if (rds_flag == FM_RDS_ENABLE)
+        payload = (FM_ON | FM_RDS_ON);
+    else
+        payload = FM_ON;
+
+    ret = fmc_send_cmd(fmdev, FM_REG_RDS_SYS, &payload, sizeof(payload),
+            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): FM_REG_RDS_SYS write done");
+
+    fmdev->rx.rds.rds_flag = rds_flag;
+    return ret;
+}
+
+/*
+ * Turn off FM
+ */
+int fmc_turn_fm_off(struct fmdrv_ops *fmdev)
+{
+    int ret = -EINVAL;
+    unsigned char payload;
+
+    /* Mute audio */
+    payload = FM_MUTE_ON;
+    ret = fm_rx_set_mute_mode(fmdev, payload);
+
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    if(ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): FM mute off during FM Disable operation has failed");
+        return ret;
+    }
+
+    /* Disable FM */
+    payload = FM_OFF;
+
+    ret = fmc_send_cmd(fmdev, FM_REG_RDS_SYS, &payload, sizeof(payload),
+            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    return ret;
+}
+
+/*
+ * Set FM Modes(TX, RX, OFF)
+ * TX and RX modes are exclusive
+ */
+int fmc_set_mode(struct fmdrv_ops *fmdev, unsigned char fm_mode)
+{
+    int ret = 0;
+
+    if (fm_mode >= FM_MODE_ENTRY_MAX) {
+        pr_err("(fmdrv): Invalid FM mode : %d", fm_mode);
+        ret = -EINVAL;
+        return ret;
+    }
+    if (fmdev->curr_fmmode == fm_mode) {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): Already fm is in mode(%d)", fm_mode);
+         return ret;
+    }
+    fmdev->curr_fmmode = fm_mode;
+    return ret;
+}
+
+/*
+ * Turn on FM, and other initialization to enable FM
+ */
+int fmc_enable (struct fmdrv_ops *fmdev, unsigned char opt)
+{
+    int ret;
+    unsigned char rds_en_dis, rdbs_en_dis;
+
+    unsigned short aud_ctrl;
+    unsigned char read_length;
+    unsigned char resp_buf [1];
+    int resp_len;
+
+    if (!test_bit(FM_CORE_READY, &fmdev->flag))
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): FM core is not ready");
+        return -EPERM;
+    }
+
+    fmc_set_mode (fmdev, FM_MODE_RX);
+
+    /* turn FM ON */
+    rds_en_dis = (opt & (FM_RDS_BIT | FM_RBDS_BIT)) ?
+                            FM_RDS_ENABLE : FM_RDS_DISABLE;
+
+    ret = fmc_turn_fm_on (fmdev, rds_en_dis);
+
+    if (ret < 0)
+    {
+        pr_err ("(fmdrv): FM turn on failed");
+        return ret;
+    }
+    fmdev->rx.fm_func_mask = opt;
+    /* wait for 300 ms before sending any more commands */
+    mdelay (V4L2_FM_ENABLE_DELAY);
+
+    /* wrire rds control */
+    rdbs_en_dis = (opt & FM_RBDS_BIT) ?
+            FM_RDBS_ENABLE : FM_RDBS_DISABLE;
+    ret = fm_rx_set_rds_system (fmdev, rdbs_en_dis);
+
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): set rds mode failed");
+        return ret;
+    }
+    ret = fm_rx_set_region( fmdev,(opt & FM_REGION_MASK));
+
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): set region has failed");
+        return ret;
+    }
+    /* Read PCM Route settings */
+    read_length = FM_READ_1_BYTE_DATA;
+    ret = fmc_send_cmd(fmdev, FM_REG_PCM_ROUTE, &read_length, sizeof(read_length), REG_RD,
+                    &fmdev->maintask_completion, &resp_buf, &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->rx.pcm_reg = resp_buf[0];
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): pcm_reg value %d", fmdev->rx.pcm_reg);
+
+    /* fm enable with mute state. added FM_MANUAL_MUTE*/
+    aud_ctrl = (unsigned short)(FM_AUDIO_DAC_ON | \
+                    FM_RF_MUTE | FM_Z_MUTE_LEFT_OFF | FM_Z_MUTE_RITE_OFF | \
+                    fmdev->rx.region.deemphasis);
+
+    ret = fm_rx_set_audio_ctrl(fmdev, aud_ctrl);
+
+    fmdev->rx.curr_rssi_threshold = DEF_V4L2_FM_SIGNAL_STRENGTH;
+
+    /* Set world region */
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdrv): FM Set world region option : %d", DEF_V4L2_FM_WORLD_REGION);
+    ret = fmc_set_region(fmdev, DEF_V4L2_FM_WORLD_REGION);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Unable to set World region");
+        return ret;
+    }
+    fmdev->rx.curr_region = DEF_V4L2_FM_WORLD_REGION;
+
+    /* Set Scan Step */
+#if(defined(DEF_V4L2_FM_WORLD_REGION) && DEF_V4L2_FM_WORLD_REGION == FM_REGION_NA)
+    fmdev->rx.sch_step = FM_STEP_200KHZ;
+#else
+    fmdev->rx.sch_step = FM_STEP_100KHZ;
+#endif
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdrv): FM Set Scan Step : 0x%x", fmdev->rx.sch_step);
+    ret = fmc_set_scan_step(fmdev, fmdev->rx.sch_step);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Unable to set scan step");
+        return ret;
+    }
+
+    /* Enable RDS */
+    fm_rx_enable_rds(fmdev);
+
+    return ret;
+}
+
+/*
+* Returns current FM mode (TX, RX, OFF) */
+int fmc_get_mode(struct fmdrv_ops *fmdev, unsigned char *fmmode)
+{
+    if (!test_bit(FM_CORE_READY, &fmdev->flag)) {
+        pr_err("(fmdrv): FM core is not ready");
+        return -EPERM;
+    }
+    if (fmmode == NULL) {
+        pr_err("(fmdrv): Invalid memory");
+        return -ENOMEM;
+    }
+
+    *fmmode = fmdev->curr_fmmode;
+    return 0;
+}
+
+/*
+* Called by LDisc layer when FM packet is available. The pointer to
+* this function is registered to LDisc during brcm_sh_ldisc_register() call.*/
+static long fm_st_receive(void *arg, struct sk_buff *skb)
+{
+    struct fmdrv_ops *fmdev;
+    __u8 pkt_type = 0x08;
+
+    fmdev = (struct fmdrv_ops *)arg;
+
+    if (skb == NULL) {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid SKB received from LDisp");
+        return -EFAULT;
+    }
+    if (skb->cb[0] != FM_PKT_LOGICAL_CHAN_NUMBER) {
+        V4L2_FM_DRV_ERR("(fmdrv): Received SKB (%p) is not FM Channel 8 pkt", skb);
+        return -EINVAL;
+    }
+
+    memcpy(skb_push(skb, 1), &pkt_type, 1);
+    skb_queue_tail(&fmdev->rx_q, skb);
+
+#ifdef TASKLET_SUPPORT
+    tasklet_schedule(&fmdev->rx_task);
+#else
+    queue_work(fmdev->rx_wq,&fmdev->rx_workqueue);
+#endif
+    return 0;
+}
+
+/*
+ * This function will be called from FM V4L2 open function.
+ * Register with shared ldisc driver and initialize driver data.
+ */
+int fmc_prepare(struct fmdrv_ops *fmdev)
+{
+    static struct sh_proto_s fm_st_proto;
+    int ret = 0;
+
+    if (test_bit(FM_CORE_READY, &fmdev->flag)) {
+        V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "(fmdrv): FM Core is already up");
+        return ret;
+    }
+
+    memset(&fm_st_proto, 0, sizeof(fm_st_proto));
+    fm_st_proto.type = PROTO_SH_FM;
+    fm_st_proto.recv = fm_st_receive;
+    fm_st_proto.match_packet = NULL;
+    fm_st_proto.write = NULL; /* shared ldisc driver will fill write pointer */
+    fm_st_proto.priv_data = fmdev;
+
+    /* Register with the shared line discipline */
+    ret = brcm_sh_ldisc_register(&fm_st_proto);
+    if (ret == -1) {
+        pr_err("(fmdrv): brcm_sh_ldisc_register failed %d", ret);
+        ret = -EAGAIN;
+        return ret;
+    }
+    else {
+        V4L2_FM_DRV_DBG(V4L2_DBG_OPEN,"(fmdrv): fmc_prepare: brcm_sh_ldisc_register sucess %d", ret);
+    }
+
+    if (fm_st_proto.write != NULL) {
+        g_bcm_write = fm_st_proto.write;
+    }
+    else {
+        V4L2_FM_DRV_ERR("(fmdrv): Failed to get shared ldisc write func pointer");
+        ret = brcm_sh_ldisc_unregister(PROTO_SH_FM);
+        if (ret < 0)
+            V4L2_FM_DRV_ERR("(fmdrv): brcm_sh_ldisc_unregister failed %d", ret);
+            ret = -EAGAIN;
+            return ret;
+    }
+
+    spin_lock_init(&fmdev->resp_skb_lock);
+
+    /* Initialize TX queue and TX tasklet */
+    skb_queue_head_init(&fmdev->tx_q);
+    /* Initialize RX Queue and RX tasklet */
+    skb_queue_head_init(&fmdev->rx_q);
+#ifdef TASKLET_SUPPORT
+    tasklet_init(&fmdev->tx_task, __send_tasklet, (unsigned long)fmdev);
+    tasklet_init(&fmdev->rx_task, __recv_tasklet, (unsigned long)fmdev);
+#else
+INIT_WORK(&fmdev->tx_workqueue,fm_send_data_ldisc);
+INIT_WORK(&fmdev->rx_workqueue,fm_receive_data_ldisc);
+#endif
+    atomic_set(&fmdev->tx_cnt, 1);
+    fmdev->response_completion = NULL;
+
+    /* Do all the broadcom FM hardware specific initialization */
+    fmdev->rx.curr_mute_mode = FM_MUTE_OFF;
+    fmdev->rx.rds.rds_flag = FM_RDS_DISABLE;
+    fmdev->rx.curr_region = DEF_V4L2_FM_WORLD_REGION;
+    memcpy(&fmdev->rx.region, &region_configs[fmdev->rx.curr_region],
+                            sizeof(struct region_info));
+    fmdev->rx.curr_freq = fmdev->rx.region.low_bound;
+    fmdev->rx.rds_mode = FM_RDS_SYSTEM_NONE;
+    fmdev->rx.curr_snr_threshold = FM_RX_SNR_MAX + 1;
+    fmdev->rx.curr_sch_mode = FM_SCAN_NONE;
+    fmdev->rx.curr_noise_floor = FM_NFE_DEFAILT;
+    fmdev->rx.curr_volume = FM_RX_VOLUME_MAX;
+    fmdev->rx.audio_mode = FM_AUTO_MODE;
+    fmdev->rx.audio_path = FM_AUDIO_NONE;
+    fmdev->rx.sch_step = FM_STEP_NONE;
+    fmdev->device_info.capabilities = V4L2_CAP_HW_FREQ_SEEK | V4L2_CAP_TUNER |
+                                V4L2_CAP_RADIO | V4L2_CAP_MODULATOR |
+                                V4L2_CAP_AUDIO | V4L2_CAP_READWRITE | V4L2_CAP_RDS_CAPTURE;
+    fmdev->device_info.type = V4L2_TUNER_RADIO;
+    fmdev->device_info.rxsubchans = V4L2_TUNER_SUB_MONO | V4L2_TUNER_SUB_STEREO;
+    fmdev->device_info.tuner_capability =V4L2_TUNER_CAP_STEREO | V4L2_TUNER_CAP_LOW | V4L2_TUNER_CAP_RDS;
+
+    /* RDS initialization */
+    fmc_reset_rds_cache(fmdev);
+    init_waitqueue_head(&fmdev->rx.rds.read_queue);
+
+    set_bit(FM_CORE_READY, &fmdev->flag);
+    return ret;
+}
+
+/* This function will be called from FM V4L2 release function.
+ * Unregister from line discipline driver.
+ */
+int fmc_release(struct fmdrv_ops *fmdev)
+{
+    int ret;
+    V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "(fmdrv) %s", __func__);
+
+    if (!test_bit(FM_CORE_READY, &fmdev->flag)) {
+        V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "(fmdrv): FM Core is already down");
+        return 0;
+    }
+
+#ifndef TASKLET_SUPPORT
+    cancel_work_sync(&fmdev->tx_workqueue);
+    cancel_work_sync(&fmdev->rx_workqueue);
+#endif
+    ret = brcm_sh_ldisc_unregister(PROTO_SH_FM);
+    if (ret < 0)
+        V4L2_FM_DRV_ERR("(fmdrv): Failed to de-register FM from HCI LDisc - %d", ret);
+    else
+        V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "(fmdrv): Successfully unregistered from  HCI LDisc");
+
+    /* Sevice pending read */
+    wake_up_interruptible(&fmdev->rx.rds.read_queue);
+#ifdef TASKLET_SUPPORT
+    tasklet_kill(&fmdev->tx_task);
+    tasklet_kill(&fmdev->rx_task);
+#else
+    skb_queue_purge(&fmdev->tx_q);
+    skb_queue_purge(&fmdev->rx_q);
+#endif
+
+    fmdev->response_completion = NULL;
+    fmdev->rx.curr_freq = 0;
+
+    clear_bit(FM_CORE_READY, &fmdev->flag);
+    return ret;
+}
+
+/* Module init function. Ask FM V4L module to register video device.
+ * Allocate memory for FM driver context
+ */
+static int __init fm_drv_init(void)
+{
+    struct fmdrv_ops *fmdev = NULL;
+    int ret = -ENOMEM;
+/*This is an initialization of CT variable. To perform unit testing*/
+/*Even if you remove this initilization functionality won't be effected*/
+    current_ct.day = 1;
+    current_ct.hour = 2;
+    current_ct.minute = 3;
+    current_ct.second = 4;
+
+    pr_info("(fmdrv): FM driver version %s", FM_DRV_VERSION);
+
+    fmdev = kzalloc(sizeof(struct fmdrv_ops), GFP_KERNEL);
+    if (NULL == fmdev) {
+        V4L2_FM_DRV_ERR("(fmdrv): Can't allocate operation structure memory");
+        return ret;
+    }
+
+    fmdev->rx.rds.buf_size = default_rds_buf * FM_RDS_TUPLE_LENGTH;
+    /* Allocate memory for RDS ring buffer */
+    fmdev->rx.rds.cbuffer = kzalloc(fmdev->rx.rds.buf_size, GFP_KERNEL);
+    if (fmdev->rx.rds.cbuffer == NULL) {
+        V4L2_FM_DRV_ERR("Can't allocate rds ring buffer");
+        kfree(fmdev);
+        return -ENOMEM;
+    }
+
+    ret = fm_v4l2_init_video_device(fmdev, radio_nr);
+    if (ret < 0)
+    {
+        kfree(fmdev);
+        return ret;
+    }
+#ifndef TASKLET_SUPPORT
+    fmdev->tx_wq= create_workqueue("fm_drv_tx");
+    if (!fmdev->tx_wq) {
+        V4L2_FM_DRV_ERR("%s(): Unable to create workqueue fm_drv_tx\n", __func__);
+        return -ENOMEM;
+    }
+    fmdev->rx_wq= create_workqueue("fm_drv_rx");
+    if (!fmdev->rx_wq) {
+        V4L2_FM_DRV_ERR("%s(): Unable to create workqueue fm_drv_rx\n", __func__);
+        return -ENOMEM;
+    }
+#endif
+
+    fmdev->curr_fmmode = FM_MODE_OFF;
+    return 0;
+}
+
+/* Module exit function. Ask FM V4L module to unregister video device */
+static void __exit fm_drv_exit(void)
+{
+    struct fmdrv_ops *fmdev = NULL;
+    V4L2_FM_DRV_DBG(V4L2_DBG_INIT, "(fmdrv): fm_drv_exit");
+
+    fmdev = fm_v4l2_deinit_video_device();
+    if (fmdev != NULL) {
+#ifndef TASKLET_SUPPORT
+    destroy_workqueue(fmdev->tx_wq);
+    destroy_workqueue(fmdev->rx_wq);
+#endif
+    kfree(fmdev);
+    }
+}
+
+module_init(fm_drv_init);
+module_exit(fm_drv_exit);
+
+module_param(fm_dbg_param, int, S_IRUGO);
+MODULE_PARM_DESC(fm_dbg_param, \
+               "Set to integer value from 1 to 31 for enabling/disabling" \
+               " specific categories of logs");
+
+
+/* ------------- Module Info ------------- */
+MODULE_AUTHOR("Satyajit Roy <roys@broadcom.com>, Syed Ibrahim Moosa <syedibrahim.moosa@broadcom.com>");
+MODULE_DESCRIPTION("FM Driver for Connectivity chip of Broadcom Corporation");
+MODULE_VERSION(VERSION); /* defined in makefile */
+MODULE_LICENSE("GPL");

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.h
@@ -1,0 +1,362 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+/************************************************************************************
+*
+*  Filename:      fmdrv_main.h
+*
+*  Description:   Header for FM V4L2 driver
+*
+***********************************************************************************/
+
+#ifndef _FMDRV_MAIN_H
+#define _FMDRV_MAIN_H
+#include <linux/module.h>
+#include <net/bluetooth/bluetooth.h>
+#include <net/bluetooth/hci_core.h>
+
+/*******************************************************************************
+**  Constants & Macros
+*******************************************************************************/
+
+#define FM_PKT_LOGICAL_CHAN_NUMBER  0x08
+
+#define REG_RD       0x1
+#define REG_WR       0x0
+#define VSC_HCI_CMD  0x2
+
+#define HCI_COMMAND  0x01
+#define VSC_HCI_WRITE_PCM_PINS_OCF 0x0061
+#define FM_2048_OP_CODE         0x0015
+#define HCI_GRP_VENDOR_SPECIFIC 0x3F
+#define BRCM_FM_VS_EVENT 0xff
+#define BRCM_FM_VS_CMD_CMPL HCI_EV_CMD_COMPLETE
+#define BRCM_VSE_SUBCODE_FM_INTERRUPT  0x08
+
+/* FM RX registers */
+#define FM_REG_RDS_SYS          0x00
+#define FM_REG_FM_CTRL          0x01
+#define FM_REG_RDS_CTL0         0x02
+
+#define FM_REG_AUD_PAUS         0x04
+#define FM_REG_AUD_CTL0         0x05
+#define FM_REG_AUD_CTL1         0x06
+#define FM_REG_SCH_CTL0         0x07
+#define FM_SEARCH_SNR           0x08        /* search criteria for SNR */
+#define FM_REG_SCH_TUNE         0x09
+#define FM_REG_FM_FREQ          0x0a
+#define FM_REG_FM_FREQ1         0x0b
+#define FM_REG_AF_FREQ0         0x0c
+#define FM_REG_AF_FREQ1         0x0d
+#define FM_REG_CARRIER          0x0e
+#define FM_REG_RSSI             0x0f
+#define FM_REG_FM_RDS_MSK       0x10
+#define FM_REG_FM_RDS_MSK1      0x11
+#define FM_REG_FM_RDS_FLAG      0x12
+#define FM_REG_FM_RDS_FLAG1     0x13
+#define FM_REG_RDS_WLINE        0x14
+
+#define FM_REG_BB_MAC0          0x16
+#define FM_REG_BB_MAC1          0x17
+#define FM_REG_BB_MSK0          0x18
+#define FM_REG_BB_MSK1          0x19
+#define FM_REG_PI_MAC0          0x1a
+#define FM_REG_PI_MAC1          0x1b
+#define FM_REG_PI_MSK0          0x1c
+#define FM_REG_PI_MSK1          0x1d
+
+#define FM_REG_RCV_ID           0x28
+#define FM_REG_CFG              0x29
+#define FM_REG_RDS_DATA         0x80
+#define FM_REG_AF_FAILURE       0x90    /* AF jump failure reason code */
+#define FM_REG_PCM_ROUTE        0x4d
+#define FM_RES_PRESCAN_QUALITY  0xde    /* preset scan CO slope threshold */
+#define FM_REG_SNR              0xdf    /* SNR reading of currently tuned channel */
+#define FM_REG_VOLUME_CTRL      0xf8    /* audio control register */
+#define FM_REG_BLEND_MUTE       0xf9
+#define FM_SEARCH_BOUNDARY      0xfb    /* search boundary */
+#define FM_SEARCH_METHOD        0xfc    /* scan mode for 2048B0 FW */
+#define FM_REG_PRESET_MAX       0xfe
+#define FM_REG_SCH_STEP         0xfd
+#define FM_REG_PRESET_STA       0xff
+
+/*******************************************************************************
+**  Type definitions
+*******************************************************************************/
+
+/* SKB helpers */
+struct fm_skb_cb {
+    __u8 fm_opcode;
+    struct completion *completion;
+};
+
+#define fm_cb(skb) ((struct fm_skb_cb *)(skb->cb))
+
+/* FM Channel-8 command message format */
+struct fm_cmd_msg_hdr {
+    __u8 header;        /* Logical Channel-8 */
+    __u16 cmd;          /* vendor specific command */
+    __u8 len;           /* Number of bytes follows */
+    __u8 fm_opcode;     /* FM Opcode */
+    __u8 rd_wr;         /* Read/Write command */
+} __attribute__ ((packed));
+
+
+/* FM Channel-8 command message format */
+struct fm_vsc_hci_cmd_msg_hdr {
+    __u8 header;        /* Logical Channel-8 */
+    __u16 cmd;          /* vendor specific command */
+    __u8 len;           /* Number of bytes follows */
+} __attribute__ ((packed));
+
+
+#define FM_CMD_MSG_HDR_SIZE    6    /* sizeof(struct fm_cmd_msg_hdr) */
+#define FM_VSC_HCI_CMD_MSG_HDR_SIZE    4
+
+
+
+/* FM Channel-8 event messgage format */
+struct fm_event_msg_hdr {
+    __u8 header;        /* Logical Channel-8 */
+    __u8 event_id;      /* event identification */
+    __u8 len;           /* Number of bytes follows */
+} __attribute__ ((packed));
+
+#define FM_EVT_MSG_HDR_SIZE     3 /* sizeof(struct fm_event_msg_hdr) */
+struct fm_cmd_complete_hdr {
+    struct hci_ev_cmd_complete hci_cmd_complete;
+    __u8 status;
+    __u8 fm_opcode;        /* FM Opcode */
+    __u8 rd_wr;
+} __attribute__ ((packed));
+
+#define FM_CMD_COMPLETE_HDR_SIZE     6 /* sizeof(struct fm_cmd_complete_hdr ) */
+
+/* Converts little endian to big endian */
+#define FM_STORE_LE16_TO_BE16(data, value)   \
+    (data = ((value >> 8) | ((value & 0xFF) << 8)))
+#define FM_LE16_TO_BE16(value)   (((value >> 8) | ((value & 0xFF) << 8)))
+
+#define FM_STORE_LE32_TO_BE32(data, value)   \
+    (data = (((value & 0xFF) >> 24) | ((value & 0xFF00) >> 8) \
+             | ((value & 0xFF0000) << 8) | ((value & 0xFF000000) << 24)))
+#define FM_LE32_TO_BE32(value)   (((value & 0xFF) >> 24) | ((value & 0xFF00) >> 8) \
+             | ((value & 0xFF0000) << 8) | ((value & 0xFF000000) << 24))
+
+
+/* Converts big endian to little endian */
+#define FM_STORE_BE16_TO_LE16(data, value)   \
+    (data = ((value & 0xFF) << 8) | ((value >> 8)))
+#define FM_BE16_TO_LE16(value)   (((value & 0xFF) << 8) | ((value >> 8)))
+
+#define FM_STORE_BE32_TO_LE32(data, value)   \
+    (data = (((value & 0xFF) >> 24) | ((value & 0xFF00) >> 8) \
+             | ((value & 0xFF0000) << 8) | ((value & 0xFF000000) << 24)))
+#define FM_BE32_TO_LE32(value)   (((value & 0xFF000000) << 24) | ((value & 0xFF0000) << 8)  \
+    | ((value & 0xFF00) >> 8) | ((value & 0xFF) >> 24))
+
+#define STREAM_TO_UINT8(u8, p)   {u8 = (unsigned int)(*(p)); (p) += 1;}
+
+#define FM_CHECK_SEND_CMD_STATUS(ret)  \
+    if (ret < 0) {\
+        return ret;\
+    }
+
+/* Seek directions */
+#define FM_SEARCH_DIRECTION_DOWN    0
+#define FM_SEARCH_DIRECTION_UP      1
+
+/* Frequency scanning direction */
+#define FM_SCAN_DOWN 0x00 /* bit 7 = 0 : Scan towards lower frequency */
+#define FM_SCAN_UP 0x80 /* bit 7 = 1 : Scan towards upper frequency */
+
+#define FM_SCAN_DIRECT_MASK     0xf0 /* high 4 bits for search direction */
+
+/* Tunner modes */
+#define FM_TUNER_NORMAL_SCAN_MODE       0
+#define FM_TUNER_PRESET_MODE            1
+#define FM_TUNER_SEEK_MODE 2
+#define FM_TUNER_AF_JUMP_MODE           3
+
+#define FM_SCAN_FULL        (FM_SCAN_UP | FM_TUNER_NORMAL_SCAN_MODE |0x02)       /* full band scan */
+#define FM_FAST_SCAN        (FM_SCAN_UP | FM_TUNER_PRESET_MODE)                 /* use preset scan */
+#define FM_SCAN_NONE         0xff
+
+/* Min and Max volume */
+#define FM_RX_VOLUME_MIN    0
+#define FM_RX_VOLUME_MAX    255 /* Max volume 0x100 */
+
+/*TI GUI app is setting max volume as 16383
+16383/255=63*/
+#define FM_RX_VOLUME_RATIO 63
+
+#define COMP_SCAN_START         1
+#define COMP_SCAN_READ          2
+#define COMP_SCAN_STOP          3
+
+/* FM RX De-emphasis filter modes */
+#define FM_RX_EMPHASIS_FILTER_50_USEC   0
+#define FM_RX_EMPHASIS_FILTER_75_USEC   1
+
+/* RSSI threshold min and max */
+#define FM_RX_RSSI_THRESHOLD_MIN    0   /* 0 dBuV */
+#define FM_RX_RSSI_THRESHOLD_MAX    127 /* 191.1477 dBuV */
+
+/*SNR threshold min and max*/
+#define FM_RX_SNR_THRESHOLD_MIN    0
+#define FM_RX_SNR_THRESHOLD_MAX    31
+
+
+/* AF on/off */
+#define FM_RX_RDS_AF_SWITCH_MODE_ON 1
+#define FM_RX_RDS_AF_SWITCH_MODE_OFF 0
+
+/* Band types */
+#define FM_BAND_EUROPE      0
+#define FM_BAND_JAPAN       1
+#define FM_BAND_NA          2
+#define FM_BAND_RUSSIAN     3
+#define FM_BAND_CHINA       4
+#define FM_BAND_ITALY       5
+#define FM_BAND_WEATHER     6
+
+/* noise floor estimation */
+#define     FM_NFE_DEFAILT      93      /* default Noise floor value */
+#define     FM_NFE_THRESH       0x32    /* default NFE threshold 53 db */
+#define     FM_NFE_SNR_STEREO   19      /* Stereo audio mode SNR level above NFL */
+#define     FM_NFE_SNR_MONO     10      /* Mono audio mode SNR level above NFL */
+
+/* Mute modes */
+#define    FM_MUTE_OFF         0
+#define    FM_MUTE_ON          1
+#define    FM_MUTE_ATTENUATE   2
+
+/* RF dependent mute mode */
+#define FM_RX_RF_DEPENDENT_MUTE_ON  1
+#define FM_RX_RF_DEPENDENT_MUTE_OFF 0
+
+/* SNR threshold max */
+#define FM_RX_SNR_MAX      31
+
+/* FM RDS modes */
+#define FM_RDS_DISABLE    0
+#define FM_RDS_ENABLE    1
+
+/* FM RBDS modes */
+#define FM_RDBS_DISABLE 0
+#define FM_RDBS_ENABLE  1
+
+/* RDS system type (RDS/RBDS) */
+#define FM_RDS_SYSTEM_NONE  0
+#define FM_RDS_SYSTEM_RDS   1
+#define FM_RDS_SYSTEM_RBDS  2
+
+/* Default RX mode configuration. Chip will be configured
+ * with this default values after loading RX firmware.
+ */
+#define FM_DEFAULT_RX_VOLUME        150
+
+/* length of RDS tuple retreived from RDS FIFO */
+#define FM_RDS_TUPLE_LENGTH          3    /* 3 bytes */
+
+/* max number of bytes to be read from RDS FIFO */
+#define FM_RDS_FIFO_MAX               240
+/* length of a RDS group based on RDS tuple */
+#define FM_RDS_GROUP_LEN            12
+/* 1st byte of a RDS tuple index */
+#define FM_RDS_TUPLE_BYTE1         0
+/* 2nd byte of a RDS tuple index */
+#define FM_RDS_TUPLE_BYTE2         1
+/* 3rd byte of a RDS tuple index */
+#define FM_RDS_TUPLE_BYTE3         2
+
+#define FM_RDS_BLOCK_SIZE             3    /* 3 bytes */
+
+/* RDS block types */
+#define FM_RDS_BLOCK_A                0x00
+#define FM_RDS_BLOCK_B                0x10
+#define FM_RDS_BLOCK_C                0x20
+#define FM_RDS_BLOCK_Ctag            0x40
+#define FM_RDS_BLOCK_D                0x30
+#define FM_RDS_BLOCK_E_RBDS            0x50
+#define FM_RDS_BLOCK_E                0x60
+
+#define FM_RDS_BLOCK_INDEX_A            0
+#define FM_RDS_BLOCK_INDEX_B            1
+#define FM_RDS_BLOCK_INDEX_C            2
+#define FM_RDS_BLOCK_INDEX_D            3
+#define FM_RDS_BLOCK_INDEX_Ctag            4
+#define FM_RDS_BLOCK_INDEX_UNKNOWN      0xF0
+
+#define BRCM_RDS_BIT_0                              (0x01 << 0)
+#define BRCM_RDS_BIT_1                              (0x01 << 1)
+#define BRCM_RDS_BIT_2                              (0x01 << 2)
+#define BRCM_RDS_BIT_3                              (0x01 << 3)
+#define BRCM_RDS_BIT_4                              (0x01 << 4)
+#define BRCM_RDS_BIT_5                              (0x01 << 5)
+#define BRCM_RDS_BIT_6                              (0x01 << 6)
+#define BRCM_RDS_BIT_7                              (0x01 << 7)
+
+#define FM_RDS_STATUS_ERROR_MASK        0x30
+#define BRCM_RDS_GRP_TYPE_MASK               0xF0 /* Group type mask */
+#define BRCM_RDS_GRP_QLTY_MASK               (BRCM_RDS_BIT_2 | BRCM_RDS_BIT_3) /* Group Quality mask */
+
+/* RDS block data quality */
+enum
+{
+        BRCM_RDS_NO_ERR,        /* 0x00 */
+        BRCM_RDS_2BIT_ERR,     /* 0x01 */
+        BRCM_RDS_3BIT_ERR,     /* 0x02 */
+        BRCM_RDS_UNRECOVER  /* 0x03 */
+};
+
+typedef unsigned char tBRCM_RDS_QUALITY;
+
+/*******************************************************************************
+**  Functions
+*******************************************************************************/
+
+/* Functions exported by FM common sub-module */
+int fmc_prepare(struct fmdrv_ops *);
+int fmc_release(struct fmdrv_ops *);
+
+void fmc_update_region_info(struct fmdrv_ops *, unsigned char);
+int fmc_send_cmd(struct fmdrv_ops *, unsigned char, void *, int,unsigned char,
+            struct completion *, void *, int *);
+
+int fmc_set_frequency(struct fmdrv_ops *, unsigned int);
+int fmc_set_mode(struct fmdrv_ops *, unsigned char);
+int fmc_set_region(struct fmdrv_ops *, unsigned char);
+int fmc_set_audio_mode(struct fmdrv_ops *, unsigned char);
+int fmc_seek_station(struct fmdrv_ops *, unsigned char, unsigned char);
+
+int fmc_get_frequency(struct fmdrv_ops *, unsigned int *);
+int fmc_get_region(struct fmdrv_ops *, unsigned char *);
+int fmc_get_audio_mode(struct fmdrv_ops *fmdev, unsigned char *audio_mode);
+int fmc_get_mode(struct fmdrv_ops *, unsigned char *);
+int fmc_enable (struct fmdrv_ops *, unsigned char);
+int fmc_turn_fm_off(struct fmdrv_ops *);
+int fmc_turn_fm_on (struct fmdrv_ops *, unsigned char);
+int fmc_set_scan_step(struct fmdrv_ops *, unsigned char);
+int fmc_transfer_rds_from_cbuff(struct fmdrv_ops *, struct file *,
+                    char __user *, size_t);
+void fmc_reset_rds_cache(struct fmdrv_ops *);
+void get_rds_element_value(int ioctl_num, char __user *ioctl_value);
+
+#endif
+

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_rx.c
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_rx.c
@@ -1,0 +1,1207 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+/*******************************************************************************
+ *
+ *  Filename:      fmdrv_rx.c
+ *
+ *  Description:   This sub-module of FM driver implements FM RX functionality.
+ *
+ *******************************************************************************/
+
+#include "fmdrv.h"
+#include "fmdrv_main.h"
+#include "fmdrv_rx.h"
+#include "fmdrv_config.h"
+#include "fm_public.h"
+#include "../include/v4l2_target.h"
+#include "../include/v4l2_logs.h"
+
+
+/*******************************************************************************
+**  Constants & Macros
+*******************************************************************************/
+
+#ifndef V4L2_FM_DEBUG
+#define V4L2_FM_DEBUG TRUE
+#endif
+
+/* set this module parameter to enable debug info */
+extern int fm_dbg_param;
+
+extern struct region_info region_configs[];
+
+#if V4L2_FM_DEBUG
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...) \
+        do { \
+            if (fm_dbg_param & flag) \
+                printk(KERN_DEBUG "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg); \
+        } while(0)
+#else
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...)
+#endif
+#define V4L2_FM_DRV_ERR(fmt, arg...)  printk(KERN_ERR "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg)
+
+const unsigned short fm_sch_step_size[] =
+{
+    50,
+    100,
+    200
+};
+
+/*******************************************************************************
+**  Functions
+*******************************************************************************/
+/*******************************************************************************
+**  Helper functions
+*******************************************************************************/
+
+/* Configures Alternate Frequency switch mode */
+int fm_rx_set_af_switch(struct fmdrv_ops *fmdev, u8 af_mode)
+{
+    u16 payload;
+    int ret;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (af_mode != FM_RX_RDS_AF_SWITCH_MODE_ON &&
+        af_mode != FM_RX_RDS_AF_SWITCH_MODE_OFF) {
+        V4L2_FM_DRV_ERR("Invalid af mode\n");
+        return -EINVAL;
+    }
+    /* Enable/disable low RSSI interrupt based on af_mode */
+    if (af_mode == FM_RX_RDS_AF_SWITCH_MODE_ON)
+        fmdev->rx.fm_rds_mask |= I2C_MASK_RSSI_LOW_BIT;
+    else
+        fmdev->rx.fm_rds_mask &= ~I2C_MASK_RSSI_LOW_BIT;
+
+    payload = fmdev->rx.fm_rds_mask;
+
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &fmdev->rx.fm_rds_mask,
+                            2, REG_WR,&fmdev->maintask_completion, NULL, NULL);
+
+    if (ret < 0)
+        return ret;
+
+    fmdev->rx.af_mode = af_mode;
+
+    return 0;
+}
+
+
+/*
+ * Sets the signal strength level that once reached
+ * will stop the auto search process
+ */
+int fm_rx_set_rssi_threshold(struct fmdrv_ops *fmdev, short rssi_lvl_toset)
+{
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, " fm_rx_set_rssi_threshold to set is %d",\
+        rssi_lvl_toset);
+
+    if (rssi_lvl_toset < FM_RX_RSSI_THRESHOLD_MIN ||
+        rssi_lvl_toset > FM_RX_RSSI_THRESHOLD_MAX) {
+        V4L2_FM_DRV_ERR("Invalid RSSI threshold level\n");
+        return -EINVAL;
+    }
+
+    fmdev->rx.curr_rssi_threshold = rssi_lvl_toset;
+    return 0;
+}
+
+/*
+ * Sets the signal strength level that once reached
+ * will stop the auto search process
+ */
+int fm_rx_set_snr_threshold(struct fmdrv_ops *fmdev, short snr_lvl_toset)
+{
+    u16 payload;
+    int ret;
+
+    if (snr_lvl_toset < FM_RX_SNR_THRESHOLD_MIN ||
+        snr_lvl_toset > FM_RX_SNR_THRESHOLD_MAX) {
+        V4L2_FM_DRV_ERR("Invalid SNR threshold level\n");
+        return -EINVAL;
+    }
+    payload = (u16) snr_lvl_toset;
+    ret = fmc_send_cmd(fmdev, FM_SEARCH_SNR, &payload, sizeof(payload),
+            REG_WR, &fmdev->maintask_completion, NULL,NULL);
+
+    if (ret < 0)
+        return ret;
+
+    fmdev->rx.curr_snr_threshold= snr_lvl_toset;
+
+    return 0;
+}
+
+
+
+/*
+* Function to validate if the tuned/scanned frequency is valid
+* or not
+*/
+int check_if_valid_freq(struct fmdrv_ops *fmdev, unsigned short frequency)
+{
+    if(frequency < fmdev->rx.region.low_bound ||
+            frequency > fmdev->rx.region.high_bound)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv)%s %d - Literally out of range", \
+            __func__, FM_SET_FREQ(frequency));
+        return FALSE;
+    }
+    else
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv)%s %d - Freq in range", __func__, \
+            FM_SET_FREQ(frequency));
+        return TRUE;
+    }
+}
+
+/*
+* Function to read the FM_RDS_FLAG registry
+*/
+int read_fm_rds_flag(struct fmdrv_ops *fmdev, unsigned short *value)
+{
+    unsigned char read_length;
+    int ret;
+    int resp_len;
+    unsigned char resp_buf [2];
+
+    read_length = FM_READ_2_BYTE_DATA;
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_FLAG, &read_length,
+        sizeof(read_length), REG_RD,
+                    &fmdev->maintask_completion, &resp_buf, &resp_len);
+    *value = (unsigned short)resp_buf[0] +
+                ((unsigned short)resp_buf[1] << 8);
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) FM Mask : 0x%x ", *value);
+    return 0;
+}
+
+/*
+* Function to read the FM_RDS_FLAG registry
+*/
+int fm_rx_set_mask(struct fmdrv_ops *fmdev, unsigned short mask)
+{
+    int ret;
+    unsigned short flag;
+
+    fmdev->rx.fm_rds_flag|= FM_RDS_FLAG_CLEAN_BIT; /* clean FM_RDS_FLAG */
+    ret = read_fm_rds_flag(fmdev, &flag);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &mask, sizeof(mask), REG_WR,
+            &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    return ret;
+}
+
+/*
+* Helper Function to initialize and start a search operation
+* (SEEK or TUNE). This method is internally called by fm_rx_set_frequency()
+* and fm_rx_seek_station().
+*/
+int init_start_search(struct fmdrv_ops *fmdev, unsigned short start_freq,
+                        unsigned char mode)
+{
+    unsigned char payload;
+    unsigned short tmp_fm_rds_mask;
+    int ret;
+
+    if(mode == FM_TUNER_SEEK_MODE)
+    {
+        /* Set Scan mode */
+        payload = FM_TUNER_NORMAL_SCAN_MODE;
+        ret = fmc_send_cmd(fmdev, FM_SEARCH_METHOD, &payload, 1, REG_WR,
+                &fmdev->maintask_completion, NULL, NULL);
+        FM_CHECK_SEND_CMD_STATUS(ret);
+
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdev) %s FM_SEARCH_METHOD set to 0x%x",\
+            __func__, payload);
+
+        /* Set Preset stations number to 0 */
+        payload = 0;
+        ret = fmc_send_cmd(fmdev, FM_REG_PRESET_MAX, &payload, 1, REG_WR,
+                &fmdev->maintask_completion, NULL, NULL);
+        FM_CHECK_SEND_CMD_STATUS(ret);
+
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) %s FM_REG_PRESET_MAX set to 0x%x",\
+            __func__, payload);
+
+        /* Set FM Search control params to controller */
+        payload = fmdev->rx.curr_rssi_threshold | (fmdev->rx.curr_sch_mode &
+                                                          FM_SCAN_DIRECT_MASK);
+        ret = fmc_send_cmd(fmdev, FM_REG_SCH_CTL0, &payload, 1, REG_WR,
+                &fmdev->maintask_completion, NULL, NULL);
+        FM_CHECK_SEND_CMD_STATUS(ret);
+
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) %s FM_REG_SCH_CTL0 set to 0x%x",\
+            __func__, payload);
+
+    }
+
+    /* freeze interrupt event before SCH_TUNE is commanded */
+    fmdev->rx.fm_rds_flag |= FM_RDS_FLAG_SCH_FRZ_BIT;
+    /* set sch_tune pending bit */
+    fmdev->rx.fm_rds_flag |= FM_RDS_FLAG_SCH_BIT;
+
+    /* Write Frequency */
+    /* Write FM_REG_FM_FREQ (0x0a) register first */
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_FREQ, &start_freq,
+            sizeof(start_freq), REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) %s FM_REG_FM_FREQ set to 0x%x", \
+        __func__, FM_SET_FREQ(start_freq));
+
+    /* Set the mask flag to Register FM_REG_FM_RDS_MSK(0x10)
+    & FM_REG_FM_RDS_MSK1(0x11) */
+    tmp_fm_rds_mask= I2C_MASK_SRH_TUNE_CMPL_BIT | I2C_MASK_SRH_TUNE_FAIL_BIT;
+    ret = fm_rx_set_mask(fmdev, tmp_fm_rds_mask);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    /* Reset the fm_rds_flag here as for the first time we dont get
+    any interrupt during ENABLE to cleanup the bit */
+    fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_CLEAN_BIT;
+
+    /* Write FM_REG_SCH_TUNE (0x09) register */
+    /*payload = FM_TUNER_SEEK_MODE;*/ /* Scan parameter (0x02) */
+    payload = mode;
+    ret = fmc_send_cmd(fmdev, FM_REG_SCH_TUNE, &payload, sizeof(payload),
+            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->rx.curr_search_state = (mode == FM_TUNER_SEEK_MODE)?
+        FM_STATE_SEEKING:FM_STATE_TUNING;
+
+    fmc_reset_rds_cache(fmdev);
+
+    return 0;
+}
+
+/*
+* Function to process a SEEK complete event. This function determines
+* whether to wrap the search, or stop the search or return error
+* to user-space. This is called internally by fm_rx_seek_station() function.
+*/
+int process_seek_event(struct fmdrv_ops *fmdev)
+{
+    unsigned short tmp_freq, start_freq;
+    int ret = -EINVAL;
+    bool is_valid_freq;
+
+    tmp_freq = fmdev->rx.curr_freq;
+    is_valid_freq = check_if_valid_freq(fmdev, tmp_freq);
+    if(((FM_SET_FREQ(tmp_freq) - 5) <= FM_SET_FREQ(fmdev->rx.region.low_bound)) ||
+       ((FM_SET_FREQ(tmp_freq) + 5)  >= FM_SET_FREQ(fmdev->rx.region.high_bound)))
+    {
+        is_valid_freq = FALSE;
+    }
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) %s tmp:%d low:%d high:%d", __func__,\
+        tmp_freq, fmdev->rx.region.low_bound, fmdev->rx.region.high_bound);
+
+    /* First check if Scan suceeded or not */
+    if(fmdev->rx.curr_search_state == FM_STATE_SEEK_ERR)
+    {
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+        if(!fmdev->rx.seek_wrap && !is_valid_freq)
+        {
+            fmdev->rx.curr_search_state = FM_STATE_SEEK_ERR;
+            V4L2_FM_DRV_ERR("(fmdrv) Seek ended with out of bound frequency %d",\
+                FM_SET_FREQ(tmp_freq));
+           return FALSE;
+        }
+        else if(fmdev->rx.seek_wrap && !is_valid_freq)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv) Scan ended with out of bound frequency." \
+                "Wrapping search again..");
+
+            start_freq = (fmdev->rx.seek_direction==FM_SCAN_DOWN)?
+                (fmdev->rx.region.high_bound):(fmdev->rx.region.low_bound);
+            V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdev) Current scanned frequency " \
+                "is out of bounds. Resetting to freq (%d) ",
+                        FM_SET_FREQ(start_freq));
+
+            ret = init_start_search(fmdev, start_freq, FM_TUNER_SEEK_MODE);
+            if(ret < 0)
+            {
+                fmdev->rx.curr_search_state = FM_STATE_SEEK_ERR;
+                fmdev->rx.curr_freq = 0;
+                V4L2_FM_DRV_ERR ("(fmdrv): Error starting search for Seek " \
+                    "operation");
+                return FALSE;
+            }
+
+            fmdev->rx.curr_search_state = FM_STATE_SEEKING;
+            V4L2_FM_DRV_DBG (V4L2_DBG_RX, "(fmdrv): Started wrapped-up Seek " \
+                "operation");
+            return TRUE;
+        }
+        else
+        {
+            fmdev->rx.curr_search_state = FM_STATE_SEEK_ERR;
+            V4L2_FM_DRV_ERR("(fmdrv) *** ERROR :: Seek failed for %d " \
+                "frequency ***", FM_SET_FREQ(tmp_freq));
+            return FALSE;
+        }
+    }
+    else
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) Seek success!");
+        fmdev->rx.curr_search_state = FM_STATE_SEEK_CMPL;
+        return TRUE;
+    }
+}
+
+/*******************************************************************************
+**  Main functions - Called by fmdrv_main and fmdrv_v4l2.
+*******************************************************************************/
+
+/*
+* Function to read current RSSI and tuned frequency
+*/
+int fm_rx_read_curr_rssi_freq(struct fmdrv_ops *fmdev,
+                                   unsigned char rssi_only)
+{
+    int ret = 0, resp_len;
+    unsigned char payload;
+    unsigned short tmp_frq;
+    unsigned char resp_buf[2];
+
+    /* Read current RSSI */
+    payload = FM_READ_1_BYTE_DATA;
+    ret = fmc_send_cmd(fmdev, FM_REG_RSSI, &payload, 1,
+            REG_RD, &fmdev->maintask_completion, &resp_buf[0], &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    /* Calculating 2's compliment number into an absolute value number */
+    fmdev->rx.curr_rssi = (unsigned char) ((0x80 - resp_buf[0]) & (~0x80));
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) FM_REG_RSSI : %d", \
+        fmdev->rx.curr_rssi);
+
+    if(rssi_only)
+        return 0;
+
+    /* Read current frequency */
+    payload = FM_READ_2_BYTE_DATA;
+    tmp_frq = 0;
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_FREQ, &payload, 1,
+            REG_RD, &fmdev->maintask_completion, &tmp_frq, &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) FM_REG_FM_FREQ : %d", \
+        FM_SET_FREQ(tmp_frq));
+
+    fmdev->rx.curr_freq = tmp_frq;
+
+    return ret;
+}
+
+/*
+* Function for FM TUNE frequency implementation
+*   * Set the other registries such as Search method, search
+*    direction, etc.
+*   * Start preset search.
+*   * Based on interrupt received, read the current tuned freq
+*     and validate the search.
+*   * If search frequency out of bound, return error code -EAGAIN
+*   * If not, read RSSI, reset RDS cache and set RDS MASK to the earlier value.
+*/
+int fm_rx_set_frequency(struct fmdrv_ops *fmdev, unsigned int freq_to_set)
+{
+    unsigned short tmp_frq;
+    int ret = -EINVAL;
+    unsigned long timeleft;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): current region = %d",\
+        fmdev->rx.curr_region);
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+    tmp_frq = FM_GET_FREQ(freq_to_set);
+    if(!check_if_valid_freq(fmdev, tmp_frq))
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Set frequency called with %d - out of "\
+            "bound range (%d-%d)",
+            freq_to_set, FM_SET_FREQ(fmdev->rx.region.low_bound),
+            FM_SET_FREQ(fmdev->rx.region.high_bound));
+        return -EINVAL;
+    }
+
+    ret = init_start_search(fmdev, tmp_frq, FM_TUNER_PRESET_MODE);
+    if(ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error starting search for Seek operation");
+        return ret;
+    }
+
+    /* Wait for tune ended interrupt */
+    init_completion(&fmdev->maintask_completion);
+    timeleft = wait_for_completion_timeout(&fmdev->maintask_completion,
+                           FM_DRV_TX_TIMEOUT);
+    if (!timeleft)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) Timeout(%d sec),didn't get tune ended interrupt",\
+               jiffies_to_msecs(FM_DRV_TX_TIMEOUT) / 1000);
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+        return -ETIMEDOUT;
+    }
+
+    /* First check if Tune suceeded or not */
+    if(fmdev->rx.curr_search_state == FM_STATE_TUNE_ERR)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) Tune failed for %d MHz frequency", \
+            FM_SET_FREQ(tmp_frq));
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+        return -EAGAIN;
+    }
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Set frequency done!");
+    fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+
+    fm_rx_read_curr_rssi_freq(fmdev, FALSE);
+    /* Reset RDS Cache */
+    fmc_reset_rds_cache(fmdev);
+
+    if(fmdev->rx.fm_rds_mask)
+    {
+        /* Update the FM_RDS_MASK to set the earlier bits */
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Update FM_RDS_MASK : 0x%x", \
+        fmdev->rx.fm_rds_mask);
+        ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &fmdev->rx.fm_rds_mask,
+            sizeof(fmdev->rx.fm_rds_mask), REG_WR,
+            &fmdev->maintask_completion, NULL, NULL);
+    }
+
+    return 0;
+}
+
+/*
+* Function to get the current tuned frequency
+* This function will query controller by reading the FM_REG_FM_FREQ(0x0a)
+* to determine the current tuned frequency.
+*/
+int fm_rx_get_frequency(struct fmdrv_ops *fmdev, unsigned int *curr_freq)
+{
+    unsigned char payload;
+    unsigned short tmp_frq;
+    int ret;
+    int resp_len;
+
+    payload = 2;
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_FREQ, &payload, 1, REG_RD,
+            &fmdev->maintask_completion, &tmp_frq, &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) FM_REG_FM_FREQ : %d", \
+        FM_SET_FREQ(tmp_frq));
+
+    *curr_freq = FM_SET_FREQ(tmp_frq);
+
+    return ret;
+}
+
+/*
+* Function to start a FM SEEK Operation.
+*   * Set the start frequency.
+*   * Set the other registries such as Search method, search
+*    direction, etc.
+*   * Start search.
+*   * Based on interrupt received, read the current tuned freq
+*     and validate the search.
+*   * If search frequency out of bound and no wrap_around needed,
+*    end the search and return error code -EAGAIN
+*   * If not, start the search again and check for interrupt.
+*   * If no interrupt is received by 20 sec, timeout the seek operation
+*/
+int fm_rx_seek_station(struct fmdrv_ops *fmdev, unsigned char direction_upward,
+                            unsigned char wrap_around)
+{
+    int ret = 0, freq;
+    unsigned short tmp_freq, start_freq;
+    unsigned long timeleft;
+
+    fmdev->rx.seek_direction = (direction_upward)?FM_SCAN_UP:FM_SCAN_DOWN;
+    fmdev->rx.curr_sch_mode = ((FM_TUNER_NORMAL_SCAN_MODE & 0x01) |
+                                                (fmdev->rx.seek_direction & 0x80));
+    fmdev->rx.seek_wrap = wrap_around;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) seek_direction:0x%x "\
+        "curr_sch_mode:0x%x seek_wrap:0x%x", \
+        fmdev->rx.seek_direction, fmdev->rx.curr_sch_mode, fmdev->rx.seek_wrap);
+
+    ret = fm_rx_get_frequency(fmdev, &freq);
+    tmp_freq = FM_GET_FREQ(freq);
+
+    if(!check_if_valid_freq(fmdev, tmp_freq))
+    {
+        start_freq = (direction_upward)?(fmdev->rx.region.low_bound+
+            fm_sch_step_size[fmdev->rx.sch_step])
+            :(fmdev->rx.region.high_bound - fm_sch_step_size[fmdev->rx.sch_step]);
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdev) Current frequency is out of "\
+            "bounds. Resetting to freq (%d) ", FM_SET_FREQ(start_freq));
+    }
+    else
+    {
+        start_freq = (direction_upward)?(tmp_freq + fm_sch_step_size[fmdev->rx.sch_step])
+            :(tmp_freq - fm_sch_step_size[fmdev->rx.sch_step]);
+        if(start_freq >= fmdev->rx.region.high_bound ||
+            start_freq <= fmdev->rx.region.low_bound)
+                start_freq =  (direction_upward)?
+                (fmdev->rx.region.low_bound):(fmdev->rx.region.high_bound);
+    }
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Starting FM seek (%s) from %d..", \
+        (direction_upward?"SEEKUP":"SEEKDOWN"), FM_SET_FREQ(start_freq));
+
+
+
+    ret = init_start_search(fmdev, start_freq, FM_TUNER_SEEK_MODE);
+    if(ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error starting search for Seek operation");
+        return -EINVAL;
+    }
+
+    /* Wait for tune ended interrupt */
+    init_completion(&fmdev->seektask_completion);
+    timeleft = wait_for_completion_timeout(&fmdev->seektask_completion,
+                           FM_DRV_RX_SEEK_TIMEOUT);
+    if (!timeleft)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) Timeout(%d sec),didn't get seek ended interrupt",\
+               jiffies_to_msecs(FM_DRV_RX_SEEK_TIMEOUT) / 1000);
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+        return -ETIMEDOUT;
+    }
+
+    fm_rx_read_curr_rssi_freq(fmdev, FALSE);
+    tmp_freq = fmdev->rx.curr_freq;
+    ret = process_seek_event(fmdev);
+    if(ret && fmdev->rx.curr_search_state == FM_STATE_SEEK_CMPL)
+    {
+        /* Reset RDS Cache */
+        fmc_reset_rds_cache(fmdev);
+        if(fmdev->rx.fm_rds_mask)
+        /* Update the FM_RDS_MASK to set the earlier bits */
+        ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &fmdev->rx.fm_rds_mask,
+            sizeof(fmdev->rx.fm_rds_mask), REG_WR,
+            &fmdev->maintask_completion, NULL, NULL);
+        return 0;
+    }
+    if(!ret)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) Error during Seek. Try again!");
+        return -EAGAIN;
+    }
+    else if(ret && fmdev->rx.curr_search_state == FM_STATE_SEEKING)
+    {
+
+        /* Wait for tune ended interrupt */
+        init_completion(&fmdev->seektask_completion);
+        timeleft = wait_for_completion_timeout(&fmdev->seektask_completion,
+                               FM_DRV_RX_SEEK_TIMEOUT);
+
+        fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_SCH_FRZ_BIT;
+        if (!timeleft)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv) Timeout(%d sec),didn't get Seek ended "\
+                "interrupt", jiffies_to_msecs(FM_DRV_RX_SEEK_TIMEOUT) / 1000);
+            return -ETIMEDOUT;
+        }
+
+        fm_rx_read_curr_rssi_freq(fmdev, FALSE);
+
+        /* First check if Scan suceeded or not */
+        if(fmdev->rx.curr_search_state == FM_STATE_SEEK_ERR)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv) Wrap Seek failed for %d frequency", \
+                FM_SET_FREQ(fmdev->rx.curr_freq));
+            return -EAGAIN;
+        }
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Wrap Seek done!");
+        /* Reset RDS Cache */
+        fmc_reset_rds_cache(fmdev);
+        /* Update the FM_RDS_MASK to set the earlier bits */
+        ret = fmc_send_cmd(fmdev, FM_REG_FM_RDS_MSK, &fmdev->rx.fm_rds_mask,
+            sizeof(fmdev->rx.fm_rds_mask), REG_WR,
+            &fmdev->maintask_completion, NULL, NULL);
+        return 0;
+    }
+
+    V4L2_FM_DRV_ERR("(fmdrv) Unhandled case in Seek");
+    return -EINVAL;
+}
+
+/*
+*Function to set band's high and low frequencies
+*/
+int fm_rx_set_band_frequencies(struct fmdrv_ops *fmdev,
+                         unsigned int low_freq, unsigned int high_freq)
+{
+    if((fmdev->rx.region.high_bound == FM_GET_FREQ(high_freq)) &&
+        (fmdev->rx.region.low_bound = FM_GET_FREQ(low_freq)))
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) Ignoring setting the same band frequencies");
+        return 0;
+    }
+    fmdev->rx.region.high_bound = FM_GET_FREQ(high_freq);
+    fmdev->rx.region.low_bound = FM_GET_FREQ(low_freq);
+    return 0;
+}
+
+/*
+*Function to get the current band's high and low frequencies
+*/
+int fm_rx_get_band_frequencies(struct fmdrv_ops *fmdev,
+                              unsigned int *low_freq,  unsigned int *high_freq)
+{
+    *high_freq= FM_SET_FREQ(fmdev->rx.region.high_bound);
+    *low_freq= FM_SET_FREQ(fmdev->rx.region.low_bound) ;
+    return 0;
+}
+
+/*
+* Function to set the volume
+*/
+int fm_rx_set_volume(struct fmdrv_ops *fmdev, unsigned short vol_to_set)
+{
+    unsigned short payload;
+    int ret;
+    unsigned char read_length;
+    unsigned short actual_volume;
+
+    if(vol_to_set > FM_RX_VOLUME_MAX)
+        actual_volume = (vol_to_set/FM_RX_VOLUME_RATIO);
+    else
+        actual_volume = vol_to_set;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Actual volume to set  : %d", \
+        actual_volume);
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (actual_volume > FM_RX_VOLUME_MAX)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Volume %d is not within(%d-%d) "
+            "range setting the maximum allowed", vol_to_set,FM_RX_VOLUME_MIN,\
+            FM_RX_VOLUME_MAX);
+        actual_volume = 0xFF;
+    }
+
+    payload = actual_volume & 0x1ff;
+    ret = fmc_send_cmd(fmdev, FM_REG_VOLUME_CTRL, &payload, sizeof(payload),
+        REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    fmdev->rx.curr_volume = vol_to_set;
+    /* Read current volume */
+    read_length = FM_READ_1_BYTE_DATA;
+    ret = fm_rx_get_volume(fmdev, &(fmdev->rx.curr_volume));
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Volume read : %d", \
+        fmdev->rx.curr_volume);
+    if(ret == -ETIMEDOUT)
+        return -EBUSY;
+    return ret;
+}
+
+/*
+*Function to Get volume
+*/
+int fm_rx_get_volume(struct fmdrv_ops *fmdev, unsigned short *curr_vol)
+{
+    int ret, resp_len;
+    unsigned short resp_buf;
+    unsigned char read_length;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (curr_vol == NULL)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid memory");
+        return -ENOMEM;
+    }
+
+    /* Read current volume */
+    read_length = FM_READ_2_BYTE_DATA;
+    ret = fmc_send_cmd(fmdev, FM_REG_VOLUME_CTRL, &read_length, 1, REG_RD,
+                        &fmdev->maintask_completion, &resp_buf, &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    *curr_vol = fmdev->rx.curr_volume = resp_buf;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Volume read : %d", \
+        fmdev->rx.curr_volume);
+    return ret;
+}
+
+/* Sets band (0-Europe; 1-Japan; 2-North America; 3-Russia, 4-China) */
+int fm_rx_set_region(struct fmdrv_ops *fmdev,
+            unsigned char region_to_set)
+{
+    unsigned char payload = FM_STEREO_AUTO|FM_BAND_REG_WEST;
+    unsigned short boundary[2];
+
+    int ret = -EPERM;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX,"fm_rx_set_region In region_to_set %d",\
+        region_to_set);
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return ret;
+
+    if (region_to_set != FM_REGION_NA &&
+        region_to_set != FM_REGION_EUR &&
+        region_to_set != FM_REGION_JP &&
+        region_to_set != FM_REGION_RUS &&
+        region_to_set != FM_REGION_CHN &&
+        region_to_set != FM_REGION_IT)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid band");
+        ret = -EINVAL;
+        return ret;
+    }
+
+    if (region_to_set == FM_REGION_JP ||
+        region_to_set == FM_REGION_RUS ||
+        region_to_set == FM_REGION_CHN)
+    {
+        /* set the low bound and high bound */
+        memcpy(&fmdev->rx.region, &region_configs[region_to_set], sizeof(struct region_info));
+        boundary[0] = fmdev->rx.region.high_bound;
+        boundary[1] = fmdev->rx.region.low_bound;
+        fmc_send_cmd(fmdev, FM_SEARCH_BOUNDARY, boundary, sizeof(boundary), REG_WR,
+                    &fmdev->maintask_completion, NULL, NULL);
+    }
+    else {
+        /* clear low bound and high bound */
+        boundary[0] = 0;
+        boundary[1] = 0;
+        fmc_send_cmd(fmdev, FM_SEARCH_BOUNDARY, boundary, sizeof(boundary), REG_WR,
+                    &fmdev->maintask_completion, NULL, NULL);
+    }
+
+    if (region_to_set == FM_REGION_JP)/* set japan region */
+    {
+        payload |= FM_BAND_REG_EAST;
+    }
+
+    /* Send cmd to set the band  */
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_CTRL, &payload, sizeof(payload), REG_WR,
+        &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    fmc_update_region_info(fmdev, region_to_set);
+
+    return ret;
+}
+
+/*
+* Function to retrieve audio control param
+* from controller
+*/
+int fm_rx_get_audio_ctrl(struct fmdrv_ops *fmdev, uint16_t *audio_ctrl)
+{
+    uint16_t payload = FM_READ_2_BYTE_DATA;
+    int ret = -EINVAL, resp_len;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return ret;
+
+    /* Send cmd to set the band  */
+    ret = fmc_send_cmd(fmdev, FM_REG_AUD_CTL0, &payload, sizeof(payload), REG_RD,
+                &fmdev->maintask_completion, audio_ctrl, &resp_len);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->aud_ctrl = fmdev->rx.aud_ctrl = *audio_ctrl;
+    if(ret == -ETIMEDOUT)
+        return -EBUSY;
+    return ret;
+}
+
+/*
+* Function to set the audio control param
+* to controller
+*/
+int fm_rx_set_audio_ctrl(struct fmdrv_ops *fmdev,uint16_t audio_ctrl)
+{
+    uint16_t payload = audio_ctrl;
+    int ret = -EINVAL;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return ret;
+
+    /* Send cmd to set the band  */
+    ret = fmc_send_cmd(fmdev, FM_REG_AUD_CTL0, &payload, sizeof(payload), REG_WR,
+                &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->aud_ctrl = fmdev->rx.aud_ctrl = audio_ctrl;
+    if(ret == -ETIMEDOUT)
+        return -EBUSY;
+    return ret;
+}
+
+/*
+* Function to Read current mute mode (Mute Off/On)
+*/
+int fm_rx_get_mute_mode(struct fmdrv_ops *fmdev,
+            unsigned char *curr_mute_mode)
+{
+    uint16_t tmp;
+    int ret = -EINVAL;
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (curr_mute_mode == NULL) {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid memory");
+        return -ENOMEM;
+    }
+    ret = fm_rx_get_audio_ctrl(fmdev, &tmp);
+    *curr_mute_mode = fmdev->rx.curr_mute_mode = tmp & FM_MANUAL_MUTE;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Mute is %s", ((*curr_mute_mode)?\
+        "ON":"OFF"));
+    return 0;
+}
+
+/*
+* Configures mute mode (Mute Off/On)
+*/
+int fm_rx_set_mute_mode(struct fmdrv_ops *fmdev,
+            unsigned char mute_mode_toset)
+{
+    int ret;
+    uint16_t aud_ctrl;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+    /* First read the aud_ctrl*/
+    ret = fm_rx_get_audio_ctrl(fmdev, &aud_ctrl);
+    /* turn on MUTE */
+    if (mute_mode_toset)
+    {
+        aud_ctrl|= FM_MANUAL_MUTE;
+    }
+    else /* unmute */
+    {
+        aud_ctrl &= (~FM_MANUAL_MUTE);
+    }
+
+    ret = fm_rx_set_audio_ctrl (fmdev, aud_ctrl);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) Current mute state : %d", \
+        mute_mode_toset);
+    fmdev->rx.curr_mute_mode = mute_mode_toset;
+    return ret;
+}
+
+/* Sets RX stereo/mono modes */
+int fm_rx_set_audio_mode(struct fmdrv_ops *fmdev, unsigned char mode)
+{
+    unsigned char audio_ctrl = FM_STEREO_SWITCH|FM_STEREO_AUTO;
+    int ret;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdrv): fm_rx_set_audio_mode in  :mode %d"\
+        "fmdev->rx.audio_mode %d", mode,fmdev->rx.audio_mode);
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+     return -EPERM;
+
+    if (mode != FM_STEREO_MODE && mode != FM_MONO_MODE &&
+        mode != FM_AUTO_MODE && mode != FM_SWITCH_MODE)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid mode :%d", mode);
+        return -EINVAL;
+    }
+
+    if (fmdev->rx.audio_mode == mode)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): no change in audio mode");
+        return 0;
+    }
+    switch (mode)
+    {
+        case FM_SWITCH_MODE: /* stereo witch in auto mode */
+            /* as default */;
+            break;
+        case FM_MONO_MODE: /* manually set to mono, bit2 OFF is mono */
+            audio_ctrl &= ~FM_STEREO_AUTO;/* set to manual mono */
+            break;
+        case FM_STEREO_MODE: /* manually set to stereo */
+            audio_ctrl  &= ~FM_STEREO_AUTO; /* set to manual */
+            audio_ctrl |= FM_STEREO_MANUAL; /* set to stereo in manual mode */
+            break;
+        case FM_AUTO_MODE:/* auto blend as default,  */
+            audio_ctrl  &= ~FM_STEREO_SWITCH; /* turn OFF bit3 to activate blend */
+            break;
+        default:
+            break;
+    }
+    /* set the region bit */
+    audio_ctrl |= (fmdev->rx.curr_region == FM_REGION_JP) ? \
+                                FM_BAND_REG_EAST : FM_BAND_REG_WEST;
+
+    /* Set stereo/mono mode */
+    ret = fmc_send_cmd(fmdev, FM_REG_FM_CTRL, &audio_ctrl, sizeof(audio_ctrl),
+            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->rx.audio_mode = mode;
+    if(mode == FM_MONO_MODE)
+    {
+        fmdev->device_info.rxsubchans |= V4L2_TUNER_SUB_MONO;
+        fmdev->device_info.rxsubchans &= ~V4L2_TUNER_SUB_STEREO;
+    }
+    if(mode == FM_STEREO_MODE)
+    {
+        fmdev->device_info.rxsubchans |= V4L2_TUNER_SUB_STEREO;
+        fmdev->device_info.rxsubchans &= ~V4L2_TUNER_SUB_MONO;
+    }
+    return 0;
+}
+
+/* Gets current RX stereo/mono mode */
+int fm_rx_get_audio_mode(struct fmdrv_ops *fmdev, unsigned char *mode)
+{
+    int ret, len;
+    unsigned char payload = FM_READ_1_BYTE_DATA, resp;
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+    return -EPERM;
+
+    if (mode == NULL)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid memory");
+        return -ENOMEM;
+    }
+    ret = fmc_send_cmd(fmdev, FM_REG_SNR, &payload, sizeof(payload),
+            REG_RD, &fmdev->maintask_completion, &resp, &len);
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv): resp(current snr) : %x", resp);
+
+    if(resp<=19)
+    {
+        *mode = FM_MONO_MODE;
+    }
+    else
+    {
+        *mode = FM_STEREO_MODE;
+    }
+
+    return ret;
+}
+
+/* Sets RX stereo/mono modes */
+int fm_rx_config_audio_path(struct fmdrv_ops *fmdev, unsigned char path)
+{
+    int ret;
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (fmdev->rx.audio_path == path)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): no change in audio path");
+        return 0;
+    }
+    /* if FM is on SCO and request to turn off FM over SCO */
+    if (!(path & FM_AUDIO_BT_MONO) &&
+                (fmdev->rx.pcm_reg & FM_PCM_ROUTE_ON_BIT))
+    {
+        /* disable pcm_reg CB value FM routing bit */
+        fmdev->rx.pcm_reg &= ~FM_PCM_ROUTE_ON_BIT;
+    }
+    else if((path & FM_AUDIO_BT_MONO) &&
+                !(fmdev->rx.pcm_reg & FM_PCM_ROUTE_ON_BIT)) /* turn on FM via SCO */
+    {
+        /* when FM to SCO active, FM enforce I2S output */
+        path |= FM_AUDIO_I2S;
+        /* turn on pcm_reg CB value FM routing bit */
+        fmdev->rx.pcm_reg |= FM_PCM_ROUTE_ON_BIT;
+    }
+
+    /* write to PCM_ROUTE register */
+    ret = fmc_send_cmd(fmdev, FM_REG_PCM_ROUTE,
+            &fmdev->rx.pcm_reg, sizeof(fmdev->rx.pcm_reg), REG_WR,
+            &fmdev->maintask_completion, NULL, NULL);
+
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    if (path & FM_AUDIO_I2S)
+        fmdev->rx.aud_ctrl |= FM_AUDIO_I2S_ON;
+    else
+        fmdev->rx.aud_ctrl &= ~((unsigned short)FM_AUDIO_I2S_ON);
+
+    if (path & FM_AUDIO_DAC)
+        fmdev->rx.aud_ctrl |= FM_AUDIO_DAC_ON;
+    else
+        fmdev->rx.aud_ctrl &= ~((unsigned short)FM_AUDIO_DAC_ON);
+
+    ret = fm_rx_set_audio_ctrl (fmdev, fmdev->rx.aud_ctrl);
+
+    FM_CHECK_SEND_CMD_STATUS(ret);
+    fmdev->rx.audio_path = path;
+
+    return 0;
+}
+
+/* Choose RX de-emphasis filter mode (50us/75us) */
+int fm_rx_config_deemphasis(struct fmdrv_ops *fmdev, unsigned long mode)
+{
+    int ret;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "fm_rx_config_deemphasis is setting  mode "\
+        "as %ld",mode);
+
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (mode != FM_DEEMPHA_50U &&
+        mode != FM_DEEMPHA_75U)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid rx de-emphasis mode");
+        return -EINVAL;
+    }
+
+    if (mode == FM_DEEMPHA_50U )
+        /* set to 50us by turning off 6th bit */
+        fmdev->rx.aud_ctrl &=  (~FM_DEEMPHA_75_ON);
+    else
+        /* set to 75us by turning on 6th bit */
+        fmdev->rx.aud_ctrl |=  FM_DEEMPHA_75_ON;
+
+    ret = fm_rx_set_audio_ctrl (fmdev, fmdev->rx.aud_ctrl);
+
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    return 0;
+}
+
+/*
+* Function to get the current scan step.
+* Returns FM_STEP_100KHZ or FM_STEP_200KHZ
+*/
+int fm_rx_get_scan_step(struct fmdrv_ops *fmdev,
+            unsigned char *step_type)
+{
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    if (step_type == NULL)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Invalid memory");
+        return -ENOMEM;
+    }
+    *step_type = fmdev->rx.sch_step;
+    return 0;
+}
+
+/*
+* Sets scan step to 100 or 200 KHz based on step type :
+* FM_STEP_100KHZ or FM_STEP_200KHZ
+*/
+int fm_rx_set_scan_step(struct fmdrv_ops *fmdev,
+            unsigned char step_type)
+{
+    int ret;
+    unsigned short payload;
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+       /* turn on MUTE */
+    if (fmdev->rx.sch_step == step_type)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): no change in scan step size");
+        return 0;
+    }
+    payload = fm_sch_step_size[step_type];
+    ret = fmc_send_cmd(fmdev, FM_REG_SCH_STEP, &payload, sizeof(payload),
+            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    fmdev->rx.sch_step = step_type;
+    return ret;
+}
+
+/*******************************************************************************
+** RDS functions
+*******************************************************************************/
+
+/* Sets RDS operation mode (RDS/RDBS) */
+int fm_rx_set_rds_system(struct fmdrv_ops *fmdev, unsigned char rdbs_en_dis)
+{
+    unsigned char payload;
+    int ret;
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdrv) %s", __func__);
+    if (fmdev->curr_fmmode != FM_MODE_RX)
+        return -EPERM;
+
+    /* Set RDS control */
+    if (rdbs_en_dis == FM_RDBS_ENABLE)
+        payload = (FM_RDS_CTRL_RBDS|FM_RDS_CTRL_FIFO_FLUSH);
+    else
+        payload = FM_RDS_CTRL_FIFO_FLUSH;
+
+    ret = fmc_send_cmd(fmdev, FM_REG_RDS_CTL0, &payload, sizeof(payload),
+                        REG_WR, &fmdev->maintask_completion, NULL, NULL);
+    FM_CHECK_SEND_CMD_STATUS(ret);
+
+    return 0;
+}
+
+/*
+* Function to enable RDS. Called during FM enable.
+*/
+void fm_rx_enable_rds(struct fmdrv_ops *fmdev)
+{
+    unsigned char payload;
+    int ret = 0;
+    if(fmdev->rx.fm_func_mask & (FM_RDS_BIT | FM_RBDS_BIT))
+    {
+        payload = FM_RDS_UPD_TUPLE;
+        /* write RDS FIFO waterline in depth of RDS tuples */
+        ret = fmc_send_cmd(fmdev, FM_REG_RDS_WLINE, &payload, sizeof(payload),
+                            REG_WR, &fmdev->maintask_completion, NULL, NULL);
+        if(ret<0)
+            V4L2_FM_DRV_ERR("(fmdrv) Error writing to RDS FIFO waterline "\
+            "register");
+        /* drain RDS FIFO */
+        payload = FM_RDS_FIFO_MAX;
+        ret = fmc_send_cmd(fmdev, FM_REG_RDS_DATA, &payload, 1,
+                            REG_RD, &fmdev->maintask_completion, NULL, NULL);
+
+        /* set new FM_RDS mask so that RDS read */
+        fmdev->rx.fm_rds_mask |= I2C_MASK_RDS_FIFO_WLINE_BIT;
+    }
+    else
+    {
+        V4L2_FM_DRV_ERR("(fmdrv) RDS not enabled during FM enable");
+        fmdev->rx.fm_rds_mask &= ~I2C_MASK_RDS_FIFO_WLINE_BIT;
+    }
+    fm_rx_set_mask(fmdev, fmdev->rx.fm_rds_mask);
+    /* Reset the fm_rds_flag here as for the first time we dont get
+    any interrupt during ENABLE to cleanup the bit */
+    fmdev->rx.fm_rds_flag &= ~FM_RDS_FLAG_CLEAN_BIT;
+
+}
+
+/*
+* Returns availability of RDS data in internel buffer.
+* If data is present in RDS buffer, return 0. Else, return -EAGAIN.
+* The V4L2 driver's poll() uses this method to determine RDS data availability.
+*/
+int fm_rx_is_rds_data_available(struct fmdrv_ops *fmdev, struct file *file,
+                  struct poll_table_struct *pts)
+{
+    poll_wait(file, &fmdev->rx.rds.read_queue, pts);
+    if (fmdev->rx.rds.rd_index != fmdev->rx.rds.wr_index) {
+        V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(fmdrv) Poll success. RDS data is "\
+            "available in buffer");
+        return 0;
+    }
+    V4L2_FM_DRV_ERR("(fmdev) RDS Buffer is empty");
+    return -EAGAIN;
+}

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_rx.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_rx.h
@@ -1,0 +1,63 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+/************************************************************************************
+ *
+ *  Filename:      fmdrv_rx.h
+ *
+ *  Description:   FM RX module header.
+************************************************************************************/
+
+#ifndef _FMDRV_RX_H
+#define _FMDRV_RX_H
+
+/*******************************************************************************
+**  Functions
+*******************************************************************************/
+
+int fm_rx_set_frequency(struct fmdrv_ops*, unsigned int);
+int fm_rx_set_band_frequencies(struct fmdrv_ops *, unsigned int, unsigned int);
+int fm_rx_set_mute_mode(struct fmdrv_ops*, unsigned char);
+int fm_rx_set_rds_system(struct fmdrv_ops *, unsigned char);
+int fm_rx_set_volume(struct fmdrv_ops*, unsigned short);
+int fm_rx_set_audio_ctrl(struct fmdrv_ops *,unsigned short);
+
+int fm_rx_set_audio_mode(struct fmdrv_ops *, unsigned char);
+int fm_rx_set_region(struct fmdrv_ops*, unsigned char);
+int fm_rx_set_scan_step(struct fmdrv_ops *, unsigned char);
+int fm_rx_config_audio_path(struct fmdrv_ops *, unsigned char);
+int fm_rx_config_deemphasis(struct fmdrv_ops *, unsigned long);
+int fm_rx_set_rssi_threshold(struct fmdrv_ops*, short);
+int fm_rx_set_snr_threshold(struct fmdrv_ops*,  short);
+int fm_rx_set_af_switch(struct fmdrv_ops *, u8);
+
+int fm_rx_get_frequency(struct fmdrv_ops*, unsigned int*);
+int fm_rx_get_mute_mode(struct fmdrv_ops*, unsigned char*);
+int fm_rx_get_volume(struct fmdrv_ops*, unsigned short*);
+int fm_rx_get_audio_mode(struct fmdrv_ops *, unsigned char *);
+int fm_rx_get_scan_step(struct fmdrv_ops *, unsigned char *);
+int fm_rx_get_band_frequencies(struct fmdrv_ops *,
+                    unsigned int *, unsigned int *);
+int fm_rx_seek_station(struct fmdrv_ops *, unsigned char, unsigned char);
+int fm_rx_read_curr_rssi_freq(struct fmdrv_ops *, unsigned char);
+void fm_rx_enable_rds(struct fmdrv_ops *);
+int fm_rx_is_rds_data_available(struct fmdrv_ops *, struct file *,
+                    struct poll_table_struct *);
+
+#endif
+

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_v4l2.c
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_v4l2.c
@@ -1,0 +1,1153 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+
+
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ */
+
+/************************************************************************************
+ *
+ *  Filename:      fmdrv_v4l2.c
+ *
+ *  Description:   FM Driver for Connectivity chip of Broadcom Corporation.
+*  This file provides interfaces to V4L2 subsystem.
+*
+*  This module registers with V4L2 subsystem as Radio
+*  data system interface (/dev/radio). During the registration,
+*  it will expose three set of function pointers to V4L2 subsystem.
+*
+*    1) File operation related API (open, close, read, write, poll...etc).
+*    2) Set of V4L2 IOCTL complaint API.
+*
+************************************************************************************/
+
+#include "fmdrv.h"
+#include "fmdrv_v4l2.h"
+#include "fmdrv_main.h"
+#include "fmdrv_rx.h"
+#include "fm_public.h"
+#include "fmdrv_config.h"
+#include "../include/v4l2_target.h"
+#include "../include/v4l2_logs.h"
+#include <linux/ioctl.h>
+
+
+/* Required to set "THIS_MODULE" during driver registration to linux system. Not required in Maguro */
+#ifndef V4L2_THIS_MODULE_SUPPORT
+#include <linux/export.h>
+#endif
+
+/************************************************************************************
+**  Constants & Macros
+************************************************************************************/
+#ifndef V4L2_FM_DEBUG
+#define V4L2_FM_DEBUG TRUE
+#endif
+
+/* The major device number. We can't rely on dynamic
+ * registration any more, because ioctls need to know
+ * it.  There is no logic behind chosing 100, it's just a random
+ * number*/
+#define MAJOR_NUM 100
+/* Set the message of the device driver */
+#define IOCTL_GET_PI_CODE _IOR(MAJOR_NUM, 0, char *)
+#define IOCTL_GET_TP_CODE _IOR(MAJOR_NUM, 1, void *)
+#define IOCTL_GET_PTY_CODE _IOR(MAJOR_NUM, 2, char *)
+#define IOCTL_GET_TA_CODE _IOR(MAJOR_NUM, 3, char *)
+#define IOCTL_GET_MS_CODE _IOR(MAJOR_NUM, 4, char *)
+#define IOCTL_GET_PS_CODE _IOR(MAJOR_NUM, 5, char *)
+#define IOCTL_GET_RT_MSG _IOR(MAJOR_NUM, 6, char *)
+#define IOCTL_GET_CT_DATA _IOR(MAJOR_NUM, 7, char *)
+#define IOCTL_GET_TMC_CHANNEL _IOR(MAJOR_NUM, 8, char *)
+
+
+/*These values are set and has to be sent together.*/
+/*Keep them as a set always, never try to further seperate them*/
+/*These are arguments to BRCM vsc HCI command to switch the FM-I2S pins */
+/*over PCM pins*/
+/*I2S works in slave mode. Host side has to be master*/
+unsigned char i2s_slave_on_pcm_pins[5] = {0x07, 0x19, 0x18, 0x19, 0x19};
+/*I2S works in master mode. Host side has to be slave*/
+unsigned char i2s_master_on_pcm_pins[5] = {0x05, 0x19, 0x18, 0x18, 0x18};
+
+/*PCM works in slave mode. Host side has to be master*/
+unsigned char bt_slave_on_pcm_pins[5] = {0x01, 0x19, 0x18, 0x19, 0x19};
+/*PCM works in master mode. Host side has to be slave*/
+unsigned char bt_master_on_pcm_pins[5] = {0x01, 0x19, 0x18, 0x18, 0x18 };
+
+/* set this module parameter to enable debug info */
+extern int fm_dbg_param;
+
+/* Query control */
+struct v4l2_queryctrl fmdrv_v4l2_queryctrl[] = {
+    {
+        .id = V4L2_CID_AUDIO_VOLUME,
+        .type = V4L2_CTRL_TYPE_INTEGER,
+        .name = "Volume",
+        .minimum = FM_RX_VOLUME_MIN,
+        .maximum = FM_RX_VOLUME_MAX,
+        .step = 1,
+        .default_value = FM_DEFAULT_RX_VOLUME,
+    },
+    {
+        .id = V4L2_CID_AUDIO_BALANCE,
+        .flags = V4L2_CTRL_FLAG_DISABLED,
+    },
+    {
+        .id = V4L2_CID_AUDIO_BASS,
+        .flags = V4L2_CTRL_FLAG_DISABLED,
+    },
+    {
+        .id = V4L2_CID_AUDIO_TREBLE,
+        .flags = V4L2_CTRL_FLAG_DISABLED,
+    },
+    {
+        .id = V4L2_CID_AUDIO_MUTE,
+        .type = V4L2_CTRL_TYPE_BOOLEAN,
+        .name = "Mute",
+        .minimum = 0,
+        .maximum = 2,
+        .step = 1,
+        .default_value = FM_MUTE_OFF,
+    },
+    {
+        .id = V4L2_CID_AUDIO_LOUDNESS,
+        .flags = V4L2_CTRL_FLAG_DISABLED,
+    },
+// may need private control
+};
+
+
+#if V4L2_FM_DEBUG
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...) \
+        do { \
+            if (fm_dbg_param & flag) \
+                printk(KERN_DEBUG "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg); \
+        } while(0)
+#else
+#define V4L2_FM_DRV_DBG(flag, fmt, arg...)
+#endif
+#define V4L2_FM_DRV_ERR(fmt, arg...)  printk(KERN_ERR "(v4l2fmdrv):%s  "fmt"\n" , \
+                                           __func__,## arg)
+
+
+
+/************************************************************************************
+**  Static variables
+************************************************************************************/
+
+static struct video_device *gradio_dev;
+static unsigned char radio_disconnected;
+
+static atomic_t v4l2_device_available = ATOMIC_INIT(1);
+
+/************************************************************************************
+**  Forward function declarations
+************************************************************************************/
+
+static int fm_v4l2_vidioc_s_hw_freq_seek(struct file *, void *,
+                    struct v4l2_hw_freq_seek *);
+
+/************************************************************************************
+**  Functions
+************************************************************************************/
+/*****************************************************************************
+**   V4L2 RADIO (/dev/radioX) device file operation interfaces
+*****************************************************************************/
+
+/* Read RX RDS data */
+static ssize_t fm_v4l2_fops_read(struct file *file, char __user * buf,
+                    size_t count, loff_t *ppos)
+{
+    int ret, bytes_read;
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+
+    if (!radio_disconnected) {
+        V4L2_FM_DRV_ERR("(fmdrv): FM device is already disconnected\n");
+        ret = -EIO;
+        return ret;
+    }
+
+    /* Copy RDS data from the cicular buffer to userspace */
+    bytes_read =
+        fmc_transfer_rds_from_cbuff(fmdev, file, buf, count);
+    return bytes_read;
+}
+
+/* Write RDS data. Since FM TX is not supported, return EINVAL
+ */
+static ssize_t fm_v4l2_fops_write(struct file *file, const char __user * buf,
+                    size_t count, loff_t *ppos)
+{
+    return -EINVAL;
+}
+
+/* Handle Poll event for "/dev/radioX" device.*/
+static unsigned int fm_v4l2_fops_poll(struct file *file,
+                      struct poll_table_struct *pts)
+{
+    int ret;
+    struct fmdrv_ops *fmdev;
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_RX, "(rds) %s", __func__ );
+
+    fmdev = video_drvdata(file);
+    /* Check if RDS data is available */
+    ret = fm_rx_is_rds_data_available(fmdev, file, pts);
+    if (!ret)
+        return POLLIN | POLLRDNORM;
+    return 0;
+}
+
+static ssize_t show_fmrx_comp_scan(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    /* Chip doesn't support complete scan for weather band */
+    if (fmdev->rx.region.fm_band == FM_BAND_WEATHER)
+        return -EINVAL;
+
+    return sprintf(buf, "%d\n", fmdev->rx.no_of_chans);
+}
+
+static ssize_t store_fmrx_comp_scan(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long comp_scan;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    /* Chip doesn't support complete scan for weather band */
+    if (fmdev->rx.region.fm_band == FM_BAND_WEATHER)
+        return -EINVAL;
+
+    if (kstrtoul(buf, 0, &comp_scan))
+        return -EINVAL;
+
+    ret = fm_rx_seek_station(fmdev, 1, 0);// FM_CHANNEL_SPACING_200KHZ, comp_scan);
+    if (ret < 0)
+        V4L2_FM_DRV_ERR("RX complete scan failed - %d\n", ret);
+
+    if (comp_scan == COMP_SCAN_READ)
+        return (size_t) fmdev->rx.no_of_chans;
+    else
+        return size;
+}
+
+static ssize_t show_fmrx_deemphasis(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", (fmdev->rx.region.deemphasis==
+                FM_RX_EMPHASIS_FILTER_50_USEC) ? 50 : 75);
+}
+
+static ssize_t store_fmrx_deemphasis(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long deemph_mode;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    if (kstrtoul(buf, 0, &deemph_mode))
+        return -EINVAL;
+
+    ret = fm_rx_config_deemphasis(fmdev,deemph_mode);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set De-emphasis Mode\n");
+        return ret;
+    }
+
+    return size;
+}
+
+static ssize_t show_fmrx_af(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", fmdev->rx.af_mode);
+}
+
+static ssize_t store_fmrx_af(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long af_mode;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    if (kstrtoul(buf, 0, &af_mode))
+        return -EINVAL;
+
+    if (af_mode < 0 || af_mode > 1)
+        return -EINVAL;
+
+    ret = fm_rx_set_af_switch(fmdev, af_mode);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set AF Switch\n");
+        return ret;
+    }
+
+    return size;
+}
+
+static ssize_t show_fmrx_band(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", fmdev->rx.region.fm_band);
+}
+
+static ssize_t store_fmrx_band(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long fm_band;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+    if (kstrtoul(buf, 0, &fm_band))
+        return -EINVAL;
+    pr_info("store_fmrx_band In  fm_band %ld",fm_band);
+
+    if (fm_band < FM_BAND_EUROPE || fm_band >= FM_BAND_WEATHER)
+        return -EINVAL;
+
+    ret = fm_rx_set_region(fmdev, fm_band);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set FM Band\n");
+        return ret;
+    }
+
+    return size;
+}
+
+static ssize_t show_fmrx_fm_audio_pins(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%s\n", fmdev->rx.current_pins);
+}
+
+static ssize_t store_fmrx_fm_audio_pins(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret = 0;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+    if(strncmp(buf, fmdev->rx.current_pins, 3) == 0) /*I2S or PCM*/
+    {
+        return size;
+    }
+
+    else if(strncmp(buf, "PCM", 3) == 0) /*use PCM pins*/
+    {
+        //send VSC to switch I2S to PCM pins
+ #if ROUTE_FM_I2S_MASTER_TO_PCM_PINS
+        V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in master mode");
+        ret = fmc_send_cmd(fmdev, 0, i2s_master_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+        if (ret < 0)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a master");
+            return ret;
+        }
+#endif
+
+#if ROUTE_FM_I2S_SLAVE_TO_PCM_PINS
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in slave mode");
+    ret = fmc_send_cmd(fmdev, 0, i2s_slave_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a slave");
+        return ret;
+    }
+#endif
+    sprintf(fmdev->rx.current_pins, "%s", buf);
+    return size;
+    }
+    else if(strncmp(buf, "I2S", 3) == 0) /*use I2S pins and release PCM pins for BT SCO*/
+    {
+    /*send VSC to release PCM pins*/
+#if ROUTE_BT_I2S_MASTER_TO_PCM_PINS
+        V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in master mode");
+        ret = fmc_send_cmd(fmdev, 0, bt_master_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+        if (ret < 0)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a master");
+            return ret;
+        }
+#endif
+
+#if ROUTE_FM_I2S_SLAVE_TO_PCM_PINS
+        V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in slave mode");
+        ret = fmc_send_cmd(fmdev, 0, bt_slave_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+        if (ret < 0)
+        {
+            V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a slave");
+            return ret;
+        }
+#endif
+        sprintf(fmdev->rx.current_pins, "%s", buf);
+        return size;
+    }
+    else
+    {
+        V4L2_FM_DRV_ERR("Wrong value: either PCM or I2S\n");
+        return ret;
+    }
+    return size;
+}
+
+
+static ssize_t show_fmrx_rssi_lvl(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", fmdev->rx.curr_rssi_threshold);
+}
+
+static ssize_t store_fmrx_rssi_lvl(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long rssi_lvl;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    if (kstrtoul(buf, 0, &rssi_lvl))
+        return -EINVAL;
+
+    ret = fm_rx_set_rssi_threshold(fmdev, rssi_lvl);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set RSSI level\n");
+        return ret;
+    }
+
+    return size;
+}
+
+static ssize_t show_fmrx_snr_lvl(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", fmdev->rx.curr_snr_threshold);
+}
+
+static ssize_t store_fmrx_snr_lvl(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long snr_lvl;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    if (kstrtoul(buf, 0, &snr_lvl))
+        return -EINVAL;
+
+    ret = fm_rx_set_snr_threshold(fmdev, snr_lvl);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set SNR level\n");
+        return ret;
+    }
+
+    return size;
+}
+
+static ssize_t show_fmrx_channel_space(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    return sprintf(buf, "%d\n", fmdev->rx.sch_step);
+}
+
+static ssize_t store_fmrx_channel_space(struct device *dev,
+        struct device_attribute *attr, char *buf, size_t size)
+{
+    int ret;
+    unsigned long chl_spacing,chl_step;
+    struct fmdrv_ops *fmdev = dev_get_drvdata(dev);
+
+    if (kstrtoul(buf, 0, &chl_spacing))
+        return -EINVAL;
+    switch( chl_spacing){
+        case CHL_SPACE_ONE:
+            chl_step= FM_STEP_50KHZ;
+            break;
+        case CHL_SPACE_TWO:
+            chl_step= FM_STEP_100KHZ;
+            break;
+        case CHL_SPACE_FOUR:
+            chl_step= FM_STEP_200KHZ;
+            break;
+        default:
+            chl_step= FM_STEP_100KHZ;
+    };
+    ret = fmc_set_scan_step(fmdev, chl_spacing);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("Failed to set channel spacing\n");
+        return ret;
+    }
+
+    return size;
+}
+
+/* structures specific for sysfs entries
+ * FM GUI app belongs to group "fmradio", these sysfs entries belongs to "root",
+ * but GUI app needs both read and write permissions to these sysfs entires for
+ * below features, so these entries got permission "666"
+ */
+
+/* To start FM RX complete scan*/
+static struct kobj_attribute v4l2_fmrx_comp_scan =
+__ATTR(fmrx_comp_scan, 0666, (void *)show_fmrx_comp_scan,
+        (void *)store_fmrx_comp_scan);
+
+/* To Set De-Emphasis filter mode */
+static struct kobj_attribute v4l2_fmrx_deemph_mode =
+__ATTR(fmrx_deemph_mode, 0666, (void *)show_fmrx_deemphasis,
+        (void *)store_fmrx_deemphasis);
+
+/* To Enable/Disable FM RX RDS AF feature */
+static struct kobj_attribute v4l2_fmrx_rds_af =
+__ATTR(fmrx_rds_af, 0666, (void *)show_fmrx_af, (void *)store_fmrx_af);
+
+/* To switch between Japan/US bands */
+static struct kobj_attribute v4l2_fmrx_band =
+__ATTR(fmrx_band, 0666, (void *)show_fmrx_band, (void *)store_fmrx_band);
+
+/* To set the desired FM reception RSSI level */
+static struct kobj_attribute v4l2_fmrx_rssi_lvl =
+__ATTR(fmrx_rssi_lvl, 0666, (void *) show_fmrx_rssi_lvl,
+        (void *)store_fmrx_rssi_lvl);
+
+/* To set the desired FM reception SNR level */
+static struct kobj_attribute v4l2_fmrx_snr_lvl =
+__ATTR(fmrx_snr_lvl, 0666, (void *) show_fmrx_snr_lvl,
+        (void *)store_fmrx_snr_lvl);
+
+/* To set the desired channel spacing */
+static struct kobj_attribute v4l2_fmrx_channel_space =
+__ATTR(fmrx_chl_lvl, 0666, (void *) show_fmrx_channel_space,
+        (void *)store_fmrx_channel_space);
+
+/* To switch between PCM / I2S pins*/
+static struct kobj_attribute v4l2_fmrx_fm_audio_pins =
+__ATTR(fmrx_fm_audio_pins, 0666, (void *)show_fmrx_fm_audio_pins, (void *)store_fmrx_fm_audio_pins);
+
+static struct attribute *v4l2_fm_attrs[] = {
+    &v4l2_fmrx_comp_scan.attr,
+    &v4l2_fmrx_deemph_mode.attr,
+    &v4l2_fmrx_rds_af.attr,
+    &v4l2_fmrx_band.attr,
+    &v4l2_fmrx_rssi_lvl.attr,
+    &v4l2_fmrx_snr_lvl.attr,
+    &v4l2_fmrx_channel_space.attr,
+    &v4l2_fmrx_fm_audio_pins.attr,
+    NULL,
+};
+static struct attribute_group v4l2_fm_attr_grp = {
+    .attrs = v4l2_fm_attrs,
+};
+
+/* Handle open request for "/dev/radioX" device.
+ * Start with FM RX mode as default.
+ */
+static int fm_v4l2_fops_open(struct file *file)
+{
+    int ret = -EINVAL;
+    unsigned char option;
+    struct fmdrv_ops *fmdev = NULL;
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "(fmdrv): fm_v4l2_fops_open");
+    /* Don't allow multiple open */
+    if(!atomic_dec_and_test(&v4l2_device_available))
+    {
+        atomic_inc(&v4l2_device_available);
+        V4L2_FM_DRV_ERR("(fmdrv): FM device is already opened\n");
+        return -EBUSY;
+    }
+
+    if (radio_disconnected) {
+        V4L2_FM_DRV_ERR("(fmdrv): FM device is already opened\n");
+        return  -EBUSY;
+    }
+
+    fmdev = video_drvdata(file);
+    /* initialize the driver */
+    ret = fmc_prepare(fmdev);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Unable to prepare FM CORE");
+        return ret;
+    }
+
+    radio_disconnected = 1;
+
+    ret = fmc_set_mode(fmdev, FM_MODE_RX); /* As of now, support only Rx */
+
+#if(defined(DEF_V4L2_FM_WORLD_REGION) && DEF_V4L2_FM_WORLD_REGION == FM_REGION_NA)
+    option = FM_REGION_NA | FM_RBDS_BIT;
+#elif(defined(DEF_V4L2_FM_WORLD_REGION) && DEF_V4L2_FM_WORLD_REGION == FM_REGION_EUR)
+    option = FM_REGION_EUR | FM_RDS_BIT;
+#elif(defined(DEF_V4L2_FM_WORLD_REGION) && DEF_V4L2_FM_WORLD_REGION == FM_REGION_JP)
+    option = FM_REGION_JP | FM_RDS_BIT;
+#else
+    option = 0;
+#endif
+
+    /* Enable FM */
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN,"(fmdrv): FM Enable INIT option : %d", option);
+    ret = fmc_enable(fmdev, option);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Unable to enable FM");
+        return ret;
+    }
+
+    /* Set Audio mode */
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN,"(fmdrv): FM Set Audio mode option : %d", DEF_V4L2_FM_AUDIO_MODE);
+    ret = fmc_set_audio_mode(fmdev, DEF_V4L2_FM_AUDIO_MODE);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting Audio mode during FM enable operation");
+        return ret;
+    }
+
+    /* Register sysfs entries */
+    ret = sysfs_create_group(&fmdev->radio_dev->dev.kobj,
+            &v4l2_fm_attr_grp);
+    if (ret) {
+        V4L2_FM_DRV_ERR("failed to create sysfs entries");
+        return ret;
+    }
+
+    /* Set Audio path */
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN,"(fmdrv): FM Set Audio path option : %d", DEF_V4L2_FM_AUDIO_PATH);
+    ret = fm_rx_config_audio_path(fmdev, DEF_V4L2_FM_AUDIO_PATH);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting Audio path during FM enable operation");
+        return ret;
+    }
+
+#if ROUTE_FM_I2S_MASTER_TO_PCM_PINS
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in master mode");
+    ret = fmc_send_cmd(fmdev, 0, i2s_master_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a master");
+        return ret;
+    }
+#endif
+
+#if ROUTE_FM_I2S_SLAVE_TO_PCM_PINS
+    V4L2_FM_DRV_DBG(V4L2_DBG_OPEN, "Routing I2S audio over PCM pins in slave mode");
+    ret = fmc_send_cmd(fmdev, 0, i2s_slave_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a slave");
+        return ret;
+    }
+#endif
+
+    return 0;
+}
+
+/* Handle close request for "/dev/radioX" device.
+ */
+static int fm_v4l2_fops_release(struct file *file)
+{
+    int ret =  -EINVAL;
+    struct fmdrv_ops *fmdev;
+    V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "(fmdrv): fm_v4l2_fops_release");
+
+    fmdev = video_drvdata(file);
+
+    if (!radio_disconnected) {
+        V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "(fmdrv):FM dev already closed, close called again?");
+        return ret;
+    }
+    /* First set audio path to NONE */
+    ret = fm_rx_config_audio_path(fmdev, FM_AUDIO_NONE);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Failed to set audio path to FM_AUDIO_NONE");
+        /*ret = 0;*/
+    }
+#if ROUTE_FM_I2S_MASTER_TO_PCM_PINS
+    V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "Routing I2S audio over PCM pins in master mode");
+    ret = fmc_send_cmd(fmdev, 0, bt_master_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a master");
+        return ret;
+    }
+#endif
+
+#if ROUTE_FM_I2S_SLAVE_TO_PCM_PINS
+    V4L2_FM_DRV_DBG(V4L2_DBG_CLOSE, "Routing I2S audio over PCM pins in slave mode");
+    ret = fmc_send_cmd(fmdev, 0, bt_slave_on_pcm_pins, 5, VSC_HCI_CMD, &fmdev->maintask_completion, NULL, NULL);
+    if (ret < 0) {
+        V4L2_FM_DRV_ERR("(fmdrv): Error setting switch I2s path to PCM pins as a slave");
+        return ret;
+    }
+#endif
+
+    /* Now disable FM */
+    ret = fmc_turn_fm_off(fmdev);
+    if(ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): Error disabling FM. Continuing to release FM core..");
+        ret = 0;
+    }
+    sysfs_remove_group(&fmdev->radio_dev->dev.kobj, &v4l2_fm_attr_grp);
+
+    ret = fmc_release(fmdev);
+    if (ret < 0)
+    {
+        V4L2_FM_DRV_ERR("(fmdrv): FM CORE release failed");
+        return ret;
+    }
+    radio_disconnected = 0;
+    atomic_inc(&v4l2_device_available);
+
+    return 0;
+}
+
+/*****************************************************************************
+**   V4L2 RADIO (/dev/radioX) device IOCTL interfaces
+*****************************************************************************/
+
+/*
+* Function to query the driver capabilities
+*/
+static int fm_v4l2_vidioc_querycap(struct file *file, void *priv,
+                    struct v4l2_capability *capability)
+{
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+
+    strlcpy(capability->driver, FM_DRV_NAME, sizeof(capability->driver));
+    strlcpy(capability->card, FM_DRV_CARD_SHORT_NAME,
+                                    sizeof(capability->card));
+    sprintf(capability->bus_info, "UART");
+    capability->version = FM_DRV_RADIO_VERSION;
+    capability->capabilities = fmdev->device_info.capabilities;
+    return 0;
+}
+
+/*
+* Function to query the driver control params
+*/
+static int fm_v4l2_vidioc_queryctrl(struct file *file, void *priv,
+                                        struct v4l2_queryctrl *qc)
+{
+    int index;
+    int ret = -EINVAL;
+
+    if (qc->id < V4L2_CID_BASE)
+        return ret;
+
+    /* Search control ID and copy its properties */
+    for (index = 0; index < NO_OF_ENTRIES_IN_ARRAY(fmdrv_v4l2_queryctrl);\
+            index++) {
+        if (qc->id && qc->id == fmdrv_v4l2_queryctrl[index].id) {
+            memcpy(qc, &(fmdrv_v4l2_queryctrl[index]), sizeof(*qc));
+            ret = 0;
+            break;
+        }
+    }
+    return ret;
+}
+
+/*
+* Function to get the driver control params. Called
+* by user-space via IOCTL call
+*/
+static int fm_v4l2_vidioc_g_ctrl(struct file *file, void *priv,
+                    struct v4l2_control *ctrl)
+{
+    int ret = -EINVAL;
+    unsigned short curr_vol;
+    unsigned char curr_mute_mode;
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+
+    switch (ctrl->id) {
+        case V4L2_CID_AUDIO_MUTE:    /* get mute mode */
+            ret = fm_rx_get_mute_mode(fmdev, &curr_mute_mode);
+            if (ret < 0)
+                return ret;
+            ctrl->value = curr_mute_mode;
+            break;
+
+        case V4L2_CID_AUDIO_VOLUME:    /* get volume */
+            V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv): V4L2_CID_AUDIO_VOLUME get");
+            ret = fm_rx_get_volume(fmdev, &curr_vol);
+            if (ret < 0)
+                return ret;
+            ctrl->value = curr_vol;
+            break;
+
+       default:
+           V4L2_FM_DRV_ERR("(fmdrv): Unhandled IOCTL for get Control");
+           break;
+    }
+
+    return ret;
+}
+
+/*
+* Function to Set the driver control params. Called
+* by user-space via IOCTL call
+*/
+static int fm_v4l2_vidioc_s_ctrl(struct file *file, void *priv,
+                    struct v4l2_control *ctrl)
+{
+    int ret = -EINVAL;
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+
+    switch (ctrl->id) {
+        case V4L2_CID_AUDIO_MUTE:    /* set mute */
+            ret = fm_rx_set_mute_mode(fmdev, (unsigned char)ctrl->value);
+            if (ret < 0)
+                return ret;
+            break;
+
+        case V4L2_CID_AUDIO_VOLUME:    /* set volume */
+            V4L2_FM_DRV_DBG(V4L2_DBG_TX,"(fmdrv): V4L2_CID_AUDIO_VOLUME set : %d", ctrl->value);
+            ret = fm_rx_set_volume(fmdev, (unsigned short)ctrl->value);
+            if (ret < 0)
+                return ret;
+            break;
+
+        default:
+            V4L2_FM_DRV_ERR("(fmdrv): Unhandled IOCTL for set Control");
+            break;
+    }
+
+    return ret;
+}
+
+/*
+* Function to get the driver audio params. Called
+* by user-space via IOCTL call
+*/
+static int fm_v4l2_vidioc_g_audio(struct file *file, void *priv,
+                    struct v4l2_audio *audio)
+{
+    memset(audio, 0, sizeof(*audio));
+    audio->index = 0;
+    strcpy(audio->name, "Radio");
+    /* For FM Radio device, the audio capability should always return
+   V4L2_AUDCAP_STEREO */
+    audio->capability = V4L2_AUDCAP_STEREO;
+    return 0;
+}
+
+/*
+* Function to set the driver audio params. Called
+* by user-space via IOCTL call
+*/
+static int fm_v4l2_vidioc_s_audio(struct file *file, void *priv,
+                    struct v4l2_audio *audio)
+{
+    int ret = 0;
+    if (audio->index != 0)
+        ret = -EINVAL;
+    return ret;
+}
+
+/* Get tuner attributes. This IOCTL call will return attributes like tuner type,
+   upper/lower frequency, audio mode, RSSI value and AF channel */
+static int fm_v4l2_vidioc_g_tuner(struct file *file, void *priv,
+                    struct v4l2_tuner *tuner)
+{
+    unsigned short curr_rssi;
+    unsigned int high = 0, low = 0;
+    int ret = -EINVAL;
+    struct fmdrv_ops *fmdev;
+    unsigned char mode = 0;
+
+    if (tuner->index != 0)
+        return ret;
+
+    fmdev = video_drvdata(file);
+    strcpy(tuner->name, "FM");
+    tuner->type = fmdev->device_info.type;
+    /* The V4L2 specification defines all frequencies in unit of 62.5 kHz */
+    ret = fm_rx_get_band_frequencies(fmdev, &low, &high);
+    tuner->rangelow = (low * 100000)/625;
+    tuner->rangehigh = (high * 100000)/625;
+
+    ret = fmc_get_audio_mode(fmdev, &mode);
+    tuner->audmode =  ((mode == FM_STEREO_MODE) ?
+                    V4L2_TUNER_MODE_STEREO : V4L2_TUNER_MODE_MONO);
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) tuner->audmode:%d", tuner->audmode);
+    tuner->capability = fmdev->device_info.tuner_capability;
+    tuner->rxsubchans = fmdev->device_info.rxsubchans;
+
+    ret = fm_rx_read_curr_rssi_freq(fmdev, TRUE);
+    curr_rssi = fmdev->rx.curr_rssi;
+    /* RSSI from controller will be in range of -128 to +127.
+     But V4L2 API defines the range of 0 to 65535. So convert this value
+     FM rssi is cannot be 1~128dbm normally, although range is -128 to +127 */
+
+    tuner->signal = (128-curr_rssi) * (65535 / 128);
+    ret = 0;
+    return ret;
+}
+
+/* Set tuner attributes. This IOCTL call will set attributes like
+   upper/lower frequency, audio mode.
+ */
+static int fm_v4l2_vidioc_s_tuner(struct file *file, void *priv,
+                    struct v4l2_tuner *tuner)
+{
+    int ret = -EINVAL;
+    struct fmdrv_ops *fmdev;
+    unsigned short high_freq, low_freq;
+    unsigned short mode;
+    if (tuner->index != 0)
+        return ret;
+
+    fmdev = video_drvdata(file);
+
+    /* TODO : Figure out how to set the region based on lower/upper freq */
+    /* The V4L2 specification defines all frequencies in unit of 62.5 kHz.
+    Hence translate the incoming tuner band frequencies to controller
+    recognized values. Set only if rangelow/rangehigh is not 0*/
+    if(tuner->rangelow != 0 && tuner->rangehigh != 0)
+    {
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) rangelow:%d rangehigh:%d", tuner->rangelow, tuner->rangehigh);
+        low_freq = ((tuner->rangelow) * 625)/100000;
+        high_freq= ((tuner->rangehigh) * 625)/100000;
+        V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) low_freq:%d high_freq:%d", low_freq, high_freq);
+        ret = fm_rx_set_band_frequencies(fmdev, low_freq, high_freq);
+        if (ret < 0)
+            return ret;
+    }
+
+    /* Map V4L2 stereo/mono macro to Broadcom controller equivalent audio mode */
+    mode = (tuner->audmode == V4L2_TUNER_MODE_STEREO) ?
+        FM_AUTO_MODE : FM_MONO_MODE;
+
+    ret = fmc_set_audio_mode(fmdev, mode);
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+/* Get tuner or modulator radio frequency */
+static int fm_v4l2_vidioc_g_frequency(struct file *file, void *priv,
+                    struct v4l2_frequency *freq)
+{
+    int ret;
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+    ret = fmc_get_frequency(fmdev, &freq->frequency);
+    /* Translate the controller frequency to V4L2 specific frequency
+        (frequencies in unit of 62.5 Hz):
+        x = (y * 100) * 1000/62.5  = y * 160 */
+    freq->frequency = (freq->frequency * 160);
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+/* Set tuner or modulator radio frequency, this is tune channel */
+static int fm_v4l2_vidioc_s_frequency(struct file *file, void *priv,
+                    struct v4l2_frequency *freq)
+{
+    int ret = 0;
+    struct fmdrv_ops *fmdev;
+    struct v4l2_frequency fq;
+
+    fmdev = video_drvdata(file);
+    /* Translate the incoming tuner band frequencies
+    (frequencies in unit of 62.5 Hz to controller
+    recognized values. x = y * (62.5/1000000) * 100 = y / 160 */
+    fq.frequency = (freq->frequency/160);
+    ret = fmc_set_frequency(fmdev, fq.frequency);
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+/* Set hardware frequency seek. This is scanning radio stations. */
+static int fm_v4l2_vidioc_s_hw_freq_seek(struct file *file, void *priv,
+                    struct v4l2_hw_freq_seek *seek)
+{
+    int ret = -EINVAL;
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_drvdata(file);
+
+    V4L2_FM_DRV_DBG(V4L2_DBG_TX, "(fmdrv) direction:%d wrap:%d", \
+        seek->seek_upward, seek->wrap_around);
+
+    ret = fmc_seek_station(fmdev, seek->seek_upward, seek->wrap_around);
+
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+
+/* This function is called whenever a process tries to
+ * do an ioctl on this radio device. We get two extra
+ * parameters (additional to the inode and file
+ * structures, which all device functions get): the number
+ * of the ioctl called and the parameter given to the
+ * ioctl function.
+ *
+ * If the ioctl is write or read/write (meaning output
+ * is returned to the calling process), the ioctl call
+ * returns the output of this function.
+ * Very important is that this is the Private IOCTL function to handle  RDA psrser
+ * IOCTL commands. V4L2 framework also issues some IOCTLs which we have to route
+ * them to video_ioctl2 function. So all the IOCTL other than Private ones are
+ * passed to video_ioctl2 function.
+ * And another important thing is that, it's good to return from this function as soon as
+* we handle Private IOCTL so return statement is used insteadof break.
+ */
+long rds_info_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
+{
+    /* Switch according to the ioctl called */
+    long ret = 0;
+/* Process if it is private IOCTL*/
+    switch (cmd) {
+        case IOCTL_GET_PI_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_PI_CODE");
+           get_rds_element_value(GET_PI_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_TP_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_TP_CODE");
+           get_rds_element_value(GET_TP_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_PTY_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_PTY_CODE");
+           get_rds_element_value(GET_PTY_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_TA_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_TA_CODE");
+           get_rds_element_value(GET_TA_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_MS_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_MS_CODE");
+            get_rds_element_value(GET_MS_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_PS_CODE:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_PS_CODE");
+           get_rds_element_value(GET_PS_CODE, (char *)arg);
+           return 1;
+        case IOCTL_GET_RT_MSG:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_RT_MSG");
+           get_rds_element_value(GET_RT_MSG, (char *)arg);
+           return 1;
+        case IOCTL_GET_CT_DATA:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_CT_DATA");
+           get_rds_element_value(GET_CT_DATA, (char *)arg);
+           return 1;
+        case IOCTL_GET_TMC_CHANNEL:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "IOCTL_GET_TMC_CHANNEL");
+           get_rds_element_value(GET_TMC_CHANNEL, (char *)arg);
+           return 1;
+        default:
+           V4L2_FM_DRV_DBG(V4L2_DBG_RX, "Invalid IOCTL");
+           break;
+    }
+/* If anything other than private will be passed to V4L2 framework */
+    ret = video_ioctl2(file, cmd, arg);
+    return ret;
+}
+
+static const struct v4l2_file_operations fm_drv_fops = {
+    .owner = THIS_MODULE,
+    .read = fm_v4l2_fops_read,
+    .write = fm_v4l2_fops_write,
+    .poll = fm_v4l2_fops_poll,
+/*This is the private IOCTL to handle RDS parser related IOCTLs*/
+    .unlocked_ioctl = rds_info_ioctl,
+    .open = fm_v4l2_fops_open,
+    .release = fm_v4l2_fops_release,
+};
+
+static const struct v4l2_ioctl_ops fm_drv_ioctl_ops = {
+    .vidioc_querycap = fm_v4l2_vidioc_querycap,
+    .vidioc_queryctrl = fm_v4l2_vidioc_queryctrl,
+    .vidioc_g_ctrl = fm_v4l2_vidioc_g_ctrl,
+    .vidioc_s_ctrl = fm_v4l2_vidioc_s_ctrl,
+    .vidioc_g_audio = fm_v4l2_vidioc_g_audio,
+    .vidioc_s_audio = fm_v4l2_vidioc_s_audio,
+    .vidioc_g_tuner = fm_v4l2_vidioc_g_tuner,
+    .vidioc_s_tuner = fm_v4l2_vidioc_s_tuner,
+    .vidioc_g_frequency = fm_v4l2_vidioc_g_frequency,
+    .vidioc_s_frequency = fm_v4l2_vidioc_s_frequency,
+    .vidioc_s_hw_freq_seek = fm_v4l2_vidioc_s_hw_freq_seek
+};
+
+/* V4L2 RADIO device parent structure */
+static struct video_device fm_viddev_template = {
+    .fops = &fm_drv_fops,
+    .ioctl_ops = &fm_drv_ioctl_ops,
+    .name = FM_DRV_NAME,
+    .release = video_device_release,
+    .vfl_type = VFL_TYPE_RADIO,
+};
+
+int fm_v4l2_init_video_device(struct fmdrv_ops *fmdev, int radio_nr)
+{
+    int ret = -ENOMEM;
+
+    gradio_dev = NULL;
+    /* Allocate new video device */
+    gradio_dev = video_device_alloc();
+    if (NULL == gradio_dev) {
+        pr_err("(fmdrv): Can't allocate video device");
+        return -ENOMEM;
+    }
+
+    /* Setup FM driver's V4L2 properties */
+    memcpy(gradio_dev, &fm_viddev_template, sizeof(fm_viddev_template));
+
+    video_set_drvdata(gradio_dev, fmdev);
+
+    /* Register with V4L2 subsystem as RADIO device */
+    if (video_register_device(gradio_dev, VFL_TYPE_RADIO, radio_nr)) {
+        video_device_release(gradio_dev);
+        V4L2_FM_DRV_ERR("(fmdrv): Could not register video device");
+        return -EINVAL;
+    }
+
+    fmdev->radio_dev = gradio_dev;
+    V4L2_FM_DRV_DBG(V4L2_DBG_INIT,"(fmdrv) registered with video device");
+    ret = 0;
+
+    return ret;
+}
+
+void *fm_v4l2_deinit_video_device(void)
+{
+    struct fmdrv_ops *fmdev;
+
+    fmdev = video_get_drvdata(gradio_dev);
+    /* Unregister RADIO device from V4L2 subsystem */
+    video_unregister_device(gradio_dev);
+
+    return fmdev;
+}

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_v4l2.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_v4l2.h
@@ -1,0 +1,40 @@
+/*
+ *  FM Driver for Connectivity chip of Broadcom Corporation.
+ *
+ *  FM V4L2 module header.
+ *
+ *  Copyright (C) 2009 Texas Instruments
+ *  Copyright (C) 2009-2014 Broadcom Corporation
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+/************************************************************************************
+*
+*  Filename:      fmdrv_v4l2.h
+*
+*  Description:   FM V4L2 module header.
+*
+***********************************************************************************/
+
+#ifndef _FMDRV_V4L2_H
+#define _FMDRV_V4L2_H
+
+#include <media/v4l2-common.h>
+#include <media/v4l2-ioctl.h>
+
+int fm_v4l2_init_video_device(struct fmdrv_ops *, int);
+void *fm_v4l2_deinit_video_device(void);
+
+#endif


### PR DESCRIPTION
This driver allows to enable FM functionality on BT/FM combo chips from Broadcom.
Note that this conflicts with our Qualcomm reference implementation, so needs further examination.
