### PR TITLE
[UM 5.5.r1] somc_panel fixup patchset

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
@@ -24,7 +24,7 @@
 
 &mdss_mdp {
 	dsi_auo_synaptics_cmd_4: somc,auo_synaptics_cmd_4_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -33,7 +33,7 @@
 	};
 
 	dsi_jdi_synaptics_cmd_6: somc,jdi_synaptics_cmd_6_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -42,7 +42,7 @@
 	};
 
 	dsi_lgd_synaptics_cmd_8: somc,lgd_synaptics_cmd_8_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -51,7 +51,7 @@
 	};
 
 	dsi_sharp_synaptics_cmd_3: somc,sharp_synaptics_cmd_3_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -60,7 +60,7 @@
 	};
 
 	dsi_sharp_synaptics_cmd_9: somc,sharp_synaptics_cmd_9_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -166,7 +166,7 @@
 		somc,lab-output-voltage = <5600000>;
 		somc,ibb-output-voltage = <5600000>;
 
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
@@ -22,7 +22,7 @@
 
 &mdss_mdp {
 	dsi_jdi_synaptics_cmd_6: somc,jdi_synaptics_cmd_6_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -31,7 +31,7 @@
 	};
 
 	dsi_sharp_synaptics_cmd_9: somc,sharp_synaptics_cmd_9_panel {
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
@@ -148,7 +148,7 @@
 		somc,lab-output-voltage = <5600000>;
 		somc,ibb-output-voltage = <5600000>;
 
-		qcom,mdss-dsi-panel-timings-8996 = [
+		qcom,mdss-dsi-panel-timings-phy-v2 = [
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -3880,6 +3880,7 @@ int mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable)
 	return 0;
 }
 
+#ifdef CONFIG_SOMC_PANEL_LEGACY
 static int mdss_dsi_intf_ready(struct mdss_panel_data *pdata)
 {
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata;
@@ -3893,6 +3894,7 @@ static int mdss_dsi_intf_ready(struct mdss_panel_data *pdata)
 	ctrl_pdata->spec_pdata->disp_on(pdata);
 	return 0;
 }
+#endif  /* CONFIG_SOMC_PANEL_LEGACY */
 #endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 
 struct device dsi_dev;

--- a/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_intf_cmd.c
@@ -2844,9 +2844,6 @@ static int mdss_mdp_cmd_kickoff(struct mdss_mdp_ctl *ctl, void *arg)
 int mdss_mdp_cmd_restore(struct mdss_mdp_ctl *ctl, bool locked)
 {
 	struct mdss_mdp_cmd_ctx *ctx, *sctx = NULL;
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	int rc = 0;
-#endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 
 	if (!ctl)
 		return -EINVAL;

--- a/drivers/video/msm/mdss/somc_panel/common.c
+++ b/drivers/video/msm/mdss/somc_panel/common.c
@@ -37,6 +37,32 @@
 #include "../mdss_dsi.h"
 #include "somc_panels.h"
 
+/*
+ * somc_panel_set_gpio - GPIO setting helper
+ *
+ * Sets GPIOs to the desired values by also
+ * taking care about handling its direction.
+ *
+ * Note: This function assumes that GPIO is VALID!!!
+ */
+int somc_panel_set_gpio(int gpio, int enable)
+{
+	int rc = 0;
+
+	if (enable) {
+		rc = gpio_direction_output(gpio, 1);
+		if (rc) {
+			pr_debug("%s: Failed to set GPIO %d direction!!\n",
+				 __func__, gpio);
+			return rc;
+		}
+	} else {
+		gpio_set_value(gpio, 0);
+	}
+
+	return rc;
+}
+
 int somc_panel_vreg_name_to_config(
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		struct dss_vreg *config, char *name)

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -35,6 +35,7 @@
 
 #include "../mdss_mdp.h"
 #include "../mdss_dsi.h"
+#include "../mdss_dba_utils.h"
 #include "somc_panels.h"
 
 #define DT_CMD_HDR 		  6

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -2513,6 +2513,7 @@ void mdss_dsi_panel_dsc_pps_send(struct mdss_dsi_ctrl_pdata *ctrl,
 	mdss_dsi_panel_cmds_send(ctrl, &pcmds);
 }
 
+#ifdef USE_TOPOLOGY_CONFIG_PARAMS
 static int mdss_dsi_parse_dsc_version(struct device_node *np,
 		struct mdss_panel_timing *timing)
 {
@@ -2774,7 +2775,8 @@ end:
 	of_node_put(cfg_np);
 	return rc;
 }
-#endif
+#endif  /* USE_TOPOLOGY_CONFIG_PARAMS */
+#endif  /* KERN318_FEATURESET */
 
 static void mdss_panel_parse_te_params(struct device_node *np,
 			struct mdss_panel_timing *timing)
@@ -3697,7 +3699,7 @@ static int  mdss_dsi_panel_config_res_properties(struct device_node *np,
 			"qcom,mdss-dsi-timing-switch-command",
 			"qcom,mdss-dsi-timing-switch-command-state");
 
-#if 0 //def KERN318_FEATURESET
+#ifdef USE_TOPOLOGY_CONFIG_PARAMS
 	rc = mdss_dsi_parse_topology_config(np, pt, panel_data, default_timing);
 	if (rc) {
 		pr_err("%s: parsing compression params failed. rc:%d\n",
@@ -4388,6 +4390,7 @@ error:
 	return rc;
 }
 
+#if 0
 static void mdss_dsi_set_prim_panel(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 {
 	struct mdss_dsi_ctrl_pdata *octrl = NULL;
@@ -4414,7 +4417,7 @@ static void mdss_dsi_set_prim_panel(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 		}
 	}
 }
-
+#endif
 
 int mdss_dsi_panel_init(struct device_node *node,
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata,

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -2498,7 +2498,7 @@ void mdss_dsi_panel_dsc_pps_send(struct mdss_dsi_ctrl_pdata *ctrl,
 	memset(&cmd, 0, sizeof(cmd));
 
 	cmd.dchdr.dlen = mdss_panel_dsc_prepare_pps_buf(&pinfo->dsc,
-				ctrl->pps_buf, 0 , 1, 0);
+				ctrl->pps_buf, 0);
 	cmd.dchdr.dtype = DTYPE_PPS;
 	cmd.dchdr.last = 1;
 	cmd.dchdr.wait = 10;
@@ -2511,6 +2511,47 @@ void mdss_dsi_panel_dsc_pps_send(struct mdss_dsi_ctrl_pdata *ctrl,
 	pcmds.link_state = DSI_LP_MODE;
 
 	mdss_dsi_panel_cmds_send(ctrl, &pcmds);
+}
+
+static int mdss_dsi_parse_dsc_version(struct device_node *np,
+		struct mdss_panel_timing *timing)
+{
+	u32 data;
+	int rc = 0;
+	struct dsc_desc *dsc = &timing->dsc;
+
+	rc = of_property_read_u32(np, "qcom,mdss-dsc-version", &data);
+	if (rc) {
+		dsc->version = 0x11;
+		rc = 0;
+	} else {
+		dsc->version = data & 0xff;
+		/* only support DSC 1.1 rev */
+		if (dsc->version != 0x11) {
+			pr_err("%s: DSC version:%d not supported\n", __func__,
+				dsc->version);
+			rc = -EINVAL;
+			goto end;
+		}
+	}
+
+	rc = of_property_read_u32(np, "qcom,mdss-dsc-scr-version", &data);
+	if (rc) {
+		dsc->scr_rev = 0x0;
+		rc = 0;
+	} else {
+		dsc->scr_rev = data & 0xff;
+		/* only one scr rev supported */
+		if (dsc->scr_rev > 0x1) {
+			pr_err("%s: DSC scr version:%d not supported\n",
+				__func__, dsc->scr_rev);
+			rc = -EINVAL;
+			goto end;
+		}
+	}
+
+end:
+	return rc;
 }
 
 static int mdss_dsi_parse_dsc_params(struct device_node *np,
@@ -2628,8 +2669,39 @@ end:
 	return rc;
 }
 
+static struct device_node *mdss_dsi_panel_get_dsc_cfg_np(
+		struct device_node *np, struct mdss_panel_data *panel_data,
+		bool default_timing)
+{
+	struct device_node *dsc_cfg_np = NULL;
+
+
+	/* Read the dsc config node specified by command line */
+	if (default_timing) {
+		dsc_cfg_np = of_get_child_by_name(np,
+				panel_data->dsc_cfg_np_name);
+		if (!dsc_cfg_np)
+			pr_warn_once("%s: cannot find dsc config node:%s\n",
+				__func__, panel_data->dsc_cfg_np_name);
+	}
+
+	/*
+	 * Fall back to default from DT as nothing is specified
+	 * in command line.
+	 */
+	if (!dsc_cfg_np && of_find_property(np, "qcom,config-select", NULL)) {
+		dsc_cfg_np = of_parse_phandle(np, "qcom,config-select", 0);
+		if (!dsc_cfg_np)
+			pr_warn_once("%s:err parsing qcom,config-select\n",
+					__func__);
+	}
+
+	return dsc_cfg_np;
+}
+
 static int mdss_dsi_parse_topology_config(struct device_node *np,
-	struct dsi_panel_timing *pt, struct mdss_panel_data *panel_data)
+	struct dsi_panel_timing *pt, struct mdss_panel_data *panel_data,
+	bool default_timing)
 {
 	int rc = 0;
 	bool is_split_display = panel_data->panel_info.is_split_display;
@@ -2637,19 +2709,15 @@ static int mdss_dsi_parse_topology_config(struct device_node *np,
 	struct mdss_panel_timing *timing = &pt->timing;
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
 	struct mdss_panel_info *pinfo;
-	struct device_node *cfg_np;
+	struct device_node *cfg_np = NULL;
 
 	ctrl_pdata = container_of(panel_data, struct mdss_dsi_ctrl_pdata,
 							panel_data);
-	cfg_np = ctrl_pdata->panel_data.cfg_np;
+
 	pinfo = &ctrl_pdata->panel_data.panel_info;
 
-	if (!cfg_np && of_find_property(np, "qcom,config-select", NULL)) {
-		cfg_np = of_parse_phandle(np, "qcom,config-select", 0);
-		if (!cfg_np)
-			pr_err("%s:err parsing qcom,config-select\n", __func__);
-		ctrl_pdata->panel_data.cfg_np = cfg_np;
-	}
+	cfg_np = mdss_dsi_panel_get_dsc_cfg_np(np,
+				&ctrl_pdata->panel_data, default_timing);
 
 	if (cfg_np) {
 		if (!of_property_read_u32_array(cfg_np, "qcom,lm-split",
@@ -2686,11 +2754,20 @@ static int mdss_dsi_parse_topology_config(struct device_node *np,
 
 	data = of_get_property(np, "qcom,compression-mode", NULL);
 	if (data) {
-		if (cfg_np && !strcmp(data, "dsc"))
+		if (cfg_np && !strcmp(data, "dsc")) {
+			rc = mdss_dsi_parse_dsc_version(np, &pt->timing);
+			if (rc)
+				goto end;
+
+			pinfo->send_pps_before_switch =
+				of_property_read_bool(np,
+				"qcom,mdss-dsi-send-pps-before-switch");
+
 			rc = mdss_dsi_parse_dsc_params(cfg_np, &pt->timing,
 					is_split_display);
-		else if (!strcmp(data, "fbc"))
+		} else if (!strcmp(data, "fbc")) {
 			rc = mdss_dsi_parse_fbc_params(np, &pt->timing);
+		}
 	}
 
 end:
@@ -2734,6 +2811,7 @@ static void mdss_panel_parse_te_params(struct device_node *np,
 		(np, "qcom,mdss-tear-check-rd-ptr-trigger-intr", &tmp);
 	//te->rd_ptr_irq = (!rc ? tmp : te->vsync_init_val + 1);
 	te->rd_ptr_irq = (!rc ? tmp : timing->yres + 1);
+	te->wr_ptr_irq = 0;
 }
 
 
@@ -2789,11 +2867,13 @@ static int mdss_dsi_nt35596_read_status(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 }
 
 static void mdss_dsi_parse_roi_alignment(struct device_node *np,
-		struct mdss_panel_info *pinfo)
+		struct dsi_panel_timing *pt)
 {
 	int len = 0;
 	u32 value[6];
 	struct property *data;
+	struct mdss_panel_timing *timing = &pt->timing;
+
 	data = of_find_property(np, "qcom,panel-roi-alignment", &len);
 	len /= sizeof(u32);
 	if (!data || (len != 6)) {
@@ -2805,19 +2885,21 @@ static void mdss_dsi_parse_roi_alignment(struct device_node *np,
 			pr_debug("%s: Error reading panel roi alignment values",
 					__func__);
 		else {
-			pinfo->xstart_pix_align = value[0];
-			pinfo->width_pix_align = value[1];
-			pinfo->ystart_pix_align = value[2];
-			pinfo->height_pix_align = value[3];
-			pinfo->min_width = value[4];
-			pinfo->min_height = value[5];
+			timing->roi_alignment.xstart_pix_align = value[0];
+			timing->roi_alignment.ystart_pix_align = value[1];
+			timing->roi_alignment.width_pix_align = value[2];
+			timing->roi_alignment.height_pix_align = value[3];
+			timing->roi_alignment.min_width = value[4];
+			timing->roi_alignment.min_height = value[5];
 		}
 
 		pr_debug("%s: ROI alignment: [%d, %d, %d, %d, %d, %d]",
-				__func__, pinfo->xstart_pix_align,
-				pinfo->width_pix_align, pinfo->ystart_pix_align,
-				pinfo->height_pix_align, pinfo->min_width,
-				pinfo->min_height);
+			__func__, timing->roi_alignment.xstart_pix_align,
+			timing->roi_alignment.width_pix_align,
+			timing->roi_alignment.ystart_pix_align,
+			timing->roi_alignment.height_pix_align,
+			timing->roi_alignment.min_width,
+			timing->roi_alignment.min_height);
 	}
 }
 
@@ -2882,10 +2964,61 @@ exit:
 	return;
 }
 
+/* the length of all the valid values to be checked should not be great
+ * than the length of returned data from read command.
+ */
+static bool
+mdss_dsi_parse_esd_check_valid_params(struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	int i;
+
+	for (i = 0; i < ctrl->status_cmds.cmd_cnt; ++i) {
+		if (ctrl->status_valid_params[i] > ctrl->status_cmds_rlen[i]) {
+			pr_debug("%s: ignore valid params!\n", __func__);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool mdss_dsi_parse_esd_status_len(struct device_node *np,
+	char *prop_key, u32 **target, u32 cmd_cnt)
+{
+	int tmp;
+
+	if (!of_find_property(np, prop_key, &tmp))
+		return false;
+
+	tmp /= sizeof(u32);
+	if (tmp != cmd_cnt) {
+		pr_err("%s: request property number(%d) not match command count(%d)\n",
+			__func__, tmp, cmd_cnt);
+		return false;
+	}
+
+	*target = kcalloc(tmp, sizeof(u32), GFP_KERNEL);
+	if (IS_ERR_OR_NULL(*target)) {
+		pr_err("%s: Error allocating memory for property\n",
+			__func__);
+		return false;
+	}
+
+	if (of_property_read_u32_array(np, prop_key, *target, tmp)) {
+		pr_err("%s: cannot get values from dts\n", __func__);
+		kfree(*target);
+		*target = NULL;
+		return false;
+	}
+
+	return true;
+}
+
 static void mdss_dsi_parse_esd_params(struct device_node *np,
 	struct mdss_dsi_ctrl_pdata *ctrl)
 {
 	u32 tmp;
+	u32 i, status_len, *lenp;
 	int rc;
 	struct property *data;
 	const char *string;
@@ -2896,43 +3029,6 @@ static void mdss_dsi_parse_esd_params(struct device_node *np,
 
 	if (!pinfo->esd_check_enabled)
 		return;
-
-	mdss_dsi_parse_dcs_cmds(np, &ctrl->status_cmds,
-			"qcom,mdss-dsi-panel-status-command",
-				"qcom,mdss-dsi-panel-status-command-state");
-
-	rc = of_property_read_u32(np, "qcom,mdss-dsi-panel-status-read-length",
-		&tmp);
-	ctrl->status_cmds_rlen = (!rc ? tmp : 1);
-
-	rc = of_property_read_u32(np, "qcom,mdss-dsi-panel-max-error-count",
-		&tmp);
-	ctrl->max_status_error_count = (!rc ? tmp : 0);
-
-	ctrl->status_value = kzalloc(sizeof(u32) * ctrl->status_cmds_rlen,
-				GFP_KERNEL);
-	if (!ctrl->status_value) {
-		pr_err("%s: Error allocating memory for status buffer\n",
-			__func__);
-		pinfo->esd_check_enabled = false;
-		return;
-	}
-
-	data = of_find_property(np, "qcom,mdss-dsi-panel-status-value", &tmp);
-	tmp /= sizeof(u32);
-	if (!data || (tmp != ctrl->status_cmds_rlen)) {
-		pr_debug("%s: Panel status values not found\n", __func__);
-		memset(ctrl->status_value, 0, ctrl->status_cmds_rlen);
-	} else {
-		rc = of_property_read_u32_array(np,
-			"qcom,mdss-dsi-panel-status-value",
-			ctrl->status_value, tmp);
-		if (rc) {
-			pr_debug("%s: Error reading panel status values\n",
-					__func__);
-			memset(ctrl->status_value, 0, ctrl->status_cmds_rlen);
-		}
-	}
 
 	ctrl->status_mode = ESD_MAX;
 	rc = of_property_read_string(np,
@@ -2961,10 +3057,74 @@ static void mdss_dsi_parse_esd_params(struct device_node *np,
 			goto error;
 		}
 	}
+
+	if ((ctrl->status_mode == ESD_BTA) || (ctrl->status_mode == ESD_TE) ||
+			(ctrl->status_mode == ESD_MAX))
+		return;
+
+	mdss_dsi_parse_dcs_cmds(np, &ctrl->status_cmds,
+			"qcom,mdss-dsi-panel-status-command",
+				"qcom,mdss-dsi-panel-status-command-state");
+
+	rc = of_property_read_u32(np, "qcom,mdss-dsi-panel-max-error-count",
+		&tmp);
+	ctrl->max_status_error_count = (!rc ? tmp : 0);
+
+	if (!mdss_dsi_parse_esd_status_len(np,
+		"qcom,mdss-dsi-panel-status-read-length",
+		&ctrl->status_cmds_rlen, ctrl->status_cmds.cmd_cnt)) {
+		pinfo->esd_check_enabled = false;
+		return;
+	}
+
+	if (mdss_dsi_parse_esd_status_len(np,
+		"qcom,mdss-dsi-panel-status-valid-params",
+		&ctrl->status_valid_params, ctrl->status_cmds.cmd_cnt)) {
+		if (!mdss_dsi_parse_esd_check_valid_params(ctrl))
+			goto error1;
+	}
+
+	status_len = 0;
+	lenp = ctrl->status_valid_params ?: ctrl->status_cmds_rlen;
+	for (i = 0; i < ctrl->status_cmds.cmd_cnt; ++i)
+		status_len += lenp[i];
+
+	data = of_find_property(np, "qcom,mdss-dsi-panel-status-value", &tmp);
+	tmp /= sizeof(u32);
+	if (!IS_ERR_OR_NULL(data) && tmp != 0 && (tmp % status_len) == 0) {
+		ctrl->groups = tmp / status_len;
+	} else {
+		pr_err("%s: Error parse panel-status-value\n", __func__);
+		goto error1;
+	}
+
+	ctrl->status_value = kzalloc(sizeof(u32) * status_len * ctrl->groups,
+				GFP_KERNEL);
+	if (!ctrl->status_value)
+		goto error1;
+
+	ctrl->return_buf = kcalloc(status_len * ctrl->groups,
+			sizeof(unsigned char), GFP_KERNEL);
+	if (!ctrl->return_buf)
+		goto error2;
+
+	rc = of_property_read_u32_array(np,
+		"qcom,mdss-dsi-panel-status-value",
+		ctrl->status_value, ctrl->groups * status_len);
+	if (rc) {
+		pr_debug("%s: Error reading panel status values\n",
+				__func__);
+		memset(ctrl->status_value, 0, ctrl->groups * status_len);
+	}
+
 	return;
 
-error:
+error2:
 	kfree(ctrl->status_value);
+error1:
+	kfree(ctrl->status_valid_params);
+	kfree(ctrl->status_cmds_rlen);
+error:
 	pinfo->esd_check_enabled = false;
 }
 
@@ -3012,6 +3172,9 @@ static int mdss_dsi_parse_panel_features(struct device_node *np,
 
 	pinfo->panel_ack_disabled = pinfo->sim_panel_mode ?
 		1 : of_property_read_bool(np, "qcom,panel-ack-disabled");
+
+	pinfo->allow_phy_power_off = of_property_read_bool(np,
+		"qcom,panel-allow-phy-poweroff");
 
 	mdss_dsi_parse_esd_params(np, ctrl);
 
@@ -3071,6 +3234,13 @@ static void mdss_dsi_parse_panel_horizontal_line_idle(struct device_node *np,
 		kp++;
 		ctrl->horizontal_idle_cnt++;
 	}
+
+	/*
+	 * idle is enabled for this controller, this will be used to
+	 * enable/disable burst mode since both features are mutually
+	 * exclusive.
+	 */
+	ctrl->idle_enabled = true;
 
 	pr_debug("%s: horizontal_idle_cnt=%d\n", __func__,
 				ctrl->horizontal_idle_cnt);
@@ -3474,7 +3644,7 @@ static int mdss_dsi_panel_timing_from_dt(struct device_node *np,
 	}
 
 #ifdef KERN318_FEATURESET
-	data = of_get_property(np, "qcom,mdss-dsi-panel-timings-8996", &len);
+	data = of_get_property(np, "qcom,mdss-dsi-panel-timings-phy-v2", &len);
 	if ((!data) || (len != 40)) {
 		pr_debug("%s:%d, Unable to read 8996 Phy lane timing settings",
 		       __func__, __LINE__);
@@ -3503,9 +3673,12 @@ static int mdss_dsi_panel_timing_from_dt(struct device_node *np,
 
 static int  mdss_dsi_panel_config_res_properties(struct device_node *np,
 		struct dsi_panel_timing *pt,
-		struct mdss_panel_data *panel_data)
+		struct mdss_panel_data *panel_data,
+		bool default_timing)
 {
 	int rc = 0;
+
+	mdss_dsi_parse_roi_alignment(np, pt);
 
 	mdss_dsi_parse_dcs_cmds(np, &pt->einit_cmds,
 		"somc,mdss-dsi-early-init-command", NULL);
@@ -3525,7 +3698,7 @@ static int  mdss_dsi_panel_config_res_properties(struct device_node *np,
 			"qcom,mdss-dsi-timing-switch-command-state");
 
 #if 0 //def KERN318_FEATURESET
-	rc = mdss_dsi_parse_topology_config(np, pt, panel_data);
+	rc = mdss_dsi_parse_topology_config(np, pt, panel_data, default_timing);
 	if (rc) {
 		pr_err("%s: parsing compression params failed. rc:%d\n",
 			__func__, rc);
@@ -3549,6 +3722,7 @@ static int mdss_panel_parse_display_timings(struct device_node *np,
 	struct device_node *entry;
 	int num_timings, rc;
 	int i = 0, active_ndx = 0;
+	bool default_timing = false;
 
 	ctrl = container_of(panel_data, struct mdss_dsi_ctrl_pdata, panel_data);
 
@@ -3567,7 +3741,7 @@ static int mdss_panel_parse_display_timings(struct device_node *np,
 		rc = mdss_dsi_panel_timing_from_dt(np, &pt, panel_data);
 		if (!rc) {
 			mdss_dsi_panel_config_res_properties(np,
-				&pt, panel_data);
+				&pt, panel_data, true);
 			rc = mdss_dsi_panel_timing_switch(ctrl, &pt.timing);
 		}
 		return rc;
@@ -3595,13 +3769,13 @@ static int mdss_panel_parse_display_timings(struct device_node *np,
 			goto exit;
 		}
 
-		mdss_dsi_panel_config_res_properties(entry,
-			(modedb + i), panel_data);
-
-		/* if default is set, use it otherwise use first as default */
-		if (of_property_read_bool(entry,
-				"qcom,mdss-dsi-timing-default"))
+		default_timing = of_property_read_bool(entry,
+				"qcom,mdss-dsi-timing-default");
+		if (default_timing)
 			active_ndx = i;
+
+		mdss_dsi_panel_config_res_properties(entry,
+			(modedb + i), panel_data, default_timing);
 
 		list_add(&modedb[i].timing.list,
 				&panel_data->timings_list);
@@ -3619,6 +3793,7 @@ exit:
 	return rc;
 }
 
+
 int mdss_panel_parse_dt(struct device_node *np,
 			struct mdss_dsi_ctrl_pdata *ctrl_pdata)
 {
@@ -3627,6 +3802,7 @@ int mdss_panel_parse_dt(struct device_node *np,
 	const char *data;
 	static const char *pdest;
 	static const char *panel_name;
+	const char *bridge_chip_name;
 	struct mdss_panel_info *pinfo = &(ctrl_pdata->panel_data.panel_info);
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
 	struct device_node *cfg_np = NULL;
@@ -3896,6 +4072,9 @@ int mdss_panel_parse_dt(struct device_node *np,
 			&tmp);
 	pinfo->mipi.init_delay = (!rc ? tmp : 0);
 
+	rc = of_property_read_u32(np, "qcom,mdss-dsi-post-init-delay", &tmp);
+	pinfo->mipi.post_init_delay = (!rc ? tmp : 0);
+
 	rc = of_property_read_u32(np,
 		"qcom,mdss-dsi-panel-framerate", &tmp);
 	pinfo->mipi.frame_rate = !rc ? tmp : 60;
@@ -3927,8 +4106,6 @@ int mdss_panel_parse_dt(struct device_node *np,
 	} else
 		pr_err("%s:%d, Unable to read Phy lane configure\n",
 			__func__, __LINE__);
-
-	mdss_dsi_parse_roi_alignment(np, pinfo);
 
 	mdss_dsi_parse_trigger(np, &(pinfo->mipi.mdp_trigger),
 		"qcom,mdss-dsi-mdp-trigger");
@@ -4118,6 +4295,19 @@ int mdss_panel_parse_dt(struct device_node *np,
 
 	pinfo->is_dba_panel = of_property_read_bool(np,
 			"qcom,dba-panel");
+
+	if (pinfo->is_dba_panel) {
+		bridge_chip_name = of_get_property(np,
+			"qcom,bridge-name", &len);
+		if (!bridge_chip_name || len <= 0) {
+			pr_err("%s:%d Unable to read qcom,bridge_name, data=%p,len=%d\n",
+				__func__, __LINE__, bridge_chip_name, len);
+			rc = -EINVAL;
+			goto error;
+		}
+		strlcpy(ctrl_pdata->bridge_name, bridge_chip_name,
+			MSM_DBA_CHIP_NAME_MAX_LEN);
+	}
 
 	pinfo->lcdc.chg_fps.enable = of_property_read_bool(np,
 					"somc,change-fps-enable");

--- a/drivers/video/msm/mdss/somc_panel/panel_incell.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_incell.c
@@ -218,7 +218,7 @@ static int somc_panel_calc_gpio_sleep(
 	return wait;
 }
 
-static void somc_panel_gpio_output(
+static void incell_panel_gpio_output(
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		int gpio, bool enable, int value)
 {
@@ -233,7 +233,7 @@ static void somc_panel_gpio_output(
 		usleep_range(wait, wait + 100);
 }
 
-static void somc_panel_set_gpio(
+static void incell_panel_set_gpio(
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		int gpio, bool enable, int value)
 {
@@ -324,10 +324,10 @@ static int incell_reset_touch(struct mdss_panel_data *pdata, int enable)
 			spec_pdata->gpios_requested = true;
 		}
 
-		somc_panel_gpio_output(ctrl_pdata,
+		incell_panel_gpio_output(ctrl_pdata,
 			(spec_pdata->touch_reset_gpio), true, 1);
 	} else {
-		somc_panel_set_gpio(ctrl_pdata,
+		incell_panel_set_gpio(ctrl_pdata,
 			(spec_pdata->touch_reset_gpio), false, 0);
 	}
 
@@ -792,10 +792,10 @@ static int incell_dsi_panel_power_off_ex(struct mdss_panel_data *pdata)
 
 	incell_touch_pinctrl_set_state(ctrl_pdata, false);
 
-	somc_panel_set_gpio(ctrl_pdata,
+	incell_panel_set_gpio(ctrl_pdata,
 		(spec_pdata->touch_vddio_gpio), false, 1);
 
-	somc_panel_set_gpio(ctrl_pdata,
+	incell_panel_set_gpio(ctrl_pdata,
 		(spec_pdata->disp_vddio_gpio), false, 1);
 
 	ret += somc_panel_vreg_ctrl(ctrl_pdata, "vddio", false);
@@ -1036,10 +1036,10 @@ static int incell_dsi_panel_power_on_ex(struct mdss_panel_data *pdata)
 	ret += somc_panel_vreg_ctrl(ctrl_pdata, "touch-avdd", true);
 	ret += somc_panel_vreg_ctrl(ctrl_pdata, "vddio", true);
 
-	somc_panel_gpio_output(ctrl_pdata,
+	incell_panel_gpio_output(ctrl_pdata,
 		(spec_pdata->disp_vddio_gpio), true, 0);
 
-	somc_panel_gpio_output(ctrl_pdata,
+	incell_panel_gpio_output(ctrl_pdata,
 		(spec_pdata->touch_vddio_gpio), true, 0);
 
 	incell_touch_pinctrl_set_state(ctrl_pdata, true);

--- a/drivers/video/msm/mdss/somc_panel/panel_legacy.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_legacy.c
@@ -158,7 +158,8 @@ static int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
 					pw_seq->disp_dcdc_en_pre * 1000 + 100);
 
-			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
+			somc_panel_set_gpio(spec_pdata->disp_dcdc_en_gpio,
+					enable);
 
 			if (pw_seq->disp_dcdc_en_post)
 				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
@@ -170,7 +171,7 @@ static int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 		usleep_range(pw_seq->disp_en_pre * 1000,
 				pw_seq->disp_en_pre * 1000 + 100);
 	if (gpio_is_valid(ctrl_pdata->disp_en_gpio)) {
-		gpio_set_value(ctrl_pdata->disp_en_gpio, enable);
+		somc_panel_set_gpio(ctrl_pdata->disp_en_gpio, enable);
 	}
 
 	if (pw_seq->disp_en_post)
@@ -183,7 +184,8 @@ static int mdss_dsi_panel_disp_en(struct mdss_panel_data *pdata, int enable)
 				usleep_range(pw_seq->disp_dcdc_en_pre * 1000,
 					pw_seq->disp_dcdc_en_pre * 1000 + 100);
 
-			gpio_set_value(spec_pdata->disp_dcdc_en_gpio, enable);
+			somc_panel_set_gpio(spec_pdata->disp_dcdc_en_gpio,
+					enable);
 
 			if (pw_seq->disp_dcdc_en_post)
 				usleep_range(pw_seq->disp_dcdc_en_post * 1000,
@@ -324,8 +326,8 @@ static int legacy_panel_power_on_ex(struct mdss_panel_data *pdata)
 		gpio_is_valid(spec_pdata->vsp_gpio)) {
 		usleep_range(19000, 20000);
 
-		gpio_set_value(spec_pdata->vsn_gpio, 1);
-		gpio_set_value(spec_pdata->vsp_gpio, 1);
+		somc_panel_set_gpio(spec_pdata->vsn_gpio, 1);
+		somc_panel_set_gpio(spec_pdata->vsp_gpio, 1);
 	}
 
 	if (spec_pdata->pwron_reset) {

--- a/drivers/video/msm/mdss/somc_panel/somc_panels.h
+++ b/drivers/video/msm/mdss/somc_panel/somc_panels.h
@@ -83,6 +83,8 @@ enum {
 };
 
 /* Common */
+int  somc_panel_set_gpio(int gpio, int enable);
+
 int  somc_panel_vreg_name_to_config(
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		struct dss_vreg *config, char *name);


### PR DESCRIPTION
This patchset introduces fixup for somc_panel driver.
It allows for proper GPIO management in 3.18 by properly setting output direction on GPIOs and fixes the code for the new API found in UM 5.5.r1 branch.