### PR TITLE
[UM 5.5.r1] Add QPNP Regulator SoMC code for MSM8974 to 8996 devices

### DIFF
--- a/drivers/regulator/core.c
+++ b/drivers/regulator/core.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2007, 2008 Wolfson Microelectronics PLC.
  * Copyright 2008 SlimLogic Ltd.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
  *
  * Author: Liam Girdwood <lrg@slimlogic.co.uk>
  *
@@ -3227,6 +3228,33 @@ int regulator_allow_bypass(struct regulator *regulator, bool enable)
 	return ret;
 }
 EXPORT_SYMBOL_GPL(regulator_allow_bypass);
+
+/**
+ * regulator_register_ocp_notification - register ocp notification
+ * @regulator: regulator source
+ * @notification: pointer of client ocp_notification
+ *
+ */
+int regulator_register_ocp_notification(struct regulator *regulator,
+			struct regulator_ocp_notification *notification)
+{
+	struct regulator_dev *rdev = regulator->rdev;
+	int ret;
+
+	mutex_lock(&rdev->mutex);
+
+	/* sanity check */
+	if (!rdev->desc->ops->register_ocp_notification) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	ret = rdev->desc->ops->register_ocp_notification(rdev, notification);
+out:
+	mutex_unlock(&rdev->mutex);
+	return ret;
+}
+EXPORT_SYMBOL_GPL(regulator_register_ocp_notification);
 
 /**
  * regulator_register_notifier - register regulator event notifier

--- a/drivers/regulator/qpnp-regulator.c
+++ b/drivers/regulator/qpnp-regulator.c
@@ -338,6 +338,8 @@ struct qpnp_regulator {
 	int					ocp_count;
 	int					ocp_max_retries;
 	int					ocp_retry_delay_ms;
+	struct regulator_ocp_notification	ocp_notification;
+	spinlock_t				ocp_lock;
 	int					system_load;
 	int					hpm_min_load;
 	int					slew_rate;
@@ -1243,6 +1245,34 @@ static int qpnp_regulator_common_enable_time(struct regulator_dev *rdev)
 	return vreg->enable_time;
 }
 
+static int qpnp_regulator_vs_register_ocp_notification(
+				struct regulator_dev *rdev,
+				struct regulator_ocp_notification *notification)
+{
+	unsigned long flags;
+	struct qpnp_regulator *vreg = rdev_get_drvdata(rdev);
+
+	spin_lock_irqsave(&vreg->ocp_lock, flags);
+	if (notification) {
+		/* register ocp notification */
+		vreg->ocp_notification = *notification;
+	} else {
+		/* unregister ocp notification */
+		memset(&vreg->ocp_notification, 0,
+			sizeof(vreg->ocp_notification));
+	}
+	spin_unlock_irqrestore(&vreg->ocp_lock, flags);
+
+	if (qpnp_vreg_debug_mask & QPNP_VREG_DEBUG_OCP) {
+		pr_info("%s: registered ocp notification(notify=%p, ctxt=%p)\n",
+			vreg->rdesc.name,
+			vreg->ocp_notification.notify,
+			vreg->ocp_notification.ctxt);
+	}
+
+	return 0;
+}
+
 static int qpnp_regulator_vs_clear_ocp(struct qpnp_regulator *vreg)
 {
 	int rc;
@@ -1318,8 +1348,14 @@ static irqreturn_t qpnp_regulator_vs_ocp_isr(int irq, void *data)
 		schedule_delayed_work(&vreg->ocp_work,
 			msecs_to_jiffies(vreg->ocp_retry_delay_ms) + 1);
 	} else {
+		unsigned long flags;
 		vreg_err(vreg, "OCP triggered %d times; no further retries\n",
 			vreg->ocp_count);
+		spin_lock_irqsave(&vreg->ocp_lock, flags);
+		if (vreg->ocp_notification.notify)
+			vreg->ocp_notification.notify(
+				vreg->ocp_notification.ctxt);
+		spin_unlock_irqrestore(&vreg->ocp_lock, flags);
 	}
 
 	return IRQ_HANDLED;
@@ -1554,6 +1590,8 @@ static struct regulator_ops qpnp_vs_ops = {
 	.disable		= qpnp_regulator_common_disable,
 	.is_enabled		= qpnp_regulator_common_is_enabled,
 	.enable_time		= qpnp_regulator_common_enable_time,
+	.register_ocp_notification
+		= qpnp_regulator_vs_register_ocp_notification,
 };
 
 static struct regulator_ops qpnp_boost_ops = {
@@ -2241,6 +2279,10 @@ static int qpnp_regulator_probe(struct spmi_device *spmi)
 		vreg->ocp_max_retries = QPNP_VS_OCP_DEFAULT_MAX_RETRIES;
 	if (vreg->ocp_retry_delay_ms == 0)
 		vreg->ocp_retry_delay_ms = QPNP_VS_OCP_DEFAULT_RETRY_DELAY_MS;
+
+	memset(&vreg->ocp_notification, 0,
+		sizeof(vreg->ocp_notification));
+	spin_lock_init(&vreg->ocp_lock);
 
 	rdesc			= &vreg->rdesc;
 	rdesc->id		= spmi->ctrl->nr;

--- a/include/linux/regulator/consumer.h
+++ b/include/linux/regulator/consumer.h
@@ -2,6 +2,7 @@
  * consumer.h -- SoC Regulator consumer support.
  *
  * Copyright (C) 2007, 2008 Wolfson Microelectronics PLC.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
  *
  * Author: Liam Girdwood <lrg@slimlogic.co.uk>
  *
@@ -163,6 +164,18 @@ struct regulator_bulk_data {
 	int ret;
 };
 
+/**
+ * struct regulator_ocp_notification: event notification structure
+ * @notify: pointer to client function to call when ocp event is detected.
+ *          notify function runs in interrupt context.
+ * @ctxt: client-specific context pointer
+ *
+ */
+struct regulator_ocp_notification {
+	void (*notify)(void *);
+	void *ctxt;
+};
+
 #if defined(CONFIG_REGULATOR)
 
 /* regulator get and put */
@@ -259,6 +272,10 @@ int regulator_get_hardware_vsel_register(struct regulator *regulator,
 					 unsigned *vsel_mask);
 int regulator_list_hardware_vsel(struct regulator *regulator,
 				 unsigned selector);
+
+/* regulator register ocp notification */
+int regulator_register_ocp_notification(struct regulator *regulator,
+			struct regulator_ocp_notification *ocp_notification);
 
 /* regulator notifier block */
 int regulator_register_notifier(struct regulator *regulator,
@@ -518,6 +535,13 @@ static inline int regulator_list_hardware_vsel(struct regulator *regulator,
 					       unsigned selector)
 {
 	return -EOPNOTSUPP;
+}
+
+static inline int regulator_register_ocp_notification(
+			struct regulator *regulator,
+			struct regulator_ocp_notification *ocp_notification);
+{
+	return 0;
 }
 
 static inline int regulator_register_notifier(struct regulator *regulator,

--- a/include/linux/regulator/driver.h
+++ b/include/linux/regulator/driver.h
@@ -2,6 +2,7 @@
  * driver.h -- SoC Regulator driver support.
  *
  * Copyright (C) 2007, 2008 Wolfson Microelectronics PLC.
+ * Copyright (C) 2013 Sony Mobile Communications AB.
  *
  * Author: Liam Girdwood <lrg@slimlogic.co.uk>
  *
@@ -115,6 +116,8 @@ struct regulator_linear_range {
  *               The function provides the from and to voltage selector, the
  *               function should return the worst case.
  *
+ * @register_ocp_notification: Register the notification for ocp.
+ *
  * @set_suspend_voltage: Set the voltage for the regulator when the system
  *                       is suspended.
  * @set_suspend_enable: Mark the regulator as enabled when the system is
@@ -176,6 +179,10 @@ struct regulator_ops {
 	/* control and report on bypass mode */
 	int (*set_bypass)(struct regulator_dev *dev, bool enable);
 	int (*get_bypass)(struct regulator_dev *dev, bool *enable);
+
+	/* register ocp notification */
+	int (*register_ocp_notification) (struct regulator_dev *,
+			struct regulator_ocp_notification *notification);
 
 	/* the operations below are for configuration of regulator state when
 	 * its parent PMIC enters a global STANDBY/HIBERNATE state */


### PR DESCRIPTION
drivers: regulator: Update QPNP Regulator driver for SONY
Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>