### PR TITLE
power: bcl: add special triggering conditions for kitakami

### DIFF
--- a/drivers/power/Kconfig
+++ b/drivers/power/Kconfig
@@ -585,6 +585,12 @@ config MSM_BCL_PERIPHERAL_CTL
 	  provides routines to configure and monitor the BCL
 	  PMIC peripheral.
 
+config MSM_BCL_SOMC_CTL
+	bool "BCL driver to control with new condition"
+	depends on BATTERY_BCL
+	help
+	  Say Y here to enable new condition.
+
 source "drivers/power/reset/Kconfig"
 
 endif # POWER_SUPPLY


### PR DESCRIPTION
kitakami devices sometimes draw more power than what is allow by bcl.
this causes bcl to trigger its mitigations, which means limiting
frequencies and number of maximum online cores as soon as drawn current
increases beyond a specific threshold.
this behaviour has been adjusted on kernel-copyleft by means of
modifying bcl conditions. Applying the same conditions from
kernel-copyleft here will help improve performance considerably, as
cores won't get throttled as soon as high workloads appear.
