### PR TITLE
net: wireless: controlfnc: add sysfs for loire

### DIFF
--- a/drivers/net/wireless/controlfnc/somc-wifi-ctrl.c
+++ b/drivers/net/wireless/controlfnc/somc-wifi-ctrl.c
@@ -298,7 +298,11 @@ EXPORT_SYMBOL(somc_wifi_deinit);
 #if defined(CONFIG_MACH_SONY_SHINANO)
 #define FILE_WIFI_MACADDR "/sys/devices/platform/bcmdhd_wlan/macaddr"
 #else
+#if defined(CONFIG_MACH_SONY_KITAKAMI)
 #define FILE_WIFI_MACADDR "/sys/devices/soc.0/bcmdhd_wlan.90/macaddr"
+#else
+#define FILE_WIFI_MACADDR "/sys/devices/soc.0/bcmdhd_wlan.114/macaddr" /* LOIRE */
+#endif /* CONFIG_MACH_SONY_KITAKAMI */
 #endif /* CONFIG_MACH_SONY_SHINANO */
 
 static inline int xdigit (char c)


### PR DESCRIPTION
Following 554c173aabf8eac2f2ae790782576ac55b6f1d95 this adds the proper
loire path.
