### PR TITLE
[UM 5.5.r1] arm: DT: Tone: Fix LAB/IBB voltages, add more configuration

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -539,8 +539,8 @@
 		qcom,panel-supply-entry@1 {
 			reg = <1>;
 			qcom,supply-name = "lab";
-			qcom,supply-min-voltage = <4600000>;
-			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-min-voltage = <5500000>;
+			qcom,supply-max-voltage = <5700000>;
 			qcom,supply-enable-load = <100000>;
 			qcom,supply-disable-load = <100>;
 		};
@@ -548,8 +548,8 @@
 		qcom,panel-supply-entry@2 {
 			reg = <2>;
 			qcom,supply-name = "ibb";
-			qcom,supply-min-voltage = <4600000>;
-			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-min-voltage = <5500000>;
+			qcom,supply-max-voltage = <5700000>;
 			qcom,supply-enable-load = <100000>;
 			qcom,supply-disable-load = <100>;
 		};
@@ -580,8 +580,8 @@
 		qcom,panel-supply-entry@1 {
 			reg = <1>;
 			qcom,supply-name = "lab";
-			qcom,supply-min-voltage = <4600000>;
-			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-min-voltage = <5500000>;
+			qcom,supply-max-voltage = <5700000>;
 			qcom,supply-enable-load = <100000>;
 			qcom,supply-disable-load = <100>;
 		};
@@ -589,8 +589,8 @@
 		qcom,panel-supply-entry@2 {
 			reg = <2>;
 			qcom,supply-name = "ibb";
-			qcom,supply-min-voltage = <4600000>;
-			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-min-voltage = <5500000>;
+			qcom,supply-max-voltage = <5700000>;
 			qcom,supply-enable-load = <100000>;
 			qcom,supply-disable-load = <100>;
 		};
@@ -3248,14 +3248,20 @@
 
 &labibb {
 	qcom,lab@de00 {
-		qcom,qpnp-lab-init-voltage = <6000000>;
-		qcom,qpnp-lab-init-lcd-voltage = <6000000>;
+		qcom,qpnp-lab-init-voltage = <5700000>;
+		qcom,qpnp-lab-init-lcd-voltage = <5700000>;
+		qcom,qpnp-lab-soft-start = <800>;
+		qcom,qpnp-lab-max-precharge-time = <300>;
+		qcom,qpnp-lab-pull-down-enable;
+		qcom,qpnp-lab-full-pull-down-enable;
 		interrupts = <0x3 0xde 0x0>;
 		interrupt-names = "lab_vreg_not_ok_interrupt";
 	};
 	qcom,ibb@dc00 {
-		qcom,qpnp-ibb-init-voltage = <6000000>;
-		qcom,qpnp-ibb-init-lcd-voltage = <6000000>;
+		qcom,qpnp-ibb-init-voltage = <5700000>;
+		qcom,qpnp-ibb-init-lcd-voltage = <5700000>;
+		qcom,qpnp-ibb-pull-down-enable;
+		qcom,qpnp-ibb-full-pull-down-enable;
 		interrupts = <0x3 0xdc 0x0>;
 		interrupt-names = "ibb_vreg_not_ok_interrupt";
 	};


### PR DESCRIPTION
LAB's max precharge time is 300uS, soft-start time is 800uS.
Also, enable pull down at full strength for both LAB and IBB.

Finally, fix LAB and IBB voltages: maximum required voltage is
5.7V, while minimum is 5.5V. Initialize LAB and IBB at 5.7V and
low and high voltage limits at respectively 5.7 and 5.5V.