### PR TITLE
[1.3.3] Android.mk: Add kugo

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@
 # Android makefile to build kernel as a part of Android Build
 
 ifeq ($(BUILD_KERNEL),true)
-ifeq ($(filter-out amami aries castor castor_windy eagle flamingo honami ivy karin karin_windy leo satsuki scorpion scorpion_windy seagull sirius sumire suzu suzuran tianchi tianchi_dsds togari tulip,$(TARGET_DEVICE)),)
+ifeq ($(filter-out amami aries castor castor_windy eagle flamingo honami ivy karin karin_windy kugo leo satsuki scorpion scorpion_windy seagull sirius sumire suzu suzuran tianchi tianchi_dsds togari tulip,$(TARGET_DEVICE)),)
 
 KERNEL_SRC := $(call my-dir)
 


### PR DESCRIPTION
Allow Sony Xperia X Compact (kugo) to use inline kernel build system

Signed-off-by: Humberto Borba humberos@gmail.com
