### PR TITLE
[LA.UM.5.5.r1] Android.mk: Fix inline kernel build on Nougat due to new build rules

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -221,13 +221,9 @@ kernelconfig: $(KERNEL_OUT_STAMP)
 	cp $(KERNEL_OUT)/defconfig $(KERNEL_DEFCONFIG_SRC)
 
 ## Install it
-INSTALLED_KERNEL_TARGET ?= $(PRODUCT_OUT)/kernel
-file := $(INSTALLED_KERNEL_TARGET)
-ALL_PREBUILT += $(file)
-$(file) : $(KERNEL_BIN) | $(ACP)
-	$(transform-prebuilt-to-target)
-
-ALL_PREBUILT += $(INSTALLED_KERNEL_TARGET)
+.PHONY: $(PRODUCT_OUT)/kernel
+$(PRODUCT_OUT)/kernel: $(KERNEL_BIN)
+	cp $(KERNEL_BIN) $(PRODUCT_OUT)/kernel
 
 endif # Sony AOSP devices
 endif # BUILD_KERNEL


### PR DESCRIPTION
ALL_PREBUILT is now forbidden

Signed-off-by: Adam Farden adam@farden.cz
