### PR TITLE
[1.3.3] arm64: DT: loire: Fix qcom leds naming

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -379,6 +379,7 @@
 &spmi_bus {
 	qcom,pmi8950@3 {
 		qcom,leds@d800 {
+			linux,name = "wled:backlight";
 			somc,init-br-ua = <10000>;
 			somc-s1,br-power-save-ua = <800>;
 			qcom,led-strings-list = [00 01];

--- a/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
@@ -85,6 +85,7 @@
 &spmi_bus {
 	qcom,pmi8950@3 {
 		qcom,leds@d800 {
+			linux,name = "wled:backlight";
 			somc,init-br-ua = <10000>;
 			somc-s1,br-power-save-ua = <800>;
 			qcom,led-strings-list = [00 01 02];


### PR DESCRIPTION
Update the leds sysfs paths as required for ueventd here:
https://github.com/sonyxperiadev/device-sony-loire/blob/master/rootdir/ueventd.loire.rc#L126-L127

Also it should be consistent with the whole project.

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ia8ac5f0ff28f703492f0b6806879bc9c1674a930
