### PR TITLE
kernel: Makefile: use PRODUCT_PLATFORM rule instead TARGET_DEVICE

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@
 # Android makefile to build kernel as a part of Android Build
 
 ifeq ($(BUILD_KERNEL),true)
-ifeq ($(filter-out amami aries castor castor_windy eagle flamingo honami ivy karin karin_windy leo satsuki scorpion scorpion_windy seagull sirius sumire suzu suzuran tianchi tianchi_dsds togari tulip,$(TARGET_DEVICE)),)
+ifeq ($(filter-out kanuti kitakami loire rhine shinano,$(PRODUCT_PLATFORM)),)
 
 KERNEL_SRC := $(call my-dir)
 


### PR DESCRIPTION
to avoid big list here

Signed-off-by: David Viteri davidteri91@gmail.com
