### PR TITLE
dts: kitakami: Rename thermal sensor-information child nodes

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -345,28 +345,28 @@
 
 	qcom,sensor-information {
 		/* msm_therm */
-		qcom,sensor-information@17 {
+		qcom,sensor-information-17 {
 			qcom,scaling-factor = <10>;
 		};
 
 		/* emmc_therm */
-		qcom,sensor-information@18 {
+		qcom,sensor-information-18 {
 			qcom,scaling-factor = <10>;
 		};
 
 		/* quiet_therm */
-		qcom,sensor-information@21 {
+		qcom,sensor-information-21 {
 			qcom,alias-name = "bl_therm";
 		};
 
-		sensor_information100: qcom,sensor-information@100 {
+		sensor_information100: qcom,sensor-information-100 {
 			qcom,sensor-type = "adc";
 			qcom,sensor-name = "bms";
 			qcom,alias-name = "batt_therm";
 			qcom,scaling-factor = <1000>;
 		};
 
-		sensor_information101: qcom,sensor-information@101 {
+		sensor_information101: qcom,sensor-information-101 {
 			qcom,sensor-type = "adc";
 			qcom,sensor-name = "xo_therm";
 		};

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_r2_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_r2_common.dtsi
@@ -96,7 +96,7 @@
 	};
 
 	qcom,sensor-information {
-		sensor_information102: qcom,sensor-information@102 {
+		sensor_information102: qcom,sensor-information-102 {
 			qcom,sensor-type = "adc";
 			qcom,sensor-name = "flash_therm";
 			qcom,scaling-factor = <10>;


### PR DESCRIPTION
this commit makes kitakami follow the renaming that was introduced in
https://github.com/sonyxperiadev/kernel/commit/a884800d19f536ba066b737b38494287fc6a624b
this fixes the issue where reading /sys/module/msm_thermal/sensor_info
would cause kernel to crash.
