### PR TITLE
camera: msm: isp40: add bit shift for VFE write masters

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp40.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp40.c
@@ -1490,11 +1490,6 @@ static void msm_vfe40_axi_cfg_wm_reg(
 	    vfe_dev->vfe_hw_version == VFE40_8939_VERSION) {
 		burst_len = VFE40_BURST_LEN_8916_VERSION;
 		wm_bit_shift = VFE40_WM_BIT_SHIFT;
-	} else if (vfe_dev->vfe_hw_version == VFE40_8974V1_VERSION ||
-			vfe_dev->vfe_hw_version == VFE40_8974V2_VERSION ||
-			vfe_dev->vfe_hw_version == VFE40_8974V3_VERSION) {
-		burst_len = VFE40_BURST_LEN;
-		wm_bit_shift = VFE40_WM_BIT_SHIFT;
 	} else if (vfe_dev->vfe_hw_version == VFE40_8952_VERSION) {
 		burst_len = VFE40_BURST_LEN_8952_VERSION;
 		wm_bit_shift = VFE40_WM_BIT_SHIFT;
@@ -1503,6 +1498,7 @@ static void msm_vfe40_axi_cfg_wm_reg(
 		wm_bit_shift = VFE40_WM_BIT_SHIFT_8976_VERSION;
 	} else {
 		burst_len = VFE40_BURST_LEN;
+		wm_bit_shift = VFE40_WM_BIT_SHIFT;
 	}
 
 	if (!stream_info->frame_based) {


### PR DESCRIPTION
code cleanup and make it available for all targets using vfe40...
since platforms like msm8974 uses dual vfe .... one vfe is off due to this...
platforms like msm8916/8939, msm8952, msm8976 have own burst_len and wm_bit_shift values
make
    burst_len = VFE40_BURST_LEN;
    wm_bit_shift = VFE40_WM_BIT_SHIFT;
    default for all other platforms using vfe40

Signed-off-by: David Viteri davidteri91@gmail.com
Signed-off-by: Erik Castricum erikcas1972@gmail.com
