### PR TITLE
[1.3.3] clk: qcom: mdss-dsi-pll-28hpm: Fix header inclusion for MSM8974

### DIFF
--- a/drivers/clk/qcom/mdss/mdss-dsi-pll-28hpm.c
+++ b/drivers/clk/qcom/mdss/mdss-dsi-pll-28hpm.c
@@ -19,7 +19,12 @@
 #include <linux/clk/msm-clk-provider.h>
 #include <linux/clk/msm-clk.h>
 #include <linux/clk/msm-clock-generic.h>
+
+#ifdef CONFIG_ARCH_MSM8974
+#include <dt-bindings/clock/msm-clocks-8974.h>
+#else
 #include <dt-bindings/clock/msm-clocks-8976.h>
+#endif
 
 #include "mdss-pll.h"
 #include "mdss-dsi-pll.h"


### PR DESCRIPTION
We were including MSM8976 clocks spec header on all SoC.
That was wrong!!! We use HPM PLL not only for 8976/8956, but
also for MSM8974, which obviously has its own clock spec header.
