### PR TITLE
[1.3.3] drivers: msm_serial_hs: Fix unbalanced BT UART clock vote

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2377,6 +2377,7 @@ void msm_hs_set_clock(int port_index, int on)
 {
 	struct uart_port *uport = msm_hs_get_uart_port(port_index);
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+	int rc = atomic_read(&msm_uport->clk_count);
 
 	// Check if there is a registered wakeup source
 	if (!msm_uport->ws.name) {
@@ -2391,8 +2392,10 @@ void msm_hs_set_clock(int port_index, int on)
 		msm_hs_request_clock_on(uport);
 		msm_hs_set_mctrl(uport, TIOCM_RTS);
 	} else {
-		msm_hs_set_mctrl(uport, 0);
-		msm_hs_request_clock_off(uport);
+		if (rc > 0) {
+			msm_hs_set_mctrl(uport, 0);
+			msm_hs_request_clock_off(uport);
+		}
 	}
 }
 EXPORT_SYMBOL(msm_hs_set_clock);


### PR DESCRIPTION
There are two ways to request BT UART clock voting.
The newest is through RFKILL block/unblock operations.

This patch will balance the BT UART clock voting process
by checking if there is an opened vote to validate
the clock OFF request.

The warning happens when the user turns BT OFF.

Warning:

[   69.939341] msm_hs_resource_unvote(): rc zero, bailing

[   69.946217] ------------[ cut here ]------------
[   69.949816] WARNING: at drivers/tty/serial/msm_serial_hs.c:415 msm_hs_resource_unvote+0xa0/0xe0()
[   69.964834] CPU: 1 PID: 5224 Comm: BT Service Call Tainted: G        W    3.10.84-gcdd9570-dirty #5
[   69.964843] Call trace:
[   69.964856] [<ffffffc000087d4c>] dump_backtrace+0x0/0x268
[   69.964863] [<ffffffc000087fc4>] show_stack+0x10/0x1c
[   69.964871] [<ffffffc000bcdeac>] dump_stack+0x1c/0x28
[   69.964879] [<ffffffc00009d920>] warn_slowpath_common+0x70/0x9c
[   69.964885] [<ffffffc00009dbec>] warn_slowpath_null+0x14/0x20
[   69.964894] [<ffffffc0003f40ec>] msm_hs_resource_unvote+0x9c/0xe0
[   69.964900] [<ffffffc0003f76f0>] msm_hs_request_clock_off+0x74/0x8c
[   69.964905] [<ffffffc0003f7ac8>] msm_hs_set_clock+0xc4/0xd4
[   69.964914] [<ffffffc00079a928>] bluesleep_rfkill_set_power+0x174/0x1f0
[   69.964921] [<ffffffc000bb258c>] rfkill_set_block+0x8c/0x11c
[   69.964928] [<ffffffc000bb2964>] rfkill_state_store+0x8c/0xc0
[   69.964935] [<ffffffc00045d75c>] dev_attr_store+0x1c/0x28
[   69.964941] [<ffffffc0001e30a4>] sysfs_write_file+0x108/0x154
[   69.964949] [<ffffffc000184314>] vfs_write+0xcc/0x190
[   69.964954] [<ffffffc0001844c8>] SyS_write+0x54/0x9c
[   69.964958] ---[ end trace 6348e49f0c4b63cf ]---

Signed-off-by: Humberto Borba humberos@gmail.com
