### PR TITLE
[1.3.3] drivers: input: clearpad: Force incel SP panel type on post probe

### DIFF
--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -8103,8 +8103,8 @@ static void clearpad_post_probe_work(struct work_struct *work)
 	get_monotonic_boottime(&ts);
 	HWLOGI(this, "start post probe @ %ld.%06ld\n", ts.tv_sec, ts.tv_nsec);
 
-//	if (unlikely(!first_blank_done))
-//		incell_force_sp_on();
+	if (unlikely(!first_blank_done))
+		incell_force_sp_on();
 
 	rc = clearpad_ctrl_session_begin(this, session);
 	if (rc) {


### PR DESCRIPTION
Now we can force SP panel type during clearpad post probe stage.
Also, this fixes the clearpad IRQ warnings as following below:

[   16.700159] ------------[ cut here ]------------
[   16.704151] WARNING: at ../../../../../../kernel/sony/msm/drivers/input/touchscreen/clearpad_incell_core.c:4046 clearpad_process_irq+0xb58/0xebc()
[   16.717574] CPU: 0 PID: 333 Comm: irq/416-clearpa Tainted: G        W    3.10.84-g0ab7733 #38
[   16.717583] Call trace:
[   16.717597] [<ffffffc000087d4c>] dump_backtrace+0x0/0x268
[   16.717603] [<ffffffc000087fc4>] show_stack+0x10/0x1c
[   16.717611] [<ffffffc000bcddf4>] dump_stack+0x1c/0x28
[   16.717618] [<ffffffc00009d920>] warn_slowpath_common+0x70/0x9c
[   16.717625] [<ffffffc00009dbec>] warn_slowpath_null+0x14/0x20
[   16.717633] [<ffffffc00062a270>] clearpad_process_irq+0xb54/0xebc
[   16.717639] [<ffffffc00062cc80>] clearpad_threaded_handler+0x118/0x1fc
[   16.717646] [<ffffffc0000f1ae8>] irq_thread+0xe4/0x174
[   16.717676] [<ffffffc0000c0054>] kthread+0xe0/0xec
[   16.717680] ---[ end trace ba8456c4e55819be ]---

Signed-off-by: Humberto Borba humberos@gmail.com
