### PR TITLE
dts:kitakami:sumire: overwrite mdss-dsi-on-command for novatek jdi panel

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-sumire.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-sumire.dtsi
@@ -26,6 +26,12 @@
 	somc,dric-gpio = <&msm_gpio 56 0>;
 	somc,mul-channel-scaling = <3>;
 	somc,postpwron-no-reset-quirk;
+
+	dsi_novatek_jdi_1080_cmd: somc,novatek_jdi_1080p_cmd_panel {
+		qcom,mdss-dsi-on-command = [05 01 00 00 00 00 01 29
+			05 01 00 00 0A 00 01 11];
+	};
+
 	dsi_default_gpio_0: somc,default_cmd_panel_0 {
 		qcom,mdss-dsi-panel-name = "default";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;


### PR DESCRIPTION
it has been noted that turning screen on for sumire devices that have a
novatek jdi panel can produce a number of issues ranging from wrong
colors to inverted display.
Noting that ivy uses the same panel, a test was started to see if some
of the different values between sumire and ivy panels would help
alleviate the issue. The conclusion was that using mdss-dsi-on-command
value from ivy fixed the issues happening on sumire.
Thanks to:
kholk@github for suggesting to try out ivy values
Myself5@github for testing on his sumire.