### PR TITLE
[UM 5.5.r1] video: msm: mdss_mdp_wfd: Remove unused, misplaced variable

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_wfd.c
+++ b/drivers/video/msm/mdss/mdss_mdp_wfd.c
@@ -135,7 +135,6 @@ int mdss_mdp_wfd_setup(struct mdss_mdp_wfd *wfd,
 	int ret = 0;
 	int mixer_type = MDSS_MDP_MIXER_TYPE_INTF;
 	u32 width, height, max_mixer_width;
-	u32 nmixer_without_dspp = ctl->mdata->nmixers_intf - ctl->mdata->ndspp;
 
 	if (!ctl)
 		return -EINVAL;


### PR DESCRIPTION
The variable is misplaced because of fast migration between
HB and UM kernel branches.

This variable is supposed to be in mdss_mdp_get_interface_type
(where it already is, right now) and NOT in WFD setup.