### PR TITLE
[1.3.3] rhine: fix jack type (plug detection) and dapm widgets cleanup

### DIFF
--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -772,16 +772,6 @@ static const struct snd_soc_dapm_widget msm8974_dapm_widgets[] = {
 	SND_SOC_DAPM_SUPPLY("MCLK",  SND_SOC_NOPM, 0, 0,
 	msm8974_mclk_event, SND_SOC_DAPM_PRE_PMU | SND_SOC_DAPM_POST_PMD),
 
-#ifdef CONFIG_MACH_SONY_RHINE
-	SND_SOC_DAPM_SPK("Lineout_1 amp", msm_ext_spkramp_event),
-	SND_SOC_DAPM_SPK("Lineout_3 amp", msm_ext_spkramp_event),
-
-	SND_SOC_DAPM_SPK("Lineout_2 amp", msm_ext_spkramp_event),
-	SND_SOC_DAPM_SPK("Lineout_4 amp", msm_ext_spkramp_event),
-	SND_SOC_DAPM_SPK("SPK_ultrasound amp",
-					 msm_ext_spkramp_ultrasound_event),
-#endif
-
 	SND_SOC_DAPM_SPK("Ext Spk Bottom Pos", msm_ext_spkramp_event),
 	SND_SOC_DAPM_SPK("Ext Spk Bottom Neg", msm_ext_spkramp_event),
 

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -213,7 +213,9 @@ static struct wcd9xxx_mbhc_config mbhc_cfg = {
 	.do_recalibration = true,
 	.use_vddio_meas = true,
 	.enable_anc_mic_detect = false,
+#ifdef CONFIG_MACH_SONY_SHINANO
 	.hw_jack_type = SIX_POLE_JACK,
+#endif
 };
 
 struct msm_auxpcm_gpio {


### PR DESCRIPTION
fix rhine plug detection (3-pole headphones are clicking non-existing buttons and 4-pole ones are not recognized till button press) and remove lineouts dapm widgets as rhine has no lineouts (only one jack hole that isn't used as a lineout). Lineout clearly isn't a mic just because it's a lineOUT. There is no way that could fix any mic. 

Both mics (internal and headphone) are tested and working.