### PR TITLE
[CRITICAL] thermal: msm-tsens: Fix TRDY address for MSM8994 tz sensors

### DIFF
--- a/drivers/thermal/msm-tsens.c
+++ b/drivers/thermal/msm-tsens.c
@@ -54,7 +54,12 @@
 #define TSENS2_SN_STATUS_ADDR(n)	((n) + 0x1044)
 #define TSENS2_SN_STATUS_VALID		BIT(14)
 #define TSENS2_SN_STATUS_VALID_MASK	0x4000
+
+#ifdef CONFIG_ARCH_MSM8994
+#define TSENS2_TRDY_ADDR(n)		((n) + 0x84)
+#else
 #define TSENS2_TRDY_ADDR(n)		((n) + 0x1084)
+#endif
 
 #define TSENS3_TRDY_ADDR(n)            ((n) + 0x1084)
 


### PR DESCRIPTION
This was changed when MSM8976 was implemented.
The address is COMPLETELY wrong for MSM8994 and some MDM chips.

We have only 8994 devices, so we are fixing it the FAST way by
just adding an ifdef for them.
