### PR TITLE
[1.3.3] drivers: msm_serial_hs: Check if wake source is present for clock on/off request

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2376,6 +2376,13 @@ EXPORT_SYMBOL(msm_hs_request_clock_on);
 void msm_hs_set_clock(int port_index, int on)
 {
 	struct uart_port *uport = msm_hs_get_uart_port(port_index);
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+
+	// Check if there is a registered wakeup source
+	if (!msm_uport->ws.name) {
+		pr_debug("%s there is no registered WS source:\n", __func__);
+		return;
+	}
 
 	pr_debug("%s /dev/ttyHS%d clock: %s\n", __func__,
 		port_index, on ? "ON" : "OFF");


### PR DESCRIPTION
Check if there is a registered wakeup (WS) source before clock on/off request.
wakeup_source_activate function requires a registered WS to handling power management properly.

https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/drivers/base/power/wakeup.c#L437

Fix kernel warning during BT on/off.

[  142.916434] ------------[ cut here ]------------
[  142.920022] WARNING: at ../../../../../../kernel/sony/msm/drivers/base/power/wakeup.c:438 wakeup_source_activate+0x4c/0x110()
[  142.931294] unregistered wakeup source
[  142.931302] CPU: 1 PID: 5788 Comm: stack_manager Tainted: G        W    3.10.84-g41c6fc2 #30
[  142.931306] Call trace:
[  142.931316] [<ffffffc000087d4c>] dump_backtrace+0x0/0x268
[  142.931323] [<ffffffc000087fc4>] show_stack+0x10/0x1c
[  142.931331] [<ffffffc000bccdc0>] dump_stack+0x1c/0x28
[  142.931338] [<ffffffc00009d920>] warn_slowpath_common+0x70/0x9c
[  142.931344] [<ffffffc00009d9d4>] warn_slowpath_fmt+0x5c/0x80
[  142.931350] [<ffffffc00046ad14>] wakeup_source_activate+0x48/0x110
[  142.931356] [<ffffffc00046b67c>] __pm_stay_awake+0x58/0x84
[  142.931362] [<ffffffc0003f7720>] msm_hs_request_clock_on+0x18/0x8c
[  142.931367] [<ffffffc0003f7a74>] msm_hs_set_clock+0x70/0xa0
[  142.931376] [<ffffffc00079a7c4>] bluesleep_rfkill_set_power+0xc4/0x1d0
[  142.931383] [<ffffffc000bb24a0>] rfkill_set_block+0x8c/0x11c
[  142.931388] [<ffffffc000bb2878>] rfkill_state_store+0x8c/0xc0
[  142.931395] [<ffffffc00045d728>] dev_attr_store+0x1c/0x28
[  142.931401] [<ffffffc0001e30a4>] sysfs_write_file+0x108/0x154
[  142.931409] [<ffffffc000184314>] vfs_write+0xcc/0x190
[  142.931415] [<ffffffc0001844c8>] SyS_write+0x54/0x9c
[  142.931419] ---[ end trace 9fe09ec533920248 ]---

Signed-off-by: Humberto Borba humberos@gmail.com
