### PR TITLE
[UM 5.5.r1] Implement the MSM8976/MSM8956 SoC DTs

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -242,11 +242,6 @@ dtb-$(CONFIG_ARCH_MDM9607) += mdm9607-rumi.dtb \
 	mdm9607-rcm.dtb \
 	mdm9607-mtp-sdcard.dtb
 
-dtb-$(CONFIG_ARCH_MSM8916) += msm8952-qrd-skum.dtb \
-       msm8952-cdp.dtb \
-       msm8952-ext-codec-cdp.dtb \
-       msm8952-mtp.dtb
-
 dtb-$(CONFIG_ARCH_MSM8909) += msm8909-pm8916-mtp.dtb \
 	msm8909w-wtp.dtb \
 	apq8009w-wtp.dtb \

--- a/arch/arm/boot/dts/qcom/msm-pm8950.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-pm8950.dtsi
@@ -11,6 +11,10 @@
  */
 
 &spmi_bus {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	interrupt-controller;
+	#interrupt-cells = <3>;
 
 	qcom,pm8950@0 {
 		spmi-slave-container;

--- a/arch/arm/boot/dts/qcom/msm8956-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-mtp.dtsi
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "msm8976-pinctrl.dtsi"
+#include "msm8976-camera-sensor-mtp.dtsi"
+#include "msm8976-mdss-mtp.dtsi"
+#include "msm8976-wsa881x.dtsi"
+
+&i2c_4 { /* BLSP1 QUP4 */
+	synaptics@20 {
+		compatible = "synaptics,dsx";
+		reg = <0x20>;
+		interrupt-parent = <&msm_gpio>;
+		interrupts = <65 0x2008>;
+		avdd-supply = <&pm8950_l10>;
+		vdd-supply = <&pm8950_l6>;
+		/* pins used by touchscreen */
+		pinctrl-names = "pmx_ts_active","pmx_ts_suspend","pmx_ts_release";
+		pinctrl-0 = <&ts_int_active &ts_reset_active>;
+		pinctrl-1 = <&ts_int_suspend &ts_reset_suspend>;
+		pinctrl-2 = <&ts_release>;
+		synaptics,irq-gpio = <&msm_gpio 65 0x2008>;
+		synaptics,reset-gpio = <&msm_gpio 64 0x0>;
+		synaptics,i2c-pull-up;
+		synaptics,power-down;
+		synaptics,disable-gpios;
+		synaptics,detect-device;
+		synaptics,bypass-packrat-id-check;
+		synaptics,device1 {
+			synaptics,package-id = <3528>;
+			synaptics,bypass-sensor-coords-check;
+			synaptics,display-coords = <0 0 1439 2559>;
+			synaptics,panel-coords = <0 0 1439 2559>;
+		};
+	};
+};
+
+&i2c_2 {
+	/* Parallel-charger configuration */
+	smb1351-charger@1d {
+		compatible = "qcom,smb1351-charger";
+		reg = <0x1d>;
+		qcom,parallel-en-pin-polarity = <1>;
+		qcom,parallel-charger;
+		qcom,float-voltage-mv = <4400>;
+		qcom,recharge-mv = <100>;
+	};
+};
+
+&soc {
+	gpio_keys {
+		compatible = "gpio-keys";
+		input-name = "gpio-keys";
+		pinctrl-names = "tlmm_gpio_key_active","tlmm_gpio_key_suspend";
+		pinctrl-0 = <&gpio_key_active>;
+		pinctrl-1 = <&gpio_key_suspend>;
+
+		camera_focus {
+			label = "camera_focus";
+			gpios = <&msm_gpio 115 0x1>;
+			linux,input-type = <1>;
+			linux,code = <0x210>;
+			debounce-interval = <15>;
+		};
+
+		camera_snapshot {
+			label = "camera_snapshot";
+			gpios = <&msm_gpio 114 0x1>;
+			linux,input-type = <1>;
+			linux,code = <0x2fe>;
+			debounce-interval = <15>;
+		};
+
+		vol_up {
+			label = "volume_up";
+			gpios = <&msm_gpio 113 0x1>;
+			linux,input-type = <1>;
+			linux,code = <115>;
+			debounce-interval = <15>;
+		};
+	};
+
+	sound-9335 {
+		qcom,msm-gpios =
+			"quin_i2s",
+			"us_eu_gpio";
+		qcom,pinctrl-names =
+			"all_off",
+			"quin_act",
+			"us_eu_gpio_act",
+			"quin_us_eu_gpio_act";
+		pinctrl-names =
+			"all_off",
+			"quin_act",
+			"us_eu_gpio_act",
+			"quin_us_eu_gpio_act";
+		pinctrl-0 = <&pri_tlmm_lines_sus &cross_conn_det_sus>;
+		pinctrl-1 = <&pri_tlmm_lines_act &cross_conn_det_sus>;
+		pinctrl-2 = <&pri_tlmm_lines_sus &cross_conn_det_act>;
+		pinctrl-3 = <&pri_tlmm_lines_act &cross_conn_det_act>;
+		qcom,cdc-us-euro-gpios = <&msm_gpio 144 0>;
+	};
+};
+
+&blsp1_uart2 {
+	status = "ok";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart_console_sleep>;
+};
+
+
+&spmi_bus {
+	qcom,pmi8950@3 {
+		qcom,leds@d800 {
+			qcom,fs-curr-ua = <20000>;
+		};
+
+		qcom,haptic@c000 {
+			compatible = "qcom,qpnp-haptic";
+			reg = <0xc000 0x100>;
+			interrupts = <0x3 0xc0 0x0>,
+				<0x3 0xc0 0x1>;
+			interrupt-names = "sc-irq", "play-irq";
+			qcom,play-mode = "direct";
+			qcom,wave-play-rate-us = <5263>;
+			qcom,actuator-type = "lra";
+			qcom,wave-shape = "square";
+			qcom,vmax-mv = <2000>;
+			qcom,ilim-ma = <800>;
+			qcom,sc-deb-cycles = <8>;
+			qcom,int-pwm-freq-khz = <505>;
+			qcom,en-brake;
+			qcom,brake-pattern = [03 03 00 00];
+			qcom,use-play-irq;
+			qcom,use-sc-irq;
+			qcom,wave-samples = [3e 3e 3e 3e 3e 3e 3e 3e];
+			qcom,wave-rep-cnt = <1>;
+			qcom,wave-samp-rep-cnt = <1>;
+			qcom,lra-auto-res-mode="qwd";
+			qcom,lra-high-z="opt1";
+			qcom,lra-res-cal-period = <0>;
+			qcom,correct-lra-drive-freq;
+			qcom,misc-trim-error-rc19p2-clk-reg-present;
+		};
+	};
+};
+
+&sdhc_1 {
+	vdd-supply = <&pm8950_l8>;
+	qcom,vdd-voltage-level = <2900000 2900000>;
+	qcom,vdd-current-level = <200 570000>;
+
+	vdd-io-supply = <&pm8950_l5>;
+	qcom,vdd-io-always-on;
+	qcom,vdd-io-lpm-sup;
+	qcom,vdd-io-voltage-level = <1800000 1800000>;
+	qcom,vdd-io-current-level = <200 325000>;
+
+	pinctrl-names = "active", "sleep";
+	pinctrl-0 = <&sdc1_clk_on &sdc1_cmd_on &sdc1_data_on &sdc1_rclk_on>;
+	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off &sdc1_rclk_off>;
+
+	qcom,nonremovable;
+
+	status = "ok";
+};
+
+&sdhc_2 {
+	vdd-supply = <&pm8950_l11>;
+	qcom,vdd-voltage-level = <2950000 2950000>;
+	qcom,vdd-current-level = <15000 800000>;
+
+	vdd-io-supply = <&pm8950_l12>;
+	qcom,vdd-io-voltage-level = <1800000 2950000>;
+	qcom,vdd-io-current-level = <200 22000>;
+
+	pinctrl-names = "active", "sleep";
+	pinctrl-0 = <&sdc2_clk_on &sdc2_cmd_on &sdc2_data_on &sdc2_cd_on>;
+	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
+
+	#address-cells = <0>;
+	interrupt-parent = <&sdhc_2>;
+	interrupts = <0 1 2>;
+	#interrupt-cells = <1>;
+	interrupt-map-mask = <0xffffffff>;
+	interrupt-map = <0 &intc 0 125 0
+			1 &intc 0 221 0
+			2 &msm_gpio 100 0>;
+	interrupt-names = "hc_irq", "pwr_irq", "status_irq";
+	cd-gpios = <&msm_gpio 100 0x1>;
+
+	status = "ok";
+};
+
+&sdhc_3 {
+	vdd-supply = <&pm8950_l5>;
+	qcom,vdd-voltage-level = <1800000 1800000>;
+	qcom,vdd-current-level = <200 639000>;
+
+	vdd-io-supply = <&pm8950_l5>;
+	qcom,vdd-io-always-on;
+	qcom,vdd-io-voltage-level = <1800000 1800000>;
+	qcom,vdd-io-current-level = <200 639000>;
+
+	pinctrl-names = "active", "sleep";
+	pinctrl-0 = <&sdc3_clk_on &sdc3_cmd_on &sdc3_dat_on
+					&sdc3_wlan_gpio_active>;
+	pinctrl-1 = <&sdc3_clk_off &sdc3_cmd_off &sdc3_dat_off
+					&sdc3_wlan_gpio_sleep>;
+
+	status = "disabled";
+};
+
+
+/* CoreSight */
+&tpiu {
+	pinctrl-names = "sdcard", "trace", "swduart",
+			"swdtrc", "jtag", "spmi";
+	/* NIDnT */
+	pinctrl-0 = <&qdsd_clk_sdcard &qdsd_cmd_sdcard
+		     &qdsd_data0_sdcard &qdsd_data1_sdcard
+		     &qdsd_data2_sdcard &qdsd_data3_sdcard>;
+	pinctrl-1 = <&qdsd_clk_trace &qdsd_cmd_trace
+		     &qdsd_data0_trace &qdsd_data1_trace
+		     &qdsd_data2_trace &qdsd_data3_trace>;
+	pinctrl-2 = <&qdsd_cmd_swduart &qdsd_data0_swduart
+		     &qdsd_data1_swduart &qdsd_data2_swduart
+		     &qdsd_data3_swduart>;
+	pinctrl-3 = <&qdsd_clk_swdtrc &qdsd_cmd_swdtrc
+		     &qdsd_data0_swdtrc &qdsd_data1_swdtrc
+		     &qdsd_data2_swdtrc &qdsd_data3_swdtrc>;
+	pinctrl-4 = <&qdsd_cmd_jtag &qdsd_data0_jtag
+		     &qdsd_data1_jtag &qdsd_data2_jtag
+		     &qdsd_data3_jtag>;
+	pinctrl-5 = <&qdsd_clk_spmi &qdsd_cmd_spmi
+		     &qdsd_data0_spmi &qdsd_data3_spmi>;
+};
+
+/{
+	mtp_batterydata: qcom,battery-data {
+		qcom,batt-id-range-pct = <15>;
+		#include "batterydata-itech-3000mah-4200mv.dtsi"
+		#include "batterydata-itech-3000mah.dtsi"
+	};
+};
+
+&pmi8950_fg {
+	qcom,battery-data = <&mtp_batterydata>;
+};
+
+&pmi8950_charger {
+	qcom,battery-data = <&mtp_batterydata>;
+	qcom,chg-led-support;
+	qcom,chg-led-sw-controls;
+};
+
+&pm8950_cajon_dig {
+	status = "disabled";
+};
+
+&pm8950_cajon_analog {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/qcom/msm8956-v1.1.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-v1.1.dtsi
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/*
+ * NOTE:
+ * As a general rule, only version-specific property overrides should be placed
+ * inside this file. However, device definitions should be placed inside the
+ * msm8956.dtsi file.
+ */
+
+#include "msm8956.dtsi"
+
+/ {
+	model = "Qualcomm Technologies, Inc. MSM 8956v1.1";
+	compatible = "qcom,msm8956";
+	qcom,msm-id = <266 0x10001>;
+};
+
+/*Overwrite with V1.1 spec*/
+&clock_gcc {
+	compatible = "qcom,gcc-8976-v1";
+};
+
+&clock_gcc_mdss {
+	compatible = "qcom,gcc-mdss-8976-v1";
+};
+
+&soc {
+	/delete-node/ qcom,cpu-clock-8976@b016000;
+
+	clock_cpu: qcom,cpu-clock-8976@b016000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "qcom,cpu-clock-8976";
+		reg =   <0xb114000  0x68>,
+			<0xb014000  0x68>,
+			<0xb116000  0x40>,
+			<0xb016000  0x40>,
+			<0xb1d0000  0x40>,
+			<0xb111050  0x08>,
+			<0xb011050  0x08>,
+			<0xb1d1050  0x08>,
+			<0x00a412c  0x08>;
+		reg-names = "rcgwr-c0-base", "rcgwr-c1-base",
+			    "c0-pll", "c1-pll", "cci-pll",
+			    "c0-mux", "c1-mux", "cci-mux",
+			    "efuse";
+
+		/* RCGwR settings */
+		qcom,num-clusters = <2>;
+		qcom,lmh-sid-c0  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c0 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c0  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+		qcom,lmh-sid-c1  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c1 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c1  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+
+		vdd_mx_hf-supply = <&pm8950_s6_level_ao>;
+		vdd_hf_pll-supply = <&pm8950_l7_ao>;
+		vdd_mx_sr-supply = <&pm8950_s6_level_ao>;
+		vdd_a72-supply = <&apc1_vreg_corner>;
+		vdd_a53-supply = <&apc0_vreg_corner>;
+		vdd_cci-supply = <&apc0_vreg_corner>;
+		clocks = <&clock_gcc clk_xo_a_clk_src>,
+			 <&clock_gcc clk_gpll4_clk_src>,
+			 <&clock_gcc clk_gpll0_ao_clk_src>;
+		clock-names = "xo_a", "aux_clk_2", "aux_clk_3";
+		qcom,speed0-bin-v0-c0 =
+			<          0 0>,
+			<  400000000 1>,
+			<  691200000 2>,
+			<  806400000 3>,
+			< 1017600000 4>,
+			< 1190400000 5>,
+			< 1305600000 6>,
+			< 1382400000 7>,
+			< 1401600000 8>;
+		qcom,speed0-bin-v0-c1 =
+			<          0 0>,
+			<  400000000 1>,
+			<  883200000 2>,
+			< 1190400000 3>,
+			< 1382400000 4>,
+			< 1612800000 5>,
+			< 1747200000 6>,
+			< 1804800000 7>;
+		qcom,speed0-bin-v0-cci =
+			<          0 0>,
+			<  307200000 1>,
+			<  403200000 3>,
+			<  441600000 4>,
+			<  556800000 5>,
+			<  614400000 6>;
+		#clock-cells = <1>;
+		ranges;
+		qcom,spm@0 {
+			compatible = "qcom,cpu-spm-8976";
+			reg = <0x0b111200 0x100>,
+			      <0x0b011200 0x100>,
+			      <0x0b1d4000 0x100>;
+			reg-names = "spm_c0_base", "spm_c1_base",
+				     "spm_cci_base";
+		};
+	};
+
+	/* APC0 / APC 1 / GFX CPR nodes */
+	apc0_vreg_corner: regulator@b018000 {
+
+		/delete-property/ qcom,cpr-fuse-version-map;
+		/delete-property/ qcom,cpr-quotient-adjustment;
+
+		qcom,cpr-speed-bin-max-corners =
+				<0 0 2 4 8>;
+	};
+
+	apc1_vreg_corner: regulator@b118000 {
+
+		/delete-property/ qcom,cpr-fuse-version-map;
+		/delete-property/ qcom,cpr-quotient-adjustment;
+
+		qcom,cpr-speed-bin-max-corners =
+				<0 0 2 4 7>;
+	};
+
+	gfx_vreg_corner: regulator@98000 {
+		qcom,foundry-id-fuse = <37 40 3>;
+		qcom,cpr-fuse-version-map =
+			<0 (-1) (-1)>,
+			<4 (-1) (-1)>;
+		qcom,cpr-init-voltage-adjustment =
+			<0 0 (-35000) 0 (60000) 0 (60000) 0 (50000)>,
+			<0 0 (-35000) 0 (60000) 0 (60000) 0 (50000)>;
+		qcom,cpr-target-quotients =
+			<376  368  483  453  149 173 78  100>,
+			<562  536  675  627  264 303 163 199>,
+			<631  606  744  699  315 356 205 245>,
+			<780  752  902  854  412 459 283 330>,
+			<892  858  1014 960  498 544 357 407>,
+			<1010 971  1138 1080 579 626 428 479>,
+			<1074 1028 1198 1135 635 675 483 531>,
+			<1213 1157 1342 1268 736 771 574 619>,
+			<1326 1256 1455 1367 808 852 628 682>,
+			<413  401  520  486  173 200  96 121>,
+			<575  547  688  638  272 312 169 206>,
+			<644  617  757  710  323 365 211 252>,
+			<755  730  877  832  396 441 271 316>,
+			<829  803  951  905  458 499 327 372>,
+			<960  927  1088 1036 547 590 404 451>,
+			<1011 973  1135 1080 595 630 453 496>,
+			<1188 1135 1317 1246 720 753 562 605>,
+			<1301 1234 1430 1345 792 834 616 668>;
+	};
+
+	qcom,vidc@1d00000 {
+		/delete-property/ qcom,reset-clock-control;
+		/delete-property/ qcom,regulator-scaling;
+	};
+
+	qcom,msm-thermal {
+		vdd-mx-st-supply = <&pm8950_s6_floor_level>;
+		qcom,vdd-mx-rstr {
+			qcom,vdd-rstr-reg = "vdd-mx-st";
+			qcom,levels = <RPM_SMD_REGULATOR_LEVEL_TURBO_HIGH
+					RPM_SMD_REGULATOR_LEVEL_BINNING
+					RPM_SMD_REGULATOR_LEVEL_BINNING>;
+			qcom,min-level = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+		};
+	};
+};
+
+&mdss_dsi {
+	/delete-property/ qcom,split-dsi-independent-pll;
+};
+
+&sdhc_1 {
+	qcom,clk-rates = <400000 25000000 50000000 100000000
+					186400000 372800000>;
+};

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1,0 +1,2895 @@
+/*
+ * Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "skeleton64.dtsi"
+#include <dt-bindings/clock/msm-clocks-8976.h>
+#include <dt-bindings/regulator/qcom,rpm-smd-regulator.h>
+
+/ {
+	model = "Qualcomm Technologies, Inc. MSM 8956";
+	compatible = "qcom,msm8956";
+	qcom,msm-id = <266 0x0>;
+	interrupt-parent = <&intc>;
+
+	chosen {
+		bootargs = "sched_enable_hmp=1";
+	};
+
+	aliases {
+		/* smdtty devices */
+		smd1 = &smdtty_apps_fm;
+		smd2 = &smdtty_apps_riva_bt_acl;
+		smd3 = &smdtty_apps_riva_bt_cmd;
+		smd4 = &smdtty_mbalbridge;
+		smd5 = &smdtty_apps_riva_ant_cmd;
+		smd6 = &smdtty_apps_riva_ant_data;
+		smd7 = &smdtty_data1;
+		smd8 = &smdtty_data4;
+		smd11 = &smdtty_data11;
+		smd21 = &smdtty_data21;
+		smd36 = &smdtty_loopback;
+		i2c2  = &i2c_2;
+		i2c4  = &i2c_4;
+		i2c6  = &i2c_6;
+		i2c8  = &i2c_8;
+	};
+
+	soc: soc { };
+
+	aliases {
+		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
+		sdhc2 = &sdhc_2; /* SDC2 SD card slot */
+		sdhc3 = &sdhc_3; /* SDC3 SDIO card slot */
+		spi0 = &spi_0;
+	};
+
+	memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		other_ext_mem: other_ext_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x85e00000 0x0 0x0a00000>;
+			label = "other_ext_mem";
+		};
+
+		modem_mem: modem_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x86c00000 0x0 0x05600000>;
+			label = "modem_mem";
+		};
+
+		reloc_mem: reloc_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x8c200000 0x0 0x1700000>;
+			label = "reloc_mem";
+		};
+
+		venus_mem: venus_region@0 {
+			linux,reserve-contiguous-region;
+			linux,memory-limit = <0x90000000>;
+			reg = <0x0 0x0 0x0 0x0500000>;
+			label = "venus_mem";
+		};
+
+		secure_mem: secure_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x7A00000>;
+			label = "secure_mem";
+		};
+
+		qseecom_mem: qseecom_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x1000000>;
+			label = "qseecom_mem";
+		};
+
+		audio_mem: audio_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x314000>;
+		};
+
+		cont_splash_mem: splash_region@83000000 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			reg = <0x0 0x83000000 0x0 0x2800000>;
+			label = "cont_splash_mem";
+		};
+
+		adsp_mem: adsp_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x400000>;
+			label = "adsp_mem";
+		};
+	};
+};
+
+#include "msm8976-pinctrl.dtsi"
+#include "msm8976-ion.dtsi"
+#include "msm8976-iommu.dtsi"
+#include "msm8976-iommu-domains.dtsi"
+#include "msm8976-smp2p.dtsi"
+#include "msm8976-bus.dtsi"
+#include "msm8976-jtag.dtsi"
+#include "msm8976-coresight.dtsi"
+#include "msm8976-pm.dtsi"
+#include "msm8976-gpu.dtsi"
+#include "msm8976-cpu.dtsi"
+#include "msm8976-mdss.dtsi"
+#include "msm8976-mdss-pll.dtsi"
+#include "msm-rdbg.dtsi"
+
+&soc {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	ranges = <0 0 0 0xffffffff>;
+	compatible = "simple-bus";
+
+	arm64-cpu-erp {
+		compatible = "arm,arm64-cpu-erp";
+		interrupts = <0 275 0>,
+			     <0 276 0>,
+			     <0 273 0>,
+			     <0 274 0>,
+			     <1 7 0>;
+		interrupt-names = "pri-dbe-irq",
+				  "sec-dbe-irq",
+				  "pri-ext-irq",
+				  "sec-ext-irq",
+				  "sbe-irq";
+		poll-delay-ms = <5000>;
+	};
+
+	qcom,msm-gladiator@b1c0000 {
+		compatible = "qcom,msm-gladiator";
+		reg = <0x0b1C0000 0x4000>;
+		reg-names = "gladiator_base";
+		interrupts = <0 22 0>;
+	};
+
+	intc: interrupt-controller@b000000 {
+		compatible = "qcom,msm-qgic2";
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		reg = <0x0b000000 0x1000>,
+		      <0x0b002000 0x1000>;
+	};
+
+	qcom,msm-imem@8600000 {
+		compatible = "qcom,msm-imem";
+		reg = <0x08600000 0x1000>; /* Address and size of IMEM */
+		ranges = <0x0 0x08600000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		mem_dump_table@10 {
+			compatible = "qcom,msm-imem-mem_dump_table";
+			reg = <0x10 8>;
+		};
+
+		restart_reason@65c {
+			compatible = "qcom,msm-imem-restart_reason";
+			reg = <0x65c 4>;
+		};
+
+		boot_stats@6b0 {
+			compatible = "qcom,msm-imem-boot_stats";
+			reg = <0x6b0 32>;
+		};
+
+		pil@94c {
+			compatible = "qcom,msm-imem-pil";
+			reg = <0x94c 200>;
+		};
+	};
+
+	clock_gcc: qcom,gcc@1800000 {
+		compatible = "qcom,gcc-8976";
+		reg = <0x1800000 0x80000>;
+		reg-names = "cc_base";
+		vdd_dig-supply = <&pm8950_s2_level>;
+		#clock-cells = <1>;
+	};
+
+	clock_debug: qcom,cc-debug@1874000 {
+		compatible = "qcom,cc-debug-8976";
+		clocks = <&clock_cpu clk_cpu_debug_pri_mux>;
+		clock-names = "debug_cpu_clk";
+		#clock-cells = <1>;
+	};
+
+	clock_gcc_gfx: qcom,gcc-gfx@1800000 {
+                compatible = "qcom,gcc-gfx-8976";
+                reg = <0x1800000 0x80000>;
+                reg-names = "cc_base";
+		vdd_gfx-supply = <&gfx_vreg_corner>;
+		gpu_handle = <&msm_gpu>;
+                qcom,gfxfreq-corner =
+			<         0   0 >,
+			< 133333333   1 >,  /* Min SVS   */
+			< 200000000   2 >,  /* Low SVS   */
+			< 266666667   3 >,  /* SVS Minus */
+			< 300000000   4 >,  /* SVS       */
+			< 366670000   5 >,  /* SVS Plus  */
+			< 432000000   6 >,  /* NOM       */
+			< 480000000   7 >,  /* Turbo     */
+			< 550000000   8 >,  /* Super Turbo */
+			< 600000000   9 >;  /* Super Turbo */
+		#clock-cells = <1>;
+	};
+
+	clock_gcc_mdss: qcom,gcc-mdss@1800000 {
+		compatible = "qcom,gcc-mdss-8976";
+		reg = <0x1800000 0x80000>;
+                reg-names = "cc_base";
+		clocks = <&mdss_dsi0_pll clk_dsi_pll0_pixel_clk_src>,
+			 <&mdss_dsi0_pll clk_dsi_pll0_byte_clk_src>,
+			 <&mdss_dsi1_pll clk_dsi_pll1_pixel_clk_src>,
+			 <&mdss_dsi1_pll clk_dsi_pll1_byte_clk_src>;
+		clock-names = "pclk0_src", "byte0_src", "pclk1_src",
+				 "byte1_src";
+		#clock-cells = <1>;
+	};
+
+	clock_cpu: qcom,cpu-clock-8976@b016000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "qcom,cpu-clock-8976";
+		reg =   <0xb114000  0x68>,
+			<0xb014000  0x68>,
+			<0xb116000  0x40>,
+			<0xb016000  0x40>,
+			<0xb1d0000  0x40>,
+			<0xb111050  0x08>,
+			<0xb011050  0x08>,
+			<0xb1d1050  0x08>,
+			<0x00a412c  0x08>;
+		reg-names = "rcgwr-c0-base", "rcgwr-c1-base",
+			    "c0-pll", "c1-pll", "cci-pll",
+			    "c0-mux", "c1-mux", "cci-mux",
+			    "efuse";
+		/* RCGwR settings */
+		qcom,num-clusters = <2>;
+		qcom,lmh-sid-c0  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c0 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c0  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+		qcom,lmh-sid-c1  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c1 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c1  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+
+		vdd_mx_hf-supply = <&pm8950_s6_level_ao>;
+		vdd_hf_pll-supply = <&pm8950_l7_ao>;
+		vdd_mx_sr-supply = <&pm8950_s6_level_ao>;
+		vdd_a72-supply = <&apc1_vreg_corner>;
+		vdd_a53-supply = <&apc0_vreg_corner>;
+		vdd_cci-supply = <&apc0_vreg_corner>;
+		clocks = <&clock_gcc clk_xo_a_clk_src>,
+			 <&clock_gcc clk_gpll4_clk_src>,
+			 <&clock_gcc clk_gpll0_ao_clk_src>;
+		clock-names = "xo_a", "aux_clk_2", "aux_clk_3";
+		qcom,speed0-bin-v0-c0 =
+			<          0 0>,
+			<  400000000 1>,
+			<  691200000 2>,
+			<  806400000 3>,
+			< 1017600000 4>,
+			< 1190400000 5>,
+			< 1305600000 6>,
+			< 1382400000 7>,
+			< 1401600000 8>;
+		qcom,speed0-bin-v0-c1 =
+			<          0 0>,
+			<  400000000 1>,
+			<  883200000 2>,
+			< 1190400000 3>,
+			< 1382400000 4>,
+			< 1612800000 5>,
+			< 1747200000 6>;
+		qcom,speed0-bin-v0-cci =
+			<          0 0>,
+			<  307200000 1>,
+			<  403200000 3>,
+			<  441600000 4>,
+			<  556800000 5>,
+			<  614400000 6>;
+		qcom,speed1-bin-v0-c0 =
+			<          0 0>,
+			<  400000000 1>,
+			<  691200000 2>,
+			<  806400000 3>,
+			< 1017600000 4>,
+			< 1190400000 5>,
+			< 1305600000 6>,
+			< 1382400000 7>,
+			< 1401600000 8>,
+			< 1440000000 9>;
+		qcom,speed1-bin-v0-c1 =
+			<          0 0>,
+			<  400000000 1>,
+			<  883200000 2>,
+			< 1190400000 3>,
+			< 1382400000 4>,
+			< 1612800000 5>,
+			< 1747200000 6>,
+			< 1804800000 7>;
+		qcom,speed1-bin-v0-cci =
+			<          0 0>,
+			<  307200000 1>,
+			<  403200000 3>,
+			<  441600000 4>,
+			<  556800000 5>,
+			<  614400000 6>;
+		#clock-cells = <1>;
+		ranges;
+		qcom,spm@0 {
+			compatible = "qcom,cpu-spm-8976";
+			reg = <0x0b111200 0x100>,
+			      <0x0b011200 0x100>,
+			      <0x0b1d4000 0x100>;
+			reg-names = "spm_c0_base", "spm_c1_base",
+				     "spm_cci_base";
+		};
+	};
+
+	cci_cache: qcom,cci {
+		compatible = "devfreq-simple-dev";
+		clock-names = "devfreq_clk";
+		clocks = <&clock_cpu clk_cci_clk>;
+		governor = "cpufreq";
+		freq-tbl-khz =
+			<  307200 >,
+			<  403200 >,
+			<  441600 >,
+			<  556800 >,
+			<  614400 >;
+	};
+
+	cpubw: qcom,cpubw {
+		compatible = "qcom,devbw";
+		governor = "cpufreq";
+		qcom,src-dst-ports = <1 512>;
+		qcom,active-only;
+		qcom,bw-tbl =
+			<   805 /*   52.8 MHz */ >,
+			<  1244 /*   81.6 MHz */ >,
+			<  1611 /*  105.6 MHz */ >,
+			<  2929 /*  192   MHz */ >,	/* SVS	 */
+			<  4101 /*  268.8 MHz */ >,     /* SVS+ */
+			<  5126 /*  336.0 MHz */ >,	/* NOM  */
+			<  5712 /*  374.4 MHz */ >,
+			<  6152 /*  403.2 MHz */ >,	/* TURBO */
+			<  7104 /*  465.6 MHz */ >;	/* STURBO */
+	};
+
+	mincpubw: qcom,mincpubw {
+		compatible = "qcom,devbw";
+		governor = "cpufreq";
+		qcom,src-dst-ports = <1 512>;
+		qcom,active-only;
+		qcom,bw-tbl =
+			<   805 /*   52.8 MHz */ >,
+			<  1244 /*   81.6 MHz */ >,
+			<  1611 /*  105.6 MHz */ >,
+			<  2929 /*  192   MHz */ >,	/* SVS	 */
+			<  4101 /*  268.8 MHz */ >,     /* SVS+ */
+			<  5126 /*  336.0 MHz */ >,	/* NOM  */
+			<  5712 /*  374.4 MHz */ >,
+			<  6152 /*  403.2 MHz */ >,	/* TURBO */
+			<  7104 /*  465.6 MHz */ >;	/* STURBO */
+	};
+
+	qcom,cpu-bwmon@408000 {
+		compatible = "qcom,bimc-bwmon2";
+		reg = <0x408000 0x300>, <0x401000 0x200>;
+		reg-names = "base", "global_base";
+		interrupts = <0 183 4>;
+		qcom,mport = <0>;
+		qcom,target-dev = <&cpubw>;
+	};
+
+	devfreq-cpufreq {
+		cpubw-cpufreq {
+			target-dev = <&cpubw>;
+			cpu-to-dev-map-0 =
+				<  691200   805 >,	/* SVS   */
+				<  806400  4101 >,	/* SVS+  */
+				< 1017600  5712 >,	/* NOM   */
+				< 1190400  6152 >,	/* TURBO */
+				< 1440000  7104 >;
+			cpu-to-dev-map-4 =
+				<  883200   805 >,	/* SVS   */
+				< 1190400  4101 >,	/* SVS+  */
+				< 1382400  5712 >,	/* NOM   */
+				< 1612800  6152 >,	/* TURBO */
+				< 1804800  7104 >;
+		};
+
+		mincpubw-cpufreq {
+			target-dev = <&mincpubw>;
+			cpu-to-dev-map-0 =
+				<  691200 2929 >,
+				< 1017600 2929 >,
+				< 1440000 4101 >;
+			cpu-to-dev-map-4 =
+				<  883200 2929 >,
+				< 1382400 2929 >,
+				< 1747200 4101 >;
+		};
+
+		cci-cpufreq {
+			target-dev = <&cci_cache>;
+			cpu-to-dev-map-0 =
+				<  691200  307200 >,
+				<  806400  403200 >,
+				< 1017600  441600 >,
+				< 1190400  556800 >,
+				< 1440000  614400 >;
+			cpu-to-dev-map-4 =
+				<  883200 307200 >,
+				< 1190400 403200 >,
+				< 1382400 441600 >,
+				< 1612800 556800 >,
+				< 1804800 614400 >;
+		};
+	};
+
+	qcom,msm-cpufreq {
+		compatible = "qcom,msm-cpufreq";
+		clock-names = "l2_clk", "cpu0_clk", "cpu1_clk", "cpu2_clk",
+			      "cpu3_clk", "cpu4_clk", "cpu5_clk";
+		clocks = <&clock_cpu clk_cci_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a72_clk>,
+			 <&clock_cpu clk_a72_clk>;
+		qcom,governor-per-policy;
+		qcom,cpufreq-table-0 =
+			<  400000 >,
+			<  691200 >,
+			<  806400 >,
+			< 1017600 >,
+			< 1190400 >,
+			< 1305600 >,
+			< 1382400 >,
+			< 1401600 >,
+			< 1440000 >;
+		qcom,cpufreq-table-4 =
+			<  400000 >,
+			<  883200 >,
+			<  940800 >,
+			<  998400 >,
+			< 1056000 >,
+			< 1113600 >,
+			< 1190400 >,
+			< 1248000 >,
+			< 1305600 >,
+			< 1382400 >,
+			< 1612800 >,
+			< 1747200 >,
+			< 1804800 >;
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <1 2 0xff08>,
+			     <1 3 0xff08>,
+			     <1 4 0xff08>,
+			     <1 1 0xff08>;
+		clock-frequency = <19200000>;
+	};
+
+	restart@4ab000 {
+		compatible = "qcom,pshold";
+		reg = <0x4ab000 0x4>,
+			<0x193d100 0x4>;
+		reg-names = "pshold-base", "tcsr-boot-misc-detect";
+	};
+
+	timer@b120000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		compatible = "arm,armv7-timer-mem";
+		reg = <0xb120000 0x1000>;
+		clock-frequency = <19200000>;
+
+		frame@b121000 {
+			frame-number = <0>;
+			interrupts = <0 8 0x4>,
+				     <0 7 0x4>;
+			reg = <0xb121000 0x1000>,
+			      <0xb122000 0x1000>;
+		};
+
+		frame@b123000 {
+			frame-number = <1>;
+			interrupts = <0 9 0x4>;
+			reg = <0xb123000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b124000 {
+			frame-number = <2>;
+			interrupts = <0 10 0x4>;
+			reg = <0xb124000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b125000 {
+			frame-number = <3>;
+			interrupts = <0 11 0x4>;
+			reg = <0xb125000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b126000 {
+			frame-number = <4>;
+			interrupts = <0 12 0x4>;
+			reg = <0xb126000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b127000 {
+			frame-number = <5>;
+			interrupts = <0 13 0x4>;
+			reg = <0xb127000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b128000 {
+			frame-number = <6>;
+			interrupts = <0 14 0x4>;
+			reg = <0xb128000 0x1000>;
+			status = "disabled";
+		};
+	};
+
+	qcom,sps {
+		compatible = "qcom,msm_sps_4k";
+		qcom,pipe-attr-ee;
+	};
+
+	tsens: tsens@4a8000 {
+		compatible = "qcom,msm8976-tsens";
+		reg = <0x4a8000 0x2000>,
+		      <0xa4000  0x1000>;
+		reg-names = "tsens_physical", "tsens_eeprom_physical";
+		interrupts = <0 184 0>;
+		interrupt-names = "tsens-upper-lower";
+		qcom,sensors = <11>;
+		qcom,slope = <3313 3275 3320 3246 3279 3257 3234 3269 3255 3239 3286>;
+		qcom,sensor-id = <0 1 2 3 4 5 6 7 8 9 10>;
+		qcom,tsens_base_info = <2 8>;
+		qcom,tsens_base_mask = <0 0x218 0xff 0 8>,
+				       <1 0x220 0xff 0 8>;
+		qcom,tsens_calib_mask = <0 0x228 0x3 0 3>;
+		qcom,tsens_sensor_point_bit_size = <6>;
+		qcom,tsens_sensor_point1_total_masks = <12>;
+		qcom,tsens_sensor_point1 = <0 0x218 0x00003f00 0x8 6>,
+					   <1 0x218 0x03f00000 0x14 6>,
+					   <2 0x21c 0x0000003f 0x0 6>,
+					   <3 0x21c 0x0003f000 0xc 6>,
+					   <4 0x220 0x00003f00 0x8 6>,
+					   <5 0x220 0x03f00000 0x14 6>,
+					   <6 0x224 0x0000003f 0x0 6>,
+					   <7 0x224 0x0003f000 0xc 6>,
+					   <8 0x228 0x000001f8 0x3 6>,
+					   <9 0x228 0x001f8000 0xf 6>,
+					   <10 0x228 0xf8000000 0x1b 5>,
+					   <10 0x22c 0x00000001 0x0 1>;
+		qcom,tsens_sensor_point2_total_masks = <11>;
+		qcom,tsens_sensor_point2 = <0 0x218 0x000fc000 0xe 6>,
+					   <1 0x218 0xfc000000 0x1a 6>,
+					   <2 0x21c 0x00000fc0 0x6 6>,
+					   <3 0x21c 0x00fc0000 0x12 6>,
+					   <4 0x220 0x000fc000 0xe 6>,
+					   <5 0x220 0xfc000000 0x1a 6>,
+					   <6 0x224 0x00000fc0 0x6 6>,
+					   <7 0x224 0x00fc0000 0x12 6>,
+					   <8 0x228 0x00007e00 0x9 6>,
+					   <9 0x228 0x07e00000 0x15 6>,
+					   <10 0x22c 0x0000007e 0x1 6>;
+	};
+
+	qcom,sensor-information {
+		compatible = "qcom,sensor-information";
+		sensor_information0: qcom,sensor-information-0 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor0";
+		};
+
+		sensor_information1: qcom,sensor-information-1 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor1";
+		};
+
+		sensor_information2: qcom,sensor-information-2 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor2";
+			qcom,alias-name = "pop_mem";
+		};
+
+		sensor_information3: qcom,sensor-information-3 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor3";
+		};
+
+		sensor_information4: qcom,sensor-information-4 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor4";
+		};
+
+		sensor_information5: qcom,sensor-information-5 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor5";
+		};
+
+		sensor_information6: qcom,sensor-information-6 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor6";
+		};
+
+		sensor_information7: qcom,sensor-information-7 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor7";
+		};
+
+		sensor_information8: qcom,sensor-information-8 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor8";
+			qcom,alias-name = "L2_cache_1";
+		};
+
+		sensor_information9: qcom,sensor-information-9 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor9";
+		};
+
+		sensor_information10: qcom,sensor-information-10 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor10";
+			qcom,alias-name = "gpu";
+		};
+
+		sensor_information11: qcom,sensor-information-11 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "pa_therm0";
+		};
+
+		sensor_information12: qcom,sensor-information-12 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "pa_therm1";
+		};
+
+		sensor_information13: qcom,sensor-information-13 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "xo_therm";
+		};
+
+		sensor_information14: qcom,sensor-information-14 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "xo_therm_buf";
+		};
+
+		sensor_information15: qcom,sensor-information-15 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "case_therm";
+		};
+
+		sensor_information16: qcom,sensor-information-16 {
+			qcom,sensor-type = "alarm";
+			qcom,sensor-name = "pm8950_tz";
+			qcom,scaling-factor = <1000>;
+		};
+
+		sensor_information17: qcom,sensor-information-17 {
+			qcom,sensor-type =  "llm";
+			qcom,sensor-name = "LLM_IA72";
+		};
+
+		sensor_information18: qcom,sensor-information-18 {
+			qcom,sensor-type = "alarm";
+			qcom,sensor-name = "pm8004_tz";
+			qcom,scaling-factor = <1000>;
+		};
+	};
+
+	mitigation_profile0: qcom,limit_info-0 {
+		qcom,temperature-sensor = <&sensor_information9>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile1: qcom,limit_info-1 {
+		qcom,temperature-sensor = <&sensor_information4>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile2: qcom,limit_info-2 {
+		qcom,temperature-sensor = <&sensor_information5>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile3: qcom,limit_info-3 {
+		qcom,temperature-sensor = <&sensor_information6>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile4: qcom,limit_info-4 {
+		qcom,temperature-sensor = <&sensor_information7>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	qcom,msm-thermal {
+		compatible = "qcom,msm-thermal";
+		qcom,sensor-id = <9>;
+		qcom,poll-ms = <250>;
+		qcom,limit-temp = <60>;
+		qcom,temp-hysteresis = <10>;
+		qcom,freq-step = <2>;
+		qcom,core-limit-temp = <80>;
+		qcom,core-temp-hysteresis = <10>;
+		qcom,mitigation-profile-enable;
+		qcom,hotplug-temp = <105>;
+		qcom,hotplug-temp-hysteresis = <25>;
+		qcom,freq-mitigation-temp = <105>;
+		qcom,freq-mitigation-temp-hysteresis = <20>;
+		qcom,freq-mitigation-value = <400000>;
+		qcom,therm-reset-temp = <115>;
+		qcom,online-hotplug-core;
+		qcom,synchronous-cluster-id = <0 1>;
+		qcom,synchronous-cluster-map = <0 4 &CPU0 &CPU1 &CPU2 &CPU3>,
+						<1 4 &CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,disable-cx-phase-ctrl;
+		qcom,disable-gfx-phase-ctrl;
+		qcom,disable-psm;
+		qcom,disable-ocr;
+		qcom,mx-restriction-temp = <15>;
+		qcom,mx-restriction-temp-hysteresis = <2>;
+		qcom,mx-retention-min = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd-mx-supply = <&pm8950_s6_floor_level>;
+		qcom,vdd-restriction-temp = <5>;
+		qcom,vdd-restriction-temp-hysteresis = <10>;
+		vdd-dig-supply = <&pm8950_s2_floor_level>;
+		vdd-gfx-supply = <&gfx_vreg_corner>;
+
+		qcom,vdd-dig-rstr {
+			qcom,vdd-rstr-reg = "vdd-dig";
+			qcom,levels = <RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_TURBO
+					RPM_SMD_REGULATOR_LEVEL_TURBO>;
+			qcom,min-level = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+		};
+
+		qcom,vdd-gfx-rstr {
+			qcom,vdd-rstr-reg = "vdd-gfx";
+			qcom,levels = <6 9 9>; /* Nominal, Turbo, Turbo */
+			qcom,min-level = <1>; /* No Request */
+		};
+
+		msm_thermal_freq: qcom,vdd-apps-rstr {
+			qcom,vdd-rstr-reg = "vdd-apps";
+			qcom,levels = <1017600>;
+			qcom,freq-req;
+		};
+	};
+
+	qcom,bcl {
+		compatible = "qcom,bcl";
+		qcom,bcl-enable;
+		qcom,bcl-framework-interface;
+		qcom,bcl-freq-control-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,bcl-hotplug-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,bcl-soc-hotplug-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,ibat-monitor {
+			qcom,high-threshold-uamp = <4200000>;
+			qcom,low-threshold-uamp = <3400000>;
+			qcom,mitigation-freq-khz = <1382400>;
+			qcom,vph-high-threshold-uv = <3500000>;
+			qcom,vph-low-threshold-uv = <3200000>;
+			qcom,soc-low-threshold = <10>;
+			qcom,thermal-handle = <&msm_thermal_freq>;
+		};
+	};
+
+	qcom,memshare {
+		compatible = "qcom,memshare";
+
+		qcom,client_1 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0x200000>;
+			qcom,client-id = <0>;
+			qcom,allocate-boot-time;
+			label = "modem";
+		};
+
+		qcom,client_2 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0x300000>;
+			qcom,client-id = <2>;
+			label = "modem";
+		};
+
+		qcom,client_3 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0>;
+			qcom,client-id = <1>;
+			label = "modem";
+		};
+	};
+
+	qcom,lmh@b1db000 {
+		compatible = "qcom,lmh";
+		interrupts = <0 264 4>;
+		reg = <0xb1db000 0x4>;
+		qcom,lmh-trim-err-offset = <18>;
+	};
+
+	rpm_bus: qcom,rpm-smd {
+		compatible = "qcom,rpm-smd";
+		rpm-channel-name = "rpm_requests";
+		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+	};
+
+	qcom,rmtfs_sharedmem@0 {
+		compatible = "qcom,sharedmem-uio";
+		reg = <0x0 0x00200000>; /* '0' indicates dynamic allocation */
+		reg-names = "rmtfs";
+		qcom,client-id = <0x00000001>;
+	};
+
+	sdcc1_ice: sdcc1ice@7803000 {
+		compatible = "qcom,ice";
+		reg = <0x7803000 0x8000>;
+		interrupt-names = "sdcc_ice_nonsec_level_irq", "sdcc_ice_sec_level_irq";
+		interrupts = <0 312 0>, <0 313 0>;
+		qcom,enable-ice-clk;
+		clock-names = "ice_core_clk_src", "ice_core_clk",
+				"bus_clk", "iface_clk";
+		clocks = <&clock_gcc clk_sdcc1_ice_core_clk_src>,
+			 <&clock_gcc clk_gcc_sdcc1_ice_core_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_apps_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_ahb_clk>;
+		qcom,op-freq-hz = <200000000>, <0>, <0>, <0>;
+		qcom,msm-bus,name = "sdcc_ice_noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<78 512 0 0>,    /* No vote */
+			<78 512 1000 0>; /* Max. bandwidth */
+		qcom,bus-vector-names = "MIN", "MAX";
+		qcom,instance-type = "sdcc";
+	};
+
+	sdhc_1: sdhci@7824900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7824900 0x500>, <0x7824000 0x800>, <0x7824e00 0x200>;
+		reg-names = "hc_mem", "core_mem", "cmdq_mem";
+
+		sdhc-msm-crypto = <&sdcc1_ice>;
+		interrupts = <0 123 0>, <0 138 0>;
+		interrupt-names = "hc_irq", "pwr_irq";
+
+		qcom,bus-width = <8>;
+
+		qcom,cpu-dma-latency-us = <60 340 900>;
+		qcom,cpu-affinity = "affine_cores";
+		qcom,cpu-affinity-mask = <0x0f>;
+
+		qcom,msm-bus,name = "sdhc1";
+		qcom,msm-bus,num-cases = <9>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <78 512 0 0>, /* No vote */
+			<78 512 1046 3200>,    /* 400 KB/s*/
+			<78 512 52286 160000>, /* 20 MB/s */
+			<78 512 65360 200000>, /* 25 MB/s */
+			<78 512 130718 400000>, /* 50 MB/s */
+			<78 512 130718 400000>, /* 100 MB/s */
+			<78 512 261438 800000>, /* 200 MB/s */
+			<78 512 261438 800000>, /* 400 MB/s */
+			<78 512 1338562 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+			100000000 200000000 400000000 4294967295>;
+
+		clocks = <&clock_gcc clk_gcc_sdcc1_ahb_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_apps_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_ice_core_clk>;
+		clock-names = "iface_clk", "core_clk", "ice_core_clk";
+
+		qcom,clk-rates = <400000 25000000 50000000 100000000
+						177777778 342850000>;
+		qcom,bus-speed-mode = "HS400_1p8v", "HS200_1p8v", "DDR_1p8v";
+
+		qcom,ice-clk-rates = <200000000 100000000>;
+		qcom,scaling-lower-bus-speed-mode = "DDR52";
+
+		status = "disabled";
+	};
+
+	sdhc_2: sdhci@7864900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7864900 0x11c>, <0x7864000 0x800>;
+		reg-names = "hc_mem", "core_mem";
+
+		interrupts = <0 125 0>, <0 221 0>;
+		interrupt-names = "hc_irq", "pwr_irq";
+
+		qcom,bus-width = <4>;
+
+		qcom,cpu-dma-latency-us = <701>;
+
+		qcom,msm-bus,name = "sdhc2";
+		qcom,msm-bus,num-cases = <8>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <81 512 0 0>, /* No vote */
+			<81 512 1046 3200>,    /* 400 KB/s*/
+			<81 512 52286 160000>, /* 20 MB/s */
+			<81 512 65360 200000>, /* 25 MB/s */
+			<81 512 130718 400000>, /* 50 MB/s */
+			<81 512 261438 800000>, /* 100 MB/s */
+			<81 512 261438 800000>, /* 200 MB/s */
+			<81 512 1338562 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+						100000000 200000000 4294967295>;
+
+		clocks = <&clock_gcc clk_gcc_sdcc2_ahb_clk>,
+			 <&clock_gcc clk_gcc_sdcc2_apps_clk>;
+		clock-names = "iface_clk", "core_clk";
+
+		qcom,clk-rates = <400000 25000000 50000000 100000000 200000000>;
+
+		status = "disabled";
+	};
+
+	sdhc_3: sdhci@7a24900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7a24900 0x11c>, <0x7a24000 0x800>;
+		reg-names = "hc_mem", "core_mem";
+
+		qcom,bus-width = <4>;
+		gpios = <&msm_gpio 44 0>, /* CLK */
+			<&msm_gpio 43 0>, /* CMD */
+			<&msm_gpio 42 0>, /* DATA0 */
+			<&msm_gpio 41 0>, /* DATA1 */
+			<&msm_gpio 40 0>, /* DATA2 */
+			<&msm_gpio 39 0>; /* DATA3 */
+		qcom,gpio-names = "CLK", "CMD", "DAT0", "DAT1", "DAT2", "DAT3";
+
+		qcom,clk-rates = <400000 20000000 25000000 50000000 100000000
+								200000000>;
+		qcom,cpu-dma-latency-us = <60>;
+		qcom,cpu-affinity = "affine_cores";
+		qcom,cpu-affinity-mask = <0x0f>;
+
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_sdcc3_ahb_clk>,
+			<&clock_gcc clk_gcc_sdcc3_apps_clk>;
+
+		qcom,core_3_0v_support;
+		qcom,nonremovable;
+		qcom,msm-bus,name = "sdhc3";
+		qcom,msm-bus,num-cases = <8>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <79 512 0 0>, /* No vote */
+			<79 512 1600 3200>,    /* 400 KB/s*/
+			<79 512 80000 160000>, /* 20 MB/s */
+			<79 512 100000 200000>, /* 25 MB/s */
+			<79 512 200000 400000>, /* 50 MB/s */
+			<79 512 400000 800000>, /* 100 MB/s */
+			<79 512 800000 800000>, /* 200 MB/s */
+			<79 512 2048000 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+						100000000 200000000 4294967295>;
+
+		#address-cells = <0>;
+		interrupt-parent = <&sdhc_3>;
+		interrupts = <0 1 2>;
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0xffffffff>;
+		interrupt-map = <0 &intc 0 295 0
+			1 &intc 0 297 0
+			2 &msm_gpio 45 0x4>;
+		interrupt-names = "hc_irq", "pwr_irq", "sdiowakeup_irq";
+
+		qcom,bus-speed-mode = "SDR12", "SDR25", "SDR50", "DDR50",
+						"SDR104";
+		status = "disabled";
+	};
+
+	blsp1_uart2: serial@78b0000 {
+		compatible = "qcom,msm-lsuart-v14";
+		reg = <0x78b0000 0x200>;
+		interrupts = <0 108 0>;
+		status = "disabled";
+		clock-names = "core_clk", "iface_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_uart2_apps_clk>,
+		       <&clock_gcc clk_gcc_blsp1_ahb_clk>;
+	};
+
+	blsp1_uart0: uart@78af000 {
+		compatible = "qcom,msm-hsuart-v14";
+		reg = <0x78af000 0x200>,
+			<0x7884000 0x1f000>;
+		reg-names = "core_mem", "bam_mem";
+		interrupt-names = "core_irq", "bam_irq", "wakeup_irq";
+		#address-cells = <0>;
+		interrupt-parent = <&blsp1_uart0>;
+		interrupts = <0 1 2>;
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0xffffffff>;
+		interrupt-map = <0 &intc 0 107 0
+				1 &intc 0 238 0
+				2 &msm_gpio 1 0>;
+
+		qcom,tx-gpio = <&msm_gpio 0 0>;
+		qcom,rx-gpio = <&msm_gpio 1 0>;
+		qcom,inject-rx-on-wakeup;
+		qcom,rx-char-to-inject = <0xFD>;
+		qcom,master-id = <86>;
+		clock-names = "core_clk", "iface_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_uart1_apps_clk>,
+				<&clock_gcc clk_gcc_blsp1_ahb_clk>;
+		pinctrl-names = "sleep", "default";
+		pinctrl-0 = <&hsuart_sleep>;
+		pinctrl-1 = <&hsuart_active>;
+		qcom,bam-tx-ep-pipe-index = <0>;
+		qcom,bam-rx-ep-pipe-index = <1>;
+		qcom,msm-bus,name = "blsp1_uart0";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+					<86 512 0 0>,
+					<86 512 500 800>;
+		status = "disabled";
+	};
+
+	dma_blsp1: qcom,sps-dma@7884000 { /* BLSP1 */
+                #dma-cells = <4>;
+                compatible = "qcom,sps-dma";
+                reg = <0x7884000 0x1f000>;
+                interrupts = <0 238 0>;
+                qcom,summing-threshold = <10>;
+        };
+
+        dma_blsp2: qcom,sps-dma@7ac4000 { /* BLSP2 */
+                #dma-cells = <4>;
+                compatible = "qcom,sps-dma";
+                reg = <0x7ac4000 0x1f000>;
+                interrupts = <0 239 0>;
+                qcom,summing-threshold = <10>;
+        };
+
+	i2c_2: i2c@78b6000 { /* BLSP1 QUP2 */
+                compatible = "qcom,i2c-msm-v2";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                reg-names = "qup_phys_addr";
+                reg = <0x78b6000 0x1000>;
+                interrupt-names = "qup_irq";
+                interrupts = <0 96 0>;
+                qcom,clk-freq-out = <400000>;
+                qcom,clk-freq-in  = <19200000>;
+                clock-names = "iface_clk", "core_clk";
+                clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+                         <&clock_gcc clk_gcc_blsp1_qup2_i2c_apps_clk>;
+                pinctrl-names = "i2c_active", "i2c_sleep";
+                pinctrl-0 = <&i2c_2_active>;
+                pinctrl-1 = <&i2c_2_sleep>;
+                qcom,noise-rjct-scl = <0>;
+                qcom,noise-rjct-sda = <0>;
+                qcom,master-id = <86>;
+                dmas = <&dma_blsp1 6 64 0x20000020 0x20>,
+                        <&dma_blsp1 7 32 0x20000020 0x20>;
+                dma-names = "tx", "rx";
+        };
+
+	i2c_4: i2c@78b8000 { /* BLSP1 QUP4 */
+		compatible = "qcom,i2c-msm-v2";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		reg = <0x78b8000 0x600>;
+		interrupt-names = "qup_irq";
+		interrupts = <0 98 0>;
+		qcom,clk-freq-out = <400000>;
+		qcom,clk-freq-in  = <19200000>;
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+			<&clock_gcc clk_gcc_blsp1_qup4_i2c_apps_clk>;
+		pinctrl-names = "i2c_active", "i2c_sleep";
+		pinctrl-0 = <&i2c_4_active>;
+		pinctrl-1 = <&i2c_4_sleep>;
+		qcom,noise-rjct-scl = <0>;
+		qcom,noise-rjct-sda = <0>;
+		qcom,master-id = <86>;
+		dmas = <&dma_blsp1 10 64 0x20000020 0x20>,
+			<&dma_blsp1 11 32 0x20000020 0x20>;
+		dma-names = "tx", "rx";
+	};
+
+	i2c_6: i2c@7af6000 { /* BLSP2 QUP2 */
+		compatible = "qcom,i2c-msm-v2";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		reg = <0x7af6000 0x600>;
+		interrupt-names = "qup_irq";
+		interrupts = <0 300 0>;
+		qcom,clk-freq-out = <400000>;
+		qcom,clk-freq-in  = <19200000>;
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_blsp2_ahb_clk>,
+			<&clock_gcc clk_gcc_blsp2_qup2_i2c_apps_clk>;
+		pinctrl-names = "i2c_active", "i2c_sleep";
+		pinctrl-0 = <&i2c_6_active>;
+		pinctrl-1 = <&i2c_6_sleep>;
+		qcom,noise-rjct-scl = <0>;
+		qcom,noise-rjct-sda = <0>;
+		qcom,master-id = <84>;
+		dmas = <&dma_blsp2 6 64 0x20000020 0x20>,
+			<&dma_blsp2 7 32 0x20000020 0x20>;
+		dma-names = "tx", "rx";
+	};
+
+	i2c_8: i2c@7af8000 { /* BLSP2 QUP4 */
+                compatible = "qcom,i2c-msm-v2";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                reg-names = "qup_phys_addr";
+                reg = <0x7af8000 0x600>;
+                interrupt-names = "qup_irq";
+                interrupts = <0 302 0>;
+                qcom,clk-freq-out = <400000>;
+                qcom,clk-freq-in  = <19200000>;
+                clock-names = "iface_clk", "core_clk";
+                clocks = <&clock_gcc clk_gcc_blsp2_ahb_clk>,
+                        <&clock_gcc clk_gcc_blsp2_qup4_i2c_apps_clk>;
+                pinctrl-names = "i2c_active", "i2c_sleep";
+                pinctrl-0 = <&i2c_8_active>;
+                pinctrl-1 = <&i2c_8_sleep>;
+                qcom,noise-rjct-scl = <0>;
+                qcom,noise-rjct-sda = <0>;
+                qcom,master-id = <84>;
+                dmas = <&dma_blsp2 10 64 0x20000020 0x20>,
+                        <&dma_blsp2 11 32 0x20000020 0x20>;
+                dma-names = "tx", "rx";
+        };
+
+
+	usb_otg: usb@78db000 {
+		compatible = "qcom,hsusb-otg";
+		reg = <0x78db000 0x400>, <0x6c000 0x200>;
+		reg-names = "core", "phy_csr";
+
+		interrupts = <0 134 0>, <0 140 0>;
+		interrupt-names = "core_irq", "async_irq";
+
+		hsusb_vdd_dig-supply = <&pm8950_s6_level>;
+		HSUSB_1p8-supply = <&pm8950_l7>;
+		HSUSB_3p3-supply = <&pm8950_l13>;
+		vbus_otg-supply = <&smbcharger_charger_otg>;
+		qcom,vdd-voltage-level = <RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_BINNING>;
+
+		qcom,hsusb-otg-phy-init-seq =
+			<0x73 0x80 0x38 0x81 0x1b 0x82 0xffffffff>;
+		qcom,hsusb-otg-phy-type = <3>; /* SNPS Femto PHY */
+		qcom,hsusb-otg-mode = <3>; /* OTG */
+		qcom,hsusb-otg-otg-control = <2>; /* PMIC */
+		qcom,dp-manual-pullup;
+		qcom,hsusb-otg-mpm-dpsehv-int = <49>;
+		qcom,hsusb-otg-mpm-dmsehv-int = <58>;
+		qcom,boost-sysclk-with-streaming;
+		qcom,axi-prefetch-enable;
+
+		qcom,msm-bus,name = "usb2";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<87 512 0 0>,
+				<87 512 60000 0>,
+				<87 512 6000  6000>;
+
+		clocks = <&clock_gcc clk_gcc_usb_hs_ahb_clk>,
+			 <&clock_gcc clk_gcc_usb_hs_system_clk>,
+			 <&clock_gcc clk_gcc_usb2a_phy_sleep_clk>,
+			 <&clock_gcc clk_bimc_usb_clk>,
+			 <&clock_gcc clk_snoc_usb_clk>,
+			 <&clock_gcc clk_pcnoc_usb_clk>,
+			 <&clock_gcc clk_gcc_qusb2_phy_clk>,
+			 <&clock_gcc clk_gcc_usb2_hs_phy_only_clk>,
+			 <&clock_gcc clk_gcc_usb_hs_phy_cfg_ahb_clk>,
+			 <&clock_gcc clk_xo_otg_clk>;
+		clock-names = "iface_clk", "core_clk", "sleep_clk",
+				"bimc_clk", "snoc_clk", "pcnoc_clk",
+				"phy_reset_clk", "phy_por_clk", "phy_csr_clk",
+				"xo";
+		qcom,bus-clk-rate = <320000000 200000000 100000000>;
+		qcom,max-nominal-sysclk-rate = <133330000>;
+	};
+
+	android_usb: android_usb@086000c8 {
+		compatible = "qcom,android-usb";
+		reg = <0x086000c8 0xc8>;
+		qcom,pm-qos-latency = <2 1001 12701>;
+	};
+
+	slim_msm: slim@c140000{
+		cell-index = <1>;
+		compatible = "qcom,slim-ngd";
+		reg = <0xc140000 0x2c000>,
+			<0xc104000 0x2a000>;
+		reg-names = "slimbus_physical", "slimbus_bam_physical";
+		interrupts = <0 163 0>, <0 180 0>;
+		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
+		qcom,apps-ch-pipes = <0x600000>;
+		qcom,ea-pc = <0x170>;
+	};
+
+	qcom,usbbam@78c4000 {
+		compatible = "qcom,usb-bam-msm";
+		reg = <0x78c4000 0x17000>;
+		reg-names = "hsusb";
+		interrupts = <0 135 0>;
+		interrupt-names = "hsusb";
+		qcom,usb-bam-num-pipes = <16>;
+		qcom,usb-bam-fifo-baseaddr = <0x08606000>;
+		qcom,ignore-core-reset-ack;
+		qcom,disable-clk-gating;
+		qcom,usb-bam-max-mbps-highspeed = <400>;
+		qcom,enable-hsusb-bam-on-boot;
+
+		qcom,pipe0 {
+			label = "hsusb-ipa-out-0";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <0>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <2>;
+			qcom,src-bam-physical-address = <0x78c4000>;
+			qcom,src-bam-pipe-index = <1>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		qcom,pipe1 {
+			label = "hsusb-ipa-in-0";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <2>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <0>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		qcom,pipe2 {
+			label = "hsusb-qdss-in-0";
+			qcom,usb-bam-mem-type = <3>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <1>;
+			qcom,src-bam-physical-address = <0x6084000>;
+			qcom,src-bam-pipe-index = <0>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <2>;
+			qcom,data-fifo-offset = <0x0>;
+			qcom,data-fifo-size = <0xe00>;
+			qcom,descriptor-fifo-offset = <0xe00>;
+			qcom,descriptor-fifo-size = <0x200>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		/* USB BAM pipe (consumer) configuration for accelerated DPL */
+		qcom,pipe3 {
+			label = "hsusb-dpl-ipa-in-1";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <1>;
+			qcom,peer-bam = <2>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <3>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+	};
+
+        ipa_hw: qcom,ipa@07900000 {
+                compatible = "qcom,ipa";
+                reg = <0x07900000 0x4effc>, <0x07904000 0x26934>;
+                reg-names = "ipa-base", "bam-base";
+                interrupts = <0 228 0>,
+                             <0 230 0>;
+                interrupt-names = "ipa-irq", "bam-irq";
+                qcom,ipa-hw-ver = <6>; /* IPA core version = IPAv2.6L */
+                qcom,ipa-hw-mode = <0>; /* IPA hw type = Normal */
+                clock-names = "core_clk";
+                clocks = <&clock_gcc clk_ipa_clk>;
+                qcom,ee = <0>;
+                qcom,msm-bus,name = "ipa";
+                qcom,msm-bus,num-cases = <3>;
+                qcom,msm-bus,num-paths = <1>;
+                qcom,msm-bus,vectors-KBps =
+                <90 512 0 0>,              /* No vote (ab=0 Mbps, ib=0 Mbps ~V NO BIMC vote) */
+                <90 512 100000 800000>,    /* SVS  - (ab=100Mbps, ib=800Mbps ~V 50MHz BIMC freq) */
+                <90 512 100000 1200000>;   /* PERF - (ab=100Mbps, ib=1200Mbps ~V 75MHz BIMC freq) */
+                qcom,bus-vector-names = "MIN", "SVS", "PERF";
+        };
+
+        qcom,rmnet-ipa {
+                compatible = "qcom,rmnet-ipa";
+                qcom,rmnet-ipa-ssr;
+                qcom,ipa-loaduC;
+        };
+
+	qcom,ipc-spinlock@1905000 {
+		compatible = "qcom,ipc-spinlock-sfpb";
+		reg = <0x1905000 0x8000>;
+		qcom,num-locks = <8>;
+	};
+
+	qcom,smem@86300000 {
+		compatible = "qcom,smem";
+		reg = <0x86300000 0x100000>,
+			<0x0b011008 0x4>,
+			<0x60000 0x8000>,
+			<0x193D000 0x8>;
+		reg-names = "smem", "irq-reg-base", "aux-mem1", "smem_targ_info_reg";
+		qcom,mpu-enabled;
+
+		qcom,smd-modem {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <0>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x1000>;
+			interrupts = <0 25 1>;
+			label = "modem";
+			qcom,not-loadable;
+		};
+
+		qcom,smsm-modem {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <0>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x2000>;
+			interrupts = <0 26 1>;
+		};
+
+		qcom,smd-wcnss {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <6>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x20000>;
+			interrupts = <0 142 1>;
+			label = "wcnss";
+		};
+
+		qcom,smsm-wcnss {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <6>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x80000>;
+			interrupts = <0 144 1>;
+		};
+
+		qcom,smd-adsp {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <1>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x100>;
+			interrupts = <0 289 1>;
+			label = "adsp";
+		};
+
+		qcom,smsm-adsp {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <1>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x200>;
+			interrupts = <0 290 1>;
+		};
+
+		qcom,smd-rpm {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <15>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x1>;
+			interrupts = <0 168 1>;
+			label = "rpm";
+			qcom,irq-no-suspend;
+			qcom,not-loadable;
+		};
+	};
+
+	qcom,wdt@b017000 {
+		compatible = "qcom,msm-watchdog";
+		reg = <0xb017000 0x1000>;
+		reg-names = "wdt-base";
+		interrupts = <0 3 0>, <0 4 0>;
+		qcom,bark-time = <11000>;
+		qcom,pet-time = <10000>;
+		qcom,ipi-ping;
+	};
+
+	qcom,msm-rtb {
+		compatible = "qcom,msm-rtb";
+		qcom,rtb-size = <0x100000>; /* 1M EBI1 buffer */
+	};
+
+	qcom,msm-imem@8600000 {
+		compatible = "qcom,msm-imem";
+		reg = <0x08600000 0x1000>; /* Address and size of IMEM */
+		ranges = <0x0 0x08600000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		mem_dump_table@10 {
+			compatible = "qcom,msm-imem-mem_dump_table";
+			reg = <0x10 8>;
+		};
+	};
+
+	qcom_rng: qrng@22000 {
+		compatible = "qcom,msm-rng";
+		reg = <0x22000 0x140>;
+		qcom,msm-rng-iface-clk;
+		qcom,msm-bus,name = "msm-rng-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<1 618 0 0>,            /* No vote */
+			<1 618 0 800>;          /* 100 MB/s */
+		clocks = <&clock_gcc clk_gcc_prng_ahb_clk>;
+		clock-names = "iface_clk";
+	};
+
+	qcom_tzlog: tz-log@08600720 {
+		compatible = "qcom,tz-log";
+		reg = <0x08600720 0x2000>;
+	};
+
+	qcom_crypto: qcrypto@720000 {
+		compatible = "qcom,qcrypto";
+		reg = <0x720000 0x20000>,
+		      <0x704000 0x20000>;
+		reg-names = "crypto-base","crypto-bam-base";
+		interrupts = <0 207 0>;
+		qcom,bam-pipe-pair = <2>;
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		qcom,ce-hw-shared;
+		qcom,clk-mgmt-sus-res;
+		qcom,msm-bus,name = "qcrypto-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 393600 393600>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,use-sw-aes-cbc-ecb-ctr-algo;
+		qcom,use-sw-aes-xts-algo;
+		qcom,use-sw-aes-ccm-algo;
+		qcom,use-sw-ahash-algo;
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom_cedev: qcedev@720000 {
+		compatible = "qcom,qcedev";
+		reg = <0x720000 0x20000>,
+		      <0x704000 0x20000>;
+		reg-names = "crypto-base","crypto-bam-base";
+		interrupts = <0 207 0>;
+		qcom,bam-pipe-pair = <1>;
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		qcom,ce-hw-shared;
+		qcom,msm-bus,name = "qcedev-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 393600 393600>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom_seecom: qseecom@85e00000 {
+		compatible = "qcom,qseecom";
+		reg = <0x85e00000 0x500000>;
+		reg-names = "secapp-region";
+		qcom,hlos-num-ce-hw-instances = <1>;
+		qcom,hlos-ce-hw-instance = <0>;
+		qcom,qsee-ce-hw-instance = <0>;
+		qcom,msm-bus,name = "qseecom-noc";
+		qcom,disk-encrypt-pipe-pair = <2>;
+		qcom,support-fde;
+		qcom,appsbl-qseecom-support;
+		qcom,msm-bus,num-cases = <4>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,support-bus-scaling;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 0 0>,
+			<55 512 120000 1200000>,
+			<55 512 393600 3936000>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom,ipc_router {
+		compatible = "qcom,ipc_router";
+		qcom,node-id = <1>;
+	};
+
+	qcom,ipc_router_modem_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "modem";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+		qcom,disable-pil-loading;
+	};
+
+	qcom,ipc_router_q6_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "adsp";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+	};
+
+	qcom,ipc_router_wcnss_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "wcnss";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+	};
+
+	qcom,smdtty {
+		compatible = "qcom,smdtty";
+
+		smdtty_apps_fm: qcom,smdtty-apps-fm {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_FM";
+		};
+
+		smdtty_apps_riva_bt_acl: smdtty-apps-riva-bt-acl {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_BT_ACL";
+		};
+
+		smdtty_apps_riva_bt_cmd: qcom,smdtty-apps-riva-bt-cmd {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_BT_CMD";
+		};
+
+		smdtty_mbalbridge: qcom,smdtty-mbalbridge {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "MBALBRIDGE";
+		};
+
+		smdtty_apps_riva_ant_cmd: smdtty-apps-riva-ant-cmd {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_ANT_CMD";
+		};
+
+		smdtty_apps_riva_ant_data: smdtty-apps-riva-ant-data {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_ANT_DATA";
+		};
+
+		smdtty_data1: qcom,smdtty-data1 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA1";
+		};
+
+		smdtty_data4: qcom,smdtty-data4 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA4";
+		};
+
+		smdtty_data11: qcom,smdtty-data11 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA11";
+		};
+
+		smdtty_data21: qcom,smdtty-data21 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA21";
+		};
+
+		smdtty_loopback: smdtty-loopback {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "LOOPBACK";
+			qcom,smdtty-dev-name = "LOOPBACK_TTY";
+		};
+	};
+
+	qcom,smdpkt {
+		compatible = "qcom,smdpkt";
+
+		qcom,smdpkt-data5-cntl {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA5_CNTL";
+			qcom,smdpkt-dev-name = "smdcntl0";
+		};
+
+		qcom,smdpkt-data22 {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA22";
+			qcom,smdpkt-dev-name = "smd22";
+		};
+
+		qcom,smdpkt-data40-cntl {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA40_CNTL";
+			qcom,smdpkt-dev-name = "smdcntl8";
+		};
+
+		qcom,smdpkt-apr-apps2 {
+			qcom,smdpkt-remote = "adsp";
+			qcom,smdpkt-port-name = "apr_apps2";
+			qcom,smdpkt-dev-name = "apr_apps2";
+		};
+
+		qcom,smdpkt-loopback {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "LOOPBACK";
+			qcom,smdpkt-dev-name = "smd_pkt_loopback";
+		};
+	};
+
+	qcom,iris-fm {
+		compatible = "qcom,iris_fm";
+	};
+
+	qcom,wcnss-wlan@0a000000 {
+		compatible = "qcom,wcnss_wlan";
+		reg = <0x0a000000 0x280000>,
+		      <0xb011008 0x04>,
+		      <0x0a21b000 0x3000>,
+		      <0x03204000 0x00000100>,
+		      <0x03200800 0x00000200>,
+		      <0x0a100400 0x00000200>,
+		      <0x0a205050 0x00000200>,
+		      <0x0a219000 0x00000020>,
+		      <0x0a080488 0x00000008>,
+		      <0x0a080fb0 0x00000008>,
+		      <0x0a08040c 0x00000008>,
+		      <0x0a0120a8 0x00000008>,
+		      <0x0a012448 0x00000008>,
+		      <0x0a080c00 0x00000001>;
+
+		reg-names = "wcnss_mmio", "wcnss_fiq",
+			    "pronto_phy_base", "riva_phy_base",
+			    "riva_ccu_base", "pronto_a2xb_base",
+			    "pronto_ccpu_base", "pronto_saw2_base",
+			    "wlan_tx_phy_aborts","wlan_brdg_err_source",
+			    "wlan_tx_status", "alarms_txctl",
+			    "alarms_tactl", "pronto_mcu_base";
+
+		interrupts = <0 145 0 0 146 0>;
+		interrupt-names = "wcnss_wlantx_irq", "wcnss_wlanrx_irq";
+
+		qcom,pronto-vddmx-supply = <&pm8950_s6_level_ao>;
+		qcom,pronto-vddcx-supply = <&pm8950_s2_level>;
+		qcom,pronto-vddpx-supply = <&pm8950_l5>;
+		qcom,iris-vddxo-supply   = <&pm8950_l7>;
+		qcom,iris-vddrfa-supply  = <&pm8950_l19>;
+		qcom,iris-vddpa-supply   = <&pm8950_l9>;
+		qcom,iris-vdddig-supply  = <&pm8950_l5>;
+
+		qcom,iris-vddxo-voltage-level = <1800000 0 1800000>;
+		qcom,iris-vddrfa-voltage-level = <1300000 0 1300000>;
+		qcom,iris-vddpa-voltage-level = <3300000 0 3300000>;
+		qcom,iris-vdddig-voltage-level = <1800000 0 1800000>;
+
+		qcom,vddmx-voltage-level = <RPM_SMD_REGULATOR_LEVEL_TURBO
+					RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_BINNING>;
+		qcom,vddcx-voltage-level = <RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		qcom,vddpx-voltage-level = <1800000 0 1800000>;
+
+		qcom,iris-vddxo-current = <10000>;
+		qcom,iris-vddrfa-current = <100000>;
+		qcom,iris-vddpa-current = <515000>;
+		qcom,iris-vdddig-current = <10000>;
+
+		qcom,pronto-vddmx-current = <0>;
+		qcom,pronto-vddcx-current = <0>;
+		qcom,pronto-vddpx-current = <0>;
+
+		pinctrl-names = "wcnss_default", "wcnss_sleep",
+				"wcnss_gpio_default";
+		pinctrl-0 = <&wcnss_default>;
+		pinctrl-1 = <&wcnss_sleep>;
+		pinctrl-2 = <&wcnss_gpio_default>;
+
+		gpios = <&msm_gpio 40 0>, <&msm_gpio 41 0>, <&msm_gpio 42 0>,
+			<&msm_gpio 43 0>, <&msm_gpio 44 0>;
+
+		clocks = <&clock_gcc clk_xo_wlan_clk>,
+			 <&clock_gcc clk_rf_clk2>,
+			 <&clock_debug clk_gcc_debug_mux>,
+			 <&clock_gcc clk_wcnss_m_clk>;
+
+		clock-names = "xo", "rf_clk", "measure", "wcnss_debug";
+
+		qcom,has-autodetect-xo;
+		qcom,is-pronto-v3;
+		qcom,has-pronto-hw;
+	};
+
+	qcom,vidc@1d00000 {
+		compatible = "qcom,msm-vidc";
+		reg = <0x01d00000 0xff000>,
+			<0x000a4120 0x4>;
+		reg-names = "vidc", "efuse";
+		interrupts = <0 44 0>;
+		vdd-cx-supply = <&pm8950_s2_level_ao>;
+		venus-supply = <&gdsc_venus>;
+		venus-core0-supply = <&gdsc_venus_core0>;
+		qcom,hfi = "venus";
+		qcom,firmware-name = "venus-v1";
+
+		clocks =
+			<&clock_gcc clk_gcc_venus0_vcodec0_clk>,
+			<&clock_gcc clk_gcc_venus0_core0_vcodec0_clk>,
+			<&clock_gcc clk_gcc_venus0_ahb_clk>,
+			<&clock_gcc clk_gcc_venus0_axi_clk>;
+
+		clock-names = "core_clk", "core0_clk", "iface_clk", "bus_clk";
+		qcom,clock-configs = <0x1 0x0 0x0 0x0>;
+		qcom,sw-power-collapse;
+		qcom,reset-clock-control;
+		qcom,regulator-scaling;
+		qcom,max-hw-load = <1011840>; /* 3840 x 2176 @ 30 fps + 3840 x 2176 @ 1 fps */
+		qcom,dcvs-min-load = <734400>; /* 1920 x 1088 @ 90fps */
+		qcom,dcvs-min-mbperframe = <32400>; /* 3840 x 2160 */
+
+		qcom,load-freq-tbl =
+			<979200 466000000 0x55555555>, /* TURBO, UHD30E   */
+			<979200 400000000 0xffffffff>, /* NOM+ , UHD30D   */
+			<734400 360000000 0xffffffff>, /* NOM  , 1080p90D */
+			<734400 400000000 0x55555555>, /* NOM+ , 1080p90E */
+			<489600 228570000 0xffffffff>, /* SVS  , 1080p60D */
+			<489600 466000000 0x55555555>, /* TURBO, 1080p60E */
+			<432000 228570000 0xffffffff>, /* SVS  , 720p120D */
+			<432000 400000000 0x55555555>, /* NOM+ , 720p120E */
+			<244800 133333333 0xffffffff>, /* SVS- , 1080p30D */
+			<244800 228570000 0x55555555>, /* SVS  , 1080p30E */
+			<216000 100000000 0xffffffff>, /* SVS- , 720p60D  */
+			<216000 228570000 0x55555555>, /* SVS  , 720p60E  */
+			<108000 80000000 0xffffffff>,  /* SVS--, 720p30D  */
+			<108000 100000000 0x55555555>, /* SVS- , 720p30E  */
+			<36000 72727200 0xffffffff>,   /* SVS--, 480p30D  */
+			<36000 80000000 0x55555555>;   /* SVS--, 480p30E  */
+
+		qcom,qdss-presets =
+			<0x6025000 0x1000>,
+			<0x6026000 0x1000>,
+			<0x6021000 0x1000>,
+			<0x6002000 0x1000>,
+			<0x9180000 0x1000>,
+			<0x9181000 0x1000>;
+
+		qcom,reg-presets =
+			<0xE0020 0x05555556>,
+			<0xE0024 0x05555556>,
+			<0x80124 0x00000003>;
+
+		qcom,clock-voltage-tbl =
+			<72727200 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<80000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<100000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<133333333 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<228570000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<310667000 RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM>,
+			<400000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
+			<466000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,vp9d-clock-voltage-tbl =
+			<72727200 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<80000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<100000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<133333333 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<228570000 RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+			<310667000 RPM_SMD_REGULATOR_LEVEL_NOM>,
+			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
+			<400000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,vidc-iommu-domains {
+			qcom,domain-ns {
+				qcom,vidc-domain-phandle = <&venus_domain_ns>;
+				qcom,vidc-partition-buffer-types = <0x7ff>,
+							<0x800>;
+			};
+
+			qcom,domain-sec-bs {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_bitstream>;
+				qcom,vidc-partition-buffer-types = <0x241>;
+			};
+
+			qcom,domain-sec-px {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_pixel>;
+				qcom,vidc-partition-buffer-types = <0x106>;
+			};
+
+			qcom,domain-sec-np {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_non_pixel>;
+				qcom,vidc-partition-buffer-types = <0x480>;
+			};
+		};
+
+		qcom,msm-bus-clients {
+			qcom,msm-bus-client@0 {
+				qcom,msm-bus,name = "venc-ddr";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 342000 0>,  /* 480p  30 fps */
+					<63 512 342000 0>,  /* 480p  60 fps */
+					<63 512 342000 0>,  /* 720p  30 fps */
+					<63 512 677000 0>,  /* 720p  60 fps */
+					<63 512 775000 0>,  /* 1080p 30 fps */
+					<63 512 1530000 0>, /* 1080p 60 fps */
+					<63 512 1562000 0>, /* UHD   24 fps */
+					<63 512 1669000 0>, /* 4K    24 fps */
+					<63 512 1964000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0x55555555>; /* all encoders */
+			};
+
+			qcom,msm-bus-client@1 {
+				qcom,msm-bus,name = "vdec-ddr";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 252000 0>,  /* 480p  30 fps */
+					<63 512 252000 0>,  /* 480p  60 fps */
+					<63 512 252000 0>,  /* 720p  30 fps */
+					<63 512 496000 0>,  /* 720p  60 fps */
+					<63 512 574000 0>,  /* 1080p 30 fps */
+					<63 512 1148000 0>, /* 1080p 60 fps */
+					<63 512 1967000 0>, /* UHD   24 fps */
+					<63 512 2458000 0>, /* 4K    24 fps */
+					<63 512 2458000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0xffffffff>; /* all decoders */
+			};
+
+			qcom,msm-bus-client@2 {
+				qcom,msm-bus,name = "venc-ddr-lowlatency";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 450000 0>,  /* 480p  30 fps */
+					<63 512 450000 0>,  /* 480p  60 fps */
+					<63 512 508000 0>,  /* 720p  30 fps */
+					<63 512 1010000 0>, /* 720p  60 fps */
+					<63 512 1149000 0>, /* 1080p 30 fps */
+					<63 512 2276000 0>, /* 1080p 60 fps */
+					<63 512 2159000 0>, /* UHD   24 fps */
+					<63 512 2306000 0>, /* 4K    24 fps */
+					<63 512 2688000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0x55555555>; /* all encs */
+				qcom,bus-low-latency;
+			};
+
+			qcom,msm-bus-client@3 {
+				qcom,msm-bus,name = "venus-arm9-ddr";
+				qcom,msm-bus,num-cases = <2>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 1000 1000>;
+				qcom,bus-configs = <0x00000000>;
+				qcom,bus-passive;
+			};
+		};
+	};
+
+	qcom,venus@1de0000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0x1de0000 0x4000>;
+
+		vdd-supply = <&gdsc_venus>;
+		qcom,proxy-reg-names = "vdd";
+
+		clocks = <&clock_gcc clk_gcc_venus0_vcodec0_clk>,
+			 <&clock_gcc clk_gcc_venus0_ahb_clk>,
+			 <&clock_gcc clk_gcc_venus0_axi_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+
+		clock-names = "core_clk", "iface_clk", "bus_clk",
+				"scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+
+		qcom,proxy-clock-names = "core_clk", "iface_clk",
+					 "bus_clk", "scm_core_clk",
+					 "scm_iface_clk", "scm_bus_clk",
+					 "scm_core_clk_src";
+		qcom,scm_core_clk_src-freq = <80000000>;
+
+		qcom,msm-bus,name = "pil-venus";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<63 512 0 0>,
+				<63 512 0 304000>;
+		qcom,pas-id = <9>;
+		qcom,proxy-timeout-ms = <100>;
+		qcom,firmware-name = "venus";
+		linux,contiguous-region = <&venus_mem>;
+	};
+
+	qcom,lpass@c200000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0xc200000 0x00100>;
+		interrupts = <0 293 1>;
+
+		vdd_cx-supply = <&pm8950_s2_level>;
+		qcom,proxy-reg-names = "vdd_cx";
+		qcom,vdd_cx-uV-uA = <7 100000>;
+
+		clocks = <&clock_gcc clk_xo_pil_lpass_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+		clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+		qcom,proxy-clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				 "scm_bus_clk", "scm_core_clk_src";
+		qcom,scm_core_clk_src-freq = <80000000>;
+
+		qcom,pas-id = <1>;
+		qcom,proxy-timeout-ms = <10000>;
+		qcom,smem-id = <423>;
+		qcom,sysmon-id = <1>;
+		qcom,ssctl-instance-id = <0x14>;
+		qcom,firmware-name = "adsp";
+
+		/* GPIO inputs from lpass */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_2_in 0 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_2_in 2 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_2_in 1 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_2_in 3 0>;
+
+		/* GPIO output to lpass */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_2_out 0 0>;
+
+		linux,contiguous-region = <&reloc_mem>;
+	};
+
+        spmi_bus: qcom,spmi@200f000 {
+                compatible = "qcom,spmi-pmic-arb";
+                reg = <0x200f000 0x1000>,
+                        <0x2400000 0x800000>,
+                        <0x2c00000 0x800000>,
+                        <0x3800000 0x200000>,
+                        <0x200a000 0x2100>;
+                reg-names = "core", "chnls", "obsrvr", "intr", "cnfg";
+                interrupts = <0 190 0>;
+                qcom,pmic-arb-channel = <0>;
+                qcom,pmic-arb-max-peripherals = <256>;
+                qcom,pmic-arb-max-periph-interrupts = <224>;
+                qcom,pmic-arb-ee = <0>;
+                #interrupt-cells = <3>;
+                interrupt-controller;
+                #address-cells = <1>;
+                #size-cells = <0>;
+                cell-index = <0>;
+	};
+
+	spi_0: spi@0x78B5000 { /* BLSP1 QUP0 */
+		compatible = "qcom,spi-qup-v2";
+		reg-names = "spi_physical", "spi_bam_physical";
+		reg = <0x78B5000 0x600>,
+		      <0x7884000 0x1f000>;
+		interrupt-names = "spi_irq", "spi_bam_irq";
+		interrupts = <0 95 0>, <0 238 0>;
+		spi-max-frequency = <19200000>;
+		pinctrl-names = "spi_default", "spi_sleep";
+		pinctrl-0 = <&spi0_default &spi0_cs0_active>;
+		pinctrl-1 = <&spi0_sleep &spi0_cs0_sleep>;
+		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+			 <&clock_gcc clk_gcc_blsp1_qup1_spi_apps_clk>;
+		clock-names = "iface_clk", "core_clk";
+		qcom,infinite-mode = <0>;
+		qcom,use-bam;
+		qcom,use-pinctrl;
+		qcom,ver-reg-exists;
+		qcom,bam-consumer-pipe-index = <4>;
+		qcom,bam-producer-pipe-index = <5>;
+		qcom,master-id = <86>;
+	};
+
+	qcom,,msm-ssc-sensors {
+		compatible = "qcom,msm-ssc-sensors";
+	};
+
+	qcom,pronto@a21b000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0x0a21b000 0x3000>;
+		interrupts = <0 149 1>;
+
+		vdd_pronto_pll-supply = <&pm8950_l7>;
+		proxy-reg-names = "vdd_pronto_pll";
+		vdd_pronto_pll-uV-uA = <1800000 18000>;
+		clocks = <&clock_gcc clk_xo_pil_pronto_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+
+		clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+		qcom,proxy-clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				 "scm_bus_clk", "scm_core_clk_src";
+		qcom,scm_core_clk_src = <80000000>;
+
+		qcom,pas-id = <6>;
+		qcom,proxy-timeout-ms = <10000>;
+		qcom,smem-id = <422>;
+		qcom,sysmon-id = <6>;
+		qcom,ssctl-instance-id = <0x13>;
+		qcom,firmware-name = "wcnss";
+
+		/* GPIO inputs from wcnss */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_4_in 0 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_4_in 1 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_4_in 2 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_4_in 3 0>;
+
+                /* GPIO output to wcnss */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_4_out 0 0>;
+		linux,contiguous-region = <&reloc_mem>;
+	};
+
+	dcc: dcc@b3000 {
+		compatible = "qcom,dcc";
+		reg = <0xb3000 0x1000>,
+		      <0xb4000 0x2000>;
+		reg-names = "dcc-base", "dcc-ram-base";
+
+		clocks = <&clock_gcc clk_gcc_dcc_clk>;
+		clock-names = "dcc_clk";
+
+		qcom,save-reg;
+	};
+
+	qcom,mss@4080000 {
+		compatible = "qcom,pil-q6v55-mss";
+		reg = <0x04080000 0x100>,
+		      <0x0194f000 0x010>,
+		      <0x01950000 0x008>,
+		      <0x01951000 0x008>,
+		      <0x04020000 0x040>,
+		      <0x01871000 0x004>;
+		reg-names = "qdsp6_base", "halt_q6", "halt_modem", "halt_nc",
+				 "rmb_base", "restart_reg";
+
+		interrupts = <0 24 1>;
+		vdd_mss-supply = <&pm8950_s1>;
+		vdd_cx-supply = <&pm8950_s2_level>;
+		vdd_cx-voltage = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd_mx-supply = <&pm8950_s6_level>;
+		vdd_mx-uV = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd_pll-supply = <&pm8950_l7>;
+		qcom,vdd_pll = <1800000>;
+
+		clocks = <&clock_gcc clk_xo_pil_mss_clk>,
+			 <&clock_gcc clk_gcc_mss_cfg_ahb_clk>,
+			 <&clock_gcc clk_gcc_mss_q6_bimc_axi_clk>,
+			 <&clock_gcc clk_gcc_boot_rom_ahb_clk>;
+		clock-names = "xo", "iface_clk", "bus_clk", "mem_clk";
+		qcom,proxy-clock-names = "xo";
+		qcom,active-clock-names = "iface_clk", "bus_clk", "mem_clk";
+
+		qcom,pas-id = <5>;
+		qcom,pil-mss-memsetup;
+		qcom,firmware-name = "modem";
+		qcom,pil-self-auth;
+		qcom,sysmon-id = <0>;
+		qcom,ssctl-instance-id = <0x12>;
+		qcom,qdsp6v56-1-8;
+
+		/* GPIO inputs from mss */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_1_in 0 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_1_in 1 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_1_in 2 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_1_in 3 0>;
+		qcom,gpio-shutdown-ack = <&smp2pgpio_ssr_smp2p_1_in 7 0>;
+
+		/* GPIO output to mss */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_1_out 0 0>;
+		linux,contiguous-region = <&modem_mem>;
+	};
+
+	cpu-pmu {
+		compatible = "arm,armv8-pmuv3";
+		qcom,irq-is-percpu;
+		interrupts = <1 7 0xff00>;
+	};
+
+	ext_codec: sound-9335 {
+		compatible = "qcom,msm8952-audio-slim-codec";
+		qcom,model = "msm8976-tasha-snd-card";
+
+		reg = <0xc051000 0x4>,
+		    <0xc051004 0x4>,
+		    <0xc055000 0x4>,
+		    <0xc056000 0x4>,
+		    <0xc052000 0x4>;
+
+		reg-names = "csr_gp_io_mux_mic_ctl",
+			"csr_gp_io_mux_spkr_ctl",
+			"csr_gp_io_lpaif_pri_pcm_pri_mode_muxsel",
+			"csr_gp_io_lpaif_sec_pcm_sec_mode_muxsel",
+			"csr_gp_io_mux_quin_ctl";
+
+		qcom,audio-routing =
+			"AIF4 VI", "MCLK",
+			"RX_BIAS", "MCLK",
+			"MADINPUT", "MCLK",
+			"AMIC2", "MIC BIAS2",
+			"MIC BIAS2", "Headset Mic",
+			"AMIC3", "MIC BIAS2",
+			"MIC BIAS2", "ANCRight Headset Mic",
+			"AMIC4", "MIC BIAS2",
+			"MIC BIAS2", "ANCLeft Headset Mic",
+			"AMIC5", "MIC BIAS3",
+			"MIC BIAS3", "Handset Mic",
+			"AMIC6", "MIC BIAS4",
+			"MIC BIAS4", "Analog Mic6",
+			"DMIC0", "MIC BIAS1",
+			"MIC BIAS1", "Digital Mic0",
+			"DMIC1", "MIC BIAS1",
+			"MIC BIAS1", "Digital Mic1",
+			"DMIC2", "MIC BIAS3",
+			"MIC BIAS3", "Digital Mic2",
+			"DMIC3", "MIC BIAS3",
+			"MIC BIAS3", "Digital Mic3",
+			"DMIC4", "MIC BIAS4",
+			"MIC BIAS4", "Digital Mic4",
+			"DMIC5", "MIC BIAS4",
+			"MIC BIAS4", "Digital Mic5",
+			"SpkrLeft IN", "SPK1 OUT",
+			"SpkrRight IN", "SPK2 OUT";
+
+		qcom,msm-gpios =
+			"us_eu_gpio";
+		qcom,pinctrl-names =
+			"all_off",
+			"us_eu_gpio_act";
+		pinctrl-names =
+			"all_off",
+			"us_eu_gpio_act";
+		pinctrl-0 = <&cross_conn_det_sus>;
+		pinctrl-1 = <&cross_conn_det_act>;
+		qcom,cdc-us-euro-gpios = <&msm_gpio 144 0>;
+
+		qcom,msm-mbhc-hphl-swh = <0>;
+		qcom,msm-mbhc-gnd-swh = <0>;
+		qcom,tasha-mclk-clk-freq = <9600000>;
+		asoc-platform = <&pcm0>, <&pcm1>, <&pcm2>, <&voip>, <&voice>,
+				<&loopback>, <&compress>, <&hostless>,
+				<&afe>, <&lsm>, <&routing>, <&cpe>, <&lpa>;
+		asoc-platform-names = "msm-pcm-dsp.0", "msm-pcm-dsp.1", "msm-pcm-dsp.2",
+				"msm-voip-dsp", "msm-pcm-voice", "msm-pcm-loopback",
+				"msm-compress-dsp", "msm-pcm-hostless", "msm-pcm-afe",
+				"msm-lsm-client", "msm-pcm-routing", "msm-cpe-lsm",
+				"msm-pcm-lpa";
+		asoc-cpu = <&dai_pri_auxpcm>, <&dai_sec_auxpcm>, <&dai_hdmi>,
+				<&dai_mi2s_hdmi>,
+				<&dai_mi2s2>, <&dai_mi2s3>, <&dai_mi2s5>,
+				<&sb_0_rx>, <&sb_0_tx>, <&sb_1_rx>, <&sb_1_tx>,
+				<&sb_2_rx>, <&sb_2_tx>, <&sb_3_rx>, <&sb_3_tx>,
+				<&sb_4_rx>, <&sb_4_tx>, <&sb_5_tx>, <&afe_pcm_rx>,
+				<&afe_pcm_tx>, <&afe_proxy_rx>, <&afe_proxy_tx>,
+				<&incall_record_rx>, <&incall_record_tx>,
+				<&incall_music_rx>, <&incall_music_2_rx>,
+				<&sb_5_rx>,  <&bt_sco_rx>,
+				<&bt_sco_tx>, <&int_fm_rx>, <&int_fm_tx>;
+		asoc-cpu-names = "msm-dai-q6-auxpcm.1",	"msm-dai-q6-auxpcm.2",
+				"msm-dai-q6-hdmi.8",
+				"msm-dai-q6-mi2s-hdmi.4118",
+				"msm-dai-q6-mi2s.2",
+				"msm-dai-q6-mi2s.3", "msm-dai-q6-mi2s.5",
+				"msm-dai-q6-dev.16384", "msm-dai-q6-dev.16385",
+				"msm-dai-q6-dev.16386", "msm-dai-q6-dev.16387",
+				"msm-dai-q6-dev.16388", "msm-dai-q6-dev.16389",
+				"msm-dai-q6-dev.16390", "msm-dai-q6-dev.16391",
+				"msm-dai-q6-dev.16392", "msm-dai-q6-dev.16393",
+				"msm-dai-q6-dev.16395", "msm-dai-q6-dev.224",
+				"msm-dai-q6-dev.225", "msm-dai-q6-dev.241",
+				"msm-dai-q6-dev.240", "msm-dai-q6-dev.32771",
+				"msm-dai-q6-dev.32772", "msm-dai-q6-dev.32773",
+				"msm-dai-q6-dev.32770", "msm-dai-q6-dev.16394",
+				"msm-dai-q6-dev.12288", "msm-dai-q6-dev.12289",
+				"msm-dai-q6-dev.12292", "msm-dai-q6-dev.12293";
+		asoc-codec = <&stub_codec>;
+		asoc-codec-names = "msm-stub-codec.1";
+		qcom,max-aux-codec = <2>;
+		qcom,aux-codec = "wsa881x.20170211", "wsa881x.20170212",
+				 "wsa881x.21170213", "wsa881x.21170214";
+		qcom,aux-codec-prefix = "SpkrLeft", "SpkrRight",
+					"SpkrLeft", "SpkrRight";
+	};
+
+	wcd9xxx_intc: wcd9xxx-irq {
+		compatible = "qcom,wcd9xxx-irq";
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&msm_gpio>;
+		interrupts = <120 0>;
+		interrupt-names = "cdc-int";
+	};
+
+	wcd_rst_gpio: wcd_gpio_ctrl {
+		compatible = "qcom,wcd-gpio-ctrl";
+		qcom,cdc-rst-n-gpio = <&msm_gpio 133 0>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&cdc_reset_line_act>;
+		pinctrl-1 = <&cdc_reset_line_sus>;
+	};
+
+	clock_audio: audio_ext_clk {
+		compatible = "qcom,audio-ref-clk";
+		qcom,audio-ref-clk-gpio = <&pm8950_gpios 1 0>;
+		clock-names = "osr_clk";
+		clocks = <&clock_gcc clk_div_clk2>;
+		qcom,node_has_rpm_clock;
+		#clock-cells = <1>;
+	};
+
+	pcm0: qcom,msm-pcm {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <0>;
+	};
+
+	routing: qcom,msm-pcm-routing {
+		compatible = "qcom,msm-pcm-routing";
+	};
+
+	pcm2: qcom,msm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	pcm1: qcom,msm-pcm-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <1>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "regular";
+	};
+
+	pcm2: qcom,msm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	cpe: qcom,msm-cpe-lsm {
+		compatible = "qcom,msm-cpe-lsm";
+	};
+
+	lpa: qcom,msm-pcm-lpa {
+		compatible = "qcom,msm-pcm-lpa";
+	};
+
+	compress: qcom,msm-compress-dsp {
+		compatible = "qcom,msm-compress-dsp";
+	};
+
+	voip: qcom,msm-voip-dsp {
+		compatible = "qcom,msm-voip-dsp";
+	};
+
+	voice: qcom,msm-pcm-voice {
+		compatible = "qcom,msm-pcm-voice";
+		qcom,destroy-cvd;
+		qcom,vote-bms;
+	};
+
+	stub_codec: qcom,msm-stub-codec {
+		compatible = "qcom,msm-stub-codec";
+	};
+
+	qcom,msm-dai-fe {
+		compatible = "qcom,msm-dai-fe";
+	};
+
+	afe: qcom,msm-pcm-afe {
+		compatible = "qcom,msm-pcm-afe";
+	};
+
+	voice_svc: qcom,msm-voice-svc {
+		compatible = "qcom,msm-voice-svc";
+	};
+
+	loopback: qcom,msm-pcm-loopback {
+		compatible = "qcom,msm-pcm-loopback";
+	};
+
+	qcom,msm-dai-mi2s {
+		compatible = "qcom,msm-dai-mi2s";
+		dai_mi2s0: qcom,msm-dai-q6-mi2s-prim {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <0>;
+			qcom,msm-mi2s-rx-lines = <3>;
+			qcom,msm-mi2s-tx-lines = <0>;
+		};
+
+		dai_mi2s1: qcom,msm-dai-q6-mi2s-sec {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <1>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <0>;
+		};
+
+		dai_mi2s3: qcom,msm-dai-q6-mi2s-quat {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <3>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <2>;
+		};
+
+		dai_mi2s2: qcom,msm-dai-q6-mi2s-tert {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <2>;
+			qcom,msm-mi2s-rx-lines = <0>;
+			qcom,msm-mi2s-tx-lines = <3>;
+		};
+
+		dai_mi2s5: qcom,msm-dai-q6-mi2s-quin {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <5>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <2>;
+		};
+
+		dai_mi2s6: qcom,msm-dai-q6-mi2s-senary {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <6>;
+			qcom,msm-mi2s-rx-lines = <0>;
+			qcom,msm-mi2s-tx-lines = <3>;
+		};
+	};
+
+	dai_hdmi: qcom,msm-dai-q6-hdmi {
+		compatible = "qcom,msm-dai-q6-hdmi";
+		qcom,msm-dai-q6-dev-id = <8>;
+	};
+
+	dai_mi2s_hdmi: qcom,msm-dai-q6-mi2s-hdmi {
+		compatible = "qcom,msm-dai-q6-mi2s-hdmi";
+		qcom,msm-dai-q6-mi2s-dev-id = <4118>;
+	};
+
+	lsm: qcom,msm-lsm-client {
+		compatible = "qcom,msm-lsm-client";
+	};
+
+	qcom,msm-dai-q6 {
+		compatible = "qcom,msm-dai-q6";
+		sb_0_rx: qcom,msm-dai-q6-sb-0-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16384>;
+		};
+
+		sb_0_tx: qcom,msm-dai-q6-sb-0-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16385>;
+		};
+
+		sb_1_rx: qcom,msm-dai-q6-sb-1-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16386>;
+		};
+
+		sb_1_tx: qcom,msm-dai-q6-sb-1-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16387>;
+		};
+
+		sb_2_rx: qcom,msm-dai-q6-sb-2-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16388>;
+		};
+
+		sb_2_tx: qcom,msm-dai-q6-sb-2-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16389>;
+		};
+
+
+		sb_3_rx: qcom,msm-dai-q6-sb-3-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16390>;
+		};
+
+		sb_3_tx: qcom,msm-dai-q6-sb-3-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16391>;
+		};
+
+		sb_4_rx: qcom,msm-dai-q6-sb-4-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16392>;
+		};
+
+		sb_4_tx: qcom,msm-dai-q6-sb-4-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16393>;
+		};
+
+		sb_5_tx: qcom,msm-dai-q6-sb-5-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16395>;
+		};
+
+		sb_5_rx: qcom,msm-dai-q6-sb-5-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16394>;
+		};
+
+		bt_sco_rx: qcom,msm-dai-q6-bt-sco-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12288>;
+		};
+
+		bt_sco_tx: qcom,msm-dai-q6-bt-sco-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12289>;
+		};
+
+		int_fm_rx: qcom,msm-dai-q6-int-fm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12292>;
+		};
+
+		int_fm_tx: qcom,msm-dai-q6-int-fm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12293>;
+		};
+
+		afe_pcm_rx: qcom,msm-dai-q6-be-afe-pcm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <224>;
+		};
+
+		afe_pcm_tx: qcom,msm-dai-q6-be-afe-pcm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <225>;
+		};
+
+		afe_proxy_rx: qcom,msm-dai-q6-afe-proxy-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <241>;
+		};
+
+		afe_proxy_tx: qcom,msm-dai-q6-afe-proxy-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <240>;
+		};
+
+		incall_record_rx: qcom,msm-dai-q6-incall-record-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32771>;
+		};
+
+		incall_record_tx: qcom,msm-dai-q6-incall-record-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32772>;
+		};
+
+		incall_music_rx: qcom,msm-dai-q6-incall-music-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32773>;
+		};
+
+		incall_music_2_rx: qcom,msm-dai-q6-incall-music-2-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32770>;
+		};
+	};
+
+	hostless: qcom,msm-pcm-hostless {
+		compatible = "qcom,msm-pcm-hostless";
+	};
+
+	dai_pri_auxpcm: qcom,msm-pri-auxpcm {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "primary";
+	};
+
+	dai_sec_auxpcm: qcom,msm-pri-auxpcm {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "secondary";
+	};
+
+	qcom,msm-audio-ion {
+		compatible = "qcom,msm-audio-ion";
+		qcom,smmu-enabled;
+		qcom,smmu-sid = <0x1>;
+	};
+
+	qcom,adsprpc-mem {
+		compatible = "qcom,msm-adsprpc-mem-region";
+		linux,contiguous-region = <&adsp_mem>;
+	};
+
+	qcom,msm-adsp-loader {
+		compatible = "qcom,adsp-loader";
+		qcom,adsp-state = <0>;
+	};
+
+	qcom,msmapr-audio {
+		compatible = "qcom,msmapr-audio";
+		qcom,apr-dest-type = "ADSP";
+	};
+
+	qcom,avtimer@c0a300c {
+		compatible = "qcom,avtimer";
+		reg = <0x0c0a300c 0x4>,
+			<0x0c0a3010 0x4>;
+		reg-names = "avtimer_lsb_addr", "avtimer_msb_addr";
+		qcom,clk_div = <27>;
+	};
+
+	mcd {
+		compatible = "qcom,mcd";
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+};
+
+#include "msm-pm8950-rpm-regulator.dtsi"
+#include "msm-pm8950.dtsi"
+#include "msm-pmi8950.dtsi"
+#include "msm-pm8004.dtsi"
+#include "msm8976-regulator.dtsi"
+#include "msm-gdsc-8916.dtsi"
+#include "msm8976-camera.dtsi"
+
+&gdsc_venus {
+	clock-names = "bus_clk", "core_clk";
+	clocks = <&clock_gcc clk_gcc_venus0_axi_clk>,
+		 <&clock_gcc clk_gcc_venus0_vcodec0_clk>;
+	status = "okay";
+};
+
+&gdsc_venus_core0 {
+	qcom,support-hw-trigger;
+	clock-names ="core0_clk";
+	clocks = <&clock_gcc clk_gcc_venus0_core0_vcodec0_clk>;
+	status = "okay";
+};
+
+&gdsc_venus_core1 {
+	qcom,support-hw-trigger;
+	clock-names ="core1_clk";
+	clocks = <&clock_gcc clk_gcc_venus0_core1_vcodec0_clk>;
+	status = "okay";
+};
+
+&gdsc_mdss {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_mdss_mdp_clk>,
+		 <&clock_gcc clk_gcc_mdss_axi_clk>;
+	status = "okay";
+};
+
+&gdsc_jpeg {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_camss_jpeg0_clk>,
+		 <&clock_gcc clk_gcc_camss_jpeg_axi_clk>;
+	status = "okay";
+};
+
+&gdsc_vfe {
+	clock-names = "core_clk", "bus_clk", "micro_clk",
+			"csi_clk";
+	clocks = <&clock_gcc clk_gcc_camss_vfe0_clk>,
+		 <&clock_gcc clk_gcc_camss_vfe_axi_clk>,
+		 <&clock_gcc clk_gcc_camss_micro_ahb_clk>,
+		 <&clock_gcc clk_gcc_camss_csi_vfe0_clk>;
+	status = "okay";
+};
+
+&gdsc_vfe1 {
+	clock-names = "core_clk", "bus_clk", "micro_clk",
+			"csi_clk";
+	clocks = <&clock_gcc clk_gcc_camss_vfe1_clk>,
+		 <&clock_gcc clk_gcc_camss_vfe1_axi_clk>,
+		 <&clock_gcc clk_gcc_camss_micro_ahb_clk>,
+		 <&clock_gcc clk_gcc_camss_csi_vfe1_clk>;
+	status = "okay";
+};
+
+&gdsc_cpp {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_camss_cpp_clk>,
+		 <&clock_gcc clk_gcc_camss_cpp_axi_clk>;
+	status = "okay";
+};
+
+&gdsc_oxili_gx {
+	clock-names = "core_root_clk", "gmem_clk";
+	clocks =<&clock_gcc_gfx clk_gfx3d_clk_src>,
+		<&clock_gcc_gfx clk_gcc_oxili_gmem_clk>;
+	qcom,enable-root-clk;
+	parent-supply = <&gfx_vreg_corner>;
+	status = "okay";
+};
+
+&gdsc_oxili_cx {
+	clock-names = "core_clk";
+	clocks = <&clock_gcc_gfx clk_gcc_oxili_gfx3d_clk>;
+	status = "okay";
+};
+
+&slim_msm {
+	msm_dai_slim {
+		compatible = "qcom,msm-dai-slim";
+		elemental-addr = [ff ff ff fe 17 02];
+	};
+
+	tasha_codec {
+		compatible = "qcom,tasha-slim-pgd";
+		elemental-addr = [00 01 A0 01 17 02];
+
+		interrupt-parent = <&wcd9xxx_intc>;
+		interrupts = <0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+			17 18 19 20 21 22 23 24 25 26 27 28 29
+			30>;
+
+		cdc-vdd-buck-supply = <&eldo2_8976>;
+		qcom,cdc-vdd-buck-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-buck-current = <650000>;
+
+		cdc-buck-sido-supply = <&eldo2_8976>;
+		qcom,cdc-buck-sido-voltage = <1800000 1800000>;
+		qcom,cdc-buck-sido-current = <250000>;
+		cdc-vdd-tx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-tx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-tx-h-current = <25000>;
+
+		cdc-vdd-rx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-rx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-rx-h-current = <25000>;
+
+		cdc-vdd-px-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-px-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-px-current = <10000>;
+
+		qcom,cdc-static-supplies =
+			"cdc-vdd-buck",
+			"cdc-buck-sido",
+			"cdc-vdd-tx-h",
+			"cdc-vdd-rx-h",
+			"cdc-vdd-px";
+
+		qcom,cdc-micbias1-mv = <1800>;
+		qcom,cdc-micbias2-mv = <1800>;
+		qcom,cdc-micbias3-mv = <1800>;
+		qcom,cdc-micbias4-mv = <1800>;
+
+		qcom,cdc-mclk-clk-rate = <9600000>;
+		qcom,cdc-slim-ifd = "tasha-slim-ifd";
+		qcom,cdc-slim-ifd-elemental-addr = [00 00 A0 01 17 02];
+		qcom,cdc-dmic-sample-rate = <4800000>;
+		qcom,cdc-mad-dmic-rate = <600000>;
+
+		qcom,wcd-rst-gpio-node = <&wcd_rst_gpio>;
+
+		clock-names = "wcd_clk";
+		clocks = <&clock_audio clk_audio_pmi_clk>;
+	};
+};
+
+&pm8950_gpios {
+	gpio@c000 {
+		status = "ok";
+		qcom,mode = <1>;
+		qcom,pull = <5>;
+		qcom,vin-sel = <0>;
+		qcom,src-sel = <2>;
+		qcom,master-en = <1>;
+		qcom,out-strength = <2>;
+	};
+	gpio@c600 {
+		status = "ok";
+		qcom,mode = <1>;
+		qcom,pull = <5>;
+		qcom,vin-sel = <0>;
+		qcom,src-sel = <0>;
+		qcom,master-en = <1>;
+	};
+};
+
+&pm8950_1 {
+	pm8950_cajon_dig: 8952_wcd_codec@f000 {
+		compatible = "qcom,msm8x16_wcd_codec";
+		reg = <0xf000 0x100>;
+		interrupt-parent = <&spmi_bus>;
+		interrupts = <0x1 0xf0 0x0>,
+			     <0x1 0xf0 0x1>,
+			     <0x1 0xf0 0x2>,
+			     <0x1 0xf0 0x3>,
+			     <0x1 0xf0 0x4>,
+			     <0x1 0xf0 0x5>,
+			     <0x1 0xf0 0x6>,
+			     <0x1 0xf0 0x7>;
+		interrupt-names = "spk_cnp_int",
+				  "spk_clip_int",
+				  "spk_ocp_int",
+				  "ins_rem_det1",
+				  "but_rel_det",
+				  "but_press_det",
+				  "ins_rem_det",
+				  "mbhc_int";
+
+		cdc-vdda-cp-supply = <&pm8950_s4>;
+		qcom,cdc-vdda-cp-voltage = <2050000 2050000>;
+		qcom,cdc-vdda-cp-current = <500000>;
+
+		cdc-vdda-rx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdda-rx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdda-rx-h-current = <5000>;
+
+		cdc-vdda-tx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdda-tx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdda-tx-h-current = <5000>;
+
+		cdc-vdd-px-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-px-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-px-current = <5000>;
+
+		cdc-vdd-pa-supply = <&pm8950_s4>;
+		qcom,cdc-vdd-pa-voltage = <2050000 2050000>;
+		qcom,cdc-vdd-pa-current = <260000>;
+
+		cdc-vdd-mic-bias-supply = <&pm8950_l13>;
+		qcom,cdc-vdd-mic-bias-voltage = <3075000 3075000>;
+		qcom,cdc-vdd-mic-bias-current = <5000>;
+
+		qcom,cdc-mclk-clk-rate = <9600000>;
+
+		qcom,cdc-static-supplies = "cdc-vdda-rx-h",
+					   "cdc-vdda-tx-h",
+					   "cdc-vdd-px",
+					   "cdc-vdd-pa",
+					   "cdc-vdda-cp";
+
+		qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
+		qcom,dig-cdc-base-addr = <0xc0f0000>;
+	};
+
+	pm8950_cajon_analog: 8952_wcd_codec@f100 {
+		compatible = "qcom,msm8x16_wcd_codec";
+		reg = <0xf100 0x100>;
+		interrupt-parent = <&spmi_bus>;
+		interrupts = <0x1 0xf1 0x0>,
+			     <0x1 0xf1 0x1>,
+			     <0x1 0xf1 0x2>,
+			     <0x1 0xf1 0x3>,
+			     <0x1 0xf1 0x4>,
+			     <0x1 0xf1 0x5>;
+		interrupt-names = "ear_ocp_int",
+				  "hphr_ocp_int",
+				  "hphl_ocp_det",
+				  "ear_cnp_int",
+				  "hphr_cnp_int",
+				  "hphl_cnp_int";
+		qcom,dig-cdc-base-addr = <0xc0f0000>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1252,6 +1252,81 @@
 				"xo";
 		qcom,bus-clk-rate = <320000000 200000000 100000000>;
 		qcom,max-nominal-sysclk-rate = <133330000>;
+
+		qcom,usbbam@78c4000 {
+			compatible = "qcom,usb-bam-msm";
+			reg = <0x78c4000 0x17000>;
+			reg-names = "hsusb";
+			interrupts = <0 135 0>;
+			interrupt-names = "hsusb";
+			qcom,usb-bam-num-pipes = <16>;
+			qcom,usb-bam-fifo-baseaddr = <0x08606000>;
+			qcom,ignore-core-reset-ack;
+			qcom,disable-clk-gating;
+			qcom,usb-bam-max-mbps-highspeed = <400>;
+			qcom,enable-hsusb-bam-on-boot;
+
+			qcom,pipe0 {
+				label = "hsusb-ipa-out-0";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <0>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <2>;
+				qcom,src-bam-physical-address = <0x78c4000>;
+				qcom,src-bam-pipe-index = <1>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			qcom,pipe1 {
+				label = "hsusb-ipa-in-0";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <2>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <0>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			qcom,pipe2 {
+				label = "hsusb-qdss-in-0";
+				qcom,usb-bam-mem-type = <3>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <1>;
+				qcom,src-bam-physical-address = <0x6084000>;
+				qcom,src-bam-pipe-index = <0>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <2>;
+				qcom,data-fifo-offset = <0x0>;
+				qcom,data-fifo-size = <0xe00>;
+				qcom,descriptor-fifo-offset = <0xe00>;
+				qcom,descriptor-fifo-size = <0x200>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			/* USB BAM pipe (consumer) configuration for accelerated DPL */
+			qcom,pipe3 {
+				label = "hsusb-dpl-ipa-in-1";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <1>;
+				qcom,peer-bam = <2>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <3>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+		};
 	};
 
 	android_usb: android_usb@086000c8 {
@@ -1270,81 +1345,6 @@
 		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
 		qcom,apps-ch-pipes = <0x600000>;
 		qcom,ea-pc = <0x170>;
-	};
-
-	qcom,usbbam@78c4000 {
-		compatible = "qcom,usb-bam-msm";
-		reg = <0x78c4000 0x17000>;
-		reg-names = "hsusb";
-		interrupts = <0 135 0>;
-		interrupt-names = "hsusb";
-		qcom,usb-bam-num-pipes = <16>;
-		qcom,usb-bam-fifo-baseaddr = <0x08606000>;
-		qcom,ignore-core-reset-ack;
-		qcom,disable-clk-gating;
-		qcom,usb-bam-max-mbps-highspeed = <400>;
-		qcom,enable-hsusb-bam-on-boot;
-
-		qcom,pipe0 {
-			label = "hsusb-ipa-out-0";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <0>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <2>;
-			qcom,src-bam-physical-address = <0x78c4000>;
-			qcom,src-bam-pipe-index = <1>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		qcom,pipe1 {
-			label = "hsusb-ipa-in-0";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <2>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <0>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		qcom,pipe2 {
-			label = "hsusb-qdss-in-0";
-			qcom,usb-bam-mem-type = <3>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <1>;
-			qcom,src-bam-physical-address = <0x6084000>;
-			qcom,src-bam-pipe-index = <0>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <2>;
-			qcom,data-fifo-offset = <0x0>;
-			qcom,data-fifo-size = <0xe00>;
-			qcom,descriptor-fifo-offset = <0xe00>;
-			qcom,descriptor-fifo-size = <0x200>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		/* USB BAM pipe (consumer) configuration for accelerated DPL */
-		qcom,pipe3 {
-			label = "hsusb-dpl-ipa-in-1";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <1>;
-			qcom,peer-bam = <2>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <3>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
 	};
 
         ipa_hw: qcom,ipa@07900000 {

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -58,64 +58,65 @@
 		#size-cells = <2>;
 
 		other_ext_mem: other_ext_region@0 {
-			linux,reserve-contiguous-region;
-			linux,reserve-region;
-			linux,remove-completely;
+			compatible = "removed-dma-pool";
+			no-map;
 			reg = <0x0 0x85e00000 0x0 0x0a00000>;
 			label = "other_ext_mem";
 		};
 
 		modem_mem: modem_region@0 {
-			linux,reserve-contiguous-region;
-			linux,reserve-region;
-			linux,remove-completely;
+			compatible = "removed-dma-pool";
+			no-map;
 			reg = <0x0 0x86c00000 0x0 0x05600000>;
 			label = "modem_mem";
 		};
 
 		reloc_mem: reloc_region@0 {
-			linux,reserve-contiguous-region;
-			linux,reserve-region;
-			linux,remove-completely;
+			compatible = "removed-dma-pool";
+			no-map;
 			reg = <0x0 0x8c200000 0x0 0x1700000>;
 			label = "reloc_mem";
 		};
 
 		venus_mem: venus_region@0 {
-			linux,reserve-contiguous-region;
-			linux,memory-limit = <0x90000000>;
-			reg = <0x0 0x0 0x0 0x0500000>;
-			label = "venus_mem";
+			compatible = "shared-dma-pool";
+			reusable;
+		//	linux,memory-limit = <0x90000000>;
+		//	reg = <0x0 0x0 0x0 0x0500000>;
+			alloc-ranges = <0x0 0x80000000 0x0 0x10000000>;
+			alignment = <0 0x400000>;
+			size = <0 0x0800000>;
 		};
 
 		secure_mem: secure_region@0 {
-			linux,reserve-contiguous-region;
-			reg = <0x0 0x0 0x0 0x7A00000>;
-			label = "secure_mem";
+			compatible = "shared-dma-pool";
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x7000000>;
 		};
 
 		qseecom_mem: qseecom_region@0 {
-			linux,reserve-contiguous-region;
-			reg = <0x0 0x0 0x0 0x1000000>;
-			label = "qseecom_mem";
+			compatible = "shared-dma-pool";
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
 		};
 
 		audio_mem: audio_region@0 {
-			linux,reserve-contiguous-region;
+			compatible = "shared-dma-pool";
+			reusable;
 			reg = <0x0 0x0 0x0 0x314000>;
 		};
 
 		cont_splash_mem: splash_region@83000000 {
-			linux,reserve-contiguous-region;
-			linux,reserve-region;
 			reg = <0x0 0x83000000 0x0 0x2800000>;
-			label = "cont_splash_mem";
 		};
 
 		adsp_mem: adsp_region@0 {
-			linux,reserve-contiguous-region;
-			reg = <0x0 0x0 0x0 0x400000>;
-			label = "adsp_mem";
+			compatible = "shared-dma-pool";
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x400000>;
 		};
 	};
 };
@@ -2003,7 +2004,7 @@
 		qcom,pas-id = <9>;
 		qcom,proxy-timeout-ms = <100>;
 		qcom,firmware-name = "venus";
-		linux,contiguous-region = <&venus_mem>;
+		memory-region = <&venus_mem>;
 	};
 
 	qcom,lpass@c200000 {
@@ -2042,7 +2043,7 @@
 		/* GPIO output to lpass */
 		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_2_out 0 0>;
 
-		linux,contiguous-region = <&reloc_mem>;
+		memory-region = <&reloc_mem>;
 	};
 
         spmi_bus: qcom,spmi@200f000 {
@@ -2127,7 +2128,7 @@
 
                 /* GPIO output to wcnss */
 		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_4_out 0 0>;
-		linux,contiguous-region = <&reloc_mem>;
+		memory-region = <&reloc_mem>;
 	};
 
 	dcc: dcc@b3000 {
@@ -2187,7 +2188,7 @@
 
 		/* GPIO output to mss */
 		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_1_out 0 0>;
-		linux,contiguous-region = <&modem_mem>;
+		memory-region = <&modem_mem>;
 	};
 
 	cpu-pmu {
@@ -2620,7 +2621,7 @@
 
 	qcom,adsprpc-mem {
 		compatible = "qcom,msm-adsprpc-mem-region";
-		linux,contiguous-region = <&adsp_mem>;
+		memory-region = <&adsp_mem>;
 	};
 
 	qcom,msm-adsp-loader {

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1050,6 +1050,13 @@
 		clock-names = "core_clk", "iface_clk";
 		clocks = <&clock_gcc clk_gcc_blsp1_uart2_apps_clk>,
 		       <&clock_gcc clk_gcc_blsp1_ahb_clk>;
+
+		qcom,msm-bus,name = "buart2";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			    <86 512 0 0>,
+			    <86 512 500 800>;
 	};
 
 	blsp1_uart0: uart@78af000 {

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -67,7 +67,7 @@
 
 		modem_mem: modem_region@86c00000 {
 			compatible = "removed-dma-pool";
-			no-map;
+			no-map-fixup;
 			reg = <0x0 0x86c00000 0x0 0x05600000>;
 			label = "modem_mem";
 		};
@@ -82,18 +82,16 @@
 		venus_mem: venus_region {
 			compatible = "shared-dma-pool";
 			reusable;
-		//	linux,memory-limit = <0x90000000>;
-		//	reg = <0x0 0x0 0x0 0x0500000>;
 			alloc-ranges = <0x0 0x80000000 0x0 0x10000000>;
 			alignment = <0 0x400000>;
-			size = <0 0x0800000>;
+			size = <0 0x800000>;
 		};
 
 		secure_mem: secure_region {
 			compatible = "shared-dma-pool";
 			reusable;
 			alignment = <0 0x400000>;
-			size = <0 0x7000000>;
+			size = <0 0x7C00000>;
 		};
 
 		qseecom_mem: qseecom_region {
@@ -106,7 +104,9 @@
 		audio_mem: audio_region {
 			compatible = "shared-dma-pool";
 			reusable;
-			reg = <0x0 0x0 0x0 0x314000>;
+			//reg = <0x0 0x0 0x0 0x314000>;
+			alignment = <0 0x400000>;
+			size = <0 0x400000>;
 		};
 
 		cont_splash_mem: splash_region@83000000 {
@@ -116,7 +116,6 @@
 		adsp_mem: adsp_region {
 			compatible = "shared-dma-pool";
 			reusable;
-			alignment = <0 0x400000>;
 			size = <0 0x400000>;
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -58,28 +58,28 @@
 		#size-cells = <2>;
 		ranges;
 
-		other_ext_mem: other_ext_region@0 {
+		other_ext_mem: other_ext_region {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x85e00000 0x0 0x0a00000>;
 			label = "other_ext_mem";
 		};
 
-		modem_mem: modem_region@0 {
+		modem_mem: modem_region {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x86c00000 0x0 0x05600000>;
 			label = "modem_mem";
 		};
 
-		reloc_mem: reloc_region@0 {
+		reloc_mem: reloc_region {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x8c200000 0x0 0x1700000>;
 			label = "reloc_mem";
 		};
 
-		venus_mem: venus_region@0 {
+		venus_mem: venus_region {
 			compatible = "shared-dma-pool";
 			reusable;
 		//	linux,memory-limit = <0x90000000>;
@@ -89,21 +89,21 @@
 			size = <0 0x0800000>;
 		};
 
-		secure_mem: secure_region@0 {
+		secure_mem: secure_region {
 			compatible = "shared-dma-pool";
 			reusable;
 			alignment = <0 0x400000>;
 			size = <0 0x7000000>;
 		};
 
-		qseecom_mem: qseecom_region@0 {
+		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			reusable;
 			alignment = <0 0x400000>;
 			size = <0 0x1000000>;
 		};
 
-		audio_mem: audio_region@0 {
+		audio_mem: audio_region {
 			compatible = "shared-dma-pool";
 			reusable;
 			reg = <0x0 0x0 0x0 0x314000>;
@@ -113,7 +113,7 @@
 			reg = <0x0 0x83000000 0x0 0x2800000>;
 		};
 
-		adsp_mem: adsp_region@0 {
+		adsp_mem: adsp_region {
 			compatible = "shared-dma-pool";
 			reusable;
 			alignment = <0 0x400000>;

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1205,6 +1205,9 @@
 		compatible = "qcom,hsusb-otg";
 		reg = <0x78db000 0x400>, <0x6c000 0x200>;
 		reg-names = "core", "phy_csr";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
 		interrupts = <0 134 0>, <0 140 0>;
 		interrupt-names = "core_irq", "async_irq";
@@ -1257,6 +1260,7 @@
 			compatible = "qcom,usb-bam-msm";
 			reg = <0x78c4000 0x17000>;
 			reg-names = "hsusb";
+			interrupt-parent = <&intc>;
 			interrupts = <0 135 0>;
 			interrupt-names = "hsusb";
 			qcom,usb-bam-num-pipes = <16>;

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -58,21 +58,21 @@
 		#size-cells = <2>;
 		ranges;
 
-		other_ext_mem: other_ext_region {
+		other_ext_mem: other_ext_region@85e00000 {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x85e00000 0x0 0x0a00000>;
 			label = "other_ext_mem";
 		};
 
-		modem_mem: modem_region {
+		modem_mem: modem_region@86c00000 {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x86c00000 0x0 0x05600000>;
 			label = "modem_mem";
 		};
 
-		reloc_mem: reloc_region {
+		reloc_mem: reloc_region@8c200000 {
 			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0x0 0x8c200000 0x0 0x1700000>;

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -53,9 +53,10 @@
 		spi0 = &spi_0;
 	};
 
-	memory {
+	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
+		ranges;
 
 		other_ext_mem: other_ext_region@0 {
 			compatible = "removed-dma-pool";

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1827,30 +1827,16 @@
 
 		clock-names = "core_clk", "core0_clk", "iface_clk", "bus_clk";
 		qcom,clock-configs = <0x1 0x0 0x0 0x0>;
+		qcom,allowed-clock-rates = <466000000 400000000 360000000
+					    228570000 133330000 100000000
+					    80000000 72727200>;
 		qcom,sw-power-collapse;
 		qcom,reset-clock-control;
 		qcom,regulator-scaling;
 		qcom,max-hw-load = <1011840>; /* 3840 x 2176 @ 30 fps + 3840 x 2176 @ 1 fps */
 		qcom,dcvs-min-load = <734400>; /* 1920 x 1088 @ 90fps */
 		qcom,dcvs-min-mbperframe = <32400>; /* 3840 x 2160 */
-
-		qcom,load-freq-tbl =
-			<979200 466000000 0x55555555>, /* TURBO, UHD30E   */
-			<979200 400000000 0xffffffff>, /* NOM+ , UHD30D   */
-			<734400 360000000 0xffffffff>, /* NOM  , 1080p90D */
-			<734400 400000000 0x55555555>, /* NOM+ , 1080p90E */
-			<489600 228570000 0xffffffff>, /* SVS  , 1080p60D */
-			<489600 466000000 0x55555555>, /* TURBO, 1080p60E */
-			<432000 228570000 0xffffffff>, /* SVS  , 720p120D */
-			<432000 400000000 0x55555555>, /* NOM+ , 720p120E */
-			<244800 133333333 0xffffffff>, /* SVS- , 1080p30D */
-			<244800 228570000 0x55555555>, /* SVS  , 1080p30E */
-			<216000 100000000 0xffffffff>, /* SVS- , 720p60D  */
-			<216000 228570000 0x55555555>, /* SVS  , 720p60E  */
-			<108000 80000000 0xffffffff>,  /* SVS--, 720p30D  */
-			<108000 100000000 0x55555555>, /* SVS- , 720p30E  */
-			<36000 72727200 0xffffffff>,   /* SVS--, 480p30D  */
-			<36000 80000000 0x55555555>;   /* SVS--, 480p30E  */
+		//qcom,max-hw-load = <979200>; /* TURBO, UHD30E */
 
 		qcom,qdss-presets =
 			<0x6025000 0x1000>,
@@ -1885,7 +1871,7 @@
 			<310667000 RPM_SMD_REGULATOR_LEVEL_NOM>,
 			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
 			<400000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
-/*
+
 		qcom,clock-freq-tbl {
 			qcom,profile-dec {
 				qcom,codec-mask = <0xffffffff>;
@@ -1898,7 +1884,7 @@
 				qcom,low-power-mode-factor = <65536>;
 			};
 		};
-*/
+
 		qcom,vidc-iommu-domains {
 			qcom,domain-ns {
 				qcom,vidc-domain-phandle = <&venus_domain_ns>;
@@ -1921,7 +1907,7 @@
 				qcom,vidc-buffer-types = <0x480>;
 			};
 		};
-
+#if 0
 		qcom,msm-bus-clients {
 			qcom,msm-bus-client@0 {
 				qcom,msm-bus,name = "venc-ddr";
@@ -1988,6 +1974,24 @@
 				qcom,bus-configs = <0x00000000>;
 				qcom,bus-passive;
 			};
+		};
+#endif
+		venus_bus_ddr {
+			compatible = "qcom,msm-vidc,bus";
+			label = "venus-ddr";
+			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
+			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
+			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,bus-range-kbps = <1000 1205248>;
+		};
+
+		arm9_bus_ddr {
+			compatible = "qcom,msm-vidc,bus";
+			label = "venus-arm9-ddr";
+			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
+			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
+			qcom,bus-governor = "performance";
+			qcom,bus-range-kbps = <1 1>;
 		};
 	};
 

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1817,6 +1817,7 @@
 		venus-core0-supply = <&gdsc_venus_core0>;
 		qcom,hfi = "venus";
 		qcom,firmware-name = "venus-v1";
+		//qcom,platform-version = <0x600000000 0x1D>;
 
 		clocks =
 			<&clock_gcc clk_gcc_venus0_vcodec0_clk>,
@@ -1884,27 +1885,40 @@
 			<310667000 RPM_SMD_REGULATOR_LEVEL_NOM>,
 			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
 			<400000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
-
+/*
+		qcom,clock-freq-tbl {
+			qcom,profile-dec {
+				qcom,codec-mask = <0xffffffff>;
+				qcom,cycles-per-mb = <392>;
+				qcom,low-power-mode-factor = <65536>;
+			};
+			qcom,profile-enc {
+				qcom,codec-mask = <0x55555555>;
+				qcom,cycles-per-mb = <656>;
+				qcom,low-power-mode-factor = <65536>;
+			};
+		};
+*/
 		qcom,vidc-iommu-domains {
 			qcom,domain-ns {
 				qcom,vidc-domain-phandle = <&venus_domain_ns>;
-				qcom,vidc-partition-buffer-types = <0x7ff>,
+				qcom,vidc-buffer-types = <0x7ff>,
 							<0x800>;
 			};
 
 			qcom,domain-sec-bs {
 				qcom,vidc-domain-phandle = <&venus_domain_sec_bitstream>;
-				qcom,vidc-partition-buffer-types = <0x241>;
+				qcom,vidc-buffer-types = <0x241>;
 			};
 
 			qcom,domain-sec-px {
 				qcom,vidc-domain-phandle = <&venus_domain_sec_pixel>;
-				qcom,vidc-partition-buffer-types = <0x106>;
+				qcom,vidc-buffer-types = <0x106>;
 			};
 
 			qcom,domain-sec-np {
 				qcom,vidc-domain-phandle = <&venus_domain_sec_non_pixel>;
-				qcom,vidc-partition-buffer-types = <0x480>;
+				qcom,vidc-buffer-types = <0x480>;
 			};
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8976-bus.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-bus.dtsi
@@ -1,0 +1,1162 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <dt-bindings/msm/msm-bus-ids.h>
+
+&soc {
+	/* Version = 3 */
+	ad_hoc_bus: ad-hoc-bus {
+		compatible = "qcom,msm-bus-device";
+		reg = <0x580000 0x1A000>,
+			<0x580000 0x1A000>,
+			<0x400000 0x62000>,
+			<0x500000 0x14000>;
+		reg-names = "snoc-base", "snoc-mm-base", "bimc-base", "pcnoc-base";
+
+		/*Buses*/
+		fab_bimc: fab-bimc {
+			cell-id = <MSM_BUS_FAB_BIMC>;
+			label = "fab-bimc";
+			qcom,fab-dev;
+			qcom,base-name = "bimc-base";
+			qcom,bus-type = <2>;
+			qcom,util-fact = <154>;
+			clock-names = "bus_clk", "bus_a_clk";
+			clocks = <&clock_gcc  clk_bimc_msmbus_clk>,
+				<&clock_gcc  clk_bimc_msmbus_a_clk>;
+
+			coresight-id = <203>;
+			coresight-name = "coresight-bimc";
+			coresight-nr-inports = <0>;
+			coresight-outports = <0>;
+			coresight-child-list = <&funnel_in2>;
+			coresight-child-ports = <3>;
+		};
+
+		fab_pcnoc: fab-pcnoc {
+			cell-id = <MSM_BUS_FAB_PERIPH_NOC>;
+			label = "fab-pcnoc";
+			qcom,fab-dev;
+			qcom,base-name = "pcnoc-base";
+			qcom,base-offset = <0x7000>;
+			qcom,qos-delta = <0x1000>;
+			qcom,bus-type = <1>;
+			clock-names = "bus_clk", "bus_a_clk";
+			clocks = <&clock_gcc  clk_pcnoc_msmbus_clk>,
+				<&clock_gcc  clk_pcnoc_msmbus_a_clk>;
+
+			coresight-id = <201>;
+			coresight-name = "coresight-pcnoc";
+			coresight-nr-inports = <0>;
+			coresight-outports = <0>;
+			coresight-child-list = <&funnel_in2>;
+			coresight-child-ports = <6>;
+		};
+
+		fab_snoc: fab-snoc {
+			cell-id = <MSM_BUS_FAB_SYS_NOC>;
+			label = "fab-snoc";
+			qcom,fab-dev;
+			qcom,base-name = "snoc-base";
+			qcom,base-offset = <0x7000>;
+			qcom,qos-off = <0x1000>;
+			qcom,bus-type = <1>;
+			clock-names = "bus_clk", "bus_a_clk";
+			clocks = <&clock_gcc  clk_snoc_msmbus_clk>,
+				<&clock_gcc  clk_snoc_msmbus_a_clk>;
+
+			coresight-id = <200>;
+			coresight-name = "coresight-snoc";
+			coresight-nr-inports = <0>;
+			coresight-outports = <0>;
+			coresight-child-list = <&funnel_in2>;
+			coresight-child-ports = <5>;
+		};
+
+		fab_snoc_mm: fab-snoc-mm {
+			cell-id = <MSM_BUS_FAB_MMSS_NOC>;
+			label = "fab-snoc-mm";
+			qcom,fab-dev;
+			qcom,base-name = "snoc-mm-base";
+			qcom,base-offset = <0x7000>;
+			qcom,qos-off = <0x1000>;
+			qcom,bus-type = <1>;
+			qcom,util-fact = <154>;
+			clock-names = "bus_clk", "bus_a_clk";
+			clocks = <&clock_gcc  clk_sysmmnoc_msmbus_clk>,
+				<&clock_gcc  clk_sysmmnoc_msmbus_a_clk>;
+		};
+
+		/*BIMC Masters*/
+		mas_apps_proc: mas-apps-proc {
+			cell-id = <MSM_BUS_MASTER_AMPSS_M0>;
+			label = "mas-apps-proc";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <0>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_ebi &slv_bimc_snoc>;
+			qcom,prio-lvl = <0>;
+			qcom,prio-rd = <0>;
+			qcom,prio-wr = <0>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_APPSS_PROC>;
+		};
+
+		mas_smmnoc_bimc: mas-smmnoc-bimc {
+			cell-id = <MSM_BUS_MNOC_BIMC_MAS>;
+			label = "mas-smmnoc-bimc";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <2>;
+			qcom,ap-owned;
+			qcom,qport = <2>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&slv_ebi>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SMMNOC_BIMC>;
+		};
+
+		mas_snoc_bimc: mas-snoc-bimc {
+			cell-id = <MSM_BUS_SNOC_BIMC_MAS>;
+			label = "mas-snoc-bimc";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <2>;
+			qcom,ap-owned;
+			qcom,qport = <3>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&slv_ebi>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_BIMC>;
+		};
+
+		mas_tcu_0: mas-tcu-0 {
+			cell-id = <MSM_BUS_MASTER_TCU_0>;
+			label = "mas-tcu-0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <4>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_ebi &slv_bimc_snoc>;
+			qcom,prio-lvl = <2>;
+			qcom,prio-rd = <2>;
+			qcom,prio-wr = <2>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_TCU_0>;
+		};
+
+		/*PCNOC Masters*/
+		mas_usb_hs2: mas-usb-hs2 {
+			cell-id = <MSM_BUS_MASTER_USB_HS2>;
+			label = "mas-usb-hs2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_USB_HS2>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_blsp_1: mas-blsp-1 {
+			cell-id = <MSM_BUS_MASTER_BLSP_1>;
+			label = "mas-blsp-1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_BLSP_1>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_usb_hs1: mas-usb-hs1 {
+			cell-id = <MSM_BUS_MASTER_USB_HS>;
+			label = "mas-usb-hs1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_USB_HS1>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_blsp_2: mas-blsp-2 {
+			cell-id = <MSM_BUS_MASTER_BLSP_2>;
+			label = "mas-blsp-2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_BLSP_2>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_crypto: mas-crypto {
+			cell-id = <MSM_BUS_MASTER_CRYPTO_CORE0>;
+			label = "mas-crypto";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <0>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_1>;
+			qcom,prio1 = <0>;
+			qcom,prio0 = <0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_CRYPTO>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_sdcc_1: mas-sdcc-1 {
+			cell-id = <MSM_BUS_MASTER_SDCC_1>;
+			label = "mas-sdcc-1";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <7>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SDCC_1>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_sdcc_2: mas-sdcc-2 {
+			cell-id = <MSM_BUS_MASTER_SDCC_2>;
+			label = "mas-sdcc-2";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <8>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SDCC_2>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_sdcc_3: mas-sdcc-3 {
+			cell-id = <MSM_BUS_MASTER_SDCC_3>;
+			label = "mas-sdcc-3";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <10>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SDCC_3>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_snoc_pcnoc: mas-snoc-pcnoc {
+			cell-id = <MSM_BUS_SNOC_PNOC_MAS>;
+			label = "mas-snoc-pcnoc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <9>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&pcnoc_int_2>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_PCNOC>;
+		};
+
+		mas_lpass_ahb: mas-lpass-ahb {
+			cell-id = <MSM_BUS_MASTER_LPASS_AHB>;
+			label = "mas-lpass-ahb";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <12>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_LPASS_AHB>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_spdm: mas-spdm {
+			cell-id = <MSM_BUS_MASTER_SPDM>;
+			label = "mas-spdm";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SPDM>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_dehr: mas-dehr {
+			cell-id = <MSM_BUS_MASTER_DEHR>;
+			label = "mas-dehr";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_m_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_DEHR>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		mas_xm_usb_hs1: mas-xm-usb-hs1 {
+			cell-id = <MSM_BUS_MASTER_XM_USB_HS1>;
+			label = "mas-xm-usb-hs1";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_int_0>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_XM_USB_HS1>;
+			qcom,blacklist = <&slv_blsp_2 &slv_crypto_0_cfg &slv_sdcc_2
+				 &slv_message_ram &slv_venus_cfg &slv_camera_ss_cfg
+				 &slv_usb_hs2 &slv_pdm &slv_disp_ss_cfg
+				 &slv_sdcc_3 &slv_usb_hs &slv_snoc_cfg
+				 &slv_blsp_1 &slv_tlmm &slv_pmic_arb
+				 &slv_sdcc_1 &slv_tcsr &slv_gpu_cfg
+				 &slv_dcc_cfg &slv_prng>;
+		};
+
+		/*SNOC Masters*/
+		mas_qdss_bam: mas-qdss-bam {
+			cell-id = <MSM_BUS_MASTER_QDSS_BAM>;
+			label = "mas-qdss-bam";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <11>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&qdss_int>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_BAM>;
+			qcom,blacklist = <&slv_cats_0 &slv_lpass &slv_kpss_ahb
+				 &slv_qdss_stm &slv_cats_1>;
+		};
+
+		mas_bimc_snoc: mas-bimc-snoc {
+			cell-id = <MSM_BUS_BIMC_SNOC_MAS>;
+			label = "mas-bimc-snoc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&snoc_int_2>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_BIMC_SNOC>;
+			qcom,blacklist = <&slv_snoc_bimc>;
+		};
+
+		mas_jpeg: mas-jpeg {
+			cell-id = <MSM_BUS_MASTER_JPEG>;
+			label = "mas-jpeg";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <6>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_JPEG>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_oxili: mas-oxili {
+			cell-id = <MSM_BUS_MASTER_GRAPHICS_3D>;
+			label = "mas-oxili";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <2>;
+			qcom,ap-owned;
+			qcom,qport = <16 17>;
+			qcom,qos-mode = "bypass";
+			qcom,vrail-comp = <200>;
+			qcom,connections = <&slv_smmnoc_bimc &mm_int_0>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_GFX3D>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_mdp0: mas-mdp0 {
+			cell-id = <MSM_BUS_MASTER_MDP_PORT0>;
+			label = "mas-mdp0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <7>;
+			qcom,qos-mode = "bypass";
+			qcom,vrail-comp = <50>;
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_MDP0>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_mdp1: mas-mdp1 {
+			cell-id = <MSM_BUS_MASTER_MDP_PORT1>;
+			label = "mas-mdp1";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <13>;
+			qcom,qos-mode = "bypass";
+			qcom,vrail-comp = <50>;
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_MDP1>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_pcnoc_snoc: mas-pcnoc-snoc {
+			cell-id = <MSM_BUS_PNOC_SNOC_MAS>;
+			label = "mas-pcnoc-snoc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <5>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_2>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PNOC_SNOC>;
+			qcom,blacklist = <&slv_cats_0 &slv_cats_1>;
+		};
+
+		mas_venus_0: mas-venus-0 {
+			cell-id = <MSM_BUS_MASTER_VIDEO_P0>;
+			label = "mas-venus-0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <8>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_VIDEO_P0>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_venus_1: mas-venus-1 {
+			cell-id = <MSM_BUS_MASTER_VIDEO_P1>;
+			label = "mas-venus-1";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <14>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_VIDEO_P1>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_vfe_0: mas-vfe-0 {
+			cell-id = <MSM_BUS_MASTER_VFE0>;
+			label = "mas-vfe-0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <9>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_VFE0>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_vfe_1: mas-vfe-1 {
+			cell-id = <MSM_BUS_MASTER_VFE1>;
+			label = "mas-vfe-1";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <15>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_VFE1>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_cpp: mas-cpp {
+			cell-id = <MSM_BUS_MASTER_CPP>;
+			label = "mas-cpp";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <12>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&mm_int_0 &slv_smmnoc_bimc>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_CPP>;
+			qcom,blacklist = <&slv_lpass &slv_cats_1 &slv_cats_0
+				 &slv_kpss_ahb &slv_imem &slv_qdss_stm>;
+		};
+
+		mas_qdss_etr: mas-qdss-etr {
+			cell-id = <MSM_BUS_MASTER_QDSS_ETR>;
+			label = "mas-qdss-etr";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <10>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&qdss_int>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_ETR>;
+			qcom,blacklist = <&slv_cats_0 &slv_cats_1 &slv_lpass
+				 &slv_kpss_ahb &slv_imem>;
+		};
+
+		mas_lpass_proc: mas-lpass-proc {
+			cell-id = <MSM_BUS_MASTER_LPASS_PROC>;
+			label = "mas-lpass-proc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <19>;
+			qcom,qos-mode = "bypass";
+			qcom,connections = <&snoc_int_0 &snoc_int_1 &slv_snoc_bimc>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_LPASS_PROC>;
+			qcom,blacklist = <&slv_cats_0 &slv_lpass &slv_kpss_ahb
+				 &slv_cats_1>;
+		};
+
+		mas_ipa: mas-ipa {
+			cell-id = <MSM_BUS_MASTER_IPA>;
+			label = "mas-ipa";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,qport = <18>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&snoc_int_2>;
+			qcom,prio1 = <1>;
+			qcom,prio0 = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_IPA>;
+			qcom,blacklist = <&slv_cats_0 &slv_lpass &slv_kpss_ahb
+				 &slv_cats_1>;
+		};
+
+		/* PCNOC Internal nodes*/
+		pcnoc_m_0: pcnoc-m-0 {
+			cell-id = <MSM_BUS_PNOC_M_0>;
+			label = "pcnoc-m-0";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <5>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_M_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_M_0>;
+		};
+
+		pcnoc_m_1: pcnoc-m-1 {
+			cell-id = <MSM_BUS_PNOC_M_1>;
+			label = "pcnoc-m-1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,qport = <6>;
+			qcom,qos-mode = "fixed";
+			qcom,connections = <&slv_pcnoc_snoc>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_M_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_M_1>;
+		};
+
+		pcnoc_int_0: pcnoc-int-0 {
+			cell-id = <MSM_BUS_PNOC_INT_0>;
+			label = "pcnoc-int-0";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_pcnoc_snoc &pcnoc_int_2>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_INT_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_INT_0>;
+		};
+
+		pcnoc_int_1: pcnoc-int-1 {
+			cell-id = <MSM_BUS_PNOC_INT_1>;
+			label = "pcnoc-int-1";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_pcnoc_snoc &pcnoc_int_2>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_INT_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_INT_1>;
+		};
+
+		pcnoc_int_2: pcnoc-int-2 {
+			cell-id = <MSM_BUS_PNOC_INT_2>;
+			label = "pcnoc-int-2";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&pcnoc_s_1 &pcnoc_s_2
+				 &pcnoc_s_4 &pcnoc_s_8
+				 &pcnoc_s_9 &pcnoc_s_3>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_INT_2>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_INT_2>;
+		};
+
+		pcnoc_s_1: pcnoc-s-1 {
+			cell-id = <MSM_BUS_PNOC_SLV_1>;
+			label = "pcnoc-s-1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_crypto_0_cfg &slv_prng &slv_pdm
+				 &slv_message_ram>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_1>;
+		};
+
+		pcnoc_s_2: pcnoc-s-2 {
+			cell-id = <MSM_BUS_PNOC_SLV_2>;
+			label = "pcnoc-s-2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_pmic_arb>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_2>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_2>;
+		};
+
+		pcnoc_s_3: pcnoc-s-3 {
+			cell-id = <MSM_BUS_PNOC_SLV_3>;
+			label = "pcnoc-s-3";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_snoc_cfg &slv_dcc_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_3>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_3>;
+		};
+
+		pcnoc_s_4: pcnoc-s-4 {
+			cell-id = <MSM_BUS_PNOC_SLV_4>;
+			label = "pcnoc-s-4";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_camera_ss_cfg &slv_disp_ss_cfg &slv_venus_cfg>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_4>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_4>;
+		};
+
+		pcnoc_s_8: pcnoc-s-8 {
+			cell-id = <MSM_BUS_PNOC_SLV_8>;
+			label = "pcnoc-s-8";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_usb_hs &slv_sdcc_3 &slv_blsp_1
+				&slv_sdcc_1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_8>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_8>;
+		};
+
+		pcnoc_s_9: pcnoc-s-9 {
+			cell-id = <MSM_BUS_PNOC_SLV_9>;
+			label = "pcnoc-s-9";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_gpu_cfg &slv_usb_hs2 &slv_sdcc_2
+				 &slv_blsp_2>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_PCNOC_S_9>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_S_9>;
+		};
+
+		/* SNOC Internal nodes*/
+		mm_int_0: mm-int-0 {
+			cell-id = <MSM_BUS_SNOC_MM_INT_0>;
+			label = "mm-int-0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,vrail-comp = <200>;
+			qcom,connections = <&snoc_int_0>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,mas-rpm-id = <ICBID_MASTER_MM_INT_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_MM_INT_0>;
+		};
+
+		qdss_int: qdss-int {
+			cell-id = <MSM_BUS_SNOC_QDSS_INT>;
+			label = "qdss-int";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,connections = <&snoc_int_2>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_QDSS_INT>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QDSS_INT>;
+		};
+
+		snoc_int_0: snoc-int-0 {
+			cell-id = <MSM_BUS_SNOC_INT_0>;
+			label = "snoc-int-0";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&slv_qdss_stm &slv_imem &slv_snoc_pcnoc>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_INT_0>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_INT_0>;
+		};
+
+		snoc_int_1: snoc-int-1 {
+			cell-id = <MSM_BUS_SNOC_INT_1>;
+			label = "snoc-int-1";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,connections = <&slv_lpass &slv_cats_0 &slv_cats_1
+				&slv_kpss_ahb>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_INT_1>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_INT_1>;
+		};
+
+		snoc_int_2: snoc-int-2 {
+			cell-id = <MSM_BUS_SNOC_INT_2>;
+			label = "snoc-int-2";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,connections = <&snoc_int_0 &snoc_int_1 &slv_snoc_bimc>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,mas-rpm-id = <ICBID_MASTER_SNOC_INT_2>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_INT_2>;
+		};
+
+		/* BIMC Slaves*/
+		slv_ebi:slv-ebi {
+			cell-id = <MSM_BUS_SLAVE_EBI_CH0>;
+			label = "slv-ebi";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <2>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_EBI1>;
+		};
+
+		slv_bimc_snoc:slv-bimc-snoc {
+			cell-id = <MSM_BUS_BIMC_SNOC_SLV>;
+			label = "slv-bimc-snoc";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_bimc>;
+			qcom,connections = <&mas_bimc_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_BIMC_SNOC>;
+		};
+
+		/* PCNOC Slaves*/
+		slv_tcsr:slv-tcsr {
+			cell-id = <MSM_BUS_SLAVE_TCSR>;
+			label = "slv-tcsr";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_TCSR>;
+		};
+
+		slv_tlmm:slv-tlmm {
+			cell-id = <MSM_BUS_SLAVE_TLMM>;
+			label = "slv-tlmm";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_TLMM>;
+		};
+
+		slv_crypto_0_cfg:slv-crypto-0-cfg {
+			cell-id = <MSM_BUS_SLAVE_CRYPTO_0_CFG>;
+			label = "slv-crypto-0-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CRYPTO_0_CFG>;
+		};
+
+		slv_message_ram:slv-message-ram {
+			cell-id = <MSM_BUS_SLAVE_MESSAGE_RAM>;
+			label = "slv-message-ram";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_MESSAGE_RAM>;
+		};
+
+		slv_pdm:slv-pdm {
+			cell-id = <MSM_BUS_SLAVE_PDM>;
+			label = "slv-pdm";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PDM>;
+		};
+
+		slv_prng:slv-prng {
+			cell-id = <MSM_BUS_SLAVE_PRNG>;
+			label = "slv-prng";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PRNG>;
+		};
+
+		slv_pmic_arb:slv-pmic-arb {
+			cell-id = <MSM_BUS_SLAVE_PMIC_ARB>;
+			label = "slv-pmic-arb";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PMIC_ARB>;
+		};
+
+		slv_snoc_cfg:slv-snoc-cfg {
+			cell-id = <MSM_BUS_SLAVE_SNOC_CFG>;
+			label = "slv-snoc-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_CFG>;
+		};
+
+		slv_dcc_cfg:slv-dcc-cfg {
+			cell-id = <MSM_BUS_SLAVE_DCC_CFG>;
+			label = "slv-dcc-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DCC_CFG>;
+		};
+
+		slv_camera_ss_cfg:slv-camera-ss-cfg {
+			cell-id = <MSM_BUS_SLAVE_CAMERA_CFG>;
+			label = "slv-camera-ss-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CAMERA_CFG>;
+		};
+
+		slv_disp_ss_cfg:slv-disp-ss-cfg {
+			cell-id = <MSM_BUS_SLAVE_DISPLAY_CFG>;
+			label = "slv-disp-ss-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_DISPLAY_CFG>;
+		};
+
+		slv_venus_cfg:slv-venus-cfg {
+			cell-id = <MSM_BUS_SLAVE_VENUS_CFG>;
+			label = "slv-venus-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_VENUS_CFG>;
+		};
+
+		slv_sdcc_1:slv-sdcc-1 {
+			cell-id = <MSM_BUS_SLAVE_SDCC_1>;
+			label = "slv-sdcc-1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SDCC_1>;
+		};
+
+		slv_blsp_1:slv-blsp-1 {
+			cell-id = <MSM_BUS_SLAVE_BLSP_1>;
+			label = "slv-blsp-1";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_BLSP_1>;
+		};
+
+		slv_usb_hs:slv-usb-hs {
+			cell-id = <MSM_BUS_SLAVE_USB_HS>;
+			label = "slv-usb-hs";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_USB_HS>;
+		};
+
+		slv_sdcc_3:slv-sdcc-3 {
+			cell-id = <MSM_BUS_SLAVE_SDCC_3>;
+			label = "slv-sdcc-3";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SDCC_3>;
+		};
+
+		slv_sdcc_2:slv-sdcc-2 {
+			cell-id = <MSM_BUS_SLAVE_SDCC_2>;
+			label = "slv-sdcc-2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SDCC_2>;
+		};
+
+		slv_gpu_cfg:slv-gpu-cfg {
+			cell-id = <MSM_BUS_SLAVE_GRAPHICS_3D_CFG>;
+			label = "slv-gpu-cfg";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_GFX3D_CFG>;
+		};
+
+		slv_usb_hs2:slv-usb-hs2 {
+			cell-id = <MSM_BUS_SLAVE_USB_HS2>;
+			label = "slv-usb-hs2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_USB_HS2>;
+		};
+
+		slv_blsp_2:slv-blsp-2 {
+			cell-id = <MSM_BUS_SLAVE_BLSP_2>;
+			label = "slv-blsp-2";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_BLSP_2>;
+		};
+
+		slv_pcnoc_snoc:slv-pcnoc-snoc {
+			cell-id = <MSM_BUS_PNOC_SNOC_SLV>;
+			label = "slv-pcnoc-snoc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_pcnoc>;
+			qcom,connections = <&mas_pcnoc_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_PCNOC_SNOC>;
+		};
+
+		/* SNOC Slaves*/
+		slv_kpss_ahb:slv-kpss-ahb {
+			cell-id = <MSM_BUS_SLAVE_APPSS>;
+			label = "slv-kpss-ahb";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_APPSS>;
+		};
+
+		slv_smmnoc_bimc:slv-smmnoc-bimc {
+			cell-id = <MSM_BUS_MNOC_BIMC_SLV>;
+			label = "slv-smmnoc-bimc";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <2>;
+			qcom,ap-owned;
+			qcom,vrail-comp = <200>;
+			qcom,bus-dev = <&fab_snoc_mm>;
+			qcom,connections = <&mas_smmnoc_bimc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SMMNOC_BIMC>;
+		};
+
+		slv_snoc_bimc:slv-snoc-bimc {
+			cell-id = <MSM_BUS_SNOC_BIMC_SLV>;
+			label = "slv-snoc-bimc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <2>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,connections = <&mas_snoc_bimc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_BIMC>;
+		};
+
+		slv_imem:slv-imem {
+			cell-id = <MSM_BUS_SLAVE_SYSTEM_IMEM>;
+			label = "slv-imem";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_IMEM>;
+		};
+
+		slv_snoc_pcnoc:slv-snoc-pcnoc {
+			cell-id = <MSM_BUS_SNOC_PNOC_SLV>;
+			label = "slv-snoc-pcnoc";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,connections = <&mas_snoc_pcnoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_SNOC_PCNOC>;
+		};
+
+		slv_qdss_stm:slv-qdss-stm {
+			cell-id = <MSM_BUS_SLAVE_QDSS_STM>;
+			label = "slv-qdss-stm";
+			qcom,buswidth = <4>;
+			qcom,agg-ports = <1>;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_QDSS_STM>;
+		};
+
+		slv_cats_0:slv-cats-0 {
+			cell-id = <MSM_BUS_SLAVE_CATS_128>;
+			label = "slv-cats-0";
+			qcom,buswidth = <16>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CATS_0>;
+		};
+
+		slv_cats_1:slv-cats-1 {
+			cell-id = <MSM_BUS_SLAVE_OCMEM_64>;
+			label = "slv-cats-1";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_CATS_1>;
+		};
+
+		slv_lpass:slv-lpass {
+			cell-id = <MSM_BUS_SLAVE_LPASS>;
+			label = "slv-lpass";
+			qcom,buswidth = <8>;
+			qcom,agg-ports = <1>;
+			qcom,ap-owned;
+			qcom,bus-dev = <&fab_snoc>;
+			qcom,slv-rpm-id = <ICBID_SLAVE_LPASS>;
+		};
+	};
+
+	devfreq_spdm_cpu {
+		compatible = "qcom,devfreq_spdm";
+		qcom,msm-bus,name = "devfreq_spdm";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<1 512 0 0>,
+				<1 512 0 0>;
+		qcom,msm-bus,active-only;
+		qcom,spdm-client = <0>;
+
+		clock-names = "cci_clk";
+		clocks = <&clock_cpu clk_cci_clk>;
+
+		qcom,bw-upstep = <520>;
+		qcom,bw-dwnstep = <3640>;
+		qcom,max-vote = <6760>;
+		qcom,up-step-multp = <2>;
+		qcom,spdm-interval = <50>;
+
+		qcom,ports = <11>;
+		qcom,alpha-up = <8>;
+		qcom,alpha-down = <15>;
+		qcom,bucket-size = <8>;
+
+		/*max pl1 freq, max pl2 freq*/
+		qcom,pl-freqs = <320000 620000>;
+
+		/* pl1 low, pl1 high, pl2 low, pl2 high, pl3 low, pl3 high */
+		qcom,reject-rate = <5000 5000 5000 5000 5000 5000>;
+		/* pl1 low, pl1 high, pl2 low, pl2 high, pl3 low, pl3 high */
+		qcom,response-time-us = <1000 1000 1000 1000 1000 1000>;
+		/* pl1 low, pl1 high, pl2 low, pl2 high, pl3 low, pl3 high */
+		qcom,cci-response-time-us = <1000 1000 1000 1000 1000 1000>;
+		qcom,max-cci-freq = <500000>;
+	};
+
+	devfreq_spdm_gov {
+		compatible = "qcom,gov_spdm_hyp";
+		interrupt-names = "spdm-irq";
+		interrupts = <0 192 0>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-camera-sensor-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera-sensor-mtp.dtsi
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	led_flash0: qcom,camera-flash {
+		cell-index = <0>;
+		compatible = "qcom,camera-flash";
+		qcom,flash-type = <1>;
+		qcom,flash-source = <&pmi8950_flash0 &pmi8950_flash1>;
+		qcom,torch-source = <&pmi8950_torch0 &pmi8950_torch1>;
+		qcom,switch-source = <&pmi8950_switch>;
+	};
+};
+
+&cci {
+	actuator0: qcom,actuator@0 {
+		cell-index = <0>;
+		reg = <0x0>;
+		compatible = "qcom,actuator";
+		qcom,cci-master = <0>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vaf";
+		qcom,cam-vreg-min-voltage = <2850000>;
+		qcom,cam-vreg-max-voltage = <2850000>;
+		qcom,cam-vreg-op-mode = <80000>;
+	};
+
+	actuator1: qcom,actuator@1 {
+		cell-index = <1>;
+		reg = <0x1>;
+		compatible = "qcom,actuator";
+		qcom,cci-master = <0>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vaf";
+		qcom,cam-vreg-min-voltage = <2850000>;
+		qcom,cam-vreg-max-voltage = <2850000>;
+		qcom,cam-vreg-op-mode = <80000>;
+	};
+
+	eeprom0: qcom,eeprom@0 {
+		cell-index = <0>;
+		reg = <0x0>;
+		qcom,eeprom-name = "le2464c";
+		compatible = "qcom,eeprom";
+		qcom,slave-addr = <0xa0>;
+		qcom,cci-master = <0>;
+		qcom,num-blocks = <1>;
+
+		qcom,page0 = <0 0 0 0 0 0>;
+		qcom,poll0 = <0 0 0 0 0 0>;
+		qcom,saddr0 = <0xa0>;
+		qcom,mem0 = <8192 0x0000 2 0 1 0>;
+
+		cam_vio-supply = <&pm8950_l6>;
+		qcom,cam-vreg-name = "cam_vio";
+		qcom,cam-vreg-min-voltage = <0>;
+		qcom,cam-vreg-max-voltage = <0>;
+		qcom,cam-vreg-op-mode = <0>;
+		qcom,cam-power-seq-type = "sensor_vreg";
+		qcom,cam-power-seq-val = "cam_vio";
+		qcom,cam-power-seq-cfg-val = <1>;
+		qcom,cam-power-seq-delay = <1>;
+		qcom,i2c-freq-mode = <1>;
+		status = "ok";
+	};
+
+	eeprom1: qcom,eeprom@1 {
+		cell-index = <1>;
+		reg = <0x1>;
+		qcom,eeprom-name = "sunny_8865";
+		compatible = "qcom,eeprom";
+		qcom,slave-addr = <0x6c>;
+		qcom,num-blocks = <8>;
+
+		qcom,page0 = <1 0x0100 2 0x01 1 1>;
+		qcom,poll0 = <0 0x0 2 0x0 1 0>;
+		qcom,mem0 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page1 = <1 0x5002 2 0x00 1 0>;
+		qcom,poll1 = <0 0x0 2 0x0 1 0>;
+		qcom,mem1 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page2 = <1 0x3d84 2 0xC0 1 0>;
+		qcom,poll2 = <0 0x0 2 0x0 1 0>;
+		qcom,mem2 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page3 = <1 0x3d88 2 0x70 1 0>;
+		qcom,poll3 = <0 0x0 2 0x0 1 0>;
+		qcom,mem3 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page4 = <1 0x3d89 2 0x10 1 0>;
+		qcom,poll4 = <0 0x0 2 0x0 1 0>;
+		qcom,mem4 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page5 = <1 0x3d8A 2 0x70 1 0>;
+		qcom,poll5 = <0 0x0 2 0x0 1 0>;
+		qcom,mem5 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page6 = <1 0x3d8B 2 0xf4 1 0>;
+		qcom,poll6 = <0 0x0 2 0x0 1 0>;
+		qcom,mem6 = <0 0x0 2 0x0 1 0>;
+
+		qcom,page7 = <1 0x3d81 2 0x01 1 10>;
+		qcom,poll7 = <0 0x0 2 0x0 1 1>;
+		qcom,mem7 = <1536 0x7010 2 0 1 0>;
+
+		cam_vdig-supply = <&pm8950_l23>;
+		cam_vana-supply = <&pm8950_l22>;
+		cam_vio-supply = <&pm8950_l6>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-op-mode = <105000 0 80000 100000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_default &cam_sensor_front1_default>;
+		pinctrl-1 = <&cam_sensor_mclk2_sleep &cam_sensor_front1_sleep>;
+		gpios = <&msm_gpio 28 0>,
+			<&msm_gpio 131 0>,
+			<&msm_gpio 38 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2",
+					  "CAM_RESET2",
+					  "CAM_STANDBY2";
+		qcom,cam-power-seq-type = "sensor_vreg", "sensor_vreg", "sensor_vreg",
+			"sensor_gpio", "sensor_gpio" , "sensor_clk";
+		qcom,cam-power-seq-val = "cam_vdig", "cam_vana", "cam_vio",
+			"sensor_gpio_reset", "sensor_gpio_standby","sensor_cam_mclk";
+		qcom,cam-power-seq-cfg-val = <1 1 1 1 1 24000000>;
+			qcom,cam-power-seq-delay = <1 1 1 30 30 5>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk2_clk_src>,
+			<&clock_gcc clk_gcc_camss_mclk2_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@0 {
+		cell-index = <0>;
+		compatible = "qcom,camera";
+		reg = <0x0>;
+		qcom,csiphy-sd-index = <0>;
+		qcom,csid-sd-index = <0>;
+		qcom,mount-angle = <270>;
+		qcom,eeprom-src = <&eeprom0>;
+		qcom,actuator-src = <&actuator0>;
+		qcom,led-flash-src = <&led_flash0>;
+		cam_vdig-supply = <&pm8950_l3>;
+		cam_vio-supply = <&pm8950_l6>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1100000 0 2850000>;
+		qcom,cam-vreg-max-voltage = <1100000 0 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 100000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_default
+				&cam_sensor_rear_default
+				&cam_sensor_rear_vana>;
+		pinctrl-1 = <&cam_sensor_mclk0_sleep &cam_sensor_rear_sleep
+				&cam_sensor_rear_vana_sleep>;
+		gpios = <&msm_gpio 26 0>,
+			<&msm_gpio 129 0>,
+			<&msm_gpio 35 0>,
+			<&msm_gpio 63 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-vana = <3>;
+		qcom,gpio-req-tbl-num = <0 1 2 3>;
+		qcom,gpio-req-tbl-flags = <1 0 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK0",
+			"CAM_RESET0",
+			"CAM_STANDBY0",
+			"CAM_VANA";
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk0_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk0_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@1 {
+		cell-index = <1>;
+		compatible = "qcom,camera";
+		reg = <0x1>;
+		qcom,csiphy-sd-index = <1>;
+		qcom,csid-sd-index = <1>;
+		qcom,mount-angle = <90>;
+		cam_vdig-supply = <&pm8950_l23>;
+		cam_vana-supply = <&pm8950_l22>;
+		cam_vio-supply = <&pm8950_l6>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana",
+							"cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 80000 100000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_default &cam_sensor_front_default>;
+		pinctrl-1 = <&cam_sensor_mclk1_sleep &cam_sensor_front_sleep>;
+		gpios = <&msm_gpio 27 0>,
+			<&msm_gpio 130 0>,
+			<&msm_gpio 36 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK1",
+			"CAM_RESET1",
+			"CAM_STANDBY1";
+		qcom,sensor-position = <1>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk1_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk1_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@2 {
+		cell-index = <2>;
+		compatible = "qcom,camera";
+		reg = <0x02>;
+		qcom,csiphy-sd-index = <1>;
+		qcom,csid-sd-index = <1>;
+		qcom,mount-angle = <90>;
+		qcom,eeprom-src = <&eeprom1>;
+		qcom,actuator-src = <&actuator1>;
+		cam_vdig-supply = <&pm8950_l23>;
+		cam_vana-supply = <&pm8950_l22>;
+		cam_vio-supply = <&pm8950_l6>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-max-voltage = <1200000 0 2800000 2850000>;
+		qcom,cam-vreg-op-mode = <105000 0 80000 100000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_default &cam_sensor_front1_default>;
+		pinctrl-1 = <&cam_sensor_mclk2_sleep &cam_sensor_front1_sleep>;
+		gpios = <&msm_gpio 28 0>,
+			<&msm_gpio 131 0>,
+			<&msm_gpio 38 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2",
+					  "CAM_RESET2",
+					  "CAM_STANDBY2";
+		qcom,sensor-position = <1>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk2_clk_src>,
+			<&clock_gcc clk_gcc_camss_mclk2_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@78 {
+		compatible = "ovti,ov2685";
+		reg = <0x78>;
+		qcom,slave-id = <0x78 0x300a 0x2685>;
+		qcom,csiphy-sd-index = <1>;
+		qcom,csid-sd-index = <1>;
+		qcom,mount-angle = <0>;
+		qcom,sensor-name = "ov2685";
+		cam_vio-supply = <&pm8950_l6>;
+		cam_vana-supply = <&pm8950_l22>;
+		qcom,cam-vreg-name = "cam_vio", "cam_vana";
+		qcom,cam-vreg-min-voltage = <0 2800000>;
+		qcom,cam-vreg-max-voltage = <0 2800000>;
+		qcom,cam-vreg-op-mode = <0 80000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_default &cam_sensor_front_default
+				&cam_sensor_front_vdig>;
+		pinctrl-1 = <&cam_sensor_mclk1_sleep &cam_sensor_front_sleep
+				&cam_sensor_front_vdig_sleep>;
+		gpios = <&msm_gpio 27 0>,
+			<&msm_gpio 130 0>,
+			<&msm_gpio 36 0>,
+			<&msm_gpio 105 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-vdig = <3>;
+		qcom,gpio-req-tbl-num = <0 1 2 3>;
+		qcom,gpio-req-tbl-flags = <1 0 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK1",
+					  "CAM_RESET1",
+					  "CAM_STANDBY1",
+					  "CAM_VDIG";
+		qcom,gpio-set-tbl-num = <1 1>;
+		qcom,gpio-set-tbl-flags = <0 2>;
+		qcom,gpio-set-tbl-delay = <1000 30000>;
+		qcom,csi-lane-assign = <0x4320>;
+		qcom,csi-lane-mask = <0x3>;
+		qcom,sensor-position = <0x100>;
+		qcom,sensor-mode = <1>;
+		qcom,cci-master = <1>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk1_clk_src>,
+		<&clock_gcc clk_gcc_camss_mclk1_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	qcom,msm-cam@1b00000 {
+		compatible = "qcom,msm-cam";
+		reg = <0x1b00000 0x10000>;
+		reg-names = "msm-cam";
+	};
+
+	qcom,csiphy@1b0ac00 {
+		cell-index = <0>;
+		compatible = "qcom,csiphy-v3.1", "qcom,csiphy";
+		reg = <0x1b0ac00 0x200>,
+			<0x1b00030 0x4>;
+		reg-names = "csiphy", "csiphy_clk_mux";
+		interrupts = <0 78 0>;
+		interrupt-names = "csiphy";
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_csi0phytimer_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi0phytimer_clk>,
+			<&clock_gcc clk_camss_top_ahb_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi0phy_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csiphy_timer_src_clk", "csiphy_timer_clk",
+			"camss_ahb_src", "csi_phy_clk",
+			"camss_ahb_clk";
+		qcom,clock-rates = <0 61540000 200000000 0 0 0 0>;
+	};
+
+	qcom,csiphy@1b0b000 {
+		cell-index = <1>;
+		compatible = "qcom,csiphy-v3.1", "qcom,csiphy";
+		reg = <0x1b0b000 0x200>,
+			<0x1b00038 0x4>;
+		reg-names = "csiphy", "csiphy_clk_mux";
+		interrupts = <0 79 0>;
+		interrupt-names = "csiphy";
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_csi1phytimer_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi1phytimer_clk>,
+			<&clock_gcc clk_camss_top_ahb_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi1phy_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
+			"csiphy_timer_src_clk", "csiphy_timer_clk",
+			"camss_ahb_src", "csi_phy_clk",
+			"camss_ahb_clk";
+		qcom,clock-rates = <0 61540000 200000000 0 0 0 0>;
+	};
+
+	qcom,csid@1b08000  {
+		cell-index = <0>;
+		compatible = "qcom,csid-v3.6.0", "qcom,csid";
+		reg = <0x1b08000 0x100>;
+		reg-names = "csid";
+		interrupts = <0 51 0>;
+		interrupt-names = "csid";
+		qcom,csi-vdd-voltage = <1800000>;
+		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_csi0_ahb_clk>,
+			<&clock_gcc clk_csi0_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi0_clk>,
+			<&clock_gcc clk_gcc_camss_csi0pix_clk>,
+			<&clock_gcc clk_gcc_camss_csi0rdi_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk",
+			"ispif_ahb_clk", "csi_ahb_clk", "csi_src_clk",
+			"csi_clk",  "csi_pix_clk",
+			"csi_rdi_clk", "camss_ahb_clk";
+		qcom,clock-rates = <0 61540000 0 200000000 0 0 0 0>;
+	};
+
+	qcom,csid@1b08400 {
+		cell-index = <1>;
+		compatible = "qcom,csid-v3.6.0", "qcom,csid";
+		reg = <0x1b08400 0x100>;
+		reg-names = "csid";
+		interrupts = <0 52 0>;
+		interrupt-names = "csid";
+		qcom,csi-vdd-voltage = <1800000>;
+		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_csi1_ahb_clk>,
+			<&clock_gcc clk_csi1_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi1_clk>,
+			<&clock_gcc clk_gcc_camss_csi1pix_clk>,
+			<&clock_gcc clk_gcc_camss_csi1rdi_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk",
+			"ispif_ahb_clk", "csi_ahb_clk", "csi_src_clk",
+			"csi_clk", "csi_pix_clk",
+			"csi_rdi_clk", "camss_ahb_clk";
+		qcom,clock-rates = <0 61540000 0 200000000 0 0 0 0>;
+	};
+
+	qcom,csid@1b08800 {
+		cell-index = <2>;
+		compatible = "qcom,csid-v3.6.0", "qcom,csid";
+		reg = <0x1b08800 0x100>;
+		reg-names = "csid";
+		interrupts = <0 153 0>;
+		interrupt-names = "csid";
+		qcom,csi-vdd-voltage = <1800000>;
+		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_csi2_ahb_clk>,
+			<&clock_gcc clk_csi2_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi2_clk>,
+			<&clock_gcc clk_gcc_camss_csi2pix_clk>,
+			<&clock_gcc clk_gcc_camss_csi2rdi_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk",
+			"ispif_ahb_clk", "csi_ahb_clk", "csi_src_clk",
+			"csi_clk", "csi_pix_clk",
+			"csi_rdi_clk", "camss_ahb_clk";
+		qcom,clock-rates = <0 61540000 0 200000000 0 0 0 0>;
+	};
+
+	qcom,ispif@1b0a000 {
+		cell-index = <0>;
+		compatible = "qcom,ispif-v3.0", "qcom,ispif";
+		reg = <0x1b0a000 0x500>,
+			<0x1b00020 0x10>;
+		reg-names = "ispif", "csi_clk_mux";
+		interrupts = <0 55 0>;
+		interrupt-names = "ispif";
+		qcom,num-isps = <0x2>;
+		vfe0-vdd-supply = <&gdsc_vfe>;
+		vfe1-vdd-supply = <&gdsc_vfe1>;
+		clocks = <&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_csi0_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi0_clk>,
+			<&clock_gcc clk_gcc_camss_csi0rdi_clk>,
+			<&clock_gcc clk_gcc_camss_csi0pix_clk>,
+			<&clock_gcc clk_csi1_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi1_clk>,
+			<&clock_gcc clk_gcc_camss_csi1rdi_clk>,
+			<&clock_gcc clk_gcc_camss_csi1pix_clk>,
+			<&clock_gcc clk_csi2_clk_src>,
+			<&clock_gcc clk_gcc_camss_csi2_clk>,
+			<&clock_gcc clk_gcc_camss_csi2rdi_clk>,
+			<&clock_gcc clk_gcc_camss_csi2pix_clk>,
+			<&clock_gcc clk_vfe0_clk_src>,
+			<&clock_gcc clk_gcc_camss_vfe0_clk>,
+			<&clock_gcc clk_gcc_camss_csi_vfe0_clk>,
+			<&clock_gcc clk_vfe1_clk_src>,
+			<&clock_gcc clk_gcc_camss_vfe1_clk>,
+			<&clock_gcc clk_gcc_camss_csi_vfe1_clk>;
+		clock-names = "ispif_ahb_clk",
+			"csi0_src_clk", "csi0_clk",
+			"csi0_rdi_clk", "csi0_pix_clk",
+			"csi1_src_clk", "csi1_clk",
+			"csi1_rdi_clk", "csi1_pix_clk",
+			"csi2_src_clk", "csi2_clk",
+			"csi2_rdi_clk", "csi2_pix_clk",
+			"vfe0_clk_src", "camss_vfe_vfe0_clk", "camss_csi_vfe0_clk",
+			"vfe1_clk_src", "camss_vfe_vfe1_clk", "camss_csi_vfe1_clk";
+		qcom,clock-rates = "61540000",
+			"200000000", "0", "0", "0",
+			"200000000", "0", "0", "0",
+			"200000000", "0", "0", "0",
+			"0", "0", "0",
+			"0", "0", "0";
+	};
+
+	qcom,vfe {
+		compatible = "qcom,vfe";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		vfe0: qcom,vfe0@1b10000 {
+			cell-index = <0>;
+			compatible = "qcom,vfe40";
+			reg = <0x1b10000 0x1000>,
+			<0x1b40000 0x200>;
+			reg-names = "vfe", "vfe_vbif";
+			interrupts = <0 57 0>;
+			interrupt-names = "vfe";
+			vdd-supply = <&gdsc_vfe>;
+			clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_ahb_clk>,
+				<&clock_gcc clk_vfe0_clk_src>,
+				<&clock_gcc clk_gcc_camss_vfe0_clk>,
+				<&clock_gcc clk_gcc_camss_csi_vfe0_clk>,
+				<&clock_gcc clk_gcc_camss_vfe_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_vfe_axi_clk>,
+				<&clock_gcc clk_gcc_camss_ispif_ahb_clk>;
+			clock-names = "camss_top_ahb_clk" , "camss_ahb_clk",
+				"vfe_clk_src", "camss_vfe_vfe_clk",
+				"camss_csi_vfe_clk", "iface_clk",
+				"bus_clk", "iface_ahb_clk";
+			qcom,clock-rates = <0 0 266670000 0 0 0 0 0>;
+			qos-entries = <8>;
+			qos-regs = <0x2C4 0x2C8 0x2CC 0x2D0 0x2D4 0x2D8
+				0x2DC 0x2E0>;
+			qos-settings = <0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9>;
+			vbif-entries = <1>;
+			vbif-regs = <0x124>;
+			vbif-settings = <0x3>;
+			ds-entries = <17>;
+			ds-regs = <0x988 0x98C 0x990 0x994 0x998
+				0x99C 0x9A0 0x9A4 0x9A8 0x9AC 0x9B0
+				0x9B4 0x9B8 0x9BC 0x9C0 0x9C4 0x9C8>;
+			ds-settings = <0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0x00000110>;
+			max-clk-nominal = <320000000>;
+			max-clk-turbo = <466000000>;
+		};
+
+		vfe1: qcom,vfe1@1b14000 {
+			cell-index = <1>;
+			compatible = "qcom,vfe40";
+			reg = <0x1b14000 0x1000>,
+				<0x1ba0000 0x200>;
+			reg-names = "vfe", "vfe_vbif";
+			interrupts = <0 29 0>;
+			interrupt-names = "vfe";
+			vdd-supply = <&gdsc_vfe1>;
+			clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_ahb_clk>,
+				<&clock_gcc clk_vfe1_clk_src>,
+				<&clock_gcc clk_gcc_camss_vfe1_clk>,
+				<&clock_gcc clk_gcc_camss_csi_vfe1_clk>,
+				<&clock_gcc clk_gcc_camss_vfe1_ahb_clk>,
+				<&clock_gcc clk_gcc_camss_vfe1_axi_clk>,
+				<&clock_gcc clk_gcc_camss_ispif_ahb_clk>;
+			clock-names = "camss_top_ahb_clk" , "camss_ahb_clk",
+				"vfe_clk_src", "camss_vfe_vfe_clk",
+				"camss_csi_vfe_clk", "iface_clk",
+				"bus_clk", "iface_ahb_clk";
+			qcom,clock-rates = <0 0 266670000 0 0 0 0 0>;
+			qos-entries = <8>;
+			qos-regs = <0x2C4 0x2C8 0x2CC 0x2D0 0x2D4 0x2D8
+				0x2DC 0x2E0>;
+			qos-settings = <0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9	0xaaa9aaa9
+				0xaaa9aaa9>;
+			vbif-entries = <1>;
+			vbif-regs = <0x124>;
+			vbif-settings = <0x3>;
+			ds-entries = <17>;
+			ds-regs = <0x988 0x98C 0x990 0x994 0x998
+				0x99C 0x9A0 0x9A4 0x9A8 0x9AC 0x9B0
+				0x9B4 0x9B8 0x9BC 0x9C0 0x9C4 0x9C8>;
+			ds-settings = <0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0xcccc0011
+				0xcccc0011	0x00000110>;
+			max-clk-nominal = <320000000>;
+			max-clk-turbo = <466000000>;
+		};
+	};
+
+	qcom,cam_smmu {
+		compatible = "qcom,msm-cam-smmu";
+		msm_cam_smmu_cb1: msm_cam_smmu_cb1 {
+			compatible = "qcom,qsmmu-cam-cb";
+			iommus = <&apps_iommu 0x400>,
+						<&apps_iommu 0x3400>;
+			label = "vfe";
+		};
+
+		msm_cam_smmu_cb2: msm_cam_smmu_cb2 {
+			compatible = "qcom,qsmmu-cam-cb";
+			label = "vfe_secure";
+			qcom,secure-context;
+		};
+
+		msm_cam_smmu_cb3: msm_cam_smmu_cb3 {
+			compatible = "qcom,qsmmu-cam-cb";
+			iommus = <&apps_iommu 0x2000>;
+			label = "cpp";
+		};
+
+		msm_cam_smmu_cb4: msm_cam_smmu_cb4 {
+			compatible = "qcom,qsmmu-cam-cb";
+			iommus = <&apps_iommu 0x1c00>;
+			label = "jpeg_enc0";
+		};
+	};
+
+	qcom,jpeg@1b1c000 {
+		cell-index = <0>;
+		compatible = "qcom,jpeg";
+		reg = <0x1b1c000 0x400>,
+			<0x1b60000 0xc30>;
+		reg-names = "jpeg";
+		interrupts = <0 59 0>;
+		interrupt-names = "jpeg";
+		vdd-supply = <&gdsc_jpeg>;
+		clock-names =  "core_clk", "iface_clk", "bus_clk0",
+			"camss_top_ahb_clk", "camss_ahb_clk";
+		clocks = <&clock_gcc clk_gcc_camss_jpeg0_clk>,
+			<&clock_gcc clk_gcc_camss_jpeg_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_jpeg_axi_clk>,
+			<&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		qcom,clock-rates = <266670000 0 0 0 0>;
+		qos-reg-settings = <0x28 0x0000000e>,
+			<0xc8 0x00000000>;
+		vbif-reg-settings = <0xc0 0x10101000>,
+			<0xb0 0x10100010>;
+	};
+
+	qcom,irqrouter@1b00000 {
+		cell-index = <0>;
+		compatible = "qcom,irqrouter";
+		reg = <0x1b00000 0x100>;
+		reg-names = "irqrouter";
+	};
+
+	qcom,cpp@1b04000 {
+		cell-index = <0>;
+		compatible = "qcom,cpp";
+		reg = <0x1b04000 0x100>,
+			<0x1b80000 0x200>,
+			<0x1b18000 0x018>;
+		reg-names = "cpp", "cpp_vbif", "cpp_hw";
+		interrupts = <0 49 0>;
+		interrupt-names = "cpp";
+		vdd-supply = <&gdsc_cpp>;
+		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+			<&clock_gcc clk_cpp_clk_src>,
+			<&clock_gcc clk_gcc_camss_cpp_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_cpp_axi_clk>,
+			<&clock_gcc clk_gcc_camss_cpp_clk>,
+			<&clock_gcc clk_gcc_camss_micro_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>;
+		clock-names = "camss_top_ahb_clk", "cpp_core_clk",
+			"camss_vfe_cpp_ahb_clk", "camss_vfe_cpp_axi_clk",
+			"camss_vfe_cpp_clk","micro_iface_clk", "camss_ahb_clk";
+		qcom,clock-rates = <0 240000000 0 0 240000000 0 0>;
+		qcom,min-clock-rate = <160000000>;
+		bus_master = <1>;
+		qcom,cpp-fw-payload-info {
+			qcom,stripe-base = <156>;
+			qcom,plane-base = <141>;
+			qcom,stripe-size = <27>;
+			qcom,plane-size = <5>;
+			qcom,fe-ptr-off = <5>;
+			qcom,we-ptr-off = <11>;
+		};
+	};
+
+	cci: qcom,cci@1b0c000 {
+		cell-index = <0>;
+		compatible = "qcom,cci";
+		reg = <0x1b0c000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "cci";
+		interrupts = <0 50 0>;
+		interrupt-names = "cci";
+		clocks = <&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
+			<&clock_gcc clk_cci_clk_src>,
+			<&clock_gcc clk_gcc_camss_cci_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_cci_clk>,
+			<&clock_gcc clk_gcc_camss_ahb_clk>,
+			<&clock_gcc clk_gcc_camss_top_ahb_clk>;
+		clock-names = "ispif_ahb_clk", "cci_src_clk",
+			"cci_ahb_clk", "camss_cci_clk",
+			"camss_ahb_clk", "camss_top_ahb_clk";
+		qcom,clock-rates = <61540000 19200000 0 0 0 0>,
+				<61540000 37500000 0 0 0 0>;
+		pinctrl-names = "cci_default", "cci_suspend";
+			pinctrl-0 = <&cci0_active &cci1_active>;
+			pinctrl-1 = <&cci0_suspend &cci1_suspend>;
+		gpios = <&msm_gpio 29 0>,
+			<&msm_gpio 30 0>,
+			<&msm_gpio 103 0>,
+			<&msm_gpio 104 0>;
+		qcom,gpio-tbl-num = <0 1 2 3>;
+		qcom,gpio-tbl-flags = <1 1 1 1>;
+		qcom,gpio-tbl-label = "CCI_I2C_DATA0",
+						"CCI_I2C_CLK0",
+						"CCI_I2C_DATA1",
+						"CCI_I2C_CLK1";
+		i2c_freq_100Khz: qcom,i2c_standard_mode {
+			status = "disabled";
+		};
+		i2c_freq_400Khz: qcom,i2c_fast_mode {
+			status = "disabled";
+		};
+		i2c_freq_custom: qcom,i2c_custom_mode {
+			status = "disabled";
+		};
+
+		i2c_freq_1Mhz: qcom,i2c_fast_plus_mode {
+			status = "disabled";
+		};
+
+	};
+};
+
+&i2c_freq_100Khz {
+	qcom,hw-thigh = <78>;
+	qcom,hw-tlow = <114>;
+	qcom,hw-tsu-sto = <28>;
+	qcom,hw-tsu-sta = <28>;
+	qcom,hw-thd-dat = <10>;
+	qcom,hw-thd-sta = <77>;
+	qcom,hw-tbuf = <118>;
+	qcom,hw-scl-stretch-en = <0>;
+	qcom,hw-trdhld = <6>;
+	qcom,hw-tsp = <1>;
+	status = "ok";
+};
+
+&i2c_freq_400Khz {
+	qcom,hw-thigh = <20>;
+	qcom,hw-tlow = <28>;
+	qcom,hw-tsu-sto = <21>;
+	qcom,hw-tsu-sta = <21>;
+	qcom,hw-thd-dat = <13>;
+	qcom,hw-thd-sta = <18>;
+	qcom,hw-tbuf = <32>;
+	qcom,hw-scl-stretch-en = <0>;
+	qcom,hw-trdhld = <6>;
+	qcom,hw-tsp = <3>;
+	status = "ok";
+};
+
+&i2c_freq_custom {
+	qcom,hw-thigh = <15>;
+	qcom,hw-tlow = <28>;
+	qcom,hw-tsu-sto = <21>;
+	qcom,hw-tsu-sta = <21>;
+	qcom,hw-thd-dat = <13>;
+	qcom,hw-thd-sta = <18>;
+	qcom,hw-tbuf = <25>;
+	qcom,hw-scl-stretch-en = <1>;
+	qcom,hw-trdhld = <6>;
+	qcom,hw-tsp = <3>;
+	status = "ok";
+};
+
+&i2c_freq_1Mhz {
+	qcom,hw-thigh = <16>;
+	qcom,hw-tlow = <22>;
+	qcom,hw-tsu-sto = <17>;
+	qcom,hw-tsu-sta = <18>;
+	qcom,hw-thd-dat = <16>;
+	qcom,hw-thd-sta = <15>;
+	qcom,hw-tbuf = <19>;
+	qcom,hw-scl-stretch-en = <1>;
+	qcom,hw-trdhld = <3>;
+	qcom,hw-tsp = <3>;
+	qcom,cci-clk-src = <37500000>;
+	status = "ok";
+};

--- a/arch/arm/boot/dts/qcom/msm8976-coresight.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-coresight.dtsi
@@ -1,0 +1,1052 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	tmc_etr: tmc@6026000 {
+		compatible = "arm,coresight-tmc";
+		reg = <0x6026000 0x1000>,
+		      <0x6084000 0x15000>;
+		reg-names = "tmc-base", "bam-base";
+		interrupts = <0 166 0>;
+		interrupt-names = "byte-cntr-irq";
+
+		qcom,memory-size = <0x500000>;
+		qcom,sg-enable;
+		coresight-default-sink;
+		qcom,force-reg-dump;
+
+		coresight-id = <0>;
+		coresight-name = "coresight-tmc-etr";
+		coresight-nr-inports = <1>;
+		coresight-ctis = <&cti0 &cti8>;
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpiu: tpiu@820000 {
+		compatible = "arm,coresight-tpiu";
+		reg = <0x6020000 0x1000>,
+		      <0x1100000 0xb0000>;
+		reg-names = "tpiu-base", "nidnt-base";
+
+		coresight-id = <1>;
+		coresight-name = "coresight-tpiu";
+		coresight-nr-inports = <1>;
+
+		qcom,nidnthw;
+		qcom,nidnt-swduart;
+		qcom,nidnt-swdtrc;
+		qcom,nidnt-jtag;
+		qcom,nidnt-spmi;
+		nidnt-gpio = <38>;
+		nidnt-gpio-polarity = <1>;
+
+		interrupts = <0 82 0>;
+		interrupt-names = "nidnt-irq";
+
+		vdd-supply = <&pm8950_l11>;
+		qcom,vdd-voltage-level = <2950000 2950000>;
+		qcom,vdd-current-level = <15000 400000>;
+
+		vdd-io-supply = <&pm8950_l12>;
+		qcom,vdd-io-voltage-level = <2950000 2950000>;
+		qcom,vdd-io-current-level = <200 50000>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	replicator: replicator@6024000 {
+		compatible = "qcom,coresight-replicator";
+		reg = <0x6024000 0x1000>;
+		reg-names = "replicator-base";
+
+		coresight-id = <2>;
+		coresight-name = "coresight-replicator";
+		coresight-nr-inports = <1>;
+		coresight-outports = <0 1>;
+		coresight-child-list = <&tmc_etr &tpiu>;
+		coresight-child-ports = <0 0>;
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tmc_etf: tmc@6025000 {
+		compatible = "arm,coresight-tmc";
+		reg = <0x6025000 0x1000>;
+		reg-names = "tmc-base";
+
+		coresight-id = <3>;
+		coresight-name = "coresight-tmc-etf";
+		coresight-nr-inports = <1>;
+		coresight-outports = <0>;
+		coresight-child-list = <&replicator>;
+		coresight-child-ports = <0>;
+		coresight-ctis = <&cti0 &cti8>;
+		qcom,force-reg-dump;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_merg: funnel@6023000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6023000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <4>;
+		coresight-name = "coresight-funnel-merg";
+		coresight-nr-inports = <2>;
+		coresight-outports = <0>;
+		coresight-child-list = <&tmc_etf>;
+		coresight-child-ports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_in0: funnel@6021000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6021000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <5>;
+		coresight-name = "coresight-funnel-in0";
+		coresight-nr-inports = <8>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_merg>;
+		coresight-child-ports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_in1: funnel@6022000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6022000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <6>;
+		coresight-name = "coresight-funnel-in1";
+		coresight-nr-inports = <8>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_merg>;
+		coresight-child-ports = <1>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_in2: funnel@6068000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6068000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <7>;
+		coresight-name = "coresight-funnel-in2";
+		coresight-nr-inports = <8>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <6>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_apps_l1: funnel@6b70000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6b70000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <8>;
+		coresight-name = "coresight-funnel-apps-l1";
+		coresight-nr-inports = <4>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in1>;
+		coresight-child-ports = <6>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	funnel_apps_l0: funnel@6b60000 {
+		compatible = "arm,coresight-funnel";
+		reg = <0x6b60000 0x1000>;
+		reg-names = "funnel-base";
+
+		coresight-id = <9>;
+		coresight-name = "coresight-funnel-apps-l0";
+		coresight-nr-inports = <8>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l1>;
+		coresight-child-ports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm0: etm@6840000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6840000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <10>;
+		coresight-name = "coresight-etm0";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <0>;
+		coresight-etm-cpu = <&CPU0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm1: etm@6940000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6940000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <11>;
+		coresight-name = "coresight-etm1";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <1>;
+		coresight-etm-cpu = <&CPU1>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm2: etm@6a40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6a40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <12>;
+		coresight-name = "coresight-etm2";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <2>;
+		coresight-etm-cpu = <&CPU2>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm3: etm@6b40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6b40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <13>;
+		coresight-name = "coresight-etm3";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <3>;
+		coresight-etm-cpu = <&CPU3>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm4: etm@6c40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6c40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <14>;
+		coresight-name = "coresight-etm4";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <4>;
+		coresight-etm-cpu = <&CPU4>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm5: etm@6d40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6d40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <15>;
+		coresight-name = "coresight-etm5";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <5>;
+		coresight-etm-cpu = <&CPU5>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm6: etm@6e40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6e40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <16>;
+		coresight-name = "coresight-etm6";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <6>;
+		coresight-etm-cpu = <&CPU6>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	etm7: etm@6f40000 {
+		compatible = "arm,coresight-etmv4";
+		reg = <0x6f40000 0x1000>;
+		reg-names = "etm-base";
+
+		coresight-id = <17>;
+		coresight-name = "coresight-etm7";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l0>;
+		coresight-child-ports = <7>;
+		coresight-etm-cpu = <&CPU7>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	stm: stm@6002000 {
+		compatible = "arm,coresight-stm";
+		reg = <0x6002000 0x1000>,
+		      <0x9280000 0x180000>;
+		reg-names = "stm-base", "stm-data-base";
+
+		coresight-id = <18>;
+		coresight-name = "coresight-stm";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <7>;
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	csr: csr@6001000 {
+		compatible = "qcom,coresight-csr";
+		reg = <0x6001000 0x1000>;
+		reg-names = "csr-base";
+
+		coresight-id = <19>;
+		coresight-name = "coresight-csr";
+		coresight-nr-inports = <0>;
+
+		qcom,blk-size = <1>;
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti0: cti@6010000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6010000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <20>;
+		coresight-name = "coresight-cti0";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti1: cti@6011000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6011000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <21>;
+		coresight-name = "coresight-cti1";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti2: cti@6012000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6012000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <22>;
+		coresight-name = "coresight-cti2";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti3: cti@6013000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6013000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <23>;
+		coresight-name = "coresight-cti3";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti4: cti@6014000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6014000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <24>;
+		coresight-name = "coresight-cti4";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti5: cti@6015000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6015000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <25>;
+		coresight-name = "coresight-cti5";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti6: cti@6016000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6016000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <26>;
+		coresight-name = "coresight-cti6";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,cti-gpio-trigout = <2>;
+		pinctrl-names = "cti-trigout-pctrl";
+		pinctrl-0 = <&trigout_b0>;
+	};
+
+	cti7: cti@6017000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6017000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <27>;
+		coresight-name = "coresight-cti7";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti8: cti@6018000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6018000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <28>;
+		coresight-name = "coresight-cti8";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti9: cti@6019000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6019000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <29>;
+		coresight-name = "coresight-cti9";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti10: cti@601a000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x601a000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <30>;
+		coresight-name = "coresight-cti10";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti11: cti@601b000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x601b000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <31>;
+		coresight-name = "coresight-cti11";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti12: cti@601c000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x601c000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <32>;
+		coresight-name = "coresight-cti12";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti13: cti@601d000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x601d000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <33>;
+		coresight-name = "coresight-cti13";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti14: cti@601e000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x601e000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <34>;
+		coresight-name = "coresight-cti14";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu0: cti@6820000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6820000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <35>;
+		coresight-name = "coresight-cti-cpu0";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu1: cti@6920000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6920000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <36>;
+		coresight-name = "coresight-cti-cpu1";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU1>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu2: cti@6a20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6a20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <37>;
+		coresight-name = "coresight-cti-cpu2";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU2>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu3: cti@6b20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6b20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <38>;
+		coresight-name = "coresight-cti-cpu3";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU3>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu4: cti@6c20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6c20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <39>;
+		coresight-name = "coresight-cti-cpu4";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU4>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu5: cti@6d20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6d20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <40>;
+		coresight-name = "coresight-cti-cpu5";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU5>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu6: cti@6e20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6e20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <41>;
+		coresight-name = "coresight-cti-cpu6";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU6>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cpu7: cti@6f20000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6f20000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <42>;
+		coresight-name = "coresight-cti-cpu7";
+		coresight-nr-inports = <0>;
+		coresight-cti-cpu = <&CPU7>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_isdb: cti@6141000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6141000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <43>;
+		coresight-name = "coresight-cti-isdb";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_cs: cti@6b80000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6b80000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <44>;
+		coresight-name = "coresight-cti-cs";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_rpm_cpu0: cti@603c000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x603c000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <45>;
+		coresight-name = "coresight-cti-rpm-cpu0";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_modem_cpu0: cti@6060000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6060000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <46>;
+		coresight-name = "coresight-cti-modem-cpu0";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_modem_cpu1: cti@6038000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6038000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <47>;
+		coresight-name = "coresight-cti-modem-cpu1";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_wcn_cpu0: cti@6035000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6035000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <48>;
+		coresight-name = "coresight-cti-wcn-cpu0";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_video_cpu0: cti@6030000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6030000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <49>;
+		coresight-name = "coresight-cti-video-cpu0";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	cti_audio_cpu0: cti@6064000 {
+		compatible = "arm,coresight-cti";
+		reg = <0x6064000 0x1000>;
+		reg-names = "cti-base";
+
+		coresight-id = <50>;
+		coresight-name = "coresight-cti-audio-cpu0";
+		coresight-nr-inports = <0>;
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	dbgui: dbgui@606d000 {
+		compatible = "qcom,coresight-dbgui";
+		reg = <0x606d000 0x1000>;
+		reg-names = "dbgui-base";
+
+		coresight-id = <51>;
+		coresight-name = "coresight-dbgui";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in1>;
+		coresight-child-ports = <3>;
+
+		qcom,dbgui-addr-offset = <0x30>;
+		qcom,dbgui-data-offset = <0x130>;
+		qcom,dbgui-size = <64>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpda: tpda@6003000 {
+		compatible = "qcom,coresight-tpda";
+		reg = <0x6003000 0x1000>;
+		reg-names = "tpda-base";
+
+		coresight-id = <52>;
+		coresight-name = "coresight-tpda";
+		coresight-nr-inports = <2>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <3>;
+
+		qcom,tpda-atid = <64>;
+		qcom,cmb-elem-size = <0 32>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpdm_dcc: tpdm@60a0000 {
+		compatible = "qcom,coresight-tpdm";
+		reg = <0x60a0000 0x1000>;
+		reg-names = "tpdm-base";
+
+		coresight-id = <53>;
+		coresight-name = "coresight-tpdm-dcc";
+		coresight-nr-inports = <1>;
+		coresight-outports = <0>;
+		coresight-child-list = <&tpda>;
+		coresight-child-ports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpdm_dsat: tpdm@60a4000 {
+		compatible = "qcom,coresight-tpdm";
+		reg = <0x60a4000 0x1000>;
+		reg-names = "tpdm-base";
+
+		coresight-id = <54>;
+		coresight-name = "coresight-tpdm-dsat";
+		coresight-nr-inports = <1>;
+		coresight-outports = <0>;
+		coresight-child-list = <&tpda>;
+		coresight-child-ports = <1>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpda_lmh: tpda@6b91000 {
+		compatible = "qcom,coresight-tpda";
+		reg = <0x6b91000 0x1000>;
+		reg-names = "tpda-base";
+
+		coresight-id = <55>;
+		coresight-name = "coresight-tpda-lmh";
+		coresight-nr-inports = <32>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_apps_l1>;
+		coresight-child-ports = <1>;
+
+		qcom,tpda-atid = <65>;
+		qcom,cmb-elem-size = <0 64>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	tpdm_lmh: tpdm@6b90000 {
+		compatible = "qcom,coresight-tpdm";
+		reg = <0x6b90000 0x1000>;
+		reg-names = "tpdm-base";
+
+		coresight-id = <56>;
+		coresight-name = "coresight-tpdm-lmh";
+		coresight-nr-inports = <1>;
+		coresight-outports = <0>;
+		coresight-child-list = <&tpda_lmh>;
+		coresight-child-ports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	rpm_etm0 {
+		compatible = "qcom,coresight-remote-etm";
+
+		coresight-id = <57>;
+		coresight-name = "coresight-rpm-etm0";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <0>;
+
+		qcom,inst-id = <4>;
+	};
+
+	wcn_etm0 {
+		compatible = "qcom,coresight-remote-etm";
+
+		coresight-id = <58>;
+		coresight-name = "coresight-wcn-etm0";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in1>;
+		coresight-child-ports = <0>;
+
+		qcom,inst-id = <3>;
+	};
+
+	modem_etm0 {
+		compatible = "qcom,coresight-remote-etm";
+
+		coresight-id = <59>;
+		coresight-name = "coresight-modem-etm0";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in1>;
+		coresight-child-ports = <7>;
+
+		qcom,inst-id = <2>;
+	};
+
+	modem_etm1 {
+		compatible = "qcom,coresight-remote-etm";
+
+		coresight-id = <60>;
+		coresight-name = "coresight-modem-etm1";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <1>;
+
+		qcom,inst-id = <11>;
+	};
+
+	audio_etm {
+		compatible = "qcom,coresight-remote-etm";
+
+		coresight-id = <61>;
+		coresight-name = "coresight-audio-etm0";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <2>;
+
+		qcom,inst-id = <5>;
+	};
+
+	hwevent: hwevent@606c000 {
+		compatible = "qcom,coresight-hwevent";
+		reg = <0x606c000 0x148>,
+		      <0x606cfb0 0x4>,
+		      <0x78c5010 0x4>,
+		      <0x7885010 0x4>;
+		reg-names = "wrapper-mux", "wrapper-lockaccess", "usbbam-mux",
+		            "blsp-mux";
+		coresight-id = <62>;
+		coresight-name = "coresight-hwevent";
+		coresight-nr-inports = <0>;
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+			 <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+	};
+
+	fuse: fuse@a601c {
+		compatible = "arm,coresight-fuse-v2";
+		reg = <0xa601c 0x8>,
+		      <0xa6004 0x4>,
+		      <0xa600c 0x4>;
+		reg-names = "fuse-base", "nidnt-fuse-base", "qpdi-fuse-base";
+
+		coresight-id = <63>;
+		coresight-name = "coresight-fuse";
+		coresight-nr-inports = <0>;
+	};
+
+	qpdi: qpdi@1941000 {
+		compatible = "qcom,coresight-qpdi";
+		reg = <0x1941000 0x4>;
+		reg-names = "qpdi-base";
+
+		coresight-id = <64>;
+		coresight-name = "coresight-qpdi";
+		coresight-nr-inports = <0>;
+
+		vdd-supply = <&pm8950_l11>;
+		qcom,vdd-voltage-level = <2800000 2950000>;
+		qcom,vdd-current-level = <15000 400000>;
+
+		vdd-io-supply = <&pm8950_l12>;
+		qcom,vdd-io-voltage-level = <1800000 2950000>;
+		qcom,vdd-io-current-level = <200 50000>;
+	};
+};
+

--- a/arch/arm/boot/dts/qcom/msm8976-cpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-cpu.dtsi
@@ -1,0 +1,287 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/ {
+
+	psci {
+		compatible = "arm,psci-1.0";
+		method = "smc";
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&CPU0>;
+				};
+				core1 {
+					cpu = <&CPU1>;
+				};
+				core2 {
+					cpu = <&CPU2>;
+				};
+				core3 {
+					cpu = <&CPU3>;
+				};
+			};
+
+			cluster1 {
+				core0 {
+					cpu = <&CPU4>;
+				};
+				core1 {
+					cpu = <&CPU5>;
+				};
+				core2 {
+					cpu = <&CPU6>;
+				};
+				core3 {
+					cpu = <&CPU7>;
+				};
+			};
+		};
+
+		CPU0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile0>;
+			efficiency = <1024>;
+			qcom,acc = <&acc0>;
+			next-level-cache = <&L2_0>;
+			qcom,sleep-status = <&cpu0_slp_sts>;
+			L2_0: l2-cache {
+			      compatible = "arm,arch-cache";
+			      cache-level = <2>;
+			      power-domain = <&l2ccc_0>;
+			};
+		};
+
+		CPU1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x1>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile0>;
+			efficiency = <1024>;
+			qcom,acc = <&acc1>;
+			next-level-cache = <&L2_0>;
+			qcom,sleep-status = <&cpu1_slp_sts>;
+		};
+
+		CPU2: cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x2>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile0>;
+			efficiency = <1024>;
+			qcom,acc = <&acc2>;
+			next-level-cache = <&L2_0>;
+			qcom,sleep-status = <&cpu2_slp_sts>;
+		};
+
+		CPU3: cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x3>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile0>;
+			efficiency = <1024>;
+			qcom,acc = <&acc3>;
+			next-level-cache = <&L2_0>;
+			qcom,sleep-status = <&cpu3_slp_sts>;
+		};
+
+		CPU4: cpu@100 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x100>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile1>;
+			efficiency = <1830>;
+			qcom,acc = <&acc4>;
+			qcom,ldo = <&ldo4>;
+			next-level-cache = <&L2_1>;
+			qcom,sleep-status = <&cpu4_slp_sts>;
+			L2_1: l2-cache {
+			      compatible = "arm,arch-cache";
+			      cache-level = <2>;
+			      power-domain = <&l2ccc_1>;
+			};
+		};
+
+		CPU5: cpu@101 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x101>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile2>;
+			efficiency = <1830>;
+			qcom,acc = <&acc5>;
+			qcom,ldo = <&ldo5>;
+			next-level-cache = <&L2_1>;
+			qcom,sleep-status = <&cpu5_slp_sts>;
+		};
+
+		CPU6: cpu@102 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x102>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile3>;
+			efficiency = <1830>;
+			qcom,acc = <&acc6>;
+			qcom,ldo = <&ldo6>;
+			next-level-cache = <&L2_1>;
+			qcom,sleep-status = <&cpu6_slp_sts>;
+		};
+
+		CPU7: cpu@103 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x103>;
+			enable-method = "psci";
+			qcom,limits-info = <&mitigation_profile4>;
+			efficiency = <1830>;
+			qcom,acc = <&acc7>;
+			qcom,ldo = <&ldo7>;
+			next-level-cache = <&L2_1>;
+			qcom,sleep-status = <&cpu7_slp_sts>;
+		};
+	};
+};
+
+&soc {
+
+	l2ccc_0: clock-controller@b111000 {
+		compatible = "qcom,8976-l2ccc";
+		reg = <0x0b111000 0x1000>;
+		reg-names = "l2-base";
+	};
+
+	l2ccc_1: clock-controller@b011000 {
+		compatible = "qcom,8976-l2ccc";
+		reg = <0x0b011000 0x1000>;
+		reg-names = "l2-base";
+		qcom,vctl-val = <0xb8>;
+	};
+
+	acc0:clock-controller@b188000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b188000 0x1000>;
+	};
+
+	acc1:clock-controller@b198000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b198000 0x1000>;
+	};
+
+	acc2:clock-controller@b1a8000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b1a8000 0x1000>;
+	};
+
+	acc3:clock-controller@b1b8000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b1b8000 0x1000>;
+	};
+
+	acc4:clock-controller@b088000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b088000 0x1000>;
+	};
+
+	acc5:clock-controller@b098000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b098000 0x1000>;
+	};
+
+	acc6:clock-controller@b0a8000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b0a8000 0x1000>;
+	};
+
+	acc7:clock-controller@b0b8000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b0b8000 0x1000>;
+	};
+
+	ldo4:ldo-vref@b086000 {
+		compatible = "qcom,8976-cpu-ldo-vref";
+		reg = <0xb086000 0x40>;
+		qcom,ldo-vref-ret = <0x9>;
+	};
+
+	ldo5:ldo-vref@b096000 {
+		compatible = "qcom,8976-cpu-ldo-vref";
+		reg = <0xb096000 0x40>;
+		qcom,ldo-vref-ret = <0x9>;
+	};
+
+	ldo6:ldo-vref@b0a6000 {
+		compatible = "qcom,8976-cpu-ldo-vref";
+		reg = <0xb0a6000 0x40>;
+		qcom,ldo-vref-ret = <0x9>;
+	};
+
+	ldo7:ldo-vref@b0b6000 {
+		compatible = "qcom,8976-cpu-ldo-vref";
+		reg = <0xb0b6000 0x40>;
+		qcom,ldo-vref-ret = <0x9>;
+	};
+
+	cpu0_slp_sts: cpu-sleep-status@b188008 {
+		reg = <0xb188008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu1_slp_sts: cpu-sleep-status@b198008 {
+		reg = <0xb198008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu2_slp_sts: cpu-sleep-status@b1a8008 {
+		reg = <0xb1a8008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu3_slp_sts: cpu-sleep-status@b1b8008 {
+		reg = <0xb1b8008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu4_slp_sts: cpu-sleep-status@b088008 {
+		reg = <0xb088008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu5_slp_sts: cpu-sleep-status@b098008 {
+		reg = <0xb098008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu6_slp_sts: cpu-sleep-status@b0a8008 {
+		reg = <0xb0a8008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+	cpu7_slp_sts: cpu-sleep-status@b0b8008 {
+		reg = <0xb0b8008 0x100>;
+		qcom,sleep-status-mask= <0x40000>;
+	};
+
+};

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -1,0 +1,191 @@
+/* Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	msm_bus: qcom,kgsl-busmon{
+		label = "kgsl-busmon";
+		compatible = "qcom,kgsl-busmon";
+	};
+
+	/* Bus governor */
+	gpubw: qcom,gpubw {
+		compatible = "qcom,devbw";
+		governor = "bw_vbif";
+		qcom,src-dst-ports = <26 512>;
+		qcom,bw-tbl =
+			< 0 >,    /* off                            */
+			< 805  >, /* DDR: 105.6 MHz BIMC:  52.8 MHz */
+			< 1245 >, /* DDR: 163.2 MHz BIMC:  81.6 MHz */
+			< 1611 >, /* DDR: 211.2 MHz BIMC: 105.6 MHz */
+			< 2124 >, /* DDR: 278.4 MHz BIMC: 139.2 MHz */
+			< 2929 >, /* DDR: 384.0 MHz BIMC: 192.0 MHz */
+			< 4101 >, /* DDR: 537.6 MHz BIMC: 268.8 MHz */
+			< 5126 >, /* DDR: 672.0 MHz BIMC: 336.0 MHz */
+			< 5712 >, /* DDR: 748.8 MHz BIMC: 374.4 MHz */
+			< 6152 >, /* DDR: 806.4 MHz BIMC: 403.2 MHz */
+			< 7104 >; /* DDR: 931.2 MHz BIMC: 465.6 MHz */
+	};
+
+	msm_gpu: qcom,kgsl-3d0@01c00000 {
+		label = "kgsl-3d0";
+		compatible = "qcom,kgsl-3d0", "qcom,kgsl-3d";
+		reg = <0x1C00000 0x40000
+			   0x1C40000 0x10000>;
+		reg-names = "kgsl_3d0_reg_memory" , "kgsl_3d0_shader_memory";
+		interrupts = <0 33 0>;
+		interrupt-names = "kgsl_3d0_irq";
+		qcom,id = <0>;
+
+		qcom,chipid = <0x05010000>;
+
+		qcom,initial-pwrlevel = <5>;
+
+		qcom,idle-timeout = <8>; //<HZ/12>
+		qcom,strtstp-sleepwake;
+
+		qcom,pm-qos-active-latency = <401>;
+		qcom,pm-qos-wakeup-latency = <101>;
+
+		/* Avoid L2PC on big cluster CPUs (CPU 4,5,6,7) */
+		qcom,l2pc-cpu-mask = <0x000000F0>;
+
+		/*
+		 * Clocks = KGSL_CLK_CORE | KGSL_CLK_IFACE | KGSL_CLK_MEM |
+		 * KGSL_CLK_MEM_IFACE | KGSL_CLK_RBBMTIMER |
+		 * KGSL_CLK_GFX_GTCU  | KGSL_CLK_GFX_GTBU |
+		 * KGSL_CLK_GFX_GTBU1 | KGSL_CLK_AON
+		 */
+		qcom,clk-map = <0x00000F9E>;
+
+	clocks = <&clock_gcc_gfx clk_gcc_oxili_gfx3d_clk>,
+		 <&clock_gcc_gfx clk_gcc_oxili_ahb_clk>,
+		 <&clock_gcc_gfx clk_gcc_oxili_gmem_clk>,
+		 <&clock_gcc_gfx clk_gcc_bimc_gfx_clk>,
+		 <&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,
+		 <&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
+		 <&clock_gcc_gfx clk_gcc_gfx_tbu_clk>,
+		 <&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>,
+		 <&clock_gcc_gfx clk_gcc_oxili_timer_clk>,
+		 <&clock_gcc_gfx clk_gcc_oxili_aon_clk>;
+
+	clock-names =   "core_clk", "iface_clk", "mem_clk",
+			"mem_iface_clk", "gtcu_iface_clk",
+			"gtcu_clk", "gtbu_clk", "gtbu1_clk",
+			"rbbmtimer_clk", "aon_clk";
+
+
+		/* Bus Scale Settings */
+		qcom,gpubw-dev = <&gpubw>;
+		qcom,bus-control;
+		qcom,bus-width = <16>;
+		qcom,msm-bus,name = "grp3d";
+		qcom,msm-bus,num-cases = <11>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<26 512 0 0>,	    /*  off          */
+				<26 512 0 844800>,  /* 1. 105.6  MHz */
+				<26 512 0 1305600>, /* 2. 163.2  MHz */
+				<26 512 0 1689600>, /* 3. 211.2  MHz */
+				<26 512 0 2227200>, /* 4. 278.4  MHz */
+				<26 512 0 3072000>, /* 5. 384.0  MHz */
+				<26 512 0 4300800>, /* 6. 537.6  MHz */
+				<26 512 0 5376000>, /* 7. 672.0  MHz */
+				<26 512 0 5990400>, /* 8. 748.8  MHz */
+				<26 512 0 6451200>, /* 9. 806.4  MHz */
+				<26 512 0 7449600>; /*10. 931.2  MHz */
+
+		/* GDSC oxili regulators */
+		vddcx-supply = <&gdsc_oxili_cx>;
+		vdd-supply = <&gdsc_oxili_gx>;
+
+		/* IOMMU Data */
+                iommu = <&gfx_iommu>;
+
+		/* Trace bus */
+		coresight-id = <67>;
+		coresight-name = "coresight-gfx";
+		coresight-nr-inports = <0>;
+		coresight-outports = <0>;
+		coresight-child-list = <&funnel_in0>;
+		coresight-child-ports = <4>;
+
+		/* Power levels */
+		qcom,gpu-pwrlevels {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			compatible = "qcom,gpu-pwrlevels";
+
+			/* TURBO */
+			qcom,gpu-pwrlevel@0 {
+				reg = <0>;
+				qcom,gpu-freq = <600000000>;
+				qcom,bus-freq = <9>;
+				qcom,bus-min = <9>;
+				qcom,bus-max = <10>;
+			};
+
+			/* TURBO */
+			qcom,gpu-pwrlevel@1 {
+				reg = <1>;
+				qcom,gpu-freq = <550000000>;
+				qcom,bus-freq = <9>;
+				qcom,bus-min = <9>;
+				qcom,bus-max = <10>;
+			};
+
+			/* NOM+ */
+			qcom,gpu-pwrlevel@2 {
+				reg = <2>;
+				qcom,gpu-freq = <480000000>;
+				qcom,bus-freq = <8>;
+				qcom,bus-min = <7>;
+				qcom,bus-max = <9>;
+			};
+
+			/* NOM */
+			qcom,gpu-pwrlevel@3 {
+				reg = <3>;
+				qcom,gpu-freq = <432000000>;
+				qcom,bus-freq = <7>;
+				qcom,bus-min = <5>;
+				qcom,bus-max = <9>;
+			};
+
+			/* SVS */
+			qcom,gpu-pwrlevel@4 {
+				reg = <4>;
+				qcom,gpu-freq = <300000000>;
+				qcom,bus-freq = <5>;
+				qcom,bus-min = <4>;
+				qcom,bus-max = <7>;
+			};
+
+			/* Low SVS+ */
+			qcom,gpu-pwrlevel@5 {
+				reg = <5>;
+				qcom,gpu-freq = <266666667>;
+				qcom,bus-freq = <4>;
+				qcom,bus-min = <4>;
+				qcom,bus-max = <5>;
+			};
+
+			qcom,gpu-pwrlevel@6 {
+				reg = <6>;
+				qcom,gpu-freq = <19200000>;
+				qcom,bus-freq = <0>;
+				qcom,bus-min = <0>;
+				qcom,bus-max = <0>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -50,6 +50,7 @@
 		qcom,initial-pwrlevel = <5>;
 
 		qcom,idle-timeout = <80>; //msecs
+		qcom,deep-nap-timeout = <100>; //msecs
 		qcom,strtstp-sleepwake;
 
 		qcom,pm-qos-active-latency = <401>;

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -190,6 +190,7 @@
 		};
 	};
 
+	/* ahb_base_offset: 0x40000 */
 	kgsl_msm_iommu: qcom,kgsl-iommu {
 		compatible = "qcom,kgsl-smmu-v2";
 		reg = <0x1f00000 0x10000>;
@@ -197,7 +198,9 @@
 		* The gpu can only program a single context bank
 		* at this fixed offset.
 		*/
-		qcom,protect = <0x48000 0x1000>;
+		qcom,protect = <0x40000 0x1000>;
+		//qcom,micro-mmu-control = <0x6000>;
+
 		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
 			<&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
 			<&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -199,10 +199,10 @@
 		*/
 		qcom,protect = <0x48000 0x1000>;
 		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
-			<&clock_gcc clk_gcc_gfx_tcu_clk>,
-			<&clock_gcc clk_gcc_gtcu_ahb_clk>,
-			<&clock_gcc clk_gcc_gfx_tbu_clk>;
-		clock-names = "iface_clk", "core_clk", "gtcu_iface_clk",
+			<&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
+			<&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,
+			<&clock_gcc_gfx clk_gcc_gfx_tbu_clk>;
+		clock-names = "scfg_clk", "gtcu_clk", "gtcu_iface_clk",
 				"gtbu_clk";
 		gfx3d_user: gfx3d_user {
 			compatible = "qcom,smmu-kgsl-cb";

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -49,7 +49,7 @@
 
 		qcom,initial-pwrlevel = <5>;
 
-		qcom,idle-timeout = <8>; //<HZ/12>
+		qcom,idle-timeout = <80>; //msecs
 		qcom,strtstp-sleepwake;
 
 		qcom,pm-qos-active-latency = <401>;

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -21,6 +21,8 @@
 		compatible = "qcom,devbw";
 		governor = "bw_vbif";
 		qcom,src-dst-ports = <26 512>;
+
+		qcom,active-only;
 		qcom,bw-tbl =
 			< 0 >,    /* off                            */
 			< 805  >, /* DDR: 105.6 MHz BIMC:  52.8 MHz */
@@ -50,8 +52,10 @@
 		qcom,initial-pwrlevel = <5>;
 
 		qcom,idle-timeout = <80>; //msecs
-		qcom,deep-nap-timeout = <100>; //msecs
+		qcom,deep-nap-timeout = <20>; //msecs
 		qcom,strtstp-sleepwake;
+
+		qcom,snapshot-size = <1048576>; //bytes
 
 		qcom,pm-qos-active-latency = <401>;
 		qcom,pm-qos-wakeup-latency = <101>;
@@ -67,22 +71,21 @@
 		 */
 		qcom,clk-map = <0x00000F9E>;
 
-	clocks = <&clock_gcc_gfx clk_gcc_oxili_gfx3d_clk>,
-		 <&clock_gcc_gfx clk_gcc_oxili_ahb_clk>,
-		 <&clock_gcc_gfx clk_gcc_oxili_gmem_clk>,
-		 <&clock_gcc_gfx clk_gcc_bimc_gfx_clk>,
-		 <&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,
-		 <&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
-		 <&clock_gcc_gfx clk_gcc_gfx_tbu_clk>,
-		 <&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>,
-		 <&clock_gcc_gfx clk_gcc_oxili_timer_clk>,
-		 <&clock_gcc_gfx clk_gcc_oxili_aon_clk>;
+		clocks = <&clock_gcc_gfx clk_gcc_oxili_gfx3d_clk>,
+			 <&clock_gcc_gfx clk_gcc_oxili_ahb_clk>,
+			 <&clock_gcc_gfx clk_gcc_oxili_gmem_clk>,
+			 <&clock_gcc_gfx clk_gcc_bimc_gfx_clk>,
+			 <&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,
+			 <&clock_gcc_gfx clk_gcc_oxili_timer_clk>,
+			 <&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
+			 <&clock_gcc_gfx clk_gcc_gfx_tbu_clk>,
+			 <&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>,
+			 <&clock_gcc_gfx clk_gcc_oxili_aon_clk>;
 
-	clock-names =   "core_clk", "iface_clk", "mem_clk",
-			"mem_iface_clk", "gtcu_iface_clk",
-			"gtcu_clk", "gtbu_clk", "gtbu1_clk",
-			"rbbmtimer_clk", "aon_clk";
-
+		clock-names =   "core_clk", "iface_clk", "mem_clk",
+				"mem_iface_clk", "gtcu_iface_clk", "rbbmtimer_clk",
+				"gtcu_clk", "gtbu_clk", "gtbu1_clk",
+				"alwayson_clk";
 
 		/* Bus Scale Settings */
 		qcom,gpubw-dev = <&gpubw>;
@@ -198,20 +201,30 @@
 		* The gpu can only program a single context bank
 		* at this fixed offset.
 		*/
-		qcom,protect = <0x40000 0x1000>;
-		//qcom,micro-mmu-control = <0x6000>;
+		qcom,protect = <0x40000 0x20000>;
+		qcom,micro-mmu-control = <0x6000>;
 
 		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
 			<&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
 			<&clock_gcc_gfx clk_gcc_gtcu_ahb_clk>,
-			<&clock_gcc_gfx clk_gcc_gfx_tbu_clk>;
+			<&clock_gcc_gfx clk_gcc_gfx_tbu_clk>,
+			<&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>;
 		clock-names = "scfg_clk", "gtcu_clk", "gtcu_iface_clk",
-				"gtbu_clk";
+				"gtbu_clk", "gtbu1_clk";
+
+		qcom,secure_align_mask = <0xfff>;
 		gfx3d_user: gfx3d_user {
 			compatible = "qcom,smmu-kgsl-cb";
 			label = "gfx3d_user";
 			qcom,gpu-offset = <0x48000>;
 		};
-		/* TODO: Add secure and priv contexts!!! */
+		gfx3d_secure: gfx3d_secure {
+			compatible = "qcom,smmu-kgsl-cb";
+			label = "gfx3d_secure";
+		};
+		gfx3d_priv: gfx3d_priv {
+			compatible = "qcom,smmu-kgsl-cb";
+			label = "gfx3d_priv";
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -222,9 +222,10 @@
 			compatible = "qcom,smmu-kgsl-cb";
 			label = "gfx3d_secure";
 		};
-		gfx3d_priv: gfx3d_priv {
+/*		gfx3d_priv: gfx3d_priv {
 			compatible = "qcom,smmu-kgsl-cb";
 			label = "gfx3d_priv";
 		};
+*/
 	};
 };

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -79,13 +79,12 @@
 			 <&clock_gcc_gfx clk_gcc_oxili_timer_clk>,
 			 <&clock_gcc_gfx clk_gcc_gfx_tcu_clk>,
 			 <&clock_gcc_gfx clk_gcc_gfx_tbu_clk>,
-			 <&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>,
-			 <&clock_gcc_gfx clk_gcc_oxili_aon_clk>;
+			 <&clock_gcc_gfx clk_gcc_oxili_aon_clk>,
+			 <&clock_gcc_gfx clk_gcc_gfx_1_tbu_clk>;
 
 		clock-names =   "core_clk", "iface_clk", "mem_clk",
 				"mem_iface_clk", "gtcu_iface_clk", "rbbmtimer_clk",
-				"gtcu_clk", "gtbu_clk", "gtbu1_clk",
-				"alwayson_clk";
+				"gtcu_clk", "gtbu_clk", "alwayson_clk", "gtbu1_clk";
 
 		/* Bus Scale Settings */
 		qcom,gpubw-dev = <&gpubw>;
@@ -201,7 +200,7 @@
 		* The gpu can only program a single context bank
 		* at this fixed offset.
 		*/
-		qcom,protect = <0x40000 0x20000>;
+		qcom,protect = <0x40000 0x10000>;
 		qcom,micro-mmu-control = <0x6000>;
 
 		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
@@ -221,6 +220,7 @@
 		gfx3d_secure: gfx3d_secure {
 			compatible = "qcom,smmu-kgsl-cb";
 			label = "gfx3d_secure";
+			memory-region = <&secure_mem>;
 		};
 /*		gfx3d_priv: gfx3d_priv {
 			compatible = "qcom,smmu-kgsl-cb";

--- a/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-gpu.dtsi
@@ -189,4 +189,26 @@
 			};
 		};
 	};
+
+	kgsl_msm_iommu: qcom,kgsl-iommu {
+		compatible = "qcom,kgsl-smmu-v2";
+		reg = <0x1f00000 0x10000>;
+		/*
+		* The gpu can only program a single context bank
+		* at this fixed offset.
+		*/
+		qcom,protect = <0x48000 0x1000>;
+		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
+			<&clock_gcc clk_gcc_gfx_tcu_clk>,
+			<&clock_gcc clk_gcc_gtcu_ahb_clk>,
+			<&clock_gcc clk_gcc_gfx_tbu_clk>;
+		clock-names = "iface_clk", "core_clk", "gtcu_iface_clk",
+				"gtbu_clk";
+		gfx3d_user: gfx3d_user {
+			compatible = "qcom,smmu-kgsl-cb";
+			label = "gfx3d_user";
+			qcom,gpu-offset = <0x48000>;
+		};
+		/* TODO: Add secure and priv contexts!!! */
+	};
 };

--- a/arch/arm/boot/dts/qcom/msm8976-iommu-domains.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-iommu-domains.dtsi
@@ -1,0 +1,64 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	qcom,iommu-domains {
+		compatible = "qcom,iommu-domains";
+
+		/*
+		 * non-secure addr pool from 1500 MB to 3532 MB
+		 *                           3532 MB to 3548 MB
+		 */
+		venus_domain_ns: qcom,iommu-domain1 {
+			label = "venus_ns";
+			qcom,iommu-contexts = <&venus_ns>;
+			qcom,virtual-addr-pool = <0x5dc00000 0x7f000000
+						  0xdcc00000 0x1000000>;
+		};
+
+		/*
+		 * secure bitstream addr pool from 1200 MB to 1500 MB
+		 */
+		venus_domain_sec_bitstream: qcom,iommu-domain2 {
+			label = "venus_sec_bitstream";
+			qcom,iommu-contexts = <&venus_sec_bitstream>;
+			qcom,virtual-addr-pool = <0x4b000000 0x12c00000>;
+			qcom,secure-domain;
+		};
+
+		/*
+		 * secure pixel addr pool from 616 MB to 1200 MB
+		 */
+		venus_domain_sec_pixel: qcom,iommu-domain3 {
+			label = "venus_sec_pixel";
+			qcom,iommu-contexts = <&venus_sec_pixel>;
+			qcom,virtual-addr-pool = <0x25800000 0x25800000>;
+			qcom,secure-domain;
+		};
+
+		/*
+		 * secure non-pixel addr pool from 16 MB to 616 MB
+		 */
+		venus_domain_sec_non_pixel: qcom,iommu-domain4 {
+			label = "venus_sec_non_pixel";
+			qcom,iommu-contexts = <&venus_sec_non_pixel>;
+			qcom,virtual-addr-pool = <0x1000000 0x24800000>;
+			qcom,secure-domain;
+		};
+
+		qcom,iommu-domain5 {
+			label = "lpass_audio";
+			qcom,iommu-contexts = <&adsp_io>;
+			qcom,virtual-addr-pool = <0x10000000 0x0FFFFFFF>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-iommu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-iommu.dtsi
@@ -1,0 +1,346 @@
+/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	gfx_iommu: qcom,iommu@1f00000 {
+		compatible = "qcom,msm-smmu-v2", "qcom,msm-mmu-500";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		reg = <0x1f00000 0x10000>;
+		reg-names = "iommu_base";
+		interrupts = <0 43 0>, <0 42 0>;
+		interrupt-names = "global_cfg_NS_irq", "global_cfg_S_irq";
+		label = "gfx_iommu";
+		qcom,iommu-secure-id = <18>;
+		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
+			 <&clock_gcc_gfx clk_gcc_gfx_tcu_clk>;
+		clock-names = "iface_clk", "core_clk";
+		status = "ok";
+
+		gfx3d_user: qcom,iommu-ctx@1f08000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1f08000 0x1000>;
+			interrupts = <0 240 0>;
+			qcom,iommu-ctx-sids = <0x0>;
+			qcom,iommu-sid-mask = <0x400>;
+			label = "gfx3d_user";
+		};
+
+		gfx3d_secure: qcom,iommu-ctx@1f09000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1f09000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 241 0>, <0 241 0>;
+			qcom,iommu-ctx-sids = <0x2>;
+			qcom,iommu-sid-mask = <0x401>;
+			label = "gfx3d_secure";
+		};
+
+		gfx3d_priv: qcom,iommu-ctx@1f0a000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1f0a000 0x1000>;
+			interrupts = <0 242 0>;
+			qcom,iommu-ctx-sids = <0x1>;
+			qcom,iommu-sid-mask = <0x400>;
+			label = "gfx3d_priv";
+		};
+	};
+
+	apps_iommu: qcom,iommu@1e00000 {
+		compatible = "qcom,msm-smmu-v2", "qcom,msm-mmu-500";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		reg = <0x1e00000 0x40000>;
+		reg-names = "iommu_base";
+		interrupts = <0 41 0>, <0 38 0>;
+		interrupt-names = "global_cfg_NS_irq", "global_cfg_S_irq";
+		label = "apps_iommu";
+		qcom,iommu-secure-id = <17>;
+		clocks = <&clock_gcc clk_gcc_smmu_cfg_clk>,
+			 <&clock_gcc clk_gcc_apss_tcu_clk>;
+		clock-names = "iface_clk", "core_clk";
+		qcom,cb-base-offset = <0x20000>;
+		status = "ok";
+
+		adsp_elf: qcom,iommu-ctx@1e20000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e20000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 254 0>, <0 254 0>;
+			qcom,iommu-ctx-sids = <0x2c00>;
+			label = "adsp_elf";
+		};
+
+		adsp_sec_pixel: qcom,iommu-ctx@1e21000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e21000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 255 0>, <0 255 0>;
+			qcom,iommu-ctx-sids = <0x2c02>;
+			label = "adsp_sec_pixel";
+		};
+
+		adsp_sec_bitstream: qcom,iommu-ctx@1e22000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e22000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 53 0>, <0 53 0>;
+			qcom,iommu-ctx-sids = <0x2c03>;
+			label = "adsp_sec_bitstream";
+		};
+
+		venus_fw: qcom,iommu-ctx@1e23000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e23000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 54 0>, <0 54 0>;
+			qcom,iommu-ctx-sids = <0x980 0x986 0x903
+						0x3180 0x3186 0x3103>;
+			qcom,iommu-sid-mask = <0x0 0x0 0x20
+						0x0 0x0 0x20>;
+			label = "venus_fw";
+			qcom,report-error-on-fault;
+		};
+
+		venus_sec_non_pixel: qcom,iommu-ctx@1e24000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e24000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 58 0>, <0 58 0>;
+			qcom,iommu-ctx-sids = <0x940 0x905 0x907
+					0x908 0x90d 0x925 0x92d
+					0x3140 0x3105 0x3107
+					0x3108 0x310d 0x3125 0x312d>;
+			qcom,iommu-sid-mask = <0x0 0x0 0x8
+					0x20 0x0 0x0 0x0
+					0x0 0x0 0x8
+					0x20 0x0 0x0 0x0>;
+			label = "venus_sec_non_pixel";
+			qcom,report-error-on-fault;
+		};
+
+		venus_sec_bitstream: qcom,iommu-ctx@1e25000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e25000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 60 0>, <0 60 0>;
+			qcom,iommu-ctx-sids = <0x902 0x90e 0x909
+					0x3102 0x310e 0x3109>;
+			qcom,iommu-sid-mask = <0x8 0x0 0x2
+					0x8 0x0 0x2>;
+			label = "venus_sec_bitstream";
+			qcom,report-error-on-fault;
+		};
+
+		venus_sec_pixel: qcom,iommu-ctx@1e26000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e26000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 61 0>, <0 61 0>;
+			qcom,iommu-ctx-sids = <0x904 0x90c 0x910
+					0x3104 0x310c 0x3110>;
+			qcom,iommu-sid-mask = <0x0 0x20 0x0
+					0x0 0x20 0x0>;
+			label = "venus_sec_pixel";
+			qcom,report-error-on-fault;
+		};
+
+		venus_enc: qcom,iommu-ctx@1e27000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e27000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 76 0>, <0 76 0>;
+			qcom,iommu-ctx-sids = <0x926 0x929
+					0x3126 0x3129>;
+			qcom,iommu-sid-mask = <0x0 0x2
+					0x0 0x2>;
+			label = "venus_enc";
+			qcom,report-error-on-fault;
+		};
+
+		mdp_1: qcom,iommu-ctx@1e28000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e28000 0x1000>;
+			qcom,secure-context;
+			interrupts = <0 77 0>, <0 77 0>;
+			qcom,iommu-ctx-sids = <0xc01 0x2401>;
+			label = "mdp_1";
+		};
+
+		periph_rpm: qcom,iommu-ctx@1e29000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e29000 0x1000>;
+			interrupts = <0 80 0>;
+			qcom,iommu-ctx-sids = <0x40>;
+			qcom,iommu-sid-mask = <0x1>;
+			label = "periph_rpm";
+		};
+
+		lpass: qcom,iommu-ctx@1e2a000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e2a000 0x1000>;
+			interrupts = <0 94 0>;
+			qcom,iommu-ctx-sids = <0x1c0 0x1ca 0x1cc
+					0x1d0 0x1e0 0x1f0>;
+                        qcom,iommu-sid-mask = <0x7 0x1 0x3
+					0xf 0xf 0x1>;
+			label = "lpass";
+		};
+
+		pronto_pil: qcom,iommu-ctx@1e2b000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e2b000 0x1000>;
+			interrupts = <0 101 0>;
+			qcom,iommu-ctx-sids = <0x1801 0x1802 0x1804>;
+			qcom,iommu-sid-mask = <0x0 0x1 0x0>;
+			label = "pronto_pil";
+		};
+
+		q6: qcom,iommu-ctx@1e2c000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e2c000 0x1000>;
+			interrupts = <0 102 0>;
+			qcom,iommu-ctx-sids = <0x1004>;
+			qcom,iommu-sid-mask = <0x2>;
+			label = "q6";
+		};
+
+		adsp_io: qcom,iommu-ctx@1e2f000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e2f000 0x1000>;
+			interrupts = <0 105 0>;
+			qcom,iommu-ctx-sids = <0x2c01>;
+			label = "adsp_io";
+		};
+
+		adsp_opendsp: qcom,iommu-ctx@1e30000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e30000 0x1000>;
+			interrupts = <0 106 0>;
+			qcom,iommu-ctx-sids = <0x2c04>;
+			label = "adsp_opendsp";
+		};
+
+		adsp_shared: qcom,iommu-ctx@1e31000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e31000 0x1000>;
+			interrupts = <0 109 0>;
+			qcom,iommu-ctx-sids = <0x2c05 0x2c06 0x2c08 0x2c0c>;
+			qcom,iommu-sid-mask = <0x0 0x1 0x3 0x0>;
+			label = "adsp_shared";
+		};
+
+		lpass_stream: qcom,iommu-ctx@1e32000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e32000 0x1000>;
+			interrupts = <0 110 0>;
+			qcom,iommu-ctx-sids = <0x1d4>;
+			qcom,iommu-sid-mask = <0x1>;
+			label = "lpass_stream";
+		};
+
+		cpp: qcom,iommu-ctx@1e33000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e33000 0x1000>;
+			interrupts = <0 111 0>;
+			qcom,iommu-ctx-sids = <0x2000>;
+			label = "cpp";
+		};
+
+		jpeg_enc0: qcom,iommu-ctx@1e34000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e34000 0x1000>;
+			interrupts = <0 112 0>;
+			qcom,iommu-ctx-sids = <0x1c00>;
+			label = "jpeg_enc0";
+		};
+
+		vfe: qcom,iommu-ctx@1e35000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e35000 0x1000>;
+			interrupts = <0 113 0>;
+			qcom,iommu-ctx-sids = <0x400 0x3400>;
+			label = "vfe";
+		};
+
+		venus_ns: qcom,iommu-ctx@1e36000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e36000 0x1000>;
+			interrupts = <0 114 0>;
+			qcom,iommu-ctx-sids = <0x800 0x807 0x808
+					0x80C 0x810 0x821 0x828
+					0x82B 0x82C 0x831
+					0x3000 0x3007 0x3008
+					0x300C 0x3010 0x3021 0x3028
+					0x302B 0x302C 0x3031>;
+			qcom,iommu-sid-mask = <0x1 0x0 0x3
+					0x3 0x1 0x0 0x1
+					0x0 0x1 0x0
+					0x1 0x0 0x3
+					0x3 0x1 0x0 0x1
+					0x0 0x1 0x0>;
+			label = "venus_ns";
+			qcom,report-error-on-fault;
+		};
+
+		mdp_0: qcom,iommu-ctx@1e37000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e37000 0x1000>;
+			interrupts = <0 115 0>;
+			qcom,iommu-ctx-sids = <0xc00 0x2400>;
+			label = "mdp_0";
+		};
+
+		pronto_buf: qcom,iommu-ctx@1e38000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e38000 0x1000>;
+			interrupts = <0 116 0>;
+			qcom,iommu-ctx-sids = <0x1806 0x1808 0x180c>;
+			qcom,iommu-sid-mask = <0x1 0x3 0x1>;
+			label = "pronto_buf";
+		};
+
+		mss_nav: qcom,iommu-ctx@1e39000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e39000 0x1000>;
+			interrupts = <0 117 0>;
+			qcom,iommu-ctx-sids = <0x1400>;
+			label = "mss_nav";
+		};
+
+		ipa_shared: qcom,iommu-ctx@1e3a000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e3a000 0x1000>;
+			interrupts = <0 118 0>;
+			qcom,iommu-ctx-sids = <0x2800>;
+			label = "ipa_shared";
+		};
+
+		ipa_wlan: qcom,iommu-ctx@1e3b000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e3b000 0x1000>;
+			interrupts = <0 119 0>;
+			qcom,iommu-ctx-sids = <0x2802>;
+			label = "ipa_wlan";
+		};
+
+		ipa_uc: qcom,iommu-ctx@1e3c000 {
+			compatible = "qcom,msm-smmu-v2-ctx";
+			reg = <0x1e3c000 0x1000>;
+			interrupts = <0 120 0>;
+			qcom,iommu-ctx-sids = <0x2804>;
+			label = "ipa_uc";
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-iommu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-iommu.dtsi
@@ -27,7 +27,7 @@
 		clock-names = "iface_clk", "core_clk";
 		status = "ok";
 
-		gfx3d_user: qcom,iommu-ctx@1f08000 {
+		qcom,iommu-ctx@1f08000 {
 			compatible = "qcom,msm-smmu-v2-ctx";
 			reg = <0x1f08000 0x1000>;
 			interrupts = <0 240 0>;
@@ -36,7 +36,7 @@
 			label = "gfx3d_user";
 		};
 
-		gfx3d_secure: qcom,iommu-ctx@1f09000 {
+		qcom,iommu-ctx@1f09000 {
 			compatible = "qcom,msm-smmu-v2-ctx";
 			reg = <0x1f09000 0x1000>;
 			qcom,secure-context;
@@ -46,7 +46,7 @@
 			label = "gfx3d_secure";
 		};
 
-		gfx3d_priv: qcom,iommu-ctx@1f0a000 {
+		qcom,iommu-ctx@1f0a000 {
 			compatible = "qcom,msm-smmu-v2-ctx";
 			reg = <0x1f0a000 0x1000>;
 			interrupts = <0 242 0>;

--- a/arch/arm/boot/dts/qcom/msm8976-ion.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-ion.dtsi
@@ -1,0 +1,51 @@
+/* Copyright (c) 2014, Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	qcom,ion {
+		compatible = "qcom,msm-ion";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,ion-heap@25 {
+			reg = <25>;
+			qcom,ion-heap-type = "SYSTEM";
+		};
+
+		qcom,ion-heap@21 {
+			reg = <21>;
+			qcom,ion-heap-type = "SYSTEM_CONTIG";
+		};
+
+		qcom,ion-heap@8 { /* CP_MM HEAP */
+			compatible = "qcom,msm-ion-reserve";
+			reg = <8>;
+			qcom,heap-align = <0x1000>;
+			linux,contiguous-region = <&secure_mem>;
+			qcom,ion-heap-type = "SECURE_DMA";
+		};
+
+		qcom,ion-heap@27 { /* QSEECOM HEAP */
+			compatible = "qcom,msm-ion-reserve";
+			reg = <27>;
+			linux,contiguous-region = <&qseecom_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
+		qcom,ion-heap@28 { /* AUDIO HEAP */
+			compatible = "qcom,msm-ion-reserve";
+			reg = <28>;
+			linux,contiguous-region = <&audio_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-jtag.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-jtag.dtsi
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	jtag_fuse: jtagfuse@a601c {
+		compatible = "qcom,jtag-fuse-v2";
+		reg = <0xa601c 0x8>;
+		reg-names = "fuse-base";
+	};
+
+	jtag_mm0: jtagmm@6840000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6840000 0x1000>,
+		      <0x6810000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU0>;
+	};
+
+	jtag_mm1: jtagmm@6940000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6940000 0x1000>,
+		      <0x6910000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU1>;
+	};
+
+	jtag_mm2: jtagmm@6a40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6a40000 0x1000>,
+		      <0x6a10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU2>;
+	};
+
+	jtag_mm3: jtagmm@6b40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6b40000 0x1000>,
+		      <0x6b10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU3>;
+	};
+
+	jtag_mm4: jtagmm@6c40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6c40000 0x1000>,
+		      <0x6c10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU4>;
+	};
+
+	jtag_mm5: jtagmm@6d40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6d40000 0x1000>,
+		      <0x6d10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU5>;
+	};
+
+	jtag_mm6: jtagmm@6e40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6e40000 0x1000>,
+		      <0x6e10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU6>;
+	};
+
+	jtag_mm7: jtagmm@6f40000 {
+		compatible = "qcom,jtagv8-mm";
+		reg = <0x6f40000 0x1000>,
+		      <0x6f10000 0x1000>;
+		reg-names = "etm-base", "debug-base";
+
+		clocks = <&clock_gcc clk_qdss_clk>,
+		         <&clock_gcc clk_qdss_a_clk>;
+		clock-names = "core_clk", "core_a_clk";
+
+		qcom,coresight-jtagmm-cpu = <&CPU7>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-mdss-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss-mtp.dtsi
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&mdss_mdp {
+	qcom,mdss-pref-prim-intf = "dsi";
+};
+
+&dsi_dual_nt35597_video {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-dsi-pan-enable-dynamic-fps;
+	qcom,mdss-dsi-pan-fps-update = "dfps_immediate_porch_mode_hfp";
+};
+
+&dsi_dual_nt35597_cmd {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,partial-update-enabled;
+	qcom,panel-roi-alignment = <720 128 720 128 720 128>;
+};
+
+&dsi_nt35597_dsc_video {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-dsi-mode-sel-gpio-state = "dsc_mode";
+	qcom,mdss-dsi-pan-enable-dynamic-fps;
+	qcom,mdss-dsi-pan-fps-update = "dfps_immediate_porch_mode_hfp";
+};
+
+&dsi_nt35597_dsc_cmd {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-dsi-mode-sel-gpio-state = "dsc_mode";
+};
+
+&pmx_mdss {
+	qcom,num-grp-pins = <3>;
+	qcom,pins = <&gp 25>, <&gp 66>, <&gp 107>;
+};
+
+&pmx_mdss_te {
+	qcom,num-grp-pins = <1>;
+	qcom,pins = <&gp 24>;
+};
+
+&mdss_dsi0 {
+	pinctrl-names = "mdss_default", "mdss_sleep";
+	pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+	pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
+	qcom,dsi-pref-prim-pan = <&dsi_dual_nt35597_video>;
+
+	qcom,platform-reset-gpio = <&msm_gpio 25 0>;
+	qcom,platform-bklight-en-gpio = <&msm_gpio 66 0>;
+	qcom,panel-mode-gpio = <&msm_gpio 107 0>;
+};
+
+&mdss_dsi1 {
+	pinctrl-names = "mdss_default", "mdss_sleep";
+	pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+	pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
+	qcom,dsi-pref-prim-pan = <&dsi_dual_nt35597_video>;
+
+	qcom,platform-reset-gpio = <&msm_gpio 25 0>;
+	qcom,platform-bklight-en-gpio = <&msm_gpio 66 0>;
+	qcom,panel-mode-gpio = <&msm_gpio 107 0>;
+};
+
+&labibb {
+	status = "ok";
+	qpnp,qpnp-labibb-mode = "lcd";
+};
+
+&ibb_regulator {
+	qcom,qpnp-ibb-discharge-resistor = <32>;
+};

--- a/arch/arm/boot/dts/qcom/msm8976-mdss-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss-mtp.dtsi
@@ -51,14 +51,49 @@
 	qcom,mdss-dsi-mode-sel-gpio-state = "dsc_mode";
 };
 
-&pmx_mdss {
-	qcom,num-grp-pins = <3>;
-	qcom,pins = <&gp 25>, <&gp 66>, <&gp 107>;
+&mdss_dsi_active {
+	mux {
+		pins = "gpio25" , "gpio66", "gpio107";
+		function = "gpio";
+	};
+	config {
+		pins = "gpio25" , "gpio66", "gpio107";
+		drive-strength = <2>; /* 2 mA */
+		bias-disable = <0>; /* no pull */
+		output-high;
+	};
 };
 
-&pmx_mdss_te {
-	qcom,num-grp-pins = <1>;
-	qcom,pins = <&gp 24>;
+&mdss_dsi_suspend {
+	mux {
+		pins = "gpio25" , "gpio66", "gpio107";
+		function = "gpio";
+	};
+	config {
+		pins = "gpio25" , "gpio66", "gpio107";
+		drive-strength = <2>; /* 2 mA */
+		/delete-property/ bias-pull-down;
+		bias-disable = <0>; /* no pull */
+		output-low;
+	};
+};
+
+&mdss_te_active{
+	mux {
+		pins = "gpio24";
+	};
+	config {
+		pins = "gpio24";
+	};
+};
+
+&mdss_te_suspend{
+	mux {
+		pins = "gpio24";
+	};
+	config {
+		pins = "gpio24";
+	};
 };
 
 &mdss_dsi0 {

--- a/arch/arm/boot/dts/qcom/msm8976-mdss-panels.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss-panels.dtsi
@@ -1,0 +1,68 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "dsi-panel-sim-video.dtsi"
+#include "dsi-panel-sim-cmd.dtsi"
+#include "dsi-panel-nt35597-dualmipi-wqxga-video.dtsi"
+#include "dsi-panel-nt35597-dualmipi-wqxga-cmd.dtsi"
+#include "dsi-panel-otm1906c-1080p-cmd.dtsi"
+#include "dsi-panel-hx8399a-1080p-video.dtsi"
+#include "dsi-panel-nt35597-dsc-wqxga-video.dtsi"
+#include "dsi-panel-nt35597-dsc-wqxga-cmd.dtsi"
+#include "dsi-panel-truly-1080p-video.dtsi"
+#include "dsi-panel-truly-1080p-cmd.dtsi"
+#include "dsi-panel-adv7533-1080p-video.dtsi"
+#include "dsi-panel-adv7533-720p-video.dtsi"
+
+&soc {
+	dsi_panel_pwr_supply: dsi_panel_pwr_supply {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,panel-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "vdd";
+			qcom,supply-min-voltage = <2850000>;
+			qcom,supply-max-voltage = <2850000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+
+		qcom,panel-supply-entry@1 {
+			reg = <1>;
+			qcom,supply-name = "vddio";
+			qcom,supply-min-voltage = <1800000>;
+			qcom,supply-max-voltage = <1800000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+
+		qcom,panel-supply-entry@2 {
+			reg = <2>;
+			qcom,supply-name = "lab";
+			qcom,supply-min-voltage = <4600000>;
+			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+
+		qcom,panel-supply-entry@3 {
+			reg = <3>;
+			qcom,supply-name = "ibb";
+			qcom,supply-min-voltage = <4600000>;
+			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+			qcom,supply-post-on-sleep = <20>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-mdss-pll.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss-pll.dtsi
@@ -1,0 +1,73 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	mdss_dsi0_pll: qcom,mdss_dsi_pll@1a94a00 {
+		compatible = "qcom,mdss_dsi_pll_8976";
+		label = "MDSS DSI 0 PLL";
+		cell-index = <0>;
+		#clock-cells = <1>;
+
+		reg = <0x1a94a00 0xd4>, <0x0184d074 0x8>;
+		reg-names = "pll_base", "gdsc_base";
+
+		gdsc-supply = <&gdsc_mdss>;
+
+		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>;
+		clock-names = "iface_clk";
+		clock-rate = <0>;
+
+		qcom,platform-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,platform-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+	};
+
+	mdss_dsi1_pll: qcom,mdss_dsi_pll@1a96a00 {
+		compatible = "qcom,mdss_dsi_pll_8976";
+		label = "MDSS DSI 1 PLL";
+		cell-index = <1>;
+		#clock-cells = <1>;
+
+		reg = <0x1a96a00 0xd4>, <0x0184d074 0x8>;
+		reg-names = "pll_base", "gdsc_base";
+
+		gdsc-supply = <&gdsc_mdss>;
+
+		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>;
+		clock-names = "iface_clk";
+		clock-rate = <0>;
+
+		qcom,platform-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,platform-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
@@ -1,0 +1,340 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	mdss_mdp: qcom,mdss_mdp@1a00000 {
+		compatible = "qcom,mdss_mdp";
+		reg = <0x1a00000 0x90000>,
+			<0x1ab0000 0x3000>;
+		reg-names = "mdp_phys", "vbif_phys";
+		interrupts = <0 72 0>;
+		vdd-supply = <&gdsc_mdss>;
+
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_mdp";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <2>;
+		qcom,msm-bus,vectors-KBps =
+			<22 512 0 0>, <23 512 0 0>,
+			<22 512 0 6400000>, <23 512 0 6400000>,
+			<22 512 0 6400000>, <23 512 0 6400000>;
+
+		/* Fudge factors */
+		qcom,mdss-ab-factor = <1 1>;		/* no fudge    */
+		qcom,mdss-ib-factor = <1 1>;		/* no fudge  */
+		qcom,mdss-ib-factor-cmd = <1 1>;	/* no fudge */
+		qcom,mdss-clk-factor = <105 100>;	/* 1.05 times */
+		qcom,max-bandwidth-low-kbps = <5700000>;
+		qcom,max-bandwidth-high-kbps = <5700000>;
+		qcom,max-bandwidth-per-pipe-kbps = <4 2100000>,	/* HFlip */
+						   <8 1800000>;	/* VFlip */
+
+		/* VBIF QoS remapper settings*/
+		qcom,mdss-vbif-qos-rt-setting = <2 2 2 2>;
+		qcom,mdss-vbif-qos-nrt-setting = <1 1 1 1>;
+		qcom,max-mixer-width = <2560>;
+		qcom,mdss-mdp-reg-offset = <0x00001000>;
+		qcom,max-clk-rate = <360000000>;
+		qcom,mdss-pipe-vig-off = <0x00005000 0x00007000>;
+		qcom,mdss-pipe-rgb-off = <0x00015000 0x00017000>;
+		qcom,mdss-pipe-dma-off = <0x00025000>;
+		qcom,mdss-pipe-cursor-off = <0x000450DC>;
+		qcom,mdss-pipe-vig-fetch-id = <1 9>;
+		qcom,mdss-pipe-rgb-fetch-id = <7 8>;
+		qcom,mdss-pipe-dma-fetch-id = <4>;
+		qcom,mdss-default-ot-wr-limit = <16>;
+		qcom,mdss-default-ot-rd-limit = <16>;
+
+		qcom,mdss-pipe-vig-xin-id = <0 4>;
+		qcom,mdss-pipe-rgb-xin-id = <1 5>;
+		qcom,mdss-pipe-dma-xin-id = <2>;
+		qcom,mdss-pipe-cursor-xin-id = <7>;
+
+		/* Panic/robust control register offsets for pipes */
+		qcom,mdss-pipe-vig-panic-ctrl-offsets = <0 1>;
+		qcom,mdss-pipe-rgb-panic-ctrl-offsets = <4 5>;
+		qcom,mdss-pipe-dma-panic-ctrl-offsets = <8>;
+
+		qcom,mdss-pipe-vig-clk-ctrl-offsets = <0x2ac 0 0>,
+						      <0x2b4 0 0>;
+		qcom,mdss-pipe-rgb-clk-ctrl-offsets = <0x2ac 4 8>,
+						      <0x2b4 4 8>;
+		qcom,mdss-pipe-dma-clk-ctrl-offsets = <0x2ac 8 12>;
+		qcom,mdss-pipe-cursor-clk-ctrl-offsets = <0x3a8 16 15>;
+
+		qcom,mdss-smp-data = <10 10240>;
+
+		qcom,mdss-ctl-off = <0x00002000 0x00002200 0x00002400>;
+		qcom,mdss-mixer-intf-off = <0x00045000 0x00046000>;
+		qcom,mdss-dspp-off = <0x00055000>;
+		qcom,mdss-pingpong-off = <0x00071000 0x00071800>;
+		qcom,mdss-wb-off = <0x00065000 0x00065800 0x00066000>;
+		qcom,mdss-intf-off = <0x00000000 0x0006b800 0x0006c000>;
+		qcom,mdss-ppb-off = <0x00000420>;
+		qcom,mdss-slave-pingpong-off = <0x00073000>;
+		qcom,mdss-ad-off = <0x0079000>;
+		qcom,mdss-rot-block-size = <64>;
+		qcom,mdss-wfd-mode = "intf_no_dspp";
+		qcom,mdss-has-non-scalar-rgb;
+		qcom,mdss-has-decimation;
+		qcom,mdss-no-hist-vote;
+		qcom,mdss-has-10bit-pa;
+		qcom,mdss-needs-iommu-bw-vote;
+		qcom,mdss-has-panic-ctrl;
+		qcom,mdss-has-dst-split;
+		qcom,mdss-dsc-off = <0x00081000 0x00081400>;
+
+		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>,
+			 <&clock_gcc clk_gcc_mdss_axi_clk>,
+			 <&clock_gcc clk_mdp_clk_src>,
+			 <&clock_gcc clk_gcc_mdss_mdp_clk>,
+			 <&clock_gcc clk_gcc_mdss_vsync_clk>,
+			 <&clock_gcc clk_gcc_mdp_tbu_clk>,
+			 <&clock_gcc clk_gcc_mdp_rt_tbu_clk>;
+		clock-names = "iface_clk", "bus_clk", "core_clk_src",
+				"core_clk", "vsync_clk", "tbu_clk",
+				"tbu_rt_clk";
+		qcom,mdp-settings = <0x0000117c 0x0000ffff>,
+				    <0x00001180 0x0000000f>,
+				    <0x00001184 0x0000ffc0>,
+				    <0x000011e0 0x000000e4>,
+				    <0x000011e4 0x00000000>,
+				    <0x00065048 0x00000008>,
+				    <0x00065848 0x00000008>,
+				    <0x00066048 0x00000008>;
+
+		qcom,regs-dump-mdp = <0x01000 0x01424>,
+				     <0x02000 0x02030>,
+				     <0x02200 0x02230>,
+				     <0x02400 0x02430>,
+				     <0x05000 0x05130>,
+				     <0x05200 0x05230>,
+					 <0x07000 0x07130>,
+					 <0x07200 0x07230>,
+				     <0x15000 0x15130>,
+				     <0x17000 0x17130>,
+				     <0x25000 0x2512C>,
+				     <0x45000 0x4538c>,
+				     <0x46000 0x4838c>,
+				     <0x55000 0x5522c>,
+				     <0x65000 0x652b4>,
+				     <0x65800 0x65ab4>,
+					 <0x66000 0x662b4>,
+				     <0x6b800 0x6ba54>,
+					 <0x6c000 0x6c054>,
+				     <0x71000 0x710d0>,
+					 <0x71800 0x718d0>,
+					 <0x73000 0x730d0>;
+
+		qcom,regs-dump-names-mdp = "MDP",
+			"CTL_0",     "CTL_1",  "CTL_2",
+			"VIG0_SSPP", "VIG0",
+			"VIG1_SSPP", "VIG1",
+			"RGB0_SSPP", "RGB1_SSPP",
+			"DMA0_SSPP",
+			"LAYER_0",   "LAYER_1",
+			"DSPP_0",
+			"WB_0",      "WB_1",
+			"INTF_1",	"INTF_2",
+			"PP_0",	"PP_1", "PP_4";
+
+		/* buffer parameters to calculate prefill bandwidth */
+		qcom,mdss-prefill-outstanding-buffer-bytes = <2048>;
+		qcom,mdss-prefill-y-buffer-bytes = <0>;
+		qcom,mdss-prefill-scaler-buffer-lines-bilinear = <2>;
+		qcom,mdss-prefill-scaler-buffer-lines-caf = <4>;
+		qcom,mdss-prefill-post-scaler-buffer-pixels = <2560>;
+		qcom,mdss-prefill-pingpong-buffer-pixels = <5120>;
+		qcom,mdss-prefill-fbc-lines = <0>;
+
+		mdss_fb0: qcom,mdss_fb_primary {
+			cell-index = <0>;
+			compatible = "qcom,mdss-fb";
+			qcom,mdss-fb-splash-logo-enabled;
+			qcom,cont-splash-memory {
+				linux,contiguous-region = <&cont_splash_mem>;
+			};
+		};
+
+		mdss_fb1: qcom,mdss_fb_wfd {
+			cell-index = <1>;
+			compatible = "qcom,mdss-fb";
+		};
+
+		mdss_fb2: qcom,mdss_fb_secondary {
+			cell-index = <2>;
+			compatible = "qcom,mdss-fb";
+		};
+	};
+
+	mdss_dsi: qcom,mdss_dsi@0 {
+		compatible = "qcom,mdss-dsi";
+		hw-config = "split_dsi";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		qcom,mdss-fb-map-prim = <&mdss_fb0>;
+		qcom,mdss-fb-map-sec = <&mdss_fb2>;
+		gdsc-supply = <&gdsc_mdss>;
+		vdda-supply = <&pm8950_l1>;
+		vddio-supply = <&pm8950_l6>;
+		ranges = <0x1a94000 0x1a94000 0x300
+		      0x1a94400 0x1a94400 0x280
+		      0x1a94b80 0x1a94b80 0x30
+		      0x193e000 0x193e000 0x30
+			  0x1a96000 0x1a96000 0x300
+		      0x1a96400 0x1a96400 0x280
+		      0x1a96b80 0x1a96b80 0x30
+		      0x193e000 0x193e000 0x30>;
+
+		clocks = <&clock_gcc clk_gcc_mdss_mdp_clk>,
+			<&clock_gcc clk_gcc_mdss_ahb_clk>,
+			<&clock_gcc clk_gcc_mdss_axi_clk>,
+			<&clock_gcc_mdss clk_ext_byte0_clk_src>,
+			<&clock_gcc_mdss clk_ext_byte1_clk_src>,
+			<&clock_gcc_mdss clk_ext_pclk0_clk_src>,
+			<&clock_gcc_mdss clk_ext_pclk1_clk_src>;
+		clock-names = "mdp_core_clk", "iface_clk", "bus_clk",
+			"ext_byte0_clk", "ext_byte1_clk", "ext_pixel0_clk",
+			"ext_pixel1_clk";
+
+		qcom,mmss-ulp-clamp-ctrl-offset = <0x20>;
+		qcom,mmss-phyreset-ctrl-offset = <0x24>;
+		qcom,timing-db-mode;
+		qcom,split-dsi-independent-pll;
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+		qcom,ctrl-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,ctrl-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda";
+				qcom,supply-min-voltage = <1200000>;
+				qcom,supply-max-voltage = <1200000>;
+				qcom,supply-enable-load = <100000>;
+				qcom,supply-disable-load = <100>;
+				qcom,supply-post-on-sleep = <20>;
+			};
+		};
+
+		qcom,phy-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,phy-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vddio";
+				qcom,supply-min-voltage = <1800000>;
+				qcom,supply-max-voltage = <1800000>;
+				qcom,supply-enable-load = <100000>;
+				qcom,supply-disable-load = <100>;
+			};
+		};
+
+		mdss_dsi0: qcom,mdss_dsi_ctrl0@1a94000 {
+			compatible = "qcom,mdss-dsi-ctrl";
+			label = "MDSS DSI CTRL->0";
+			cell-index = <0>;
+			reg = <0x1a94000 0x300>,
+			      <0x1a94400 0x280>,
+			      <0x1a94b80 0x30>,
+			      <0x193e000 0x30>;
+			reg-names = "dsi_ctrl", "dsi_phy",
+			      "dsi_phy_regulator", "mmss_misc_phys";
+
+			qcom,mdss-mdp = <&mdss_mdp>;
+			vdd-supply = <&pm8950_l17>;
+			vddio-supply = <&pm8950_l6>;
+			lab-supply = <&lab_regulator>;
+			ibb-supply = <&ibb_regulator>;
+
+			clocks = <&clock_gcc_mdss clk_gcc_mdss_byte0_clk>,
+				<&clock_gcc_mdss clk_gcc_mdss_pclk0_clk>,
+				<&clock_gcc clk_gcc_mdss_esc0_clk>,
+				<&clock_gcc_mdss clk_byte0_clk_src>,
+				<&clock_gcc_mdss clk_pclk0_clk_src>;
+			clock-names = "byte_clk", "pixel_clk", "core_clk",
+				"byte_clk_rcg", "pixel_clk_rcg";
+
+			qcom,platform-strength-ctrl = [ff 06];
+			qcom,platform-bist-ctrl = [00 00 b1 ff 00 00];
+			qcom,platform-regulator-settings =
+					[07 09 03 00 20 07 01];
+			qcom,platform-lane-config = [01 c0 00 00 00 00 00 01 97
+				01 c0 00 00 05 00 00 01 97
+				01 c0 00 00 0a 00 00 01 97
+				01 c0 00 00 0f 00 00 01 97
+				00 40 00 00 00 00 00 01 bb];
+
+		};
+
+		mdss_dsi1: qcom,mdss_dsi_ctrl1@1a96000 {
+			compatible = "qcom,mdss-dsi-ctrl";
+			label = "MDSS DSI CTRL->1";
+			cell-index = <1>;
+			reg = <0x1a96000 0x300>,
+			      <0x1a96400 0x280>,
+			      <0x1a94b80 0x30>,
+			      <0x193e000 0x30>;
+			reg-names = "dsi_ctrl", "dsi_phy",
+			      "dsi_phy_regulator", "mmss_misc_phys";
+
+			qcom,mdss-mdp = <&mdss_mdp>;
+			vdd-supply = <&pm8950_l17>;
+			vddio-supply = <&pm8950_l6>;
+			lab-supply = <&lab_regulator>;
+			ibb-supply = <&ibb_regulator>;
+
+			clocks = <&clock_gcc_mdss clk_gcc_mdss_byte1_clk>,
+				<&clock_gcc_mdss clk_gcc_mdss_pclk1_clk>,
+				<&clock_gcc clk_gcc_mdss_esc1_clk>,
+				<&clock_gcc_mdss clk_byte1_clk_src>,
+				<&clock_gcc_mdss clk_pclk1_clk_src>;
+			clock-names = "byte_clk", "pixel_clk", "core_clk",
+				"byte_clk_rcg", "pixel_clk_rcg";
+
+			qcom,platform-strength-ctrl = [ff 06];
+			qcom,platform-bist-ctrl = [00 00 b1 ff 00 00];
+			qcom,platform-regulator-settings =
+					[07 09 03 00 20 07 01];
+			qcom,platform-lane-config = [01 c0 00 00 00 00 00 01 97
+				01 c0 00 00 05 00 00 01 97
+				01 c0 00 00 0a 00 00 01 97
+				01 c0 00 00 0f 00 00 01 97
+				00 40 00 00 00 00 00 01 bb];
+
+		};
+	};
+
+	qcom,mdss_wb_panel {
+		compatible = "qcom,mdss_wb";
+		qcom,mdss_pan_res = <1280 720>;
+		qcom,mdss_pan_bpp = <24>;
+		qcom,mdss-fb-map = <&mdss_fb1>;
+	};
+};
+
+#include "msm8976-mdss-panels.dtsi"

--- a/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
@@ -365,6 +365,17 @@
 			<&clock_gcc_mdss clk_gcc_mdss_mdp_rotator_vote_clk>;
 		clock-names = "iface_clk", "rot_core_clk";
 
+
+		qcom,mdss-rot-reg-bus {
+			/* Reg Bus Scale Settings */
+			qcom,msm-bus,name = "mdss_rot_reg";
+			qcom,msm-bus,num-cases = <2>;
+			qcom,msm-bus,num-paths = <1>;
+			qcom,msm-bus,active-only;
+			qcom,msm-bus,vectors-KBps =
+				<1 590 0 0>,
+				<1 590 0 76800>;
+		};
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
@@ -96,7 +96,7 @@
 		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>,
 			 <&clock_gcc clk_gcc_mdss_axi_clk>,
 			 <&clock_gcc clk_mdp_clk_src>,
-			 <&clock_gcc clk_gcc_mdss_mdp_clk>,
+			 <&clock_gcc_mdss clk_gcc_mdss_mdp_vote_clk>,
 			 <&clock_gcc clk_gcc_mdss_vsync_clk>,
 			 <&clock_gcc clk_gcc_mdp_tbu_clk>,
 			 <&clock_gcc clk_gcc_mdp_rt_tbu_clk>;
@@ -204,7 +204,7 @@
 		      0x1a96b80 0x1a96b80 0x30
 		      0x193e000 0x193e000 0x30>;
 
-		clocks = <&clock_gcc clk_gcc_mdss_mdp_clk>,
+		clocks = <&clock_gcc_mdss clk_gcc_mdss_mdp_vote_clk>,
 			<&clock_gcc clk_gcc_mdss_ahb_clk>,
 			<&clock_gcc clk_gcc_mdss_axi_clk>,
 			<&clock_gcc_mdss clk_ext_byte0_clk_src>,
@@ -343,6 +343,28 @@
 		qcom,mdss_pan_res = <1280 720>;
 		qcom,mdss_pan_bpp = <24>;
 		qcom,mdss-fb-map = <&mdss_fb1>;
+	};
+
+	mdss_rotator: qcom,mdss_rotator {
+		compatible = "qcom,mdss_rotator";
+		qcom,mdss-wb-count = <1>;
+		qcom,mdss-has-downscale;
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_rotator";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<22 512 0 0>,
+			<22 512 0 6400000>,
+			<22 512 0 6400000>;
+
+		rot-vdd-supply = <&gdsc_mdss>;
+		qcom,supply-names = "rot-vdd";
+
+		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>,
+			<&clock_gcc_mdss clk_gcc_mdss_mdp_rotator_vote_clk>;
+		clock-names = "iface_clk", "rot_core_clk";
+
 	};
 };
 

--- a/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
@@ -186,6 +186,15 @@
 		gdsc-supply = <&gdsc_mdss>;
 		vdda-supply = <&pm8950_l1>;
 		vddio-supply = <&pm8950_l6>;
+
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_dsi";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<22 512 0 0>,
+			<22 512 0 1000>;
+
 		ranges = <0x1a94000 0x1a94000 0x300
 		      0x1a94400 0x1a94400 0x280
 		      0x1a94b80 0x1a94b80 0x30

--- a/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-mdss.dtsi
@@ -90,7 +90,7 @@
 		qcom,mdss-has-10bit-pa;
 		qcom,mdss-needs-iommu-bw-vote;
 		qcom,mdss-has-panic-ctrl;
-		qcom,mdss-has-dst-split;
+		qcom,mdss-has-pingpong-split;
 		qcom,mdss-dsc-off = <0x00081000 0x00081400>;
 
 		clocks = <&clock_gcc clk_gcc_mdss_ahb_clk>,

--- a/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
@@ -1,0 +1,1580 @@
+/*
+ * Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	tlmm_pinmux: pinctrl@1000000 {
+		compatible = "qcom,msm-tlmm-8916";
+		reg = <0x1000000 0x300000>;
+		interrupts = <0 208 0>;
+
+		/*General purpose pins*/
+		gp: gp {
+			qcom,num-pins = <145>;
+			#qcom,pin-cells = <1>;
+			msm_gpio: msm_gpio {
+				compatible = "qcom,msm-tlmm-gp";
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				num_irqs = <145>;
+			};
+		};
+
+		cdc-reset-line {
+			qcom,pins = <&gp 133>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "cdc-reset-line";
+			cdc_reset_line_act: cdc_reset_line_on {
+				drive-strength = <16>;
+				bias-disable;
+				output-high;
+			};
+
+			cdc_reset_line_sus: cdc_reset_line_off {
+				drive-strength = <16>;
+				bias-disable;
+				output-low;
+			};
+		};
+
+		cdc-pdm-lines {
+			qcom,pins = <&gp 120>, <&gp 121>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <1>;
+			label = "cdc-pdm-lines";
+			cdc_pdm_lines_act: pdm_lines_on {
+				drive-strength = <8>;
+			};
+
+			cdc_pdm_lines_sus: pdm_lines_off {
+				drive-strength = <2>;
+				bias-disable;
+			};
+		};
+
+		cdc-pdm-2-lines {
+			qcom,pins = <&gp 116>, <&gp 117>, <&gp 118>, <&gp 119>;
+			qcom,num-grp-pins = <4>;
+			qcom,pin-func = <2>;
+			label = "cdc-pdm-2-lines";
+			cdc_pdm_lines_2_act: pdm_lines_2_on {
+				drive-strength = <8>;
+			};
+
+			cdc_pdm_lines_2_sus: pdm_lines_2_off {
+				drive-strength = <2>;
+				bias-disable;
+			};
+		};
+
+		pmx-uartconsole {
+			qcom,pins = <&gp 4>, <&gp 5>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <2>;
+			label = "uart-console";
+			uart_console_sleep: uart-console {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		blsp1_uart1_active {
+			qcom,pins = <&gp 0>, <&gp 1>, <&gp 2>, <&gp 3>;
+			qcom,num-grp-pins = <4>;
+			qcom,pin-func = <2>;
+			label = "blsp1_uart1_active";
+			hsuart_active: default {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		 };
+
+		blsp1_uart1_sleep {
+			qcom,pins = <&gp 0>, <&gp 1>, <&gp 2>, <&gp 3>;
+			qcom,num-grp-pins = <4>;
+			qcom,pin-func = <0>;
+			label = "blsp1_uart1_sleep";
+			hsuart_sleep: sleep {
+				drive-strength = <2>;
+				bias-disable;
+			};
+		};
+
+		sdhc2_cd_pin {
+			qcom,pins = <&gp 100>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "cd-gpio";
+			sdc2_cd_on: cd_on {
+				drive-strength = <2>;
+				bias-pull-up;
+			};
+			sdc2_cd_off: cd_off {
+				drive-strength = <2>;
+				bias-disable;
+			};
+		};
+
+		usb_c_intn_pin {
+			qcom,pins = <&gp 101>, <&gp 102>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <0>;
+			label = "usb_typec-gpio";
+			usbc_int_default: usbc_int_default {
+				drive-strength = <2>;	/* 2 MA */
+				bias-pull-up;		/* PULL UP*/
+			};
+		};
+
+		cti_trigout_b0 {
+			qcom,pins = <&gp 22>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <11>;
+			label = "cti-trigout-b0";
+			trigout_b0: trigout_b0 {
+				drive-strength = <2>;
+				bias-disable;
+			};
+		};
+
+		/* SDC pin type */
+		sdc: sdc {
+			/*
+			 * 0-3 for sdc1
+			 * 4-6 for sdc2
+			 * 39-44 for sdc3
+			 */
+			qcom,num-pins = <7>;
+			/*
+			 * Order of pins:
+			 * SDC1: CLK -> 0, CMD -> 1, DATA -> 2, RCLK -> 3
+			 * SDC2: CLK -> 4, CMD -> 5, DATA -> 6
+			 */
+			#qcom,pin-cells = <1>;
+		};
+
+		pmx_sdc1_clk {
+			qcom,pins = <&sdc 0>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc1-clk";
+			sdc1_clk_on: clk_on {
+				bias-disable; /* NO pull */
+				drive-strength = <16>; /* 16 MA */
+			};
+			sdc1_clk_off: clk_off {
+				bias-disable; /* NO pull */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc1_cmd {
+			qcom,pins = <&sdc 1>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc1-cmd";
+			sdc1_cmd_on: cmd_on {
+				bias-pull-up; /* pull up */
+				drive-strength = <10>; /* 10 MA */
+			};
+			sdc1_cmd_off: cmd_off {
+				bias-pull-up; /* pull up */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc1_data {
+			qcom,pins = <&sdc 2>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc1-data";
+			sdc1_data_on: data_on {
+				bias-pull-up; /* pull up */
+				drive-strength = <10>; /* 10 MA */
+			};
+			sdc1_data_off: data_off {
+				bias-pull-up; /* pull up */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc1_rclk {
+			qcom,pins = <&sdc 3>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc1-rclk";
+			sdc1_rclk_on: rclk_on {
+				bias-pull-down; /* pull down */
+			};
+
+			sdc1_rclk_off: rclk_off {
+				bias-pull-down; /* pull down */
+			};
+		};
+
+		pmx_sdc2_clk {
+			qcom,pins = <&sdc 4>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc2-clk";
+			sdc2_clk_on: clk_on {
+				bias-disable; /* NO pull */
+				drive-strength = <16>; /* 16 MA */
+			};
+			sdc2_clk_off: clk_off {
+				bias-disable; /* NO pull */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc2_cmd {
+			qcom,pins = <&sdc 5>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc2-cmd";
+			sdc2_cmd_on: cmd_on {
+				bias-pull-up; /* pull up */
+				drive-strength = <10>; /* 10 MA */
+			};
+			sdc2_cmd_off: cmd_off {
+				bias-pull-up; /* pull up */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc2_data {
+			qcom,pins = <&sdc 6>;
+			qcom,num-grp-pins = <1>;
+			label = "sdc2-data";
+			sdc2_data_on: data_on {
+				bias-pull-up; /* pull up */
+				drive-strength = <10>; /* 10 MA */
+			};
+			sdc2_data_off: data_off {
+				bias-pull-up; /* pull up */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		pmx_sdc3_clk {
+			qcom,pins = <&gp 44>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <2>;
+			label = "sdc3_clk";
+			sdc3_clk_on: clk_on {
+				bias-disable;
+				drive-strength = <16>;
+			};
+			sdc3_clk_off: clk_off {
+				bias-disable;
+				drive-strength = <2>;
+			};
+		};
+
+		pmx_sdc3_cmd {
+			qcom,pins = <&gp 43>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <2>;
+			label = "sdc3_cmd";
+			sdc3_cmd_on: cmd_on {
+				bias-pull-up;
+				drive-strength = <10>;
+			};
+			sdc3_cmd_off: cmd_off {
+				bias-pull-up;
+				drive-strength = <2>;
+			};
+		};
+
+		pmx_sdc3_dat {
+			qcom,pins = <&gp 39>, <&gp 40>, <&gp 41>, <&gp 42>;
+			qcom,num-grp-pins = <4>;
+			qcom,pin-func = <2>;
+			label = "sdc3_dat";
+			sdc3_dat_on: dat_on {
+				bias-pull-up;
+				drive-strength = <10>;
+			};
+			sdc3_dat_off: dat_off {
+				bias-pull-up;
+				drive-strength = <2>;
+			};
+		};
+
+		sdc3_wlan_gpio {
+			qcom,pins = <&gp 34>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "wlan_en_gpio";
+			sdc3_wlan_gpio_active: sdc3_wlan_gpio_active {
+				output-high;
+				drive-strength = <8>;
+				bias-pull-up;
+			};
+			sdc3_wlan_gpio_sleep: sdc3_wlan_gpio_sleep {
+				output-low;
+				drive-strength = <2>;
+				bias-disable;
+			};
+
+		};
+
+		pmx_mdss: pmx_mdss {
+			label = "mdss-pins";
+			qcom,pin-func = <0>;
+			mdss_dsi_active: active {
+				drive-strength = <8>; /* 8 mA */
+				bias-disable = <0>; /* no pull */
+			};
+
+			mdss_dsi_suspend: suspend {
+				drive-strength = <2>; /* 2 mA */
+				bias-pull-down; /* pull down */
+			};
+		};
+
+		pmx_mdss_te: pmx_mdss_te {
+			label = "mdss-te-pin";
+			qcom,pin-func = <1>;
+			mdss_te_active: active {
+				drive-strength = <2>; /* 2 mA */
+				bias-pull-down; /* pull down */
+				input-debounce = <0>;
+			};
+
+			mdss_te_suspend: suspend {
+				drive-strength = <2>; /* 2 mA */
+				bias-pull-down; /* pull down */
+				input-debounce = <0>;
+			};
+		};
+
+		spi0_active {
+			/* MOSI, MISO, CLK */
+			qcom,pins = <&gp 0>, <&gp 1>, <&gp 3>;
+			qcom,num-grp-pins = <3>;
+			qcom,pin-func = <1>;
+			label = "spi0-active";
+			/* active state */
+			spi0_default: spi0_default {
+				drive-strength = <12>; /* 12 MA */
+				bias-disable = <0>; /* No PULL */
+			};
+		};
+
+		spi0_suspend {
+			/* MOSI, MISO, CLK */
+			qcom,pins = <&gp 0>, <&gp 1>, <&gp 3>;
+			qcom,num-grp-pins = <3>;
+			qcom,pin-func = <0>;
+			label = "spi0-suspend";
+			/* suspended state */
+			spi0_sleep: spi0_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-pull-down; /* PULL Down */
+			};
+		};
+
+		spi0_cs0_active {
+			/* CS */
+			qcom,pins = <&gp 2>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "spi0-cs0-active";
+			spi0_cs0_active: cs0_active {
+				drive-strength = <2>;
+				bias-disable = <0>;
+			};
+		};
+
+		spi0_cs0_suspend {
+			/* CS */
+			qcom,pins = <&gp 2>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "spi0-cs0-suspend";
+			spi0_cs0_sleep: cs0_sleep {
+				drive-strength = <2>;
+				bias-disable = <0>;
+			};
+		};
+
+		/* cci */
+		cci0_active {
+			/* CLK, DATA */
+			qcom,pins = <&gp 30>, <&gp 29>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <1>;
+			label = "cci0-active";
+			/* active state */
+			cci0_active: cci0_active {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cci0_suspend {
+			/* CLK, DATA */
+			qcom,pins = <&gp 30>, <&gp 29>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <0>;
+			label = "cci0-suspend";
+			/*suspended state */
+			cci0_suspend: cci0_suspend {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cci1_active {
+			/* CLK, DATA */
+			qcom,pins = <&gp 104>, <&gp 103>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <1>;
+			label = "cci1-active";
+			/* active state */
+			cci1_active: cci1_active {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cci1_suspend {
+			/* CLK, DATA */
+			qcom,pins = <&gp 104>, <&gp 103>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <0>;
+			label = "cci1-suspend";
+			/*suspended state */
+			cci1_suspend: cci1_suspend {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		pmx_i2c_2 {
+                        /* CLK, DATA */
+                        qcom,pins = <&gp 6>, <&gp 7>;
+                        qcom,num-grp-pins = <2>;
+                        qcom,pin-func = <3>;
+                        label = "pmx_i2c_2";
+			/* active state */
+                        i2c_2_active: i2c_2_active {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable = <0>; /* No PULL */
+                        };
+			/* suspend state */
+                        i2c_2_sleep: i2c_2_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable = <0>; /* No PULL */
+                        };
+                };
+
+		pmx_i2c_4 {
+			/* CLK, DATA */
+			qcom,pins = <&gp 14>, <&gp 15>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <3>;
+			label = "pmx_i2c_4";
+			/* active state */
+			i2c_4_active: i2c_4_active {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable = <0>; /* No PULL */
+			};
+                        /* suspended state */
+                        i2c_4_sleep: i2c_4_sleep {
+                                drive-strength = <2>; /* 2 MA */
+                                bias-disable = <0>; /* No PULL */
+                        };
+                };
+
+		pmx_i2c_6 {
+			/* CLK, DATA */
+			qcom,pins = <&gp 22>, <&gp 23>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <3>;
+			label = "pmx_i2c_6";
+			/* active state */
+			i2c_6_active: i2c_6_active{
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+			/* suspended state */
+			i2c_6_sleep: i2c_6_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		pmx_i2c_8 {
+                        /* CLK, DATA */
+                        qcom,pins = <&gp 18>, <&gp 19>;
+                        qcom,num-grp-pins = <2>;
+                        qcom,pin-func = <3>;
+                        label = "pmx_i2c_8";
+                        /* active state */
+                        i2c_8_active: i2c_8_active{
+                                drive-strength = <2>; /* 2 MA */
+                                bias-disable; /* No PULL */
+                        };
+                        /* suspended state */
+                        i2c_8_sleep: i2c_8_sleep {
+                                drive-strength = <2>; /* 2 MA */
+                                bias-disable; /* No PULL */
+                        };
+                };
+
+		/*sensors */
+		cam_sensor_mclk0_default {
+			/* MCLK0 */
+			qcom,pins = <&gp 26>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "cam_sensor_mclk0_default";
+			/* active state */
+			cam_sensor_mclk0_default: cam_sensor_mclk0_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_mclk0_sleep {
+			/* MCLK0 */
+			qcom,pins = <&gp 26>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_mclk0_sleep";
+			/*suspended state */
+			cam_sensor_mclk0_sleep: cam_sensor_mclk0_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-pull-down; /* PULL DOWN */
+			};
+		};
+
+		cam_sensor_rear_default {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 129>, <&gp 35>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_rear_default";
+			/* active state */
+			cam_sensor_rear_default: cam_sensor_rear_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_rear_sleep {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 129>, <&gp 35>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_rear_sleep";
+			/*suspended state */
+			cam_sensor_rear_sleep: cam_sensor_rear_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_rear_vana {
+			/* VANA */
+			qcom,pins = <&gp 63>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_rear_vana";
+			/* active state */
+			cam_sensor_rear_vana: cam_sensor_rear_vana {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_rear_vana_sleep {
+			/* VANA */
+			qcom,pins = <&gp 63>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_rear_vana_sleep";
+			/*suspended state */
+			cam_sensor_rear_vana_sleep: cam_sensor_rear_vana_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_mclk1_default {
+			/* MCLK1 */
+			qcom,pins = <&gp 27>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "cam_sensor_mclk1_default";
+			/* active state */
+			cam_sensor_mclk1_default: cam_sensor_mclk1_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_mclk1_sleep {
+			/* MCLK1 */
+			qcom,pins = <&gp 27>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_mclk1_sleep";
+			/*suspended state */
+			cam_sensor_mclk1_sleep: cam_sensor_mclk1_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-pull-down; /* PULL DOWN */
+			};
+		};
+
+		cam_sensor_front_default {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 130>, <&gp 36>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_front_default";
+			/* active state */
+			cam_sensor_front_default: cam_sensor_front_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_front_sleep {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 130>, <&gp 36>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_front_sleep";
+			/*suspended state */
+			cam_sensor_front_sleep: cam_sensor_front_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_front_vdig {
+			/* VDIG */
+			qcom,pins = <&gp 105>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_front_vdig";
+			/* active state */
+			cam_sensor_front_vdig: cam_sensor_front_vdig {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_front_vdig_sleep {
+			/* VDIG */
+			qcom,pins = <&gp 105>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_front_vdig_sleep";
+			/*suspended state */
+			cam_sensor_front_vdig_sleep:
+				cam_sensor_front_vdig_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_mclk2_default {
+			/* MCLK2 */
+			qcom,pins = <&gp 28>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "cam_sensor_mclk2_default";
+			/* active state */
+			cam_sensor_mclk2_default: cam_sensor_mclk2_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_mclk2_sleep {
+			/* MCLK2 */
+			qcom,pins = <&gp 28>;
+			qcom,num-grp-pins = <1>;
+			label = "cam_sensor_mclk2_sleep";
+			/*suspended state */
+			cam_sensor_mclk2_sleep: cam_sensor_mclk2_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-pull-down; /* PULL DOWN */
+			};
+		};
+
+		cam_sensor_front1_default {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 131>, <&gp 38>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_front1_default";
+			/* active state */
+			cam_sensor_front1_default: cam_sensor_front1_default {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		cam_sensor_front1_sleep {
+			/* RESET, STANDBY */
+			qcom,pins = <&gp 131>, <&gp 38>;
+			qcom,num-grp-pins = <2>;
+			label = "cam_sensor_front1_sleep";
+			/*suspended state */
+			cam_sensor_front1_sleep: cam_sensor_front1_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-disable; /* No PULL */
+			};
+		};
+
+		/* add pingrp for touchscreen */
+		pmx_ts_int_active {
+			qcom,pins = <&gp 65>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_ts_int_active";
+
+			ts_int_active: ts_int_active {
+				drive-strength = <8>;
+				bias-pull-up;
+			};
+		};
+
+		pmx_ts_int_suspend {
+			qcom,pins = <&gp 65>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_ts_int_suspend";
+
+			ts_int_suspend: ts_int_suspend {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		pmx_ts_reset_active {
+			qcom,pins = <&gp 64>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_ts_reset_active";
+
+			ts_reset_active: ts_reset_active {
+				drive-strength = <8>;
+				bias-pull-up;
+			};
+		};
+
+		pmx_ts_reset_suspend {
+			qcom,pins = <&gp 64>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_ts_reset_suspend";
+
+			ts_reset_suspend: ts_reset_suspend {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		pmx_ts_release {
+			qcom,pins = <&gp 65>, <&gp 64>;
+			qcom,num-grp-pins = <2>;
+			label = "pmx_ts_release";
+
+			ts_release: ts_release {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		tlmm_gpio_key: tlmm_gpio_key {
+			qcom,pins = <&gp 113>, <&gp 114>, <&gp 115>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <3>;
+			label = "tlmm_gpio_key";
+
+			gpio_key_active: gpio_key_active {
+				drive-strength = <2>;
+				bias-pull-up;
+			};
+
+			gpio_key_suspend: gpio_key_suspend {
+				drive-strength = <2>;
+				bias-pull-up;
+			};
+		};
+
+		/* QDSD pin type */
+		qdsd: qdsd {
+			/* 0-> clk, 1 -> cmd, 2->data0, 3->data1, 4->data2, 5->data3 */
+			qcom,num-pins = <6>;
+
+			#qcom,pin-cells = <1>;
+		};
+
+		pmx_qdsd_clk {
+			qcom,pins = <&qdsd 0>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-clk";
+			qdsd_clk_sdcard: clk_sdcard {
+				bias-disable; /* NO pull */
+				drive-strength = <7>; /* 7 MA */
+			};
+
+			qdsd_clk_trace: clk_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_clk_swdtrc: clk_swdtrc {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_clk_spmi: clk_spmi {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+		};
+
+		pmx_qdsd_cmd {
+			qcom,pins = <&qdsd 1>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-cmd";
+			qdsd_cmd_sdcard: cmd_sdcard {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_cmd_trace: cmd_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_cmd_swduart: cmd_uart {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_cmd_swdtrc: cmd_swdtrc {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_cmd_jtag: cmd_jtag {
+				bias-disable; /* NO pull */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_cmd_spmi: cmd_spmi {
+				bias-pull-down; /* pull down */
+				drive-strength = <4>; /* 4 MA */
+			};
+		};
+
+		pmx_qdsd_data0 {
+			qcom,pins = <&qdsd 2>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-data0";
+			qdsd_data0_sdcard: data0_sdcard {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data0_trace: data0_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data0_swduart: data0_uart {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data0_swdtrc: data0_swdtrc {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data0_jtag: data0_jtag {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data0_spmi: data0_spmi {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+		};
+
+		pmx_qdsd_data1 {
+			qcom,pins = <&qdsd 3>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-data1";
+			qdsd_data1_sdcard: data1_sdcard {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data1_trace: data1_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data1_swduart: data1_uart {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data1_swdtrc: data1_swdtrc {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data1_jtag: data1_jtag {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+		};
+
+		pmx_qdsd_data2 {
+			qcom,pins = <&qdsd 4>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-data2";
+			qdsd_data2_sdcard: data2_sdcard {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data2_trace: data2_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data2_swduart: data2_uart {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data2_swdtrc: data2_swdtrc {
+				bias-pull-down; /* pull down */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data2_jtag: data2_jtag {
+				bias-pull-up; /* pull up */
+				drive-strength = <3>; /* 3 MA */
+			};
+		};
+
+		pmx_qdsd_data3 {
+			qcom,pins = <&qdsd 5>;
+			qcom,num-grp-pins = <1>;
+			label = "qdsd-data3";
+			qdsd_data3_sdcard: data3_sdcard {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data3_trace: data3_trace {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+
+			qdsd_data3_swduart: data3_uart {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data3_swdtrc: data3_swdtrc {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data3_jtag: data3_jtag {
+				bias-pull-up; /* pull up */
+				drive-strength = <0>; /* 0 MA */
+			};
+
+			qdsd_data3_spmi: data3_spmi {
+				bias-pull-down; /* pull down */
+				drive-strength = <3>; /* 3 MA */
+			};
+		};
+
+		/* CoreSight */
+		tpiu_seta_1 {
+			qcom,pins = <&gp 8>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-seta-1";
+			seta_1: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_2 {
+			qcom,pins = <&gp 9>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <5>;
+			label = "tpiu-seta-2";
+			seta_2: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_3 {
+			qcom,pins = <&gp 10>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-seta-3";
+			seta_3: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_4 {
+			qcom,pins = <&gp 39>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-seta-4";
+			seta_4: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_5 {
+			qcom,pins = <&gp 40>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-seta-5";
+			seta_5: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_6 {
+			qcom,pins = <&gp 41>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-seta-6";
+			seta_6: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_7 {
+			qcom,pins = <&gp 42>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-seta-7";
+			seta_7: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_8 {
+			qcom,pins = <&gp 43>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <5>;
+			label = "tpiu-seta-8";
+			seta_8: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_9 {
+			qcom,pins = <&gp 45>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <3>;
+			label = "tpiu-seta-9";
+			seta_9: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_10 {
+			qcom,pins = <&gp 46>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-seta-10";
+			seta_10: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_11 {
+			qcom,pins = <&gp 47>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <3>;
+			label = "tpiu-seta-11";
+			seta_11: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_12 {
+			qcom,pins = <&gp 48>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <3>;
+			label = "tpiu-seta-12";
+			seta_12: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_13 {
+			qcom,pins = <&gp 62>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <3>;
+			label = "tpiu-seta-13";
+			seta_13: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_14 {
+			qcom,pins = <&gp 69>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "tpiu-seta-14";
+			seta_14: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_15 {
+			qcom,pins = <&gp 120>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <8>;
+			label = "tpiu-seta-15";
+			seta_15: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_16 {
+			qcom,pins = <&gp 121>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <8>;
+			label = "tpiu-seta-16";
+			seta_16: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_17 {
+			qcom,pins = <&gp 130>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "tpiu-seta-17";
+			seta_17: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_seta_18 {
+			qcom,pins = <&gp 131>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "tpiu-seta-18";
+			seta_18: seta {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_1 {
+			qcom,pins = <&gp 4>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-1";
+			setb_1: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_2 {
+			qcom,pins = <&gp 5>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-2";
+			setb_2: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_3 {
+			qcom,pins = <&gp 26>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-3";
+			setb_3: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_4 {
+			qcom,pins = <&gp 27>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <7>;
+			label = "tpiu-setb-4";
+			setb_4: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_5 {
+			qcom,pins = <&gp 28>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-5";
+			setb_5: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_6 {
+			qcom,pins = <&gp 29>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-6";
+			setb_6: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_7 {
+			qcom,pins = <&gp 30>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <7>;
+			label = "tpiu-setb-7";
+			setb_7: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_8 {
+			qcom,pins = <&gp 31>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <8>;
+			label = "tpiu-setb-8";
+			setb_8: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_9 {
+			qcom,pins = <&gp 33>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <7>;
+			label = "tpiu-setb-9";
+			setb_9: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_10 {
+			qcom,pins = <&gp 34>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <9>;
+			label = "tpiu-setb-10";
+			setb_10: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_11 {
+			qcom,pins = <&gp 35>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <9>;
+			label = "tpiu-setb-11";
+			setb_11: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_12 {
+			qcom,pins = <&gp 36>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <7>;
+			label = "tpiu-setb-12";
+			setb_12: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_13 {
+			qcom,pins = <&gp 37>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <4>;
+			label = "tpiu-setb-13";
+			setb_13: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_14 {
+			qcom,pins = <&gp 38>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <8>;
+			label = "tpiu-setb-14";
+			setb_14: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_15 {
+			qcom,pins = <&gp 116>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <6>;
+			label = "tpiu-setb-15";
+			setb_15: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_16 {
+			qcom,pins = <&gp 126>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <9>;
+			label = "tpiu-setb-16";
+			setb_16: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_17 {
+			qcom,pins = <&gp 128>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <7>;
+			label = "tpiu-setb-17";
+			setb_17: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		tpiu_setb_18 {
+			qcom,pins = <&gp 129>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <1>;
+			label = "tpiu-setb-18";
+			setb_18: setb {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		cross-conn-det {
+			qcom,pins = <&gp 144>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "cross-conn-det-sw";
+			cross_conn_det_act: lines_on {
+				drive-strength = <8>;
+				output-low;
+				bias-pull-down;
+			};
+
+			cross_conn_det_sus: lines_off {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		wsa_spkr_sd: wsa-spkr-sd {
+			qcom,pins = <&gp 132>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <0>;
+			label = "wsa-spkr-sd";
+			wsa_spkr_sd_act: lines_on {
+					 drive-strength = <8>;
+					 output-high;
+					 bias-pull-down;
+			};
+
+			wsa_spkr_sd_sus: lines_off {
+					 drive-strength = <2>;
+					 output-low;
+					 bias-disable;
+			};
+		};
+
+		/* WSA CLK */
+		wsa_clk {
+			qcom,pins = <&gp 62>;
+			qcom,num-grp-pins = <1>;
+			qcom,pin-func = <2>;
+			label = "wsa_clk";
+			wsa_clk_on: wsa_on {
+				drive-strength = <8>; /* 8 MA */
+				output-high;
+			};
+
+			wsa_clk_off: wsa_off {
+				drive-strength = <2>; /* 2 MA */
+				output-low;
+				bias-pull-down;
+			};
+		};
+
+		/* WSA VI sense */
+		wsa-vi-sense {
+			qcom,pins = <&gp 108>, <&gp 109>;
+			qcom,num-grp-pins = <2>;
+			qcom,pin-func = <1>;
+			label = "wsa_vi";
+			wsa_vi_act: vi_sense_on {
+				drive-strength = <8>;
+				bias-disable; /* NO pull */
+			};
+
+			wsa_vi_sus: vi_sense_off {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		pri-tlmm-lines {
+			qcom,pins = <&gp 123>, <&gp 124>, <&gp 125>, <&gp 127>;
+			qcom,num-grp-pins = <4>;
+			qcom,pin-func = <1>;
+			label = "pri-tlmm-lines";
+			pri_tlmm_lines_act: pri_tlmm_lines_act {
+				drive-strength = <8>;
+			};
+			pri_tlmm_lines_sus:  pri_tlmm_lines_sus {
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+		};
+
+		wcnss_pmux_5wire: wcnss_pmux_5wire {
+			/* Uses general purpose pins */
+			qcom,pins = <&gp 40>, <&gp 41>,
+				    <&gp 42>, <&gp 43>,
+				    <&gp 44>;
+			qcom,num-grp-pins = <5>;
+			qcom,pin-func = <1>;
+			label = "wcnss_5wire_pins";
+			/* Active configuration of bus pins */
+			wcnss_default: wcnss_default {
+				drive-strength = <6>; /* 6 MA */
+				bias-pull-up; /* PULL UP */
+			};
+			wcnss_sleep: wcnss_sleep {
+				drive-strength = <2>; /* 2 MA */
+				bias-pull-down; /* PULL Down */
+			};
+		};
+
+		wcnss_pmux_gpio: wcnss_pmux_gpio {
+			/* Uses general purpose pins */
+			qcom,pins = <&gp 40>, <&gp 41>,
+				    <&gp 42>, <&gp 43>,
+				    <&gp 44>;
+			qcom,num-grp-pins = <5>;
+			qcom,pin-func = <0>;
+			label = "wcnss_5gpio_pins";
+			/* Active configuration of bus pins */
+			wcnss_gpio_default: wcnss_gpio_default {
+				drive-strength = <6>; /* 6 MA */
+				bias-pull-up; /* PULL UP */
+			};
+		};
+
+		pmx_adv7533_int: pmx_adv7533_int {
+			label = "pmx_adv7533_int";
+			adv7533_int_active: adv7533_int_active {
+				drive-strength = <16>;
+				bias-disable;
+			};
+
+			adv7533_int_suspend: adv7533_int_suspend {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		pmx_adv7533_hpd_int: pmx_adv7533_hpd_int {
+			label = "pmx_adv7533_hpd_int";
+			adv7533_hpd_int_active: adv7533_hpd_int_active {
+				drive-strength = <16>;
+				bias-disable;
+			};
+
+			adv7533_hpd_int_suspend: adv7533_hpd_int_suspend {
+				drive-strength = <16>;
+				bias-disable;
+			};
+		};
+
+		pmx_rd_nfc_int {
+			qcom,pins = <&gp 21>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_nfc_int";
+
+			nfc_int_active: active {
+				drive-strength = <6>;
+				bias-pull-up;
+			};
+
+			nfc_int_suspend: suspend {
+				drive-strength = <6>;
+				bias-pull-up;
+			};
+		};
+
+		pmx_nfc_reset {
+			qcom,pins = <&gp 20>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "pmx_nfc_disable";
+
+			nfc_disable_active: active {
+				drive-strength = <6>;
+				bias-pull-up;
+			};
+
+			nfc_disable_suspend: suspend {
+				drive-strength = <6>;
+				bias-disable;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
@@ -12,256 +12,388 @@
  */
 
 &soc {
-	tlmm_pinmux: pinctrl@1000000 {
-		compatible = "qcom,msm-tlmm-8916";
+	msm_gpio: pinctrl@1000000 {
+		compatible = "qcom,msm8976-pinctrl";
 		reg = <0x1000000 0x300000>;
 		interrupts = <0 208 0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
 
-		/*General purpose pins*/
-		gp: gp {
-			qcom,num-pins = <145>;
-			#qcom,pin-cells = <1>;
-			msm_gpio: msm_gpio {
-				compatible = "qcom,msm-tlmm-gp";
-				gpio-controller;
-				#gpio-cells = <2>;
-				interrupt-controller;
-				#interrupt-cells = <2>;
-				num_irqs = <145>;
+		cdc_reset_ctrl {
+			cdc_reset_line_sus: cdc_reset_sleep {
+				mux {
+					pins = "gpio133";
+					function = "gpio";
+				};
+				config {
+					pins = "gpio133";
+					drive-strength = <16>;
+					bias-disable;
+					output-low;
+				};
 			};
-		};
-
-		cdc-reset-line {
-			qcom,pins = <&gp 133>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "cdc-reset-line";
-			cdc_reset_line_act: cdc_reset_line_on {
-				drive-strength = <16>;
-				bias-disable;
-				output-high;
-			};
-
-			cdc_reset_line_sus: cdc_reset_line_off {
-				drive-strength = <16>;
-				bias-disable;
-				output-low;
+			cdc_reset_line_act:cdc_reset_active {
+				mux {
+					pins = "gpio133";
+					function = "gpio";
+				};
+				config {
+					pins = "gpio133";
+					drive-strength = <16>;
+					bias-disable;
+					output-high;
+				};
 			};
 		};
 
 		cdc-pdm-lines {
-			qcom,pins = <&gp 120>, <&gp 121>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <1>;
-			label = "cdc-pdm-lines";
 			cdc_pdm_lines_act: pdm_lines_on {
-				drive-strength = <8>;
-			};
+				mux {
+					pins = "gpio120", "gpio121";
+					function = "cdc_pdm0";
+				};
 
+				config {
+					pins = "gpio120", "gpio121";
+					drive-strength = <8>;
+				};
+			};
 			cdc_pdm_lines_sus: pdm_lines_off {
-				drive-strength = <2>;
-				bias-disable;
+				mux {
+					pins = "gpio120", "gpio121";
+					function = "cdc_pdm0";
+				};
+
+				config {
+					pins = "gpio120", "gpio121";
+					drive-strength = <2>;
+					bias-disable;
+				};
 			};
 		};
 
 		cdc-pdm-2-lines {
-			qcom,pins = <&gp 116>, <&gp 117>, <&gp 118>, <&gp 119>;
-			qcom,num-grp-pins = <4>;
-			qcom,pin-func = <2>;
-			label = "cdc-pdm-2-lines";
 			cdc_pdm_lines_2_act: pdm_lines_2_on {
-				drive-strength = <8>;
+				mux {
+					pins = "gpio116", "gpio117",
+					       "gpio118", "gpio119";
+					function = "cdc_pdm0";
+				};
+
+				config {
+					pins = "gpio116", "gpio117",
+					       "gpio118", "gpio119";
+					drive-strength = <8>;
+				};
 			};
 
 			cdc_pdm_lines_2_sus: pdm_lines_2_off {
-				drive-strength = <2>;
-				bias-disable;
+				mux {
+					pins = "gpio116", "gpio117",
+					       "gpio118", "gpio119";
+					function = "cdc_pdm0";
+				};
+
+				config {
+					pins = "gpio116", "gpio117",
+					       "gpio118", "gpio119";
+					drive-strength = <2>;
+					bias-disable;
+				};
 			};
 		};
 
 		pmx-uartconsole {
-			qcom,pins = <&gp 4>, <&gp 5>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <2>;
-			label = "uart-console";
-			uart_console_sleep: uart-console {
-				drive-strength = <2>;
-				bias-pull-down;
+			uart_console_active: uart_console_active {
+				mux {
+					pins = "gpio4", "gpio5";
+					function = "blsp_uart2";
+				};
+
+				config {
+					pins = "gpio4", "gpio5";
+					drive-strength = <2>;
+					bias-disable;
+				};
 			};
+
+			uart_console_sleep: uart_console_sleep {
+				mux {
+					pins = "gpio4", "gpio5";
+					function = "blsp_uart2";
+				};
+
+				config {
+					pins = "gpio4", "gpio5";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
+			};
+
 		};
 
-		blsp1_uart1_active {
-			qcom,pins = <&gp 0>, <&gp 1>, <&gp 2>, <&gp 3>;
-			qcom,num-grp-pins = <4>;
-			qcom,pin-func = <2>;
-			label = "blsp1_uart1_active";
-			hsuart_active: default {
+		hsuart_active: default {
+			mux {
+				pins = "gpio0", "gpio1", "gpio2", "gpio3";
+				function = "blsp_uart1";
+			};
+
+			config {
+				pins = "gpio0", "gpio1", "gpio2", "gpio3";
 				drive-strength = <16>;
 				bias-disable;
 			};
-		 };
+		};
 
-		blsp1_uart1_sleep {
-			qcom,pins = <&gp 0>, <&gp 1>, <&gp 2>, <&gp 3>;
-			qcom,num-grp-pins = <4>;
-			qcom,pin-func = <0>;
-			label = "blsp1_uart1_sleep";
-			hsuart_sleep: sleep {
+		hsuart_sleep: sleep {
+			mux {
+				pins = "gpio0", "gpio1", "gpio2", "gpio3";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio0", "gpio1", "gpio2", "gpio3";
 				drive-strength = <2>;
 				bias-disable;
 			};
 		};
 
 		sdhc2_cd_pin {
-			qcom,pins = <&gp 100>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "cd-gpio";
 			sdc2_cd_on: cd_on {
+				mux {
+					pins = "gpio100";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio100";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			sdc2_cd_off: cd_off {
+				mux {
+					pins = "gpio100";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio100";
+					drive-strength = <2>;
+					bias-disable;
+				};
+			};
+		};
+
+		usb_c_intn_pin: usb_c_intn_pin {
+			mux {
+				pins = "gpio101", "gpio102";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio101", "gpio102";
 				drive-strength = <2>;
 				bias-pull-up;
 			};
-			sdc2_cd_off: cd_off {
+		};
+
+		trigout_b0: trigout_b0 {
+			mux {
+				pins = "gpio22";
+				function  = "qdss_cti_trig_out_b0";
+			};
+
+			config {
+				pins = "gpio22";
 				drive-strength = <2>;
 				bias-disable;
 			};
-		};
-
-		usb_c_intn_pin {
-			qcom,pins = <&gp 101>, <&gp 102>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <0>;
-			label = "usb_typec-gpio";
-			usbc_int_default: usbc_int_default {
-				drive-strength = <2>;	/* 2 MA */
-				bias-pull-up;		/* PULL UP*/
-			};
-		};
-
-		cti_trigout_b0 {
-			qcom,pins = <&gp 22>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <11>;
-			label = "cti-trigout-b0";
-			trigout_b0: trigout_b0 {
-				drive-strength = <2>;
-				bias-disable;
-			};
-		};
-
-		/* SDC pin type */
-		sdc: sdc {
-			/*
-			 * 0-3 for sdc1
-			 * 4-6 for sdc2
-			 * 39-44 for sdc3
-			 */
-			qcom,num-pins = <7>;
-			/*
-			 * Order of pins:
-			 * SDC1: CLK -> 0, CMD -> 1, DATA -> 2, RCLK -> 3
-			 * SDC2: CLK -> 4, CMD -> 5, DATA -> 6
-			 */
-			#qcom,pin-cells = <1>;
 		};
 
 		pmx_sdc1_clk {
-			qcom,pins = <&sdc 0>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc1-clk";
-			sdc1_clk_on: clk_on {
-				bias-disable; /* NO pull */
-				drive-strength = <16>; /* 16 MA */
+			sdc1_clk_on: sdc1_clk_on {
+				config {
+					pins = "sdc1_clk";
+					bias-disable; /* NO pull */
+					drive-strength = <16>; /* 16 MA */
+				};
+
 			};
-			sdc1_clk_off: clk_off {
-				bias-disable; /* NO pull */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc1_clk_off: sdc1_clk_off {
+				config {
+					pins = "sdc1_clk";
+					bias-disable; /* NO pull */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
 		pmx_sdc1_cmd {
-			qcom,pins = <&sdc 1>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc1-cmd";
-			sdc1_cmd_on: cmd_on {
-				bias-pull-up; /* pull up */
-				drive-strength = <10>; /* 10 MA */
+			sdc1_cmd_on: sdc1_cmd_on {
+				config {
+					pins = "sdc1_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
 			};
-			sdc1_cmd_off: cmd_off {
-				bias-pull-up; /* pull up */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc1_cmd_off: sdc1_cmd_off {
+				config {
+					pins = "sdc1_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
 		pmx_sdc1_data {
-			qcom,pins = <&sdc 2>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc1-data";
-			sdc1_data_on: data_on {
-				bias-pull-up; /* pull up */
-				drive-strength = <10>; /* 10 MA */
+			sdc1_data_on: sdc1_data_on {
+				config {
+					pins = "sdc1_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
 			};
-			sdc1_data_off: data_off {
-				bias-pull-up; /* pull up */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc1_data_off: sdc1_data_off {
+				config {
+					pins = "sdc1_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
 		pmx_sdc1_rclk {
-			qcom,pins = <&sdc 3>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc1-rclk";
-			sdc1_rclk_on: rclk_on {
-				bias-pull-down; /* pull down */
+			sdc1_rclk_on: sdc1_rclk_on {
+				config {
+					pins = "sdc1_rclk";
+					bias-pull-down; /* pull down */
+				};
 			};
 
-			sdc1_rclk_off: rclk_off {
-				bias-pull-down; /* pull down */
+			sdc1_rclk_off: sdc1_rclk_off {
+				config {
+					pins = "sdc1_rclk";
+					bias-pull-down; /* pull down */
+				};
 			};
 		};
 
 		pmx_sdc2_clk {
-			qcom,pins = <&sdc 4>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc2-clk";
-			sdc2_clk_on: clk_on {
-				bias-disable; /* NO pull */
-				drive-strength = <16>; /* 16 MA */
+			sdc2_clk_on: sdc2_clk_on {
+				config {
+					pins = "sdc2_clk";
+					drive-strength = <16>; /* 16 MA */
+					bias-disable; /* NO pull */
+				};
 			};
-			sdc2_clk_off: clk_off {
-				bias-disable; /* NO pull */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc2_clk_off: sdc2_clk_off {
+				config {
+					pins = "sdc2_clk";
+					bias-disable; /* NO pull */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
 		pmx_sdc2_cmd {
-			qcom,pins = <&sdc 5>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc2-cmd";
-			sdc2_cmd_on: cmd_on {
-				bias-pull-up; /* pull up */
-				drive-strength = <10>; /* 10 MA */
+			sdc2_cmd_on: sdc2_cmd_on {
+				config {
+					pins = "sdc2_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
 			};
-			sdc2_cmd_off: cmd_off {
-				bias-pull-up; /* pull up */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc2_cmd_off: sdc2_cmd_off {
+				config {
+					pins = "sdc2_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
 		pmx_sdc2_data {
-			qcom,pins = <&sdc 6>;
-			qcom,num-grp-pins = <1>;
-			label = "sdc2-data";
-			sdc2_data_on: data_on {
-				bias-pull-up; /* pull up */
-				drive-strength = <10>; /* 10 MA */
+			sdc2_data_on: sdc2_data_on {
+				config {
+					pins = "sdc2_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
 			};
-			sdc2_data_off: data_off {
-				bias-pull-up; /* pull up */
-				drive-strength = <2>; /* 2 MA */
+
+			sdc2_data_off: sdc2_data_off {
+				config {
+					pins = "sdc2_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
 			};
 		};
 
+		pmx_sdc3_clk {
+			sdc3_clk_on: sdc3_clk_on {
+				config {
+					pins = "sdc3_clk";
+					drive-strength = <16>; /* 16 MA */
+					bias-disable; /* NO pull */
+				};
+			};
+
+			sdc3_clk_off: sdc3_clk_off {
+				config {
+					pins = "sdc3_clk";
+					bias-disable; /* NO pull */
+					drive-strength = <2>; /* 2 MA */
+				};
+			};
+		};
+
+		pmx_sdc3_cmd {
+			sdc3_cmd_on: sdc3_cmd_on {
+				config {
+					pins = "sdc3_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
+			};
+
+			sdc3_cmd_off: sdc3_cmd_off {
+				config {
+					pins = "sdc3_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
+			};
+		};
+
+		pmx_sdc3_data {
+			sdc3_dat_on: sdc3_data_on {
+				config {
+					pins = "sdc3_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <10>; /* 10 MA */
+				};
+			};
+
+			sdc3_dat_off: sdc3_data_off {
+				config {
+					pins = "sdc3_data";
+					bias-pull-up; /* pull up */
+					drive-strength = <2>; /* 2 MA */
+				};
+			};
+		};
+/************************************************************************
+		// TODO: CHECK ME!!!!
 		pmx_sdc3_clk {
 			qcom,pins = <&gp 44>;
 			qcom,num-grp-pins = <1>;
@@ -324,1256 +456,1711 @@
 			};
 
 		};
+***********************************************************************/
 
 		pmx_mdss: pmx_mdss {
-			label = "mdss-pins";
-			qcom,pin-func = <0>;
-			mdss_dsi_active: active {
-				drive-strength = <8>; /* 8 mA */
-				bias-disable = <0>; /* no pull */
+			mdss_dsi_active: mdss_dsi_active {
+				mux {
+					function = "gpio";
+				};
+
+				config {
+					drive-strength = <8>; /* 8 mA */
+					bias-disable = <0>; /* no pull */
+					output-high;
+				};
 			};
 
-			mdss_dsi_suspend: suspend {
-				drive-strength = <2>; /* 2 mA */
-				bias-pull-down; /* pull down */
+			mdss_dsi_suspend: mdss_dsi_suspend {
+				mux {
+					function = "gpio";
+				};
+
+				config {
+					drive-strength = <2>; /* 2 mA */
+					bias-pull-down; /* pull down */
+					output-low;
+				};
 			};
 		};
 
 		pmx_mdss_te: pmx_mdss_te {
-			label = "mdss-te-pin";
-			qcom,pin-func = <1>;
 			mdss_te_active: active {
-				drive-strength = <2>; /* 2 mA */
-				bias-pull-down; /* pull down */
-				input-debounce = <0>;
+				mux {
+					function = "mdp_vsync";
+				};
+				config {
+					drive-strength = <2>; /* 2 mA */
+					bias-pull-down; /* pull down */
+					input-debounce = <0>;
+				};
 			};
 
 			mdss_te_suspend: suspend {
-				drive-strength = <2>; /* 2 mA */
-				bias-pull-down; /* pull down */
-				input-debounce = <0>;
+				mux {
+					function = "mdp_vsync";
+				};
+				config {
+					drive-strength = <2>; /* 2 mA */
+					bias-pull-down; /* pull down */
+					input-debounce = <0>;
+				};
 			};
 		};
 
-		spi0_active {
-			/* MOSI, MISO, CLK */
-			qcom,pins = <&gp 0>, <&gp 1>, <&gp 3>;
-			qcom,num-grp-pins = <3>;
-			qcom,pin-func = <1>;
-			label = "spi0-active";
-			/* active state */
+		spi0 {
 			spi0_default: spi0_default {
-				drive-strength = <12>; /* 12 MA */
-				bias-disable = <0>; /* No PULL */
-			};
-		};
+				/* active state */
+				mux {
+					/* MOSI, MISO, CLK */
+					pins = "gpio0", "gpio1", "gpio3";
+					function = "blsp_spi1";
+				};
 
-		spi0_suspend {
-			/* MOSI, MISO, CLK */
-			qcom,pins = <&gp 0>, <&gp 1>, <&gp 3>;
-			qcom,num-grp-pins = <3>;
-			qcom,pin-func = <0>;
-			label = "spi0-suspend";
-			/* suspended state */
+				config {
+					pins = "gpio0", "gpio1", "gpio3";
+					drive-strength = <12>; /* 12 MA */
+					bias-disable = <0>; /* No PULL */
+				};
+			};
+
+
 			spi0_sleep: spi0_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-pull-down; /* PULL Down */
-			};
-		};
+				/* suspended state */
+				mux {
+					/* MOSI, MISO, CLK */
+					pins = "gpio0", "gpio1", "gpio3";
+					function = "gpio";
+				};
 
-		spi0_cs0_active {
-			/* CS */
-			qcom,pins = <&gp 2>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "spi0-cs0-active";
+				config {
+					pins = "gpio0", "gpio1", "gpio3";
+					drive-strength = <2>; /* 2 MA */
+					bias-pull-down; /* PULL Down */
+				};
+			};
+
 			spi0_cs0_active: cs0_active {
-				drive-strength = <2>;
-				bias-disable = <0>;
-			};
-		};
+				/* CS */
+				mux {
+					pins = "gpio2";
+					function = "blsp_spi1";
+				};
 
-		spi0_cs0_suspend {
-			/* CS */
-			qcom,pins = <&gp 2>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "spi0-cs0-suspend";
+				config {
+					pins = "gpio2";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
+			};
+
 			spi0_cs0_sleep: cs0_sleep {
-				drive-strength = <2>;
-				bias-disable = <0>;
+				/* CS */
+				mux {
+					pins = "gpio2";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio2";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
 			};
 		};
 
 		/* cci */
-		cci0_active {
-			/* CLK, DATA */
-			qcom,pins = <&gp 30>, <&gp 29>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <1>;
-			label = "cci0-active";
-			/* active state */
+		cci {
 			cci0_active: cci0_active {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
+				/* cci0 active state */
+				mux {
+					/* CLK, DATA */
+					pins = "gpio29", "gpio30";
+					function = "cci_i2c";
+				};
 
-		cci0_suspend {
-			/* CLK, DATA */
-			qcom,pins = <&gp 30>, <&gp 29>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <0>;
-			label = "cci0-suspend";
-			/*suspended state */
+				config {
+					pins = "gpio29", "gpio30";
+					drive-strength = <2>; /* 2 MA */
+					bias-disable; /* No PULL */
+				};
+			};
+
 			cci0_suspend: cci0_suspend {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
+				/* cci0 suspended state */
+				mux {
+					/* CLK, DATA */
+					pins = "gpio29", "gpio30";
+					function = "cci_i2c";
+				};
 
-		cci1_active {
-			/* CLK, DATA */
-			qcom,pins = <&gp 104>, <&gp 103>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <1>;
-			label = "cci1-active";
-			/* active state */
+				config {
+					pins = "gpio29", "gpio30";
+					drive-strength = <2>; /* 2 MA */
+					bias-disable; /* No PULL */
+				};
+			};
+
 			cci1_active: cci1_active {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
+				/* cci1 active state */
+				mux {
+					/* CLK, DATA */
+					pins = "gpio104", "gpio103";
+					function = "cci_i2c";
+				};
 
-		cci1_suspend {
-			/* CLK, DATA */
-			qcom,pins = <&gp 104>, <&gp 103>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <0>;
-			label = "cci1-suspend";
-			/*suspended state */
+				config {
+					pins = "gpio104", "gpio103";
+					drive-strength = <2>; /* 2 MA */
+					bias-disable; /* No PULL */
+				};
+			};
+
 			cci1_suspend: cci1_suspend {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
+				/* cci1 suspended state */
+				mux {
+					/* CLK, DATA */
+					pins = "gpio104", "gpio103";
+					function = "cci_i2c";
+				};
+
+				config {
+					pins = "gpio104", "gpio103";
+					drive-strength = <2>; /* 2 MA */
+					bias-disable; /* No PULL */
+				};
 			};
 		};
 
-		pmx_i2c_2 {
-                        /* CLK, DATA */
-                        qcom,pins = <&gp 6>, <&gp 7>;
-                        qcom,num-grp-pins = <2>;
-                        qcom,pin-func = <3>;
-                        label = "pmx_i2c_2";
-			/* active state */
-                        i2c_2_active: i2c_2_active {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable = <0>; /* No PULL */
-                        };
-			/* suspend state */
-                        i2c_2_sleep: i2c_2_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable = <0>; /* No PULL */
-                        };
-                };
+		i2c_2 {
+			i2c_2_active: i2c_2_active {
+				/* active state */
+				mux {
+					pins = "gpio6", "gpio7";
+					function = "blsp_i2c2";
+				};
 
-		pmx_i2c_4 {
-			/* CLK, DATA */
-			qcom,pins = <&gp 14>, <&gp 15>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <3>;
-			label = "pmx_i2c_4";
-			/* active state */
+				config {
+					pins = "gpio6", "gpio7";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
+			};
+
+			i2c_2_sleep: i2c_2_sleep {
+				/* suspended state */
+				mux {
+					pins = "gpio6", "gpio7";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio6", "gpio7";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
+			};
+		};
+
+		i2c_4 {
 			i2c_4_active: i2c_4_active {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable = <0>; /* No PULL */
-			};
-                        /* suspended state */
-                        i2c_4_sleep: i2c_4_sleep {
-                                drive-strength = <2>; /* 2 MA */
-                                bias-disable = <0>; /* No PULL */
-                        };
-                };
+				/* active state */
+				mux {
+					pins = "gpio14", "gpio15";
+					function = "blsp_i2c4";
+				};
 
-		pmx_i2c_6 {
-			/* CLK, DATA */
-			qcom,pins = <&gp 22>, <&gp 23>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <3>;
-			label = "pmx_i2c_6";
-			/* active state */
-			i2c_6_active: i2c_6_active{
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
+				config {
+					pins = "gpio14", "gpio15";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
 			};
-			/* suspended state */
-			i2c_6_sleep: i2c_6_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
+
+			i2c_4_sleep: i2c_4_sleep {
+				/* suspended state */
+				mux {
+					pins = "gpio14", "gpio15";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio14", "gpio15";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
 			};
 		};
 
-		pmx_i2c_8 {
-                        /* CLK, DATA */
-                        qcom,pins = <&gp 18>, <&gp 19>;
-                        qcom,num-grp-pins = <2>;
-                        qcom,pin-func = <3>;
-                        label = "pmx_i2c_8";
-                        /* active state */
-                        i2c_8_active: i2c_8_active{
-                                drive-strength = <2>; /* 2 MA */
-                                bias-disable; /* No PULL */
-                        };
-                        /* suspended state */
-                        i2c_8_sleep: i2c_8_sleep {
-                                drive-strength = <2>; /* 2 MA */
-                                bias-disable; /* No PULL */
-                        };
-                };
+		i2c_6 {
+			i2c_6_active: i2c_6_active {
+				/* active state */
+				mux {
+					pins = "gpio22", "gpio23";
+					function = "blsp_i2c6";
+				};
+
+				config {
+					pins = "gpio22", "gpio23";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
+			};
+
+			i2c_6_sleep: i2c_6_sleep {
+				/* suspended state */
+				mux {
+					pins = "gpio22", "gpio23";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio22", "gpio23";
+					drive-strength = <2>;
+					bias-disable = <0>;
+				};
+			};
+		};
+
+		i2c_8 {
+			i2c_8_active: i2c_8_active {
+				/* active state */
+				mux {
+					pins = "gpio18", "gpio19";
+					function = "blsp_i2c8";
+				};
+
+				config {
+					pins = "gpio18", "gpio19";
+					drive-strength = <2>;
+					bias-disable;
+				};
+			};
+
+			i2c_8_sleep: i2c_8_sleep {
+				/* suspended state */
+				mux {
+					pins = "gpio18", "gpio19";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio18", "gpio19";
+					drive-strength = <2>;
+					bias-disable;
+				};
+			};
+		};
 
 		/*sensors */
-		cam_sensor_mclk0_default {
+		cam_sensor_mclk0_default: cam_sensor_mclk0_default {
 			/* MCLK0 */
-			qcom,pins = <&gp 26>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "cam_sensor_mclk0_default";
-			/* active state */
-			cam_sensor_mclk0_default: cam_sensor_mclk0_default {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio26";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio26";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_mclk0_sleep {
+		cam_sensor_mclk0_sleep: cam_sensor_mclk0_sleep {
 			/* MCLK0 */
-			qcom,pins = <&gp 26>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_mclk0_sleep";
-			/*suspended state */
-			cam_sensor_mclk0_sleep: cam_sensor_mclk0_sleep {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio26";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio26";
 				bias-pull-down; /* PULL DOWN */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_rear_default {
+		cam_sensor_rear_default: cam_sensor_rear_default {
 			/* RESET, STANDBY */
-			qcom,pins = <&gp 129>, <&gp 35>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_rear_default";
-			/* active state */
-			cam_sensor_rear_default: cam_sensor_rear_default {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				pins = "gpio129", "gpio35";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio129", "gpio35";
 				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_rear_sleep {
-			/* RESET, STANDBY */
-			qcom,pins = <&gp 129>, <&gp 35>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_rear_sleep";
-			/*suspended state */
-			cam_sensor_rear_sleep: cam_sensor_rear_sleep {
 				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
 			};
 		};
 
-		cam_sensor_rear_vana {
-			/* VANA */
-			qcom,pins = <&gp 63>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_rear_vana";
-			/* active state */
-			cam_sensor_rear_vana: cam_sensor_rear_vana {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_rear_vana_sleep {
-			/* VANA */
-			qcom,pins = <&gp 63>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_rear_vana_sleep";
-			/*suspended state */
-			cam_sensor_rear_vana_sleep: cam_sensor_rear_vana_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_mclk1_default {
-			/* MCLK1 */
-			qcom,pins = <&gp 27>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "cam_sensor_mclk1_default";
-			/* active state */
-			cam_sensor_mclk1_default: cam_sensor_mclk1_default {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_mclk1_sleep {
-			/* MCLK1 */
-			qcom,pins = <&gp 27>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_mclk1_sleep";
-			/*suspended state */
-			cam_sensor_mclk1_sleep: cam_sensor_mclk1_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-pull-down; /* PULL DOWN */
-			};
-		};
-
-		cam_sensor_front_default {
-			/* RESET, STANDBY */
-			qcom,pins = <&gp 130>, <&gp 36>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_front_default";
-			/* active state */
-			cam_sensor_front_default: cam_sensor_front_default {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_front_sleep {
-			/* RESET, STANDBY */
-			qcom,pins = <&gp 130>, <&gp 36>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_front_sleep";
-			/*suspended state */
-			cam_sensor_front_sleep: cam_sensor_front_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-disable; /* No PULL */
-			};
-		};
-
-		cam_sensor_front_vdig {
+		cam_sensor_rear_vana: cam_sensor_rear_vana {
 			/* VDIG */
-			qcom,pins = <&gp 105>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_front_vdig";
-			/* active state */
-			cam_sensor_front_vdig: cam_sensor_front_vdig {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				pins = "gpio63";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio63";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_front_vdig_sleep {
+		cam_sensor_rear_vana_sleep: cam_sensor_rear_vana_sleep {
 			/* VDIG */
-			qcom,pins = <&gp 105>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_front_vdig_sleep";
-			/*suspended state */
-			cam_sensor_front_vdig_sleep:
-				cam_sensor_front_vdig_sleep {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				pins = "gpio63";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio63";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_mclk2_default {
-			/* MCLK2 */
-			qcom,pins = <&gp 28>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "cam_sensor_mclk2_default";
-			/* active state */
-			cam_sensor_mclk2_default: cam_sensor_mclk2_default {
-				drive-strength = <2>; /* 2 MA */
+		cam_sensor_mclk1_default: cam_sensor_mclk1_default {
+			/* MCLK1 */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio27";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio27";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_mclk2_sleep {
-			/* MCLK2 */
-			qcom,pins = <&gp 28>;
-			qcom,num-grp-pins = <1>;
-			label = "cam_sensor_mclk2_sleep";
-			/*suspended state */
-			cam_sensor_mclk2_sleep: cam_sensor_mclk2_sleep {
-				drive-strength = <2>; /* 2 MA */
+		cam_sensor_mclk1_sleep: cam_sensor_mclk1_sleep {
+			/* MCLK1 */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio27";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio27";
 				bias-pull-down; /* PULL DOWN */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_front1_default {
+		cam_sensor_front_default: cam_sensor_front_default {
 			/* RESET, STANDBY */
-			qcom,pins = <&gp 131>, <&gp 38>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_front1_default";
-			/* active state */
-			cam_sensor_front1_default: cam_sensor_front1_default {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				pins = "gpio130", "gpio36";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio130", "gpio36";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
-		cam_sensor_front1_sleep {
+		cam_sensor_front_sleep: cam_sensor_front_sleep {
 			/* RESET, STANDBY */
-			qcom,pins = <&gp 131>, <&gp 38>;
-			qcom,num-grp-pins = <2>;
-			label = "cam_sensor_front1_sleep";
-			/*suspended state */
-			cam_sensor_front1_sleep: cam_sensor_front1_sleep {
-				drive-strength = <2>; /* 2 MA */
+			mux {
+				pins = "gpio130", "gpio36";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio130", "gpio36";
 				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_front_vdig: cam_sensor_front_vdig {
+			/* VDIG */
+			mux {
+				pins = "gpio105";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio105";
+				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_front_vdig_sleep: cam_sensor_front_vdig_sleep {
+			/* VDIG */
+			mux {
+				pins = "gpio105";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio105";
+				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_mclk2_default: cam_sensor_mclk2_default {
+			/* MCLK2 */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio28";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio28";
+				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_mclk2_sleep: cam_sensor_mclk2_sleep {
+			/* MCLK2 */
+			mux {
+				/* CLK, DATA */
+				pins = "gpio28";
+				function = "cam_mclk";
+			};
+
+			config {
+				pins = "gpio28";
+				bias-pull-down; /* PULL DOWN */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_front1_default: cam_sensor_front1_default {
+			/* RESET, STANDBY */
+			mux {
+				pins = "gpio131", "gpio38";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio131", "gpio38";
+				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
+			};
+		};
+
+		cam_sensor_front1_sleep: cam_sensor_front1_sleep {
+			/* RESET, STANDBY */
+			mux {
+				pins = "gpio131", "gpio38";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio131", "gpio38";
+				bias-disable; /* No PULL */
+				drive-strength = <2>; /* 2 MA */
 			};
 		};
 
 		/* add pingrp for touchscreen */
 		pmx_ts_int_active {
-			qcom,pins = <&gp 65>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_ts_int_active";
-
 			ts_int_active: ts_int_active {
-				drive-strength = <8>;
-				bias-pull-up;
+				mux {
+					pins = "gpio65";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio65";
+					drive-strength = <8>;
+					bias-pull-up;
+				};
 			};
 		};
 
 		pmx_ts_int_suspend {
-			qcom,pins = <&gp 65>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_ts_int_suspend";
-
 			ts_int_suspend: ts_int_suspend {
-				drive-strength = <2>;
-				bias-pull-down;
+				mux {
+					pins = "gpio65";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio65";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
 			};
 		};
 
 		pmx_ts_reset_active {
-			qcom,pins = <&gp 64>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_ts_reset_active";
-
 			ts_reset_active: ts_reset_active {
-				drive-strength = <8>;
-				bias-pull-up;
+				mux {
+					pins = "gpio64";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio64";
+					drive-strength = <8>;
+					bias-pull-up;
+				};
 			};
 		};
 
 		pmx_ts_reset_suspend {
-			qcom,pins = <&gp 64>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_ts_reset_suspend";
-
 			ts_reset_suspend: ts_reset_suspend {
-				drive-strength = <2>;
-				bias-pull-down;
+				mux {
+					pins = "gpio64";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio64";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
 			};
 		};
 
 		pmx_ts_release {
-			qcom,pins = <&gp 65>, <&gp 64>;
-			qcom,num-grp-pins = <2>;
-			label = "pmx_ts_release";
-
 			ts_release: ts_release {
-				drive-strength = <2>;
-				bias-pull-down;
+				mux {
+					pins = "gpio65", "gpio64";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio65", "gpio64";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
 			};
 		};
 
-		tlmm_gpio_key: tlmm_gpio_key {
-			qcom,pins = <&gp 113>, <&gp 114>, <&gp 115>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <3>;
-			label = "tlmm_gpio_key";
-
+		tlmm_gpio_key {
 			gpio_key_active: gpio_key_active {
-				drive-strength = <2>;
-				bias-pull-up;
+				mux {
+					pins = "gpio113", "gpio114", "gpio115";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio113", "gpio114", "gpio115";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
 
 			gpio_key_suspend: gpio_key_suspend {
-				drive-strength = <2>;
-				bias-pull-up;
+				mux {
+					pins = "gpio113", "gpio114", "gpio115";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio113", "gpio114", "gpio115";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
-		};
-
-		/* QDSD pin type */
-		qdsd: qdsd {
-			/* 0-> clk, 1 -> cmd, 2->data0, 3->data1, 4->data2, 5->data3 */
-			qcom,num-pins = <6>;
-
-			#qcom,pin-cells = <1>;
 		};
 
 		pmx_qdsd_clk {
-			qcom,pins = <&qdsd 0>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-clk";
 			qdsd_clk_sdcard: clk_sdcard {
-				bias-disable; /* NO pull */
-				drive-strength = <7>; /* 7 MA */
+				config {
+					pins = "qdsd_clk";
+					bias-disable;/* NO pull */
+					drive-strength = <7>; /* 7 MA */
+				};
 			};
-
 			qdsd_clk_trace: clk_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_clk";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_clk_swdtrc: clk_swdtrc {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_clk";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_clk_spmi: clk_spmi {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_clk";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
 		};
 
 		pmx_qdsd_cmd {
-			qcom,pins = <&qdsd 1>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-cmd";
 			qdsd_cmd_sdcard: cmd_sdcard {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_cmd_trace: cmd_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_cmd_swduart: cmd_uart {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_cmd_swdtrc: cmd_swdtrc {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_cmd_jtag: cmd_jtag {
-				bias-disable; /* NO pull */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-disable; /* NO pull */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_cmd_spmi: cmd_spmi {
-				bias-pull-down; /* pull down */
-				drive-strength = <4>; /* 4 MA */
+				config {
+					pins = "qdsd_cmd";
+					bias-pull-down; /* pull down */
+					drive-strength = <4>; /* 4 MA */
+				};
 			};
 		};
 
 		pmx_qdsd_data0 {
-			qcom,pins = <&qdsd 2>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-data0";
 			qdsd_data0_sdcard: data0_sdcard {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data0_trace: data0_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data0_swduart: data0_uart {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data0_swdtrc: data0_swdtrc {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data0_jtag: data0_jtag {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data0_spmi: data0_spmi {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data0";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
 		};
 
 		pmx_qdsd_data1 {
-			qcom,pins = <&qdsd 3>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-data1";
 			qdsd_data1_sdcard: data1_sdcard {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data1";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data1_trace: data1_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data1";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data1_swduart: data1_uart {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data1";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data1_swdtrc: data1_swdtrc {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data1";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data1_jtag: data1_jtag {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data1";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
 		};
 
 		pmx_qdsd_data2 {
-			qcom,pins = <&qdsd 4>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-data2";
 			qdsd_data2_sdcard: data2_sdcard {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data2";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data2_trace: data2_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data2";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data2_swduart: data2_uart {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data2";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data2_swdtrc: data2_swdtrc {
-				bias-pull-down; /* pull down */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data2";
+					bias-pull-down; /* pull down */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data2_jtag: data2_jtag {
-				bias-pull-up; /* pull up */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data2";
+					bias-pull-up; /* pull up */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
 		};
 
 		pmx_qdsd_data3 {
-			qcom,pins = <&qdsd 5>;
-			qcom,num-grp-pins = <1>;
-			label = "qdsd-data3";
 			qdsd_data3_sdcard: data3_sdcard {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data3_trace: data3_trace {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
-
 			qdsd_data3_swduart: data3_uart {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data3_swdtrc: data3_swdtrc {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data3_jtag: data3_jtag {
-				bias-pull-up; /* pull up */
-				drive-strength = <0>; /* 0 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
 			};
-
 			qdsd_data3_spmi: data3_spmi {
-				bias-pull-down; /* pull down */
-				drive-strength = <3>; /* 3 MA */
+				config {
+					pins = "qdsd_data3";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
 			};
 		};
+
+		pmx_qdsd_data4 {
+			qdsd_data4_sdcard: data4_sdcard {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+			qdsd_data4_trace: data4_trace {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+			qdsd_data4_swduart: data4_uart {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data4_swdtrc: data4_swdtrc {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data4_jtag: data4_jtag {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data4_spmi: data4_spmi {
+				config {
+					pins = "qdsd_data4";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+		};
+
+		pmx_qdsd_data5 {
+			qdsd_data5_sdcard: data5_sdcard {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+			qdsd_data5_trace: data5_trace {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+			qdsd_data5_swduart: data5_uart {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data5_swdtrc: data5_swdtrc {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data5_jtag: data5_jtag {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-up; /* pull up */
+					drive-strength = <0>; /* 0 MA */
+				};
+			};
+			qdsd_data5_spmi: data5_spmi {
+				config {
+					pins = "qdsd_data5";
+					bias-pull-down; /* pull down */
+					drive-strength = <3>; /* 3 MA */
+				};
+			};
+		};
+
 
 		/* CoreSight */
-		tpiu_seta_1 {
-			qcom,pins = <&gp 8>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-seta-1";
-			seta_1: seta {
+		seta_1: seta1 {
+			mux {
+				pins = "gpio8";
+				function = "qdss_traceclk_a";
+			};
+			config {
+				pins = "gpio8";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_2 {
-			qcom,pins = <&gp 9>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <5>;
-			label = "tpiu-seta-2";
-			seta_2: seta {
+		seta_2: seta2 {
+			mux {
+				pins = "gpio9";
+				function = "qdss_tracectl_a";
+			};
+			config {
+				pins = "gpio9";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_3 {
-			qcom,pins = <&gp 10>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-seta-3";
-			seta_3: seta {
+		seta_3: seta3 {
+			mux {
+				pins = "gpio10";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio10";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_4 {
-			qcom,pins = <&gp 39>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-seta-4";
-			seta_4: seta {
+		seta_4: seta4 {
+			mux {
+				pins = "gpio39";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio39";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_5 {
-			qcom,pins = <&gp 40>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-seta-5";
-			seta_5: seta {
+		seta_5: seta5 {
+			mux {
+				pins = "gpio40";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio40";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_6 {
-			qcom,pins = <&gp 41>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-seta-6";
-			seta_6: seta {
+		seta_6: seta6 {
+			mux {
+				pins = "gpio41";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio41";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_7 {
-			qcom,pins = <&gp 42>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-seta-7";
-			seta_7: seta {
+		seta_7: seta7 {
+			mux {
+				pins = "gpio42";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio42";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_8 {
-			qcom,pins = <&gp 43>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <5>;
-			label = "tpiu-seta-8";
-			seta_8: seta {
+		seta_8: seta8 {
+			mux {
+				pins = "gpio43";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio43";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_9 {
-			qcom,pins = <&gp 45>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <3>;
-			label = "tpiu-seta-9";
-			seta_9: seta {
+		seta_9: seta9 {
+			mux {
+				pins = "gpio45";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio45";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_10 {
-			qcom,pins = <&gp 46>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-seta-10";
-			seta_10: seta {
+		seta_10: seta10 {
+			mux {
+				pins = "gpio46";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio46";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_11 {
-			qcom,pins = <&gp 47>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <3>;
-			label = "tpiu-seta-11";
-			seta_11: seta {
+		seta_11: seta11 {
+			mux {
+				pins = "gpio47";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio47";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_12 {
-			qcom,pins = <&gp 48>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <3>;
-			label = "tpiu-seta-12";
-			seta_12: seta {
+		seta_12: seta12 {
+			mux {
+				pins = "gpio48";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio48";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_13 {
-			qcom,pins = <&gp 62>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <3>;
-			label = "tpiu-seta-13";
-			seta_13: seta {
+		seta_13: seta13 {
+			mux {
+				pins = "gpio62";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio62";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_14 {
-			qcom,pins = <&gp 69>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "tpiu-seta-14";
-			seta_14: seta {
+		seta_14: seta14 {
+			mux {
+				pins = "gpio69";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio69";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_15 {
-			qcom,pins = <&gp 120>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <8>;
-			label = "tpiu-seta-15";
-			seta_15: seta {
+		seta_15: seta15 {
+			mux {
+				pins = "gpio120";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio120";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_16 {
-			qcom,pins = <&gp 121>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <8>;
-			label = "tpiu-seta-16";
-			seta_16: seta {
+		seta_16: seta16 {
+			mux {
+				pins = "gpio121";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio121";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_17 {
-			qcom,pins = <&gp 130>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "tpiu-seta-17";
-			seta_17: seta {
+		seta_17: seta17 {
+			mux {
+				pins = "gpio130";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio130";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_seta_18 {
-			qcom,pins = <&gp 131>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "tpiu-seta-18";
-			seta_18: seta {
+		seta_18: seta18 {
+			mux {
+				pins = "gpio131";
+				function = "qdss_tracedata_a";
+			};
+			config {
+				pins = "gpio131";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_1 {
-			qcom,pins = <&gp 4>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-1";
-			setb_1: setb {
+		setb_1: setb1 {
+			mux {
+				pins = "gpio4";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio4";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_2 {
-			qcom,pins = <&gp 5>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-2";
-			setb_2: setb {
+		setb_2: setb2 {
+			mux {
+				pins = "gpio5";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio5";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_3 {
-			qcom,pins = <&gp 26>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-3";
-			setb_3: setb {
+		setb_3: setb3 {
+			mux {
+				pins = "gpio26";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio26";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_4 {
-			qcom,pins = <&gp 27>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <7>;
-			label = "tpiu-setb-4";
-			setb_4: setb {
+		setb_4: setb4 {
+			mux {
+				pins = "gpio27";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio27";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_5 {
-			qcom,pins = <&gp 28>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-5";
-			setb_5: setb {
+		setb_5: setb5 {
+			mux {
+				pins = "gpio28";
+				function = "qdss_tracectl_b";
+			};
+			config {
+				pins = "gpio28";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_6 {
-			qcom,pins = <&gp 29>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-6";
-			setb_6: setb {
+		setb_6: setb6 {
+			mux {
+				pins = "gpio29";
+				function = "qdss_traceclk_b";
+			};
+			config {
+				pins = "gpio29";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_7 {
-			qcom,pins = <&gp 30>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <7>;
-			label = "tpiu-setb-7";
-			setb_7: setb {
+		setb_7: setb7 {
+			mux {
+				pins = "gpio30";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio30";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_8 {
-			qcom,pins = <&gp 31>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <8>;
-			label = "tpiu-setb-8";
-			setb_8: setb {
+		setb_8: setb8 {
+			mux {
+				pins = "gpio31";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio31";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_9 {
-			qcom,pins = <&gp 33>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <7>;
-			label = "tpiu-setb-9";
-			setb_9: setb {
+		setb_9: setb9 {
+			mux {
+				pins = "gpio33";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio33";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_10 {
-			qcom,pins = <&gp 34>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <9>;
-			label = "tpiu-setb-10";
-			setb_10: setb {
+		setb_10: setb10 {
+			mux {
+				pins = "gpio34";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio34";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_11 {
-			qcom,pins = <&gp 35>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <9>;
-			label = "tpiu-setb-11";
-			setb_11: setb {
+		setb_11: setb11 {
+			mux {
+				pins = "gpio35";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio35";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_12 {
-			qcom,pins = <&gp 36>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <7>;
-			label = "tpiu-setb-12";
-			setb_12: setb {
+		setb_12: setb12 {
+			mux {
+				pins = "gpio36";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio36";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_13 {
-			qcom,pins = <&gp 37>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <4>;
-			label = "tpiu-setb-13";
-			setb_13: setb {
+		setb_13: setb13 {
+			mux {
+				pins = "gpio37";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio37";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_14 {
-			qcom,pins = <&gp 38>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <8>;
-			label = "tpiu-setb-14";
-			setb_14: setb {
+		setb_14: setb14 {
+			mux {
+				pins = "gpio38";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio38";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_15 {
-			qcom,pins = <&gp 116>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <6>;
-			label = "tpiu-setb-15";
-			setb_15: setb {
+		setb_15: setb15 {
+			mux {
+				pins = "gpio116";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio116";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_16 {
-			qcom,pins = <&gp 126>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <9>;
-			label = "tpiu-setb-16";
-			setb_16: setb {
+		setb_16: setb16 {
+			mux {
+				pins = "gpio126";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio126";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_17 {
-			qcom,pins = <&gp 128>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <7>;
-			label = "tpiu-setb-17";
-			setb_17: setb {
+		setb_17: setb17 {
+			mux {
+				pins = "gpio128";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio128";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
-		tpiu_setb_18 {
-			qcom,pins = <&gp 129>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <1>;
-			label = "tpiu-setb-18";
-			setb_18: setb {
+		setb_18: setb18 {
+			mux {
+				pins = "gpio129";
+				function = "qdss_tracedata_b";
+			};
+			config {
+				pins = "gpio129";
 				drive-strength = <16>;
 				bias-disable;
 			};
 		};
 
 		cross-conn-det {
-			qcom,pins = <&gp 144>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "cross-conn-det-sw";
 			cross_conn_det_act: lines_on {
-				drive-strength = <8>;
-				output-low;
-				bias-pull-down;
+				mux {
+					pins = "gpio144";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio144";
+					drive-strength = <8>;
+					output-low;
+					bias-pull-down;
+				};
 			};
 
 			cross_conn_det_sus: lines_off {
+				mux {
+					pins = "gpio144";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio144";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
+			};
+		};
+
+		wsa_spkr_sd: spkr_lines {
+			mux {
+				pins = "gpio132";
+				function = "gpio";
+			};
+			config {
+				pins = "gpio132";
 				drive-strength = <2>;
+				output-high;
 				bias-pull-down;
 			};
 		};
 
-		wsa_spkr_sd: wsa-spkr-sd {
-			qcom,pins = <&gp 132>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "wsa-spkr-sd";
-			wsa_spkr_sd_act: lines_on {
-					 drive-strength = <8>;
-					 output-high;
-					 bias-pull-down;
+		wsa_spkr_sd_act: spkr_lines_on {
+			mux {
+				pins = "gpio132";
+				function = "gpio";
 			};
+			config {
+				pins = "gpio132";
+				drive-strength = <2>;
+				output-high;
+				bias-pull-down;
+			};
+		};
 
-			wsa_spkr_sd_sus: lines_off {
-					 drive-strength = <2>;
-					 output-low;
-					 bias-disable;
+		wsa_spkr_sd_sus: spkr_lines_off {
+			mux {
+				pins = "gpio132";
+				function = "gpio";
+			};
+			config {
+				pins = "gpio132";
+				drive-strength = <2>;
+				output-low;
+				bias-disable;
 			};
 		};
 
 		/* WSA CLK */
 		wsa_clk {
-			qcom,pins = <&gp 62>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <2>;
-			label = "wsa_clk";
-			wsa_clk_on: wsa_on {
-				drive-strength = <8>; /* 8 MA */
-				output-high;
+			wsa_clk_on: wsa_clk_on {
+				mux {
+					pins = "gpio62";
+					function = "pri_mi2s_mclk_a";
+				};
+
+				config {
+					pins = "gpio62";
+					drive-strength = <8>; /* 8 MA */
+					output-high;
+				};
 			};
 
-			wsa_clk_off: wsa_off {
-				drive-strength = <2>; /* 2 MA */
-				output-low;
-				bias-pull-down;
+			wsa_clk_off: wsa_clk_off {
+				mux {
+					pins = "gpio62";
+					function = "pri_mi2s_mclk_a";
+				};
+
+				config {
+					pins = "gpio62";
+					drive-strength = <2>; /* 2 MA */
+					output-low;
+					bias-pull-down;
+				};
 			};
 		};
 
 		/* WSA VI sense */
-		wsa-vi-sense {
-			qcom,pins = <&gp 108>, <&gp 109>;
-			qcom,num-grp-pins = <2>;
-			qcom,pin-func = <1>;
-			label = "wsa_vi";
-			wsa_vi_act: vi_sense_on {
-				drive-strength = <8>;
-				bias-disable; /* NO pull */
+		wsa-vi {
+			wsa_vi_on: wsa_vi_on {
+				mux {
+					pins = "gpio108", "gpio109";
+					function = "wsa_io";
+				};
+
+				config {
+					pins = "gpio108", "gpio109";
+					drive-strength = <8>; /* 8 MA */
+					bias-disable; /* NO pull */
+				};
 			};
 
-			wsa_vi_sus: vi_sense_off {
-				drive-strength = <2>;
-				bias-pull-down;
+			wsa_vi_sus: wsa_vi_off {
+				mux {
+					pins = "gpio108", "gpio109";
+					function = "wsa_io";
+				};
+
+				config {
+					pins = "gpio108", "gpio109";
+					drive-strength = <2>; /* 2 MA */
+					bias-pull-down;
+				};
 			};
 		};
 
 		pri-tlmm-lines {
-			qcom,pins = <&gp 123>, <&gp 124>, <&gp 125>, <&gp 127>;
-			qcom,num-grp-pins = <4>;
-			qcom,pin-func = <1>;
-			label = "pri-tlmm-lines";
 			pri_tlmm_lines_act: pri_tlmm_lines_act {
-				drive-strength = <8>;
+				mux {
+					pins = "gpio123", "gpio124",
+					       "gpio125", "gpio127";
+					function = "pri_mi2s";
+				};
+
+				config {
+					pins = "gpio123", "gpio124",
+					       "gpio125", "gpio127";
+					drive-strength = <8>;
+				};
 			};
-			pri_tlmm_lines_sus:  pri_tlmm_lines_sus {
-				drive-strength = <2>;
-				bias-pull-down;
+
+			pri_tlmm_lines_sus: pri_tlmm_lines_sus {
+				mux {
+					pins = "gpio123", "gpio124",
+					       "gpio125", "gpio127";
+					function = "pri_mi2s";
+				};
+
+				config {
+					pins = "gpio123", "gpio124",
+					       "gpio125", "gpio127";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
 			};
 		};
 
-		wcnss_pmux_5wire: wcnss_pmux_5wire {
-			/* Uses general purpose pins */
-			qcom,pins = <&gp 40>, <&gp 41>,
-				    <&gp 42>, <&gp 43>,
-				    <&gp 44>;
-			qcom,num-grp-pins = <5>;
-			qcom,pin-func = <1>;
-			label = "wcnss_5wire_pins";
+		wcnss_pmux_5wire {
 			/* Active configuration of bus pins */
 			wcnss_default: wcnss_default {
-				drive-strength = <6>; /* 6 MA */
-				bias-pull-up; /* PULL UP */
+				wcss_wlan2 {
+					pins = "gpio40";
+					function = "wcss_wlan2";
+				};
+				wcss_wlan1 {
+					pins = "gpio41";
+					function = "wcss_wlan1";
+				};
+				wcss_wlan0 {
+					pins = "gpio42";
+					function = "wcss_wlan0";
+				};
+				wcss_wlan {
+					pins = "gpio43", "gpio44";
+					function = "wcss_wlan";
+				};
+
+				config {
+					pins = "gpio40", "gpio41",
+					       "gpio42", "gpio43",
+					       "gpio44";
+					drive-strength = <6>; /* 6 MA */
+					bias-pull-up; /* PULL UP */
+				};
 			};
+
 			wcnss_sleep: wcnss_sleep {
-				drive-strength = <2>; /* 2 MA */
-				bias-pull-down; /* PULL Down */
+				wcss_wlan2 {
+					pins = "gpio40";
+					function = "wcss_wlan2";
+				};
+				wcss_wlan1 {
+					pins = "gpio41";
+					function = "wcss_wlan1";
+				};
+				wcss_wlan0 {
+					pins = "gpio42";
+					function = "wcss_wlan0";
+				};
+				wcss_wlan {
+					pins = "gpio43", "gpio44";
+					function = "wcss_wlan";
+				};
+
+				config {
+					pins = "gpio40", "gpio41",
+					       "gpio42", "gpio43",
+					       "gpio44";
+					drive-strength = <2>; /* 2 MA */
+					bias-pull-down; /* PULL Down */
+				};
 			};
 		};
-
 		wcnss_pmux_gpio: wcnss_pmux_gpio {
-			/* Uses general purpose pins */
-			qcom,pins = <&gp 40>, <&gp 41>,
-				    <&gp 42>, <&gp 43>,
-				    <&gp 44>;
-			qcom,num-grp-pins = <5>;
-			qcom,pin-func = <0>;
-			label = "wcnss_5gpio_pins";
-			/* Active configuration of bus pins */
 			wcnss_gpio_default: wcnss_gpio_default {
-				drive-strength = <6>; /* 6 MA */
-				bias-pull-up; /* PULL UP */
+				/* Active configuration of bus pins */
+				mux {
+					/* Uses general purpose pins */
+					pins = "gpio40", "gpio41",
+					       "gpio42", "gpio43",
+					       "gpio44";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio40", "gpio41",
+					       "gpio42", "gpio43",
+					       "gpio44";
+					drive-strength = <6>; /* 6 MA */
+					bias-pull-up; /* PULL UP */
+				};
 			};
 		};
 
 		pmx_adv7533_int: pmx_adv7533_int {
-			label = "pmx_adv7533_int";
 			adv7533_int_active: adv7533_int_active {
-				drive-strength = <16>;
-				bias-disable;
+				config {
+					drive-strength = <16>;
+					bias-disable;
+				};
 			};
 
 			adv7533_int_suspend: adv7533_int_suspend {
-				drive-strength = <16>;
-				bias-disable;
+				config {
+					drive-strength = <16>;
+					bias-disable;
+				};
 			};
+
 		};
 
 		pmx_adv7533_hpd_int: pmx_adv7533_hpd_int {
-			label = "pmx_adv7533_hpd_int";
 			adv7533_hpd_int_active: adv7533_hpd_int_active {
-				drive-strength = <16>;
-				bias-disable;
+				config {
+					drive-strength = <16>;
+					bias-disable;
+				};
 			};
 
 			adv7533_hpd_int_suspend: adv7533_hpd_int_suspend {
-				drive-strength = <16>;
-				bias-disable;
+				config {
+					drive-strength = <16>;
+					bias-disable;
+				};
 			};
+
 		};
 
 		pmx_rd_nfc_int {
-			qcom,pins = <&gp 21>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_nfc_int";
-
 			nfc_int_active: active {
-				drive-strength = <6>;
-				bias-pull-up;
+				mux {
+					pins = "gpio21";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio21";
+					drive-strength = <6>;
+					bias-pull-up;
+				};
 			};
 
 			nfc_int_suspend: suspend {
-				drive-strength = <6>;
-				bias-pull-up;
+				mux {
+					pins = "gpio21";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio21";
+					drive-strength = <6>;
+					bias-pull-up;
+				};
 			};
 		};
 
 		pmx_nfc_reset {
-			qcom,pins = <&gp 20>;
-			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <1>;
-			label = "pmx_nfc_disable";
-
 			nfc_disable_active: active {
-				drive-strength = <6>;
-				bias-pull-up;
+				mux {
+					pins = "gpio20";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio20";
+					drive-strength = <6>;
+					bias-pull-up;
+				};
 			};
 
 			nfc_disable_suspend: suspend {
-				drive-strength = <6>;
-				bias-disable;
+				mux {
+					pins = "gpio20";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio20";
+					drive-strength = <6>;
+					bias-disable;
+				};
 			};
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
@@ -16,6 +16,7 @@
 		compatible = "qcom,msm8976-pinctrl";
 		reg = <0x1000000 0x300000>;
 		interrupts = <0 208 0>;
+		status = "ok";
 		gpio-controller;
 		#gpio-cells = <2>;
 		interrupt-controller;
@@ -492,7 +493,6 @@
 				config {
 					drive-strength = <2>; /* 2 mA */
 					bias-pull-down; /* pull down */
-					input-debounce = <0>;
 				};
 			};
 
@@ -503,7 +503,6 @@
 				config {
 					drive-strength = <2>; /* 2 mA */
 					bias-pull-down; /* pull down */
-					input-debounce = <0>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
@@ -500,9 +500,11 @@
 		qcom,master-offset = <4096>;
 	};
 
+/*
 	qcom,rpm-rbcpr-stats@0x29daa0  {
 		compatible = "qcom,rpmrbcpr-stats";
 		reg = <0x29daa0 0x1a0000>;
 		qcom,start-offset = <0x190010>;
 	};
+*/
 };

--- a/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
@@ -254,7 +254,7 @@
 						qcom,latency-us = <31>;
 						qcom,ss-power = <552>;
 						qcom,energy-overhead = <64172>;
-						qcom,time-overhead = <61>;
+						qcom,time-overhead = <81>;
 					};
 
 					qcom,pm-cpu-level@1 {
@@ -262,9 +262,9 @@
 						qcom,psci-cpu-mode = <2>;
 						qcom,spm-cpu-mode = "retention";
 						qcom,latency-us = <99>;
-						qcom,ss-power = <545>;
+						qcom,ss-power = <540>;
 						qcom,energy-overhead = <150122>;
-						qcom,time-overhead = <239>;
+						qcom,time-overhead = <241>;
 						qcom,use-broadcast-timer;
 					};
 

--- a/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
@@ -1,0 +1,508 @@
+/* Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+	qcom,spm@b1d2000 {
+		compatible = "qcom,spm-v2";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0xb1d2000 0x1000>;
+		qcom,name = "system-cci"; /* CCI SAW */
+		qcom,saw2-ver-reg = <0xfd0>;
+		qcom,saw2-cfg = <0x14>;
+		qcom,saw2-spm-dly = <0X3c102800>;
+		qcom,saw2-spm-ctl = <0x8>;
+		qcom,cpu-vctl-list = <&CPU0 &CPU1 &CPU2 &CPU3>;
+		qcom,vctl-timeout-us = <50>;
+		qcom,vctl-port = <0x0>;
+		qcom,phase-port = <0x1>;
+		qcom,saw2-pmic-data0 = <0x03030080>; /* VDD_APC0 on */
+		qcom,saw2-pmic-data1 = <0x00030000>; /* VDD_APC0 off  */
+		qcom,pfm-port = <0x2>;
+	};
+
+	cluster1_spm: qcom,spm@b012000 {
+		compatible = "qcom,spm-v2";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0xb012000 0x1000>,
+		    <0xb011210 0x8>; /* SPM_QCHANNEL_CFG */
+		qcom,name = "a72-l2"; /* A5x L2 SAW */
+		qcom,saw2-ver-reg = <0xfd0>;
+		qcom,saw2-cfg = <0x14>;
+		qcom,saw2-spm-dly = <0x3c11840a>;
+		qcom,saw2-spm-ctl = <0x8>;
+		qcom,cpu-vctl-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,vctl-timeout-us = <50>;
+		qcom,vctl-port = <0x0>;
+		qcom,phase-port = <0x1>;
+		qcom,saw2-pmic-data0 = <0x03030080>; /* VDD_APC1 on */
+		qcom,saw2-pmic-data1 = <0x00030000>; /* VDD_APC1 off  */
+		qcom,pfm-port = <0x2>;
+	};
+
+	qcom,lpm-levels {
+		status = "okay";
+		compatible = "qcom,lpm-levels";
+		qcom,use-psci;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,pm-cluster@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			label = "system";
+			qcom,spm-device-names = "cci";
+			qcom,default-level = <0>;
+			qcom,psci-mode-shift = <8>;
+			qcom,psci-mode-mask = <0xf>;
+
+			qcom,pm-cluster-level@0{
+				reg = <0>;
+				label = "system-cci-active";
+				qcom,psci-mode = <0>;
+				qcom,latency-us = <301>;
+				qcom,ss-power = <463>;
+				qcom,energy-overhead = <348515>;
+				qcom,time-overhead = <505>;
+			};
+
+			qcom,pm-cluster-level@1{
+				reg = <1>;
+				label = "system-cci-retention";
+				qcom,psci-mode = <1>;
+				qcom,latency-us = <361>;
+				qcom,ss-power = <431>;
+				qcom,energy-overhead = <501447>;
+				qcom,time-overhead = <633>;
+				qcom,min-child-idx = <2>;
+			};
+
+			qcom,pm-cluster-level@2{
+				reg = <2>;
+				label = "system-cci-pc";
+				qcom,psci-mode = <2>;
+				qcom,latency-us = <10740>;
+				qcom,ss-power = <388>;
+				qcom,energy-overhead = <1013303>;
+				qcom,time-overhead = <1158>;
+				qcom,min-child-idx = <3>;
+				qcom,notify-rpm;
+				qcom,is-reset;
+			};
+
+			qcom,pm-cluster@0{
+				reg = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "a53";
+				qcom,spm-device-names = "l2";
+				qcom,default-level=<0>;
+				qcom,cpu = <&CPU0 &CPU1 &CPU2 &CPU3>;
+				qcom,psci-mode-shift = <4>;
+				qcom,psci-mode-mask = <0xf>;
+
+				qcom,pm-cluster-level@0{
+					reg = <0>;
+					label = "a53-l2-wfi";
+					qcom,psci-mode = <1>;
+					qcom,latency-us = <149>;
+					qcom,ss-power = <489>;
+					qcom,energy-overhead = <199236>;
+					qcom,time-overhead = <330>;
+				};
+
+				qcom,pm-cluster-level@1{
+					reg = <1>;
+					label = "a53-l2-retention";
+					qcom,psci-mode = <2>;
+					qcom,latency-us = <272>;
+					qcom,ss-power = <468>;
+					qcom,energy-overhead = <277180>;
+					qcom,time-overhead = <467>;
+					qcom,min-child-idx = <1>;
+				};
+
+				qcom,pm-cluster-level@2{
+					reg = <2>;
+					label = "a53-l2-gdhs";
+					qcom,psci-mode = <3>;
+					qcom,latency-us = <331>;
+					qcom,ss-power = <442>;
+					qcom,energy-overhead = <335344>;
+					qcom,time-overhead = <541>;
+					qcom,min-child-idx = <1>;
+				};
+
+				qcom,pm-cluster-level@3{
+					reg = <3>;
+					label = "a53-l2-pc";
+					qcom,psci-mode = <4>;
+					qcom,latency-us = <419>;
+					qcom,ss-power = <423>;
+					qcom,energy-overhead = <479220>;
+					qcom,time-overhead = <779>;
+					qcom,min-child-idx = <1>;
+					qcom,is-reset;
+				};
+
+				qcom,pm-cpu {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					qcom,psci-mode-shift = <0>;
+					qcom,psci-mode-mask = <0xf>;
+
+					qcom,pm-cpu-level@0 {
+						reg = <0>;
+						qcom,psci-cpu-mode = <1>;
+						qcom,spm-cpu-mode = "wfi";
+						qcom,latency-us = <58>;
+						qcom,ss-power = <547>;
+						qcom,energy-overhead = <61640>;
+						qcom,time-overhead = <118>;
+					};
+
+					qcom,pm-cpu-level@1 {
+						reg = <1>;
+						qcom,psci-cpu-mode = <3>;
+						qcom,spm-cpu-mode = "pc";
+						qcom,latency-us = <149>;
+						qcom,ss-power = <489>;
+						qcom,energy-overhead = <199236>;
+						qcom,time-overhead = <330>;
+						qcom,use-broadcast-timer;
+						qcom,is-reset;
+					};
+				};
+			};
+
+			qcom,pm-cluster@1{
+				reg = <1>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				label = "a72";
+				qcom,spm-device-names = "l2";
+				qcom,default-level=<0>;
+				qcom,cpu = <&CPU4 &CPU5 &CPU6 &CPU7>;
+				qcom,psci-mode-shift = <4>;
+				qcom,psci-mode-mask = <0xf>;
+
+				qcom,pm-cluster-level@0{
+					reg = <0>;
+					label = "a72-l2-wfi";
+					qcom,psci-mode = <1>;
+					qcom,latency-us = <144>;
+					qcom,ss-power = <520>;
+					qcom,energy-overhead = <194277>;
+					qcom,time-overhead = <302>;
+				};
+
+				qcom,pm-cluster-level@1{
+					reg = <1>;
+					label = "a72-l2-retention";
+					qcom,psci-mode = <2>;
+					qcom,latency-us = <244>;
+					qcom,ss-power = <490>;
+					qcom,energy-overhead = <277821>;
+					qcom,time-overhead = <425>;
+					qcom,min-child-idx = <1>;
+				};
+
+				qcom,pm-cluster-level@2{
+					reg = <2>;
+					label = "a72-l2-gdhs";
+					qcom,psci-mode = <3>;
+					qcom,latency-us = <301>;
+					qcom,ss-power = <463>;
+					qcom,energy-overhead = <348515>;
+					qcom,time-overhead = <505>;
+					qcom,min-child-idx = <2>;
+				};
+
+				qcom,pm-cluster-level@3{
+					reg = <3>;
+					label = "a72-l2-pc";
+					qcom,psci-mode = <4>;
+					qcom,latency-us = <899>;
+					qcom,ss-power = <430>;
+					qcom,energy-overhead = <777359>;
+					qcom,time-overhead = <1256>;
+					qcom,min-child-idx = <2>;
+					qcom,is-reset;
+				};
+
+				qcom,pm-cpu {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					qcom,psci-mode-shift = <0>;
+					qcom,psci-mode-mask = <0xf>;
+
+					qcom,pm-cpu-level@0 {
+						reg = <0>;
+						qcom,psci-cpu-mode = <1>;
+						qcom,spm-cpu-mode = "wfi";
+						qcom,latency-us = <31>;
+						qcom,ss-power = <552>;
+						qcom,energy-overhead = <64172>;
+						qcom,time-overhead = <61>;
+					};
+
+					qcom,pm-cpu-level@1 {
+						reg = <1>;
+						qcom,psci-cpu-mode = <2>;
+						qcom,spm-cpu-mode = "retention";
+						qcom,latency-us = <99>;
+						qcom,ss-power = <545>;
+						qcom,energy-overhead = <150122>;
+						qcom,time-overhead = <239>;
+						qcom,use-broadcast-timer;
+					};
+
+					qcom,pm-cpu-level@2 {
+						reg = <2>;
+						qcom,psci-cpu-mode = <3>;
+						qcom,spm-cpu-mode = "pc";
+						qcom,latency-us = <144>;
+						qcom,ss-power = <520>;
+						qcom,energy-overhead = <194277>;
+						qcom,time-overhead = <302>;
+						qcom,use-broadcast-timer;
+						qcom,is-reset;
+					};
+				};
+			};
+		};
+
+	};
+
+	qcom,mpm@601d0 {
+		compatible = "qcom,mpm-v2";
+		reg = <0x601d0 0x1000>, /* MSM_RPM_MPM_BASE 4K */
+		    <0xb011008 0x4>;
+		reg-names = "vmpm", "ipc";
+		interrupts = <0 171 1>;
+		clocks = <&clock_gcc clk_xo_lpm_clk>;
+		clock-names = "xo";
+
+		qcom,ipc-bit-offset = <1>;
+
+		qcom,gic-parent = <&intc>;
+		qcom,gic-map = <2 216>, /* tsens_upper_lower_int */
+			<49 172>, /* usb1_hs_async_wakeup_irq */
+			<58 166>, /* usb_hs_irq */
+			<53 104>, /* mdss_irq */
+			<62 222>, /* ee0_krait_hlos_spmi_periph_irq */
+			<0xff 18>,  /* APC_qgicQTmrSecPhysIrptReq */
+			<0xff 19>,  /* APC_qgicQTmrNonSecPhysIrptReq */
+			<0xff 20>,  /* qgicQTmrVirtIrptReq */
+			<0xff 23>,  /* APC0_qgicPerfMonIrptReq */
+			<0xff 35>,  /* WDT_barkInt */
+			<0xff 39>,  /* arch_mem_timer */
+			<0xff 40>,  /* qtmr_phy_irq[0] */
+			<0xff 47>,  /* rbif_irq[0] */
+			<0xff 51>,  /* rbif_Irq[3] */
+			<0xff 54>,  /* nERRORIRQ */
+			<0xff 56>,  /* q6_wdog_expired_irq */
+			<0xff 57>,  /* mss_to_apps_irq(0) */
+			<0xff 58>,  /* mss_to_apps_irq(1) */
+			<0xff 59>,  /* mss_to_apps_irq(2) */
+			<0xff 60>,  /* mss_to_apps_irq(3) */
+			<0xff 61>,  /* mss_a2_bam_irq */
+			<0xff 65>,  /* o_gc_sys_irq[0] */
+			<0xff 73>,  /* smmu_intr_bus[1] */
+			<0xff 74>,  /* smmu_bus_intr[2] */
+			<0xff 75>,  /* smmu_bus_intr[3] */
+			<0xff 76>,  /* venus_irq */
+			<0xff 78>,  /* smmu_bus_intr[5] */
+			<0xff 79>,  /* smmu_bus_intr[6] */
+			<0xff 85>,  /* smmu_bus_intr[31] */
+			<0xff 86>,  /* smmu_bus_intr[32] */
+			<0xff 90>,  /* smmu_bus_intr[33] */
+			<0xff 92>,  /* smmu_bus_intr[34] */
+			<0xff 93>,  /* smmu_bus_intr[35] */
+			<0xff 97>,  /* smmu_bus_intr[10] */
+			<0xff 102>, /* smmu_bus_intr[14] */
+			<0xff 108>, /* smmu_bus_intr[36] */
+			<0xff 109>, /* smmu_bus_intr[37] */
+			<0xff 112>, /* smmu_bus_intr[38] */
+			<0xff 114>, /* qdsd_intr_out */
+			<0xff 126>, /* app_cxt_irpt_10 */
+			<0xff 128>, /* blsp1_peripheral_irq[3] */
+			<0xff 129>, /* blsp1_peripheral_irq[4] */
+			<0xff 130>, /* qup_irq */
+			<0xff 131>, /* qup_irq */
+			<0xff 133>, /* app_cxt_irpt_11 */
+			<0xff 134>, /* app_cxt_irpt_12 */
+			<0xff 137>, /* smmu_intr_bus[44] */
+			<0xff 138>, /* smmu_intr_bus[45] */
+			<0xff 140>, /* uart_dm_intr */
+			<0xff 141>, /* app_cxt_irpt_17 */
+			<0xff 142>, /* smmu_bus_intr[47] */
+			<0xff 143>, /* smmu_bus_intr[48] */
+			<0xff 144>, /* smmu_bus_intr[49] */
+			<0xff 145>, /* smmu_bus_intr[50] */
+			<0xff 146>, /* smmu_bus_intr[51] */
+			<0xff 147>, /* smmu_bus_intr[52] */
+			<0xff 148>, /* smmu_bus_intr[53] */
+			<0xff 149>, /* smmu_bus_intr[54] */
+			<0xff 150>, /* smmu_bus_intr[55] */
+			<0xff 151>, /* smmu_bus_intr[56] */
+			<0xff 152>, /* smmu_bus_intr[57] */
+			<0xff 153>, /* smmu_bus_intr[58] */
+			<0xff 155>, /* sdc1_irq(0) */
+			<0xff 157>, /* sdc2_irq(0) */
+			<0xff 167>, /* usb1_hs_bam_irq */
+			<0xff 170>, /* sdc1_pwr_cmd_irq */
+			<0xff 173>, /* o_wcss_apss_smd_hi */
+			<0xff 174>, /* o_wcss_apss_smd_med */
+			<0xff 175>, /* o_wcss_apss_smd_low */
+			<0xff 176>, /* o_wcss_apss_smsm_irq */
+			<0xff 177>, /* o_wcss_apss_wlan_data_xfer_done */
+			<0xff 178>, /* o_wcss_apss_wlan_rx_data_avail */
+			<0xff 179>, /* o_wcss_apss_asic_intr */
+			<0xff 181>, /* o_wcss_apss_wdog_bite_and_reset_rdy */
+			<0xff 188>, /* lpass_irq_out_apcs(0) */
+			<0xff 189>, /* lpass_irq_out_apcs(1) */
+			<0xff 190>, /* lpass_irq_out_apcs(2) */
+			<0xff 191>, /* lpass_irq_out_apcs(3) */
+			<0xff 192>, /* lpass_irq_out_apcs(4) */
+			<0xff 193>, /* lpass_irq_out_apcs(5) */
+			<0xff 194>, /* lpass_irq_out_apcs(6) */
+			<0xff 195>, /* lpass_irq_out_apcs(7) */
+			<0xff 196>, /* lpass_irq_out_apcs(8) */
+			<0xff 197>, /* lpass_irq_out_apcs(9) */
+			<0xff 198>, /* coresight-tmc-etr interrupt */
+			<0xff 200>, /* rpm_ipc(4) */
+			<0xff 201>, /* rpm_ipc(5) */
+			<0xff 202>, /* rpm_ipc(6) */
+			<0xff 203>, /* rpm_ipc(7) */
+			<0xff 204>, /* rpm_ipc(24) */
+			<0xff 205>, /* rpm_ipc(25) */
+			<0xff 206>, /* rpm_ipc(26) */
+			<0xff 207>, /* rpm_ipc(27) */
+			<0xff 212>, /* lpass_slimbus_bam_ee1_irq */
+			<0xff 215>, /* o_bimc_intr[0] */
+			<0xff 224>, /* spdm_realtime_irq[1] */
+			<0xff 239>, /* crypto_bam_irq[1]*/
+			<0xff 240>, /* summary_irq_kpss */
+			<0xff 253>, /* sdc2_pwr_cmd_irq */
+			<0xff 260>, /* ipa_irq[0] */
+			<0xff 262>, /* ipa_bam_irq[0] */
+			<0xff 269>, /* rpm_wdog_expired_irq */
+			<0xff 270>, /* blsp1_bam_irq[0] */
+			<0xff 272>, /* smmu_intr_bus[17] */
+			<0xff 273>, /* smmu_bus_intr[18] */
+			<0xff 274>, /* smmu_bus_intr[19] */
+			<0xff 275>, /* rpm_ipc(30) */
+			<0xff 276>, /* rpm_ipc(31) */
+			<0xff 277>, /* smmu_intr_bus[20] */
+			<0xff 286>, /* app_cxt_irpt_0 */
+			<0xff 287>, /* app_cxt_irpt_1 */
+			<0xff 296>, /* lmh_interrupt */
+			<0xff 305>, /* nEXTERRIRQ_C0 */
+			<0xff 306>, /* nEXTERRIRQ_C1 */
+			<0xff 307>, /* nINTERRIRQ_C0 */
+			<0xff 308>, /* nINTERRIRQ_C1 */
+			<0xff 321>, /* q6ss_irq_out(4) */
+			<0xff 322>, /* q6ss_irq_out(5) */
+			<0xff 323>, /* q6ss_irq_out(6) */
+			<0xff 325>, /* q6ss_wdog_exp_irq */
+			<0xff 327>, /* sdhc_3 */
+			<0xff 329>; /* sdhc_3 */
+
+		qcom,gpio-parent = <&msm_gpio>;
+		qcom,gpio-map = <3  100>,
+			<4  1>,
+			<5  5>,
+			<6  9>,
+			<8  106>,
+			<9  119>,
+			<10  133>,
+			<11  135>,
+			<12  12>,
+			<13  13>,
+			<14  138>,
+			<15  139>,
+			<16  140>,
+			<17  21>,
+			<18  52>,
+			<19  25>,
+			<20  141>,
+			<21  142>,
+			<22  28>,
+			<23  144>,
+			<24  17>,
+			<25  33>,
+			<26  56>,
+			<27  60>,
+			<28  38>,
+			<29  107>,
+			<30  109>,
+			<31  45>,
+			<32  67>,
+			<33  112>,
+			<34  113>,
+			<35  114>,
+			<36  115>,
+			<37  68>,
+			<38  118>,
+			<39  120>,
+			<40  121>,
+			<41  102>,
+			<50  105>,
+			<51  130>,
+			<52  65>,
+			<53  131>,
+			<54  39>,
+			<55  41>,
+			<56  35>;
+	};
+
+	qcom,cpu-sleep-status{
+		compatible = "qcom,cpu-sleep-status";
+	};
+
+	qcom,rpm-log@29dc00 {
+		compatible = "qcom,rpm-log";
+		reg = <0x29dc00 0x4000>;
+		qcom,rpm-addr-phys = <0x200000>;
+		qcom,offset-version = <4>;
+		qcom,offset-page-buffer-addr = <36>;
+		qcom,offset-log-len = <40>;
+		qcom,offset-log-len-mask = <44>;
+		qcom,offset-page-indices = <56>;
+	};
+
+	qcom,rpm-stats@200000 {
+		compatible = "qcom,rpm-stats";
+		reg = <0x200000 0x1000>,
+		      <0x290014 0x4>,
+		      <0x29001c 0x4>;
+		reg-names = "phys_addr_base", "offset_addr", "heap_phys_addrbase";
+		qcom,sleep-stats-version = <2>;
+	};
+
+	qcom,rpm-master-stats@60150 {
+		compatible = "qcom,rpm-master-stats";
+		reg = <0x60150 0x5000>;
+		qcom,masters = "APSS", "MPSS", "PRONTO", "TZ", "LPASS";
+		qcom,master-stats-version = <2>;
+		qcom,master-offset = <4096>;
+	};
+
+	qcom,rpm-rbcpr-stats@0x29daa0  {
+		compatible = "qcom,rpmrbcpr-stats";
+		reg = <0x29daa0 0x1a0000>;
+		qcom,start-offset = <0x190010>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
@@ -1,0 +1,699 @@
+/*
+ * Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&rpm_bus {
+	rpm-regulator-smpa1 {
+		status = "okay";
+		pm8950_s1: regulator-s1 {
+			regulator-min-microvolt = <1000000>;
+			regulator-max-microvolt = <1162500>;
+			qcom,init-voltage = <1000000>;
+			status = "okay";
+		};
+	};
+
+	/* PM8950 S2 - VDD_CX supply */
+	rpm-regulator-smpa2 {
+		status = "okay";
+		pm8950_s2_level: regulator-s2-level {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s2_level";
+			qcom,set = <3>;
+			regulator-min-microvolt = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+			qcom,init-voltage-level = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			qcom,use-voltage-level;
+		};
+
+		pm8950_s2_floor_level: regulator-s2-floor-level {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s2_floor_level";
+			qcom,set = <3>;
+			regulator-min-microvolt = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+			qcom,use-voltage-floor-level;
+			qcom,always-send-voltage;
+		};
+
+		pm8950_s2_level_ao: regulator-s2-level-ao {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s2_level_ao";
+			qcom,set = <1>;
+			regulator-min-microvolt = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+			qcom,use-voltage-level;
+		};
+	};
+
+	rpm-regulator-smpa3 {
+		status = "okay";
+		pm8950_s3: regulator-s3 {
+			regulator-min-microvolt = <1325000>;
+			regulator-max-microvolt = <1325000>;
+			qcom,init-voltage = <1325000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-smpa4 {
+		status = "okay";
+		pm8950_s4: regulator-s4 {
+			regulator-min-microvolt = <2050000>;
+			regulator-max-microvolt = <2050000>;
+			qcom,init-voltage = <2050000>;
+			status = "okay";
+		};
+	};
+
+	/* VDD_MX supply */
+	rpm-regulator-smpa6 {
+		status = "okay";
+		/* TODO: check this node */
+		pm8950_s6_level: regulator-s6-level {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s6_level";
+			qcom,set = <3>;
+			regulator-min-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_TURBO_HIGH>;
+			qcom,init-voltage-level =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			qcom,use-voltage-level;
+			qcom,always-send-voltage;
+		};
+
+		pm8950_s6_level_ao: regulator-s6-level-ao {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s6_level_ao";
+			qcom,set = <1>;
+			regulator-min-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_TURBO_HIGH>;
+			qcom,use-voltage-level;
+			qcom,always-send-voltage;
+		};
+
+		pm8950_s6_level_so: regulator-s6-level-so {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s6_level_so";
+			qcom,set = <2>;
+			regulator-min-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_TURBO_HIGH>;
+			qcom,init-voltage-level =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			qcom,use-voltage-level;
+		};
+
+		pm8950_s6_floor_level: regulator-s6-floor-level {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_s6_floor_level";
+			qcom,set = <3>;
+			regulator-min-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+			regulator-max-microvolt =
+					<RPM_SMD_REGULATOR_LEVEL_TURBO_HIGH>;
+			qcom,use-voltage-floor-level;
+			qcom,always-send-voltage;
+		};
+	};
+
+	rpm-regulator-ldoa1 {
+		status = "okay";
+		pm8950_l1: regulator-l1 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			qcom,init-voltage = <1200000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa2 {
+		status = "okay";
+		pm8950_l2: regulator-l2 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			qcom,init-voltage = <1200000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa3 {
+		status = "okay";
+		pm8950_l3: regulator-l3 {
+			regulator-min-microvolt = <1000000>;
+			regulator-max-microvolt = <1100000>;
+			qcom,init-voltage = <1000000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa5 {
+		status = "okay";
+		pm8950_l5: regulator-l5 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa6 {
+		status = "okay";
+		pm8950_l6: regulator-l6 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa7 {
+		status = "okay";
+		pm8950_l7: regulator-l7 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+
+		pm8950_l7_ao: regulator-l7-ao {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_l7_ao";
+			qcom,set = <1>;
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			qcom,init-voltage = <1800000>;
+		};
+	};
+
+	rpm-regulator-ldoa8 {
+		status = "okay";
+		pm8950_l8: regulator-l8 {
+			regulator-min-microvolt = <2900000>;
+			regulator-max-microvolt = <2900000>;
+			qcom,init-voltage = <2900000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa9 {
+		status = "okay";
+		pm8950_l9: regulator-l9 {
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3300000>;
+			qcom,init-voltage = <3000000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa10 {
+		status = "okay";
+		pm8950_l10: regulator-l10 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+			qcom,init-voltage = <2800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa11 {
+		status = "okay";
+		pm8950_l11: regulator-l11 {
+			regulator-min-microvolt = <2950000>;
+			regulator-max-microvolt = <2950000>;
+			qcom,init-voltage = <2950000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa12 {
+		status = "okay";
+		pm8950_l12: regulator-l12 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2950000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa13 {
+		status = "okay";
+		pm8950_l13: regulator-l13 {
+			regulator-min-microvolt = <3075000>;
+			regulator-max-microvolt = <3075000>;
+			qcom,init-voltage = <3075000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa14 {
+		status = "okay";
+		pm8950_l14: regulator-l14 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3300000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa15 {
+		status = "okay";
+		pm8950_l15: regulator-l15 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3300000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa16 {
+		status = "okay";
+		pm8950_l16: regulator-l16 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			qcom,init-voltage = <1800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa17 {
+		status = "okay";
+		pm8950_l17: regulator-l17 {
+			regulator-min-microvolt = <2850000>;
+			regulator-max-microvolt = <2850000>;
+			qcom,init-voltage = <2850000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa19 {
+		status = "okay";
+		pm8950_l19: regulator-l19 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1350000>;
+			qcom,init-voltage = <1200000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa22 {
+		status = "okay";
+		pm8950_l22: regulator-l22 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+			qcom,init-voltage = <2800000>;
+			status = "okay";
+		};
+	};
+
+	rpm-regulator-ldoa23 {
+		status = "okay";
+		pm8950_l23: regulator-l23 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			qcom,init-voltage = <1200000>;
+			status = "okay";
+		};
+	};
+
+	/* TODO: BOOST-BYPASS */
+};
+
+/* SPM controlled regulators */
+&spmi_bus {
+	qcom,pm8950@1 {
+		/* PM8950 S5 VDD_APC0 supply */
+		pm8950_s5: spm-regulator@2000 {
+			compatible = "qcom,spm-regulator";
+			reg = <0x2000 0x100>;
+			regulator-name = "pm8950_s5";
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <1165000>;
+			qcom,cpu-num = <0>;
+		};
+	};
+
+	qcom,pm8004@5 {
+		/* PM8004 S2-S4 VDD_APC1 supply */
+		pm8004_s2: spm-regulator@1700 {
+			compatible = "qcom,spm-regulator";
+			reg = <0x1700 0x100>;
+			regulator-name = "pm8004_s2";
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <1165000>;
+			qcom,cpu-num = <4>;
+		};
+
+		/* PM8004 S5 = VDD_GFX supply */
+		pm8004_s5: qpnp-regulator@2000 {
+			compatible = "qcom,qpnp-regulator";
+			reg = <0x2000 0x100>;
+			regulator-name = "pm8004_s5";
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <1165000>;
+			qcom,auto-mode-enable = <1>;
+			qcom,enable-time = <500>;
+		};
+	};
+};
+
+&soc {
+/* CPR controlled regulators */
+	apc0_vreg_corner: regulator@b018000 {
+		compatible = "qcom,cpr-regulator";
+		reg = <0xb018000 0x1000>, <0xa4000 0x1000>;
+		reg-names = "rbcpr", "efuse_addr";
+		interrupts = <0 15 0>;
+		regulator-name = "apc0_corner";
+		regulator-min-microvolt = <1>;
+		regulator-max-microvolt = <9>;
+
+		qcom,cpr-fuse-corners = <3>;
+		qcom,cpr-voltage-ceiling = <950000 1050000 1165000>;
+		qcom,cpr-voltage-floor =   <795000  835000  930000>;
+		vdd-apc-supply = <&pm8950_s5>;
+
+		vdd-mx-supply = <&pm8950_s6_level_ao>;
+		qcom,vdd-mx-vmin-method = <5>;
+		qcom,vdd-mx-vmax = <RPM_SMD_REGULATOR_LEVEL_BINNING>;
+		qcom,vdd-mx-corner-map = <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+					 <RPM_SMD_REGULATOR_LEVEL_NOM>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,cpr-ref-clk = <19200>;
+		qcom,cpr-timer-delay = <5000>;
+		qcom,cpr-timer-cons-up = <0>;
+		qcom,cpr-timer-cons-down = <2>;
+		qcom,cpr-irq-line = <0>;
+		qcom,cpr-step-quotient = <16>;
+		qcom,cpr-up-threshold = <2>;
+		qcom,cpr-down-threshold = <4>;
+		qcom,cpr-idle-clocks = <15>;
+		qcom,cpr-gcnt-time = <1>;
+		qcom,vdd-apc-step-up-limit = <1>;
+		qcom,vdd-apc-step-down-limit = <1>;
+		qcom,cpr-apc-volt-step = <5000>;
+
+		qcom,cpr-fuse-row = <73 0>;
+		qcom,cpr-fuse-target-quot = <48 40 32>;
+		qcom,cpr-fuse-target-quot-size = <8 8 8>;
+		qcom,cpr-fuse-target-quot-scale =
+					<0 10>,
+					<0 10>,
+					<0 10>;
+		qcom,cpr-fuse-ro-sel = <11 8 5>;
+		qcom,cpr-fuse-init-voltage =
+					<73 26 6 0>,
+					<73 20 6 0>,
+					<73 14 6 0>;
+		qcom,cpr-fuse-quot-offset =
+					<74 21 6 0>,
+					<74 15 6 0>,
+					<74  8 7 0>;
+		qcom,cpr-fuse-quot-offset-scale = <10 10 10>;
+		qcom,cpr-fuse-revision = <59 53 3 0>;
+		qcom,speed-bin-fuse-sel = <37 34 3 0>;
+
+		qcom,cpr-init-voltage-ref = <950000 1050000 1165000>;
+		qcom,cpr-init-voltage-step = <10000>;
+
+		qcom,cpr-corner-map = <1 1 2 2 3 3 3 3 3>;
+
+		qcom,cpr-scaled-init-voltage-as-ceiling;
+		qcom,cpr-voltage-scaling-factor-max = <0 2000 2000>;
+		qcom,cpr-quot-adjust-scaling-factor-max = <0 1400 1400>;
+		qcom,cpr-corner-frequency-map =
+				<1   400000000>,
+				<2   691200000>,
+				<3   806400000>,
+				<4  1017600000>,
+				<5  1190400000>,
+				<6  1305600000>,
+				<7  1382400000>,
+				<8  1401600000>,
+				<9  1440000000>;
+		qcom,cpr-speed-bin-max-corners =
+				<0 0 2 4 8>,
+				<1 0 2 4 9>;
+		qcom,cpr-fuse-version-map =
+		/* <Speed_bits PVS_version CPR_Rev - - -> */
+			<  0  (-1)   1  (-1) (-1) (-1)>,
+			<  0  (-1)   2  (-1) (-1) (-1)>,
+			<  0  (-1)   3  (-1) (-1) (-1)>,
+			<(-1) (-1) (-1) (-1) (-1) (-1)>;
+		qcom,cpr-quotient-adjustment =
+			<0 37 150>, /* NOM + 15mv, TURBO + 60mv */
+			<0 37 150>, /* NOM + 15mv, TURBO + 60mv */
+			<0 37 150>, /* NOM + 15mv, TURBO + 60mv */
+			<0  0   0>;
+		qcom,cpr-voltage-floor-override =
+			<(-1) (-1) 795000 795000 835000 855000
+			945000 945000 990000 990000 990000>;
+		qcom,cpr-enable;
+	};
+
+	apc1_vreg_corner: regulator@b118000 {
+		compatible = "qcom,cpr-regulator";
+		reg = <0xb118000 0x1000>, <0xa0000 0x1000>;
+		reg-names = "rbcpr", "efuse_addr";
+		interrupts = <0 19 0>;
+		regulator-name = "apc1_corner";
+		regulator-min-microvolt = <1>;
+		regulator-max-microvolt = <7>;
+
+		qcom,cpr-fuse-corners = <3>;
+		qcom,cpr-voltage-ceiling = <950000 1050000 1165000>;
+		qcom,cpr-voltage-floor =   <790000  820000  915000>;
+		vdd-apc-supply = <&pm8004_s2>;
+
+		vdd-mx-supply = <&pm8950_s6_level_ao>;
+		qcom,vdd-mx-vmin-method = <5>;
+		qcom,vdd-mx-vmax = <RPM_SMD_REGULATOR_LEVEL_BINNING>;
+		qcom,vdd-mx-corner-map = <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+					 <RPM_SMD_REGULATOR_LEVEL_NOM>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,cpr-ref-clk = <19200>;
+		qcom,cpr-timer-delay = <5000>;
+		qcom,cpr-timer-cons-up = <0>;
+		qcom,cpr-timer-cons-down = <2>;
+		qcom,cpr-irq-line = <0>;
+		qcom,cpr-step-quotient = <16>;
+		qcom,cpr-up-threshold = <2>;
+		qcom,cpr-down-threshold = <4>;
+		qcom,cpr-idle-clocks = <15>;
+		qcom,cpr-gcnt-time = <1>;
+		qcom,cpr-clamp-timer-interval = <1>;
+		qcom,vdd-apc-step-up-limit = <1>;
+		qcom,vdd-apc-step-down-limit = <1>;
+		qcom,cpr-apc-volt-step = <5000>;
+
+		qcom,cpr-fuse-row = <74 0>;
+		qcom,cpr-fuse-target-quot = <80 72 64>;
+		qcom,cpr-fuse-target-quot-size = <8 8 8>;
+		qcom,cpr-fuse-target-quot-scale =
+					<0 10>,
+					<0 10>,
+					<0 10>;
+		qcom,cpr-fuse-ro-sel = <33 30 27>;
+		qcom,cpr-fuse-init-voltage =
+					<74 48 6 0>,
+					<74 42 6 0>,
+					<74 36 6 0>;
+		qcom,cpr-fuse-quot-offset =
+					<75 37 6 0>,
+					<75 31 6 0>,
+					<75 24 7 0>;
+		qcom,cpr-fuse-quot-offset-scale = <10 10 10>;
+		qcom,cpr-fuse-revision = <59 53 3 0>;
+		qcom,speed-bin-fuse-sel = <37 34 3 0>;
+
+		qcom,cpr-init-voltage-ref = <950000 1050000 1165000>;
+		qcom,cpr-init-voltage-step = <10000>;
+
+		qcom,cpr-corner-map = <1 1 2 2 3 3 3>;
+		qcom,cpr-scaled-init-voltage-as-ceiling;
+		qcom,cpr-voltage-scaling-factor-max = <0 2000 2000>;
+		qcom,cpr-quot-adjust-scaling-factor-max = <0 1400 1400>;
+		qcom,cpr-corner-frequency-map =
+				<1   400000000>,
+				<2   883200000>,
+				<3  1190400000>,
+				<4  1382400000>,
+				<5  1612800000>,
+				<6  1747200000>,
+				<7  1804800000>;
+		qcom,cpr-speed-bin-max-corners =
+				<0 0 2 4 6>,
+				<1 0 2 4 7>;
+		qcom,cpr-fuse-version-map =
+		/* <Speed_bits PVS_version CPR_Rev - - -> */
+			<  0  (-1)   1  (-1) (-1) (-1)>,
+			<  0  (-1)   2  (-1) (-1) (-1)>,
+			<  0  (-1)   3  (-1) (-1) (-1)>,
+			<(-1) (-1) (-1) (-1) (-1) (-1)>;
+		qcom,cpr-quotient-adjustment =
+			<0 (-37) 0>, /* NOM - 15mv */
+			<0 (-37) 0>, /* NOM - 15mv */
+			<0 (-37) 0>, /* NOM - 15mv */
+			<0    0  0>;
+		qcom,cpr-voltage-floor-override =
+			<(-1) (-1) 790000 790000 820000 850000
+			940000 990000 990000>;
+		qcom,cpr-enable;
+	};
+
+	mem_acc_gfx_vreg_corner: mem-acc-gfx-regulator {
+		compatible = "qcom,mem-acc-regulator";
+		reg = <0x01944130 0x4>;
+		reg-names = "acc-sel-l1";
+		regulator-name = "mem_acc_gfx_corner";
+		regulator-min-microvolt = <1>;
+		regulator-max-microvolt = <9>;
+
+		qcom,acc-sel-l1-bit-pos = <0>;
+		qcom,acc-sel-l1-bit-size = <2>;
+		qcom,corner-acc-map = <0 0 0 1 1 1 1 1 1>;
+	};
+
+	/* CPR regulators */
+	gfx_vreg_corner: regulator@98000 {
+		compatible = "qcom,cpr2-gfx-regulator";
+		reg = <0x98000 0x1000>, <0xa4000 0x1000>;
+		reg-names = "rbcpr", "efuse_addr";
+		clocks = <&clock_gcc clk_gcc_rbcpr_gfx_clk>,
+			<&clock_gcc clk_gcc_rbcpr_gfx_ahb_clk>;
+		clock-names = "core_clk", "iface_clk";
+		interrupts = <0 314 0>;
+
+		regulator-name = "gfx_corner";
+		qcom,cpr-corners = <9>;
+		regulator-min-microvolt = <1>;
+		regulator-max-microvolt = <9>;
+
+		qcom,cpr-voltage-ceiling =
+				<810000 865000 900000 950000 1010000
+				1050000 1110000 1165000 1165000>;
+		qcom,cpr-voltage-floor =
+				<755000 755000 755000 795000 835000
+				855000 920000 945000 945000>;
+		vdd-gfx-supply = <&pm8004_s5>;
+
+		vdd-mx-supply = <&pm8950_s6_level_ao>;
+		qcom,vdd-mx-vmax = <RPM_SMD_REGULATOR_LEVEL_BINNING>;
+		qcom,vdd-mx-corner-map = <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS>,
+					 <RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+					 <RPM_SMD_REGULATOR_LEVEL_NOM>,
+					 <RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>,
+					 <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		mem-acc-supply = <&mem_acc_gfx_vreg_corner>;
+
+		qcom,cpr-ref-clk = <19200>;
+		qcom,cpr-timer-delay = <5000>;
+		qcom,cpr-timer-cons-up = <0>;
+		qcom,cpr-timer-cons-down = <2>;
+		qcom,cpr-irq-line = <0>;
+		qcom,cpr-step-quotient = <16>;
+		qcom,cpr-up-threshold = <2>;
+		qcom,cpr-down-threshold = <4>;
+		qcom,cpr-idle-clocks = <15>;
+		qcom,cpr-gcnt-time = <1>;
+		qcom,vdd-gfx-step-up-limit = <1>;
+		qcom,vdd-gfx-step-down-limit = <1>;
+		qcom,cpr-gfx-volt-step = <5000>;
+
+		qcom,cpr-init-voltage-ref =
+				<865000 865000 950000 950000 950000
+				1050000 1050000 1165000 1165000>;
+		qcom,cpr-fuse-init-voltage =
+					<72 50 5>,
+					<72 50 5>,
+					<72 45 5>,
+					<72 45 5>,
+					<72 45 5>,
+					<72 40 5>,
+					<72 40 5>,
+					<72 35 5>,
+					<72 35 5>;
+		qcom,cpr-init-voltage-step = <12500>;
+		qcom,cpr-ro-count = <8>;
+		qcom,cpr-init-voltage-as-ceiling;
+		qcom,cpr-init-voltage-adjustment =
+			<(-55000) 0 (-60000) 0 (60000) 0 (60000) 0 (50000)>;
+		qcom,cpr-target-quotients =
+			<513  489  620  574  237 272 144 177>,
+			<575  547  688  638  272 312 169 206>,
+			<706  672  819  765  363 410 241 287>,
+			<768  741  890  843  404 450 277 323>,
+			<917  880  1039 982  514 562 369 421>,
+			<998  960  1126 1069 571 617 422 472>,
+			<1074 1028 1198 1135 635 675 483 531>,
+			<1188 1135 1317 1246 720 753 562 605>,
+			<1276 1212 1405 1323 776 816 604 654>;
+		qcom,cpr-enable;
+	};
+};
+
+&pmi8950_charger {
+	smbcharger_charger_otg: qcom,smbcharger-boost-otg {
+		regulator-name = "smbcharger_charger_otg";
+	};
+};
+
+&soc {
+	eldo2_8976: eldo2 {
+		compatible = "regulator-fixed";
+		regulator-name = "eldo2_8976";
+		startup-delay-us = <0>;
+		enable-active-high;
+		gpio = <&pm8950_gpios 7 0>;
+		regulator-always-on;
+	};
+
+	adv_vreg: adv_vreg {
+		compatible = "regulator-fixed";
+		regulator-name = "adv_vreg";
+		startup-delay-us = <400>;
+		enable-avtive-high;
+		gpio = <&pm8004_mpps 4 0>;
+	};
+
+	/* Rome 3.3V supply */
+	rome_vreg: rome_vreg {
+		compatible = "regulator-fixed";
+		startup-delay-us = <4000>;
+		enable-active-high;
+		gpio = <&pm8950_gpios 5 0>;
+		regulator-name = "rome_vreg";
+		status = "disabled";
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
@@ -77,7 +77,13 @@
 
 	/* VDD_MX supply */
 	rpm-regulator-smpa6 {
+		compatible = "qcom,rpm-smd-regulator-resource";
+		qcom,resource-name = "smpa";
+		qcom,resource-id = <6>;
+		qcom,regulator-type = <1>;
+		qcom,hpm-min-load = <100000>;
 		status = "okay";
+
 		/* TODO: check this node */
 		pm8950_s6_level: regulator-s6-level {
 			compatible = "qcom,rpm-smd-regulator";
@@ -132,8 +138,17 @@
 	};
 
 	rpm-regulator-ldoa1 {
+		compatible = "qcom,rpm-smd-regulator-resource";
+		qcom,resource-name = "ldoa";
+		qcom,resource-id = <1>;
+		qcom,regulator-type = <0>;
+		qcom,hpm-min-load = <10000>;
 		status = "okay";
+
 		pm8950_l1: regulator-l1 {
+			compatible = "qcom,rpm-smd-regulator";
+			regulator-name = "pm8950_l1";
+			qcom,set = <3>;
 			regulator-min-microvolt = <1200000>;
 			regulator-max-microvolt = <1200000>;
 			qcom,init-voltage = <1200000>;

--- a/arch/arm/boot/dts/qcom/msm8976-smp2p.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-smp2p.dtsi
@@ -1,0 +1,225 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+&soc {
+	qcom,smp2p-modem@0x0b011008 {
+		compatible = "qcom,smp2p";
+		reg = <0x0b011008 0x4>;
+		qcom,remote-pid = <1>;
+		qcom,irq-bitmask = <0x4000>;
+		interrupts = <0 27 1>;
+	};
+
+	qcom,smp2p-wcnss@0x0b011008 {
+		compatible = "qcom,smp2p";
+		reg = <0x0b011008 0x4>;
+		qcom,remote-pid = <4>;
+		qcom,irq-bitmask = <0x40000>;
+		interrupts = <0 143 1>;
+	};
+
+	qcom,smp2p-adsp@0x0b011008 {
+		compatible = "qcom,smp2p";
+		reg = <0x0b011008 0x4>;
+		qcom,remote-pid = <2>;
+		qcom,irq-bitmask = <0x400>;
+		interrupts = <0 291 1>;
+	};
+
+	smp2pgpio_smp2p_15_in: qcom,smp2pgpio-smp2p-15-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <15>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_15_in {
+		compatible = "qcom,smp2pgpio_test_smp2p_15_in";
+		gpios = <&smp2pgpio_smp2p_15_in 0 0>;
+	};
+
+	smp2pgpio_smp2p_15_out: qcom,smp2pgpio-smp2p-15-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <15>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_15_out {
+		compatible = "qcom,smp2pgpio_test_smp2p_15_out";
+		gpios = <&smp2pgpio_smp2p_15_out 0 0>;
+	};
+
+	smp2pgpio_smp2p_1_in: qcom,smp2pgpio-smp2p-1-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <1>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_1_in {
+		compatible = "qcom,smp2pgpio_test_smp2p_1_in";
+		gpios = <&smp2pgpio_smp2p_1_in 0 0>;
+	};
+
+	smp2pgpio_smp2p_1_out: qcom,smp2pgpio-smp2p-1-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <1>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_1_out {
+		compatible = "qcom,smp2pgpio_test_smp2p_1_out";
+		gpios = <&smp2pgpio_smp2p_1_out 0 0>;
+	};
+
+	smp2pgpio_smp2p_4_in: qcom,smp2pgpio-smp2p-4-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <4>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_4_in {
+		compatible = "qcom,smp2pgpio_test_smp2p_4_in";
+		gpios = <&smp2pgpio_smp2p_4_in 0 0>;
+	};
+
+	smp2pgpio_smp2p_4_out: qcom,smp2pgpio-smp2p-4-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <4>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_4_out {
+		compatible = "qcom,smp2pgpio_test_smp2p_4_out";
+		gpios = <&smp2pgpio_smp2p_4_out 0 0>;
+	};
+
+	smp2pgpio_smp2p_2_in: qcom,smp2pgpio-smp2p-2-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <2>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_2_in {
+		compatible = "qcom,smp2pgpio_test_smp2p_2_in";
+		gpios = <&smp2pgpio_smp2p_2_in 0 0>;
+	};
+
+	smp2pgpio_smp2p_2_out: qcom,smp2pgpio-smp2p-2-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "smp2p";
+		qcom,remote-pid = <2>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	qcom,smp2pgpio_test_smp2p_2_out {
+		compatible = "qcom,smp2pgpio_test_smp2p_2_out";
+		gpios = <&smp2pgpio_smp2p_2_out 0 0>;
+	};
+
+	/* ssr - inbound entry from lpass. */
+	smp2pgpio_ssr_smp2p_2_in: qcom,smp2pgpio-ssr-smp2p-2-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "slave-kernel";
+		qcom,remote-pid = <2>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	/* ssr - outbound entry to lpass */
+	smp2pgpio_ssr_smp2p_2_out: qcom,smp2pgpio-ssr-smp2p-2-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "master-kernel";
+		qcom,remote-pid = <2>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	smp2pgpio_ssr_smp2p_4_in: qcom,smp2pgpio-ssr-smp2p-4-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "slave-kernel";
+		qcom,remote-pid = <4>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	smp2pgpio_ssr_smp2p_4_out: qcom,smp2pgpio-ssr-smp2p-4-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "master-kernel";
+		qcom,remote-pid = <4>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	smp2pgpio_ssr_smp2p_1_in: qcom,smp2pgpio-ssr-smp2p-1-in {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "slave-kernel";
+		qcom,remote-pid = <1>;
+		qcom,is-inbound;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	smp2pgpio_ssr_smp2p_1_out: qcom,smp2pgpio-ssr-smp2p-1-out {
+		compatible = "qcom,smp2pgpio";
+		qcom,entry-name = "master-kernel";
+		qcom,remote-pid = <1>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976-wsa881x.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-wsa881x.dtsi
@@ -1,0 +1,49 @@
+/* Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&slim_msm {
+	tasha_codec {
+		swr_master {
+			compatible = "qcom,swr-wcd";
+			#address-cells = <2>;
+			#size-cells = <0>;
+
+			wsa881x@20170211 {
+				compatible = "qcom,wsa881x";
+				reg = <0x00 0x20170211>;
+				qcom,spkr-sd-n-gpio = <&msm_gpio 132 0>;
+
+			};
+
+			wsa881x@20170212 {
+				compatible = "qcom,wsa881x";
+				reg = <0x00 0x20170212>;
+				qcom,spkr-sd-n-gpio = <&msm_gpio 132 0>;
+
+			};
+
+			wsa881x@21170213 {
+				compatible = "qcom,wsa881x";
+				reg = <0x00 0x21170213>;
+				qcom,spkr-sd-n-gpio = <&msm_gpio 132 0>;
+
+			};
+
+			wsa881x@21170214 {
+				compatible = "qcom,wsa881x";
+				reg = <0x00 0x21170214>;
+				qcom,spkr-sd-n-gpio = <&msm_gpio 132 0>;
+
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -1,0 +1,2998 @@
+/*
+ * Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "skeleton64.dtsi"
+#include <dt-bindings/clock/msm-clocks-8976.h>
+#include <dt-bindings/regulator/qcom,rpm-smd-regulator.h>
+
+/ {
+	model = "Qualcomm Technologies, Inc. MSM 8976";
+	compatible = "qcom,msm8976";
+	qcom,msm-id = <278 0x0>;
+	interrupt-parent = <&intc>;
+
+	chosen {
+		bootargs = "boot_cpus=0,1,2,3,4,5 sched_enable_hmp=1";
+	};
+
+	aliases {
+		/* smdtty devices */
+		smd1 = &smdtty_apps_fm;
+		smd2 = &smdtty_apps_riva_bt_acl;
+		smd3 = &smdtty_apps_riva_bt_cmd;
+		smd4 = &smdtty_mbalbridge;
+		smd5 = &smdtty_apps_riva_ant_cmd;
+		smd6 = &smdtty_apps_riva_ant_data;
+		smd7 = &smdtty_data1;
+		smd8 = &smdtty_data4;
+		smd11 = &smdtty_data11;
+		smd21 = &smdtty_data21;
+		smd36 = &smdtty_loopback;
+		i2c2  = &i2c_2;
+		i2c4  = &i2c_4;
+		i2c6  = &i2c_6;
+		i2c8  = &i2c_8;
+		qup10 = &test_pacman;
+	};
+
+	soc: soc { };
+
+	aliases {
+		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
+		sdhc2 = &sdhc_2; /* SDC2 SD card slot */
+		sdhc3 = &sdhc_3; /* SDC3 SDIO card slot */
+		spi0 = &spi_0;
+	};
+
+	memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		other_ext_mem: other_ext_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x85E00000 0x0 0x0A00000>;
+			label = "other_ext_mem";
+		};
+
+		modem_mem: modem_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x86C00000 0x0 0x05600000>;
+			label = "modem_mem";
+		};
+
+		reloc_mem: reloc_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x0 0x8c200000 0x0 0x1700000>;
+			label = "reloc_mem";
+		};
+
+		venus_mem: venus_region@0 {
+			linux,reserve-contiguous-region;
+			linux,memory-limit = <0x90000000>;
+			reg = <0x0 0x0 0x0 0x0500000>;
+			label = "venus_mem";
+		};
+
+		secure_mem: secure_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x7A00000>;
+			label = "secure_mem";
+		};
+
+		qseecom_mem: qseecom_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x1000000>;
+			label = "qseecom_mem";
+		};
+
+		audio_mem: audio_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x314000>;
+		};
+
+		cont_splash_mem: splash_region@83000000 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			reg = <0x0 0x83000000 0x0 0x2800000>;
+			label = "cont_splash_mem";
+		};
+
+		adsp_mem: adsp_region@0 {
+			linux,reserve-contiguous-region;
+			reg = <0x0 0x0 0x0 0x400000>;
+			label = "adsp_mem";
+		};
+	};
+};
+
+#include "msm8976-pinctrl.dtsi"
+#include "msm8976-ion.dtsi"
+#include "msm8976-iommu.dtsi"
+#include "msm8976-mdss.dtsi"
+#include "msm8976-iommu-domains.dtsi"
+#include "msm8976-smp2p.dtsi"
+#include "msm8976-bus.dtsi"
+#include "msm8976-jtag.dtsi"
+#include "msm8976-coresight.dtsi"
+#include "msm8976-pm.dtsi"
+#include "msm8976-gpu.dtsi"
+#include "msm8976-mdss-pll.dtsi"
+#include "msm8976-cpu.dtsi"
+#include "msm-rdbg.dtsi"
+
+&soc {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	ranges = <0 0 0 0xffffffff>;
+	compatible = "simple-bus";
+
+	arm64-cpu-erp {
+		compatible = "arm,arm64-cpu-erp";
+		interrupts = <0 275 0>,
+			     <0 276 0>,
+			     <0 273 0>,
+			     <0 274 0>,
+			     <1 7 0>;
+		interrupt-names = "pri-dbe-irq",
+				  "sec-dbe-irq",
+				  "pri-ext-irq",
+				  "sec-ext-irq",
+				  "sbe-irq";
+		poll-delay-ms = <5000>;
+	};
+
+	qcom,msm-gladiator@b1c0000 {
+		compatible = "qcom,msm-gladiator";
+		reg = <0x0b1C0000 0x4000>;
+		reg-names = "gladiator_base";
+		interrupts = <0 22 0>;
+	};
+
+	intc: interrupt-controller@b000000 {
+		compatible = "qcom,msm-qgic2";
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		reg = <0x0b000000 0x1000>,
+		      <0x0b002000 0x1000>;
+	};
+
+	qcom,msm-imem@8600000 {
+		compatible = "qcom,msm-imem";
+		reg = <0x08600000 0x1000>; /* Address and size of IMEM */
+		ranges = <0x0 0x08600000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		mem_dump_table@10 {
+			compatible = "qcom,msm-imem-mem_dump_table";
+			reg = <0x10 8>;
+		};
+
+		restart_reason@65c {
+			compatible = "qcom,msm-imem-restart_reason";
+			reg = <0x65c 4>;
+		};
+
+		boot_stats@6b0 {
+			compatible = "qcom,msm-imem-boot_stats";
+			reg = <0x6b0 32>;
+		};
+
+		pil@94c {
+			compatible = "qcom,msm-imem-pil";
+			reg = <0x94c 200>;
+		};
+	};
+
+	clock_gcc: qcom,gcc@1800000 {
+		compatible = "qcom,gcc-8976";
+		reg = <0x1800000 0x80000>;
+		reg-names = "cc_base";
+		vdd_dig-supply = <&pm8950_s2_level>;
+		#clock-cells = <1>;
+	};
+
+	clock_debug: qcom,cc-debug@1874000 {
+		compatible = "qcom,cc-debug-8976";
+		clocks = <&clock_cpu clk_cpu_debug_pri_mux>;
+		clock-names = "debug_cpu_clk";
+		#clock-cells = <1>;
+	};
+
+	clock_gcc_gfx: qcom,gcc-gfx@1800000 {
+                compatible = "qcom,gcc-gfx-8976";
+                reg = <0x1800000 0x80000>;
+                reg-names = "cc_base";
+		vdd_gfx-supply = <&gfx_vreg_corner>;
+		gpu_handle = <&msm_gpu>;
+                qcom,gfxfreq-corner =
+			<         0   0 >,
+			< 133333333   1 >,  /* Min SVS   */
+			< 200000000   2 >,  /* Low SVS   */
+			< 266666667   3 >,  /* SVS Minus */
+			< 300000000   4 >,  /* SVS       */
+			< 366670000   5 >,  /* SVS Plus  */
+			< 432000000   6 >,  /* NOM       */
+			< 480000000   7 >,  /* Turbo     */
+			< 550000000   8 >,  /* Super Turbo */
+			< 600000000   9 >;  /* Super Turbo */
+		#clock-cells = <1>;
+	};
+
+	clock_gcc_mdss: qcom,gcc-mdss@1800000 {
+		compatible = "qcom,gcc-mdss-8976";
+		reg = <0x1800000 0x80000>;
+                reg-names = "cc_base";
+		clocks = <&mdss_dsi0_pll clk_dsi_pll0_pixel_clk_src>,
+			 <&mdss_dsi0_pll clk_dsi_pll0_byte_clk_src>,
+			 <&mdss_dsi1_pll clk_dsi_pll1_pixel_clk_src>,
+			 <&mdss_dsi1_pll clk_dsi_pll1_byte_clk_src>;
+		clock-names = "pclk0_src", "byte0_src", "pclk1_src",
+				 "byte1_src";
+		#clock-cells = <1>;
+	};
+
+	clock_cpu: qcom,cpu-clock-8976@b016000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "qcom,cpu-clock-8976";
+		reg =   <0xb114000  0x68>,
+			<0xb014000  0x68>,
+			<0xb116000  0x40>,
+			<0xb016000  0x40>,
+			<0xb1d0000  0x40>,
+			<0xb111050  0x08>,
+			<0xb011050  0x08>,
+			<0xb1d1050  0x08>,
+			<0x00a412c  0x08>;
+		reg-names = "rcgwr-c0-base", "rcgwr-c1-base",
+			    "c0-pll", "c1-pll", "cci-pll",
+			    "c0-mux", "c1-mux", "cci-mux",
+			    "efuse";
+		/* RCGwR settings */
+		qcom,num-clusters = <2>;
+		qcom,lmh-sid-c0  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c0 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c0  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+		qcom,lmh-sid-c1  = < 0x30 0x077706db>,
+				   < 0x34 0x05550249>,
+				   < 0x38 0x00000111>;
+		qcom,link-sid-c1 = < 0x40 0x000fc987>;
+		qcom,dfs-sid-c1  = < 0x10 0xfefebff7>,
+				   < 0x14 0xfdff7fef>,
+				   < 0x18 0xfbffdefb>,
+				   < 0x1c 0xb69b5555>,
+				   < 0x20 0x24929249>,
+				   < 0x24 0x49241112>,
+				   < 0x28 0x11112111>,
+				   < 0x2c 0x00008102>;
+
+		vdd_mx_hf-supply = <&pm8950_s6_level_ao>;
+		vdd_hf_pll-supply = <&pm8950_l7_ao>;
+		vdd_mx_sr-supply = <&pm8950_s6_level_ao>;
+		vdd_a72-supply = <&apc1_vreg_corner>;
+		vdd_a53-supply = <&apc0_vreg_corner>;
+		vdd_cci-supply = <&apc0_vreg_corner>;
+		clocks = <&clock_gcc clk_xo_a_clk_src>,
+			 <&clock_gcc clk_gpll4_clk_src>,
+			 <&clock_gcc clk_gpll0_ao_clk_src>;
+		clock-names = "xo_a", "aux_clk_2", "aux_clk_3";
+		qcom,speed0-bin-v0-c0 =
+			<          0 0>,
+			<  400000000 1>,
+			<  691200000 2>,
+			<  806400000 3>,
+			< 1017600000 4>,
+			< 1190400000 5>,
+			< 1305600000 6>,
+			< 1382400000 7>,
+			< 1401600000 8>;
+		qcom,speed0-bin-v0-c1 =
+			<          0 0>,
+			<  400000000 1>,
+			<  883200000 2>,
+			< 1190400000 3>,
+			< 1382400000 4>,
+			< 1612800000 5>,
+			< 1747200000 6>;
+		qcom,speed0-bin-v0-cci =
+			<          0 0>,
+			<  307200000 1>,
+			<  403200000 3>,
+			<  441600000 4>,
+			<  556800000 5>,
+			<  614400000 6>;
+		qcom,speed1-bin-v0-c0 =
+			<          0 0>,
+			<  400000000 1>,
+			<  691200000 2>,
+			<  806400000 3>,
+			< 1017600000 4>,
+			< 1190400000 5>,
+			< 1305600000 6>,
+			< 1382400000 7>,
+			< 1401600000 8>,
+			< 1440000000 9>;
+		qcom,speed1-bin-v0-c1 =
+			<          0 0>,
+			<  400000000 1>,
+			<  883200000 2>,
+			< 1190400000 3>,
+			< 1382400000 4>,
+			< 1612800000 5>,
+			< 1747200000 6>,
+			< 1804800000 7>;
+		qcom,speed1-bin-v0-cci =
+			<          0 0>,
+			<  307200000 1>,
+			<  403200000 3>,
+			<  441600000 4>,
+			<  556800000 5>,
+			<  614400000 6>;
+		#clock-cells = <1>;
+		ranges;
+		qcom,spm@0 {
+			compatible = "qcom,cpu-spm-8976";
+			reg = <0x0b111200 0x100>,
+			      <0x0b011200 0x100>,
+			      <0x0b1d4000 0x100>;
+			reg-names = "spm_c0_base", "spm_c1_base",
+				     "spm_cci_base";
+		};
+	};
+
+	qcom,mpm2-sleep-counter@4a3000 {
+		compatible = "qcom,mpm2-sleep-counter";
+		reg = <0x4a3000 0x1000>;
+		clock-frequency = <32768>;
+	};
+
+	cci_cache: qcom,cci {
+		compatible = "devfreq-simple-dev";
+		clock-names = "devfreq_clk";
+		clocks = <&clock_cpu clk_cci_clk>;
+		governor = "cpufreq";
+		freq-tbl-khz =
+			<  307200 >, /* SVS    */
+			<  403200 >, /* SVS+   */
+			<  441600 >, /* NOM    */
+			<  556800 >, /* TURBO  */
+			<  614400 >; /* STURBO */
+	};
+
+	cpubw: qcom,cpubw {
+		compatible = "qcom,devbw";
+		governor = "cpufreq";
+		qcom,src-dst-ports = <1 512>;
+		qcom,active-only;
+		qcom,bw-tbl =
+			<   805 /*   52.8 MHz */ >,
+			<  1244 /*   81.6 MHz */ >,
+			<  1611 /*  105.6 MHz */ >,
+			<  2929 /*  192   MHz */ >,	/* SVS	 */
+			<  4101 /*  268.8 MHz */ >,     /* SVS+ */
+			<  5126 /*  336.0 MHz */ >,	/* NOM  */
+			<  5712 /*  374.4 MHz */ >,
+			<  6152 /*  403.2 MHz */ >,	/* TURBO */
+			<  7104 /*  465.6 MHz */ >;	/* STURBO */
+	};
+
+	mincpubw: qcom,mincpubw {
+		compatible = "qcom,devbw";
+		governor = "cpufreq";
+		qcom,src-dst-ports = <1 512>;
+		qcom,active-only;
+		qcom,bw-tbl =
+			<   805 /*   52.8 MHz */ >,
+			<  1244 /*   81.6 MHz */ >,
+			<  1611 /*  105.6 MHz */ >,
+			<  2929 /*  192   MHz */ >,	/* SVS	 */
+			<  4101 /*  268.8 MHz */ >,     /* SVS+ */
+			<  5126 /*  336.0 MHz */ >,	/* NOM  */
+			<  5712 /*  374.4 MHz */ >,
+			<  6152 /*  403.2 MHz */ >,	/* TURBO */
+			<  7104 /*  465.6 MHz */ >;	/* STURBO */
+	};
+
+	qcom,cpu-bwmon@408000 {
+		compatible = "qcom,bimc-bwmon2";
+		reg = <0x408000 0x300>, <0x401000 0x200>;
+		reg-names = "base", "global_base";
+		interrupts = <0 183 4>;
+		qcom,mport = <0>;
+		qcom,target-dev = <&cpubw>;
+	};
+
+	qcom,msmcci-ccimon {
+		compatible = "qcom,msmcci-hwmon";
+		reg = <0xb1dc000 0xb0>,
+			<0xb1dc004 0xb0>;
+		interrupts = <0 272 4>;
+		qcom,counter-event-sel = <1 2>;
+		qcom,target-dev = <&cci_cache>;
+		qcom,shared-irq;
+	};
+
+	devfreq-cpufreq {
+		cpubw-cpufreq {
+			target-dev = <&cpubw>;
+			cpu-to-dev-map-0 =
+				<  691200   805 >,	/* SVS   */
+				<  806400  4101 >,	/* SVS+  */
+				< 1017600  5712 >,	/* NOM   */
+				< 1190400  6152 >,	/* TURBO */
+				< 1440000  7104 >;
+			cpu-to-dev-map-4 =
+				<  883200   805 >,	/* SVS   */
+				< 1190400  4101 >,	/* SVS+  */
+				< 1382400  5712 >,	/* NOM   */
+				< 1612800  6152 >,	/* TURBO */
+				< 1804800  7104 >;
+		};
+
+		mincpubw-cpufreq {
+			target-dev = <&mincpubw>;
+			cpu-to-dev-map-0 =
+				<  691200 2929 >,
+				< 1017600 2929 >,
+				< 1401600 4101 >;
+			cpu-to-dev-map-4 =
+				<  883200 2929 >,
+				< 1382400 2929 >,
+				< 1747200 4101 >;
+		};
+
+		cci-cpufreq {
+			target-dev = <&cci_cache>;
+			cpu-to-dev-map-0 =
+				<  691200  307200 >,
+				<  806400  403200 >,
+				< 1017600  441600 >,
+				< 1190400  556800 >,
+				< 1440000  614400 >;
+			cpu-to-dev-map-4 =
+				<  883200 307200 >,
+				< 1190400 403200 >,
+				< 1382400 441600 >,
+				< 1612800 556800 >,
+				< 1804800 614400 >;
+		};
+	};
+
+	qcom,msm-cpufreq {
+		compatible = "qcom,msm-cpufreq";
+		clock-names = "l2_clk", "cpu0_clk", "cpu1_clk", "cpu2_clk",
+			      "cpu3_clk", "cpu4_clk", "cpu5_clk", "cpu6_clk",
+			      "cpu7_clk";
+		clocks = <&clock_cpu clk_cci_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a53_clk>,
+			 <&clock_cpu clk_a72_clk>,
+			 <&clock_cpu clk_a72_clk>,
+			 <&clock_cpu clk_a72_clk>,
+			 <&clock_cpu clk_a72_clk>;
+		qcom,governor-per-policy;
+		qcom,cpufreq-table-0 =
+			<  400000 >,
+			<  691200 >,
+			<  806400 >,
+			< 1017600 >,
+			< 1190400 >,
+			< 1305600 >,
+			< 1382400 >,
+			< 1401600 >,
+			< 1440000 >;
+		qcom,cpufreq-table-4 =
+			<  400000 >,
+			<  883200 >,
+			<  940800 >,
+			<  998400 >,
+			< 1056000 >,
+			< 1113600 >,
+			< 1190400 >,
+			< 1248000 >,
+			< 1305600 >,
+			< 1382400 >,
+			< 1612800 >,
+			< 1747200 >,
+			< 1804800 >;
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <1 2 0xff08>,
+			     <1 3 0xff08>,
+			     <1 4 0xff08>,
+			     <1 1 0xff08>;
+		clock-frequency = <19200000>;
+	};
+
+	restart@4ab000 {
+		compatible = "qcom,pshold";
+		reg = <0x4ab000 0x4>,
+			<0x193d100 0x4>;
+		reg-names = "pshold-base", "tcsr-boot-misc-detect";
+	};
+
+	timer@b120000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		compatible = "arm,armv7-timer-mem";
+		reg = <0xb120000 0x1000>;
+		clock-frequency = <19200000>;
+
+		frame@b121000 {
+			frame-number = <0>;
+			interrupts = <0 8 0x4>,
+				     <0 7 0x4>;
+			reg = <0xb121000 0x1000>,
+			      <0xb122000 0x1000>;
+		};
+
+		frame@b123000 {
+			frame-number = <1>;
+			interrupts = <0 9 0x4>;
+			reg = <0xb123000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b124000 {
+			frame-number = <2>;
+			interrupts = <0 10 0x4>;
+			reg = <0xb124000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b125000 {
+			frame-number = <3>;
+			interrupts = <0 11 0x4>;
+			reg = <0xb125000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b126000 {
+			frame-number = <4>;
+			interrupts = <0 12 0x4>;
+			reg = <0xb126000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b127000 {
+			frame-number = <5>;
+			interrupts = <0 13 0x4>;
+			reg = <0xb127000 0x1000>;
+			status = "disabled";
+		};
+
+		frame@b128000 {
+			frame-number = <6>;
+			interrupts = <0 14 0x4>;
+			reg = <0xb128000 0x1000>;
+			status = "disabled";
+		};
+	};
+
+	qcom,sps {
+		compatible = "qcom,msm_sps_4k";
+		qcom,pipe-attr-ee;
+	};
+
+	tsens: tsens@4a8000 {
+		compatible = "qcom,msm8976-tsens";
+		reg = <0x4a8000 0x2000>,
+		      <0xa4000  0x1000>;
+		reg-names = "tsens_physical", "tsens_eeprom_physical";
+		interrupts = <0 184 0>;
+		interrupt-names = "tsens-upper-lower";
+		qcom,sensors = <11>;
+		qcom,slope = <3200 3200 3200 3200 3200 3200 3200 3200 3200 3200 3200>;
+		qcom,sensor-id = <0 1 2 3 4 5 6 7 8 9 10>;
+		qcom,tsens_base_info = <2 8>;
+		qcom,tsens_base_mask = <0 0x218 0xff 0 8>,
+				       <1 0x220 0xff 0 8>;
+		qcom,tsens_calib_mask = <0 0x228 0x3 0 3>;
+		qcom,tsens_sensor_point_bit_size = <6>;
+		qcom,tsens_sensor_point1_total_masks = <12>;
+		qcom,tsens_sensor_point1 = <0 0x218 0x00003f00 0x8 6>,
+					   <1 0x218 0x03f00000 0x14 6>,
+					   <2 0x21c 0x0000003f 0x0 6>,
+					   <3 0x21c 0x0003f000 0xc 6>,
+					   <4 0x220 0x00003f00 0x8 6>,
+					   <5 0x220 0x03f00000 0x14 6>,
+					   <6 0x224 0x0000003f 0x0 6>,
+					   <7 0x224 0x0003f000 0xc 6>,
+					   <8 0x228 0x000001f8 0x3 6>,
+					   <9 0x228 0x001f8000 0xf 6>,
+					   <10 0x228 0xf8000000 0x1b 5>,
+					   <10 0x22c 0x00000001 0x0 1>;
+		qcom,tsens_sensor_point2_total_masks = <11>;
+		qcom,tsens_sensor_point2 = <0 0x218 0x000fc000 0xe 6>,
+					   <1 0x218 0xfc000000 0x1a 6>,
+					   <2 0x21c 0x00000fc0 0x6 6>,
+					   <3 0x21c 0x00fc0000 0x12 6>,
+					   <4 0x220 0x000fc000 0xe 6>,
+					   <5 0x220 0xfc000000 0x1a 6>,
+					   <6 0x224 0x00000fc0 0x6 6>,
+					   <7 0x224 0x00fc0000 0x12 6>,
+					   <8 0x228 0x00007e00 0x9 6>,
+					   <9 0x228 0x07e00000 0x15 6>,
+					   <10 0x22c 0x0000007e 0x1 6>;
+	};
+
+	qcom,sensor-information {
+		compatible = "qcom,sensor-information";
+		sensor_information0: qcom,sensor-information-0 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor0";
+		};
+
+		sensor_information1: qcom,sensor-information-1 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor1";
+		};
+
+		sensor_information2: qcom,sensor-information-2 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor2";
+			qcom,alias-name = "pop_mem";
+		};
+
+		sensor_information3: qcom,sensor-information-3 {
+			qcom,sensor-type =  "tsens";
+			qcom,sensor-name = "tsens_tz_sensor3";
+		};
+
+		sensor_information4: qcom,sensor-information-4 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor4";
+		};
+
+		sensor_information5: qcom,sensor-information-5 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor5";
+		};
+
+		sensor_information6: qcom,sensor-information-6 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor6";
+		};
+
+		sensor_information7: qcom,sensor-information-7 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor7";
+		};
+
+		sensor_information8: qcom,sensor-information-8 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor8";
+			qcom,alias-name = "L2_cache_1";
+		};
+
+		sensor_information9: qcom,sensor-information-9 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor9";
+		};
+
+		sensor_information10: qcom,sensor-information-10 {
+			qcom,sensor-type = "tsens";
+			qcom,sensor-name = "tsens_tz_sensor10";
+			qcom,alias-name = "gpu";
+		};
+
+		sensor_information11: qcom,sensor-information-11 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "pa_therm0";
+		};
+
+		sensor_information12: qcom,sensor-information-12 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "pa_therm1";
+		};
+
+		sensor_information13: qcom,sensor-information-13 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "xo_therm";
+		};
+
+		sensor_information14: qcom,sensor-information-14 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "xo_therm_buf";
+		};
+
+		sensor_information15: qcom,sensor-information-15 {
+			qcom,sensor-type = "adc";
+			qcom,sensor-name = "case_therm";
+		};
+
+		sensor_information16: qcom,sensor-information-16 {
+			qcom,sensor-type = "alarm";
+			qcom,sensor-name = "pm8950_tz";
+			qcom,scaling-factor = <1000>;
+		};
+
+		sensor_information17: qcom,sensor-information-17 {
+			qcom,sensor-type =  "llm";
+			qcom,sensor-name = "LLM_IA72";
+		};
+
+		sensor_information18: qcom,sensor-information-18 {
+			qcom,sensor-type = "alarm";
+			qcom,sensor-name = "pm8004_tz";
+			qcom,scaling-factor = <1000>;
+		};
+	};
+
+	mitigation_profile0: qcom,limit_info-0 {
+		qcom,temperature-sensor = <&sensor_information9>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile1: qcom,limit_info-1 {
+		qcom,temperature-sensor = <&sensor_information4>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile2: qcom,limit_info-2 {
+		qcom,temperature-sensor = <&sensor_information5>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile3: qcom,limit_info-3 {
+		qcom,temperature-sensor = <&sensor_information6>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	mitigation_profile4: qcom,limit_info-4 {
+		qcom,temperature-sensor = <&sensor_information7>;
+		qcom,boot-frequency-mitigate;
+		qcom,hotplug-mitigation-enable;
+		qcom,emergency-frequency-mitigate;
+	};
+
+	qcom,msm-thermal {
+		compatible = "qcom,msm-thermal";
+		qcom,sensor-id = <9>;
+		qcom,poll-ms = <250>;
+		qcom,limit-temp = <60>;
+		qcom,temp-hysteresis = <10>;
+		qcom,freq-step = <2>;
+		qcom,core-limit-temp = <80>;
+		qcom,core-temp-hysteresis = <10>;
+		qcom,mitigation-profile-enable;
+		qcom,hotplug-temp = <105>;
+		qcom,hotplug-temp-hysteresis = <25>;
+		qcom,freq-mitigation-temp = <105>;
+		qcom,freq-mitigation-temp-hysteresis = <20>;
+		qcom,freq-mitigation-value = <400000>;
+		qcom,therm-reset-temp = <115>;
+		qcom,online-hotplug-core;
+		qcom,synchronous-cluster-id = <0 1>;
+		qcom,synchronous-cluster-map = <0 4 &CPU0 &CPU1 &CPU2 &CPU3>,
+						<1 4 &CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,disable-cx-phase-ctrl;
+		qcom,disable-gfx-phase-ctrl;
+		qcom,disable-psm;
+		qcom,disable-ocr;
+		qcom,mx-restriction-temp = <15>;
+		qcom,mx-restriction-temp-hysteresis = <2>;
+		qcom,mx-retention-min = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd-mx-supply = <&pm8950_s6_floor_level>;
+		qcom,vdd-restriction-temp = <5>;
+		qcom,vdd-restriction-temp-hysteresis = <10>;
+		vdd-dig-supply = <&pm8950_s2_floor_level>;
+		vdd-gfx-supply = <&gfx_vreg_corner>;
+
+		qcom,vdd-dig-rstr {
+			qcom,vdd-rstr-reg = "vdd-dig";
+			qcom,levels = <RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_TURBO
+					RPM_SMD_REGULATOR_LEVEL_TURBO>;
+			qcom,min-level = <RPM_SMD_REGULATOR_LEVEL_RETENTION>;
+		};
+
+		qcom,vdd-gfx-rstr {
+			qcom,vdd-rstr-reg = "vdd-gfx";
+			qcom,levels = <6 9 9>; /* Nominal, Turbo, Turbo */
+			qcom,min-level = <1>; /* No Request */
+		};
+
+		msm_thermal_freq: qcom,vdd-apps-rstr {
+			qcom,vdd-rstr-reg = "vdd-apps";
+			qcom,levels = <1017600>;
+			qcom,freq-req;
+		};
+	};
+
+	qcom,bcl {
+		compatible = "qcom,bcl";
+		qcom,bcl-enable;
+		qcom,bcl-framework-interface;
+		qcom,bcl-freq-control-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,bcl-hotplug-list = <&CPU6 &CPU7>;
+		qcom,bcl-soc-hotplug-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,ibat-monitor {
+			qcom,high-threshold-uamp = <4200000>;
+			qcom,low-threshold-uamp = <3400000>;
+			qcom,mitigation-freq-khz = <1382400>;
+			qcom,vph-high-threshold-uv = <3500000>;
+			qcom,vph-low-threshold-uv = <3200000>;
+			qcom,soc-low-threshold = <10>;
+			qcom,thermal-handle = <&msm_thermal_freq>;
+		};
+	};
+
+	qcom,memshare {
+		compatible = "qcom,memshare";
+
+		qcom,client_1 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0x200000>;
+			qcom,client-id = <0>;
+			qcom,allocate-boot-time;
+			label = "modem";
+		};
+
+		qcom,client_2 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0x300000>;
+			qcom,client-id = <2>;
+			label = "modem";
+		};
+
+		mem_client_3_size: qcom,client_3 {
+			compatible = "qcom,memshare-peripheral";
+			qcom,peripheral-size = <0x0>;
+			qcom,client-id = <1>;
+			label = "modem";
+		};
+	};
+
+	qcom,lmh@b1db000 {
+		compatible = "qcom,lmh";
+		interrupts = <0 264 4>;
+		reg = <0xb1db000 0x4>;
+		qcom,lmh-trim-err-offset = <18>;
+	};
+
+	rpm_bus: qcom,rpm-smd {
+		compatible = "qcom,rpm-smd";
+		rpm-channel-name = "rpm_requests";
+		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+	};
+
+	qcom,rmtfs_sharedmem@0 {
+		compatible = "qcom,sharedmem-uio";
+		reg = <0x0 0x00200000>; /* '0' indicates dynamic allocation */
+		reg-names = "rmtfs";
+		qcom,client-id = <0x00000001>;
+	};
+
+	sdcc1_ice: sdcc1ice@7803000 {
+		compatible = "qcom,ice";
+		reg = <0x7803000 0x8000>;
+		interrupt-names = "sdcc_ice_nonsec_level_irq", "sdcc_ice_sec_level_irq";
+		interrupts = <0 312 0>, <0 313 0>;
+		qcom,enable-ice-clk;
+		clock-names = "ice_core_clk_src", "ice_core_clk",
+				"bus_clk", "iface_clk";
+		clocks = <&clock_gcc clk_sdcc1_ice_core_clk_src>,
+			 <&clock_gcc clk_gcc_sdcc1_ice_core_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_apps_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_ahb_clk>;
+		qcom,op-freq-hz = <200000000>, <0>, <0>, <0>;
+		qcom,msm-bus,name = "sdcc_ice_noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<78 512 0 0>,    /* No vote */
+			<78 512 1000 0>; /* Max. bandwidth */
+		qcom,bus-vector-names = "MIN", "MAX";
+		qcom,instance-type = "sdcc";
+	};
+
+	sdhc_1: sdhci@7824900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7824900 0x500>, <0x7824000 0x800>, <0x7824e00 0x200>;
+		reg-names = "hc_mem", "core_mem", "cmdq_mem";
+
+		interrupts = <0 123 0>, <0 138 0>;
+		interrupt-names = "hc_irq", "pwr_irq";
+
+		sdhc-msm-crypto = <&sdcc1_ice>;
+		qcom,bus-width = <8>;
+
+		qcom,cpu-dma-latency-us = <60 340 900>;
+		qcom,cpu-affinity = "affine_cores";
+		qcom,cpu-affinity-mask = <0x0f>;
+
+		qcom,msm-bus,name = "sdhc1";
+		qcom,msm-bus,num-cases = <9>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <78 512 0 0>, /* No vote */
+			<78 512 1046 3200>,    /* 400 KB/s*/
+			<78 512 52286 160000>, /* 20 MB/s */
+			<78 512 65360 200000>, /* 25 MB/s */
+			<78 512 130718 400000>, /* 50 MB/s */
+			<78 512 130718 400000>, /* 100 MB/s */
+			<78 512 261438 800000>, /* 200 MB/s */
+			<78 512 261438 800000>, /* 400 MB/s */
+			<78 512 1338562 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+			100000000 200000000 400000000 4294967295>;
+
+		clocks = <&clock_gcc clk_gcc_sdcc1_ahb_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_apps_clk>,
+			 <&clock_gcc clk_gcc_sdcc1_ice_core_clk>;
+		clock-names = "iface_clk", "core_clk", "ice_core_clk";
+
+		qcom,clk-rates = <400000 25000000 50000000 100000000
+						177777778 342850000>;
+		qcom,bus-speed-mode = "HS400_1p8v", "HS200_1p8v", "DDR_1p8v";
+
+		qcom,ice-clk-rates = <200000000 100000000>;
+		qcom,scaling-lower-bus-speed-mode = "DDR52";
+
+		status = "disabled";
+	};
+
+	sdhc_2: sdhci@7864900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7864900 0x11c>, <0x7864000 0x800>;
+		reg-names = "hc_mem", "core_mem";
+
+		interrupts = <0 125 0>, <0 221 0>;
+		interrupt-names = "hc_irq", "pwr_irq";
+
+		qcom,bus-width = <4>;
+
+		qcom,cpu-dma-latency-us = <701>;
+
+		qcom,msm-bus,name = "sdhc2";
+		qcom,msm-bus,num-cases = <8>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <81 512 0 0>, /* No vote */
+			<81 512 1046 3200>,    /* 400 KB/s*/
+			<81 512 52286 160000>, /* 20 MB/s */
+			<81 512 65360 200000>, /* 25 MB/s */
+			<81 512 130718 400000>, /* 50 MB/s */
+			<81 512 261438 800000>, /* 100 MB/s */
+			<81 512 261438 800000>, /* 200 MB/s */
+			<81 512 1338562 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+						100000000 200000000 4294967295>;
+
+		clocks = <&clock_gcc clk_gcc_sdcc2_ahb_clk>,
+			 <&clock_gcc clk_gcc_sdcc2_apps_clk>;
+		clock-names = "iface_clk", "core_clk";
+
+		qcom,clk-rates = <400000 25000000 50000000 100000000 200000000>;
+
+		status = "disabled";
+	};
+
+	sdhc_3: sdhci@7a24900 {
+		compatible = "qcom,sdhci-msm";
+		reg = <0x7a24900 0x11c>, <0x7a24000 0x800>;
+		reg-names = "hc_mem", "core_mem";
+
+		qcom,bus-width = <4>;
+		gpios = <&msm_gpio 44 0>, /* CLK */
+			<&msm_gpio 43 0>, /* CMD */
+			<&msm_gpio 42 0>, /* DATA0 */
+			<&msm_gpio 41 0>, /* DATA1 */
+			<&msm_gpio 40 0>, /* DATA2 */
+			<&msm_gpio 39 0>; /* DATA3 */
+		qcom,gpio-names = "CLK", "CMD", "DAT0", "DAT1", "DAT2", "DAT3";
+
+		qcom,clk-rates = <400000 20000000 25000000 50000000 100000000
+								200000000>;
+		qcom,cpu-dma-latency-us = <60>;
+		qcom,cpu-affinity = "affine_cores";
+		qcom,cpu-affinity-mask = <0x0f>;
+
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_sdcc3_ahb_clk>,
+			<&clock_gcc clk_gcc_sdcc3_apps_clk>;
+
+		qcom,core_3_0v_support;
+		qcom,nonremovable;
+		qcom,msm-bus,name = "sdhc3";
+		qcom,msm-bus,num-cases = <8>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps = <79 512 0 0>, /* No vote */
+			<79 512 1600 3200>,    /* 400 KB/s*/
+			<79 512 80000 160000>, /* 20 MB/s */
+			<79 512 100000 200000>, /* 25 MB/s */
+			<79 512 200000 400000>, /* 50 MB/s */
+			<79 512 400000 800000>, /* 100 MB/s */
+			<79 512 800000 800000>, /* 200 MB/s */
+			<79 512 2048000 4096000>; /* Max. bandwidth */
+		qcom,bus-bw-vectors-bps = <0 400000 20000000 25000000 50000000
+						100000000 200000000 4294967295>;
+
+		#address-cells = <0>;
+		interrupt-parent = <&sdhc_3>;
+		interrupts = <0 1 2>;
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0xffffffff>;
+		interrupt-map = <0 &intc 0 295 0
+			1 &intc 0 297 0
+			2 &msm_gpio 45 0x4>;
+		interrupt-names = "hc_irq", "pwr_irq", "sdiowakeup_irq";
+
+		qcom,bus-speed-mode = "SDR12", "SDR25", "SDR50", "DDR50",
+						"SDR104";
+		status = "disabled";
+	};
+
+	blsp1_uart2: serial@78b0000 {
+		compatible = "qcom,msm-lsuart-v14";
+		reg = <0x78b0000 0x200>;
+		interrupts = <0 108 0>;
+		status = "disabled";
+		clock-names = "core_clk", "iface_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_uart2_apps_clk>,
+		       <&clock_gcc clk_gcc_blsp1_ahb_clk>;
+	};
+
+	blsp1_uart0: uart@78af000 {
+		compatible = "qcom,msm-hsuart-v14";
+		reg = <0x78af000 0x200>,
+			<0x7884000 0x1f000>;
+		reg-names = "core_mem", "bam_mem";
+		interrupt-names = "core_irq", "bam_irq", "wakeup_irq";
+		#address-cells = <0>;
+		interrupt-parent = <&blsp1_uart0>;
+		interrupts = <0 1 2>;
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0xffffffff>;
+		interrupt-map = <0 &intc 0 107 0
+				1 &intc 0 238 0
+				2 &msm_gpio 1 0>;
+
+		qcom,tx-gpio = <&msm_gpio 0 0>;
+		qcom,rx-gpio = <&msm_gpio 1 0>;
+		qcom,inject-rx-on-wakeup;
+		qcom,rx-char-to-inject = <0xFD>;
+		qcom,master-id = <86>;
+		clock-names = "core_clk", "iface_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_uart1_apps_clk>,
+				<&clock_gcc clk_gcc_blsp1_ahb_clk>;
+		pinctrl-names = "sleep", "default";
+		pinctrl-0 = <&hsuart_sleep>;
+		pinctrl-1 = <&hsuart_active>;
+		qcom,bam-tx-ep-pipe-index = <0>;
+		qcom,bam-rx-ep-pipe-index = <1>;
+		qcom,msm-bus,name = "blsp1_uart0";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+					<86 512 0 0>,
+					<86 512 500 800>;
+		status = "disabled";
+	};
+
+	dma_blsp1: qcom,sps-dma@7884000 { /* BLSP1 */
+                #dma-cells = <4>;
+                compatible = "qcom,sps-dma";
+                reg = <0x7884000 0x1f000>;
+                interrupts = <0 238 0>;
+                qcom,summing-threshold = <10>;
+        };
+
+        dma_blsp2: qcom,sps-dma@7ac4000 { /* BLSP2 */
+                #dma-cells = <4>;
+                compatible = "qcom,sps-dma";
+                reg = <0x7ac4000 0x1f000>;
+                interrupts = <0 239 0>;
+                qcom,summing-threshold = <10>;
+        };
+
+	i2c_2: i2c@78b6000 { /* BLSP1 QUP2 */
+                compatible = "qcom,i2c-msm-v2";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                reg-names = "qup_phys_addr";
+                reg = <0x78b6000 0x1000>;
+                interrupt-names = "qup_irq";
+                interrupts = <0 96 0>;
+                qcom,clk-freq-out = <400000>;
+                qcom,clk-freq-in  = <19200000>;
+                clock-names = "iface_clk", "core_clk";
+                clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+                         <&clock_gcc clk_gcc_blsp1_qup2_i2c_apps_clk>;
+                pinctrl-names = "i2c_active", "i2c_sleep";
+                pinctrl-0 = <&i2c_2_active>;
+                pinctrl-1 = <&i2c_2_sleep>;
+                qcom,noise-rjct-scl = <0>;
+                qcom,noise-rjct-sda = <0>;
+                qcom,master-id = <86>;
+                dmas = <&dma_blsp1 6 64 0x20000020 0x20>,
+                        <&dma_blsp1 7 32 0x20000020 0x20>;
+                dma-names = "tx", "rx";
+        };
+
+	i2c_4: i2c@78b8000 { /* BLSP1 QUP4 */
+		compatible = "qcom,i2c-msm-v2";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		reg = <0x78b8000 0x600>;
+		interrupt-names = "qup_irq";
+		interrupts = <0 98 0>;
+		qcom,clk-freq-out = <400000>;
+		qcom,clk-freq-in  = <19200000>;
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+			<&clock_gcc clk_gcc_blsp1_qup4_i2c_apps_clk>;
+		pinctrl-names = "i2c_active", "i2c_sleep";
+		pinctrl-0 = <&i2c_4_active>;
+		pinctrl-1 = <&i2c_4_sleep>;
+		qcom,noise-rjct-scl = <0>;
+		qcom,noise-rjct-sda = <0>;
+		qcom,master-id = <86>;
+		dmas = <&dma_blsp1 10 64 0x20000020 0x20>,
+			<&dma_blsp1 11 32 0x20000020 0x20>;
+		dma-names = "tx", "rx";
+	};
+
+	i2c_6: i2c@7af6000 { /* BLSP2 QUP2 */
+		compatible = "qcom,i2c-msm-v2";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg-names = "qup_phys_addr";
+		reg = <0x7af6000 0x600>;
+		interrupt-names = "qup_irq";
+		interrupts = <0 300 0>;
+		qcom,clk-freq-out = <400000>;
+		qcom,clk-freq-in  = <19200000>;
+		clock-names = "iface_clk", "core_clk";
+		clocks = <&clock_gcc clk_gcc_blsp2_ahb_clk>,
+			<&clock_gcc clk_gcc_blsp2_qup2_i2c_apps_clk>;
+		pinctrl-names = "i2c_active", "i2c_sleep";
+		pinctrl-0 = <&i2c_6_active>;
+		pinctrl-1 = <&i2c_6_sleep>;
+		qcom,noise-rjct-scl = <0>;
+		qcom,noise-rjct-sda = <0>;
+		qcom,master-id = <84>;
+		dmas = <&dma_blsp2 6 64 0x20000020 0x20>,
+			<&dma_blsp2 7 32 0x20000020 0x20>;
+		dma-names = "tx", "rx";
+	};
+
+	i2c_8: i2c@7af8000 { /* BLSP2 QUP4 */
+                compatible = "qcom,i2c-msm-v2";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                reg-names = "qup_phys_addr";
+                reg = <0x7af8000 0x600>;
+                interrupt-names = "qup_irq";
+                interrupts = <0 302 0>;
+                qcom,clk-freq-out = <400000>;
+                qcom,clk-freq-in  = <19200000>;
+                clock-names = "iface_clk", "core_clk";
+                clocks = <&clock_gcc clk_gcc_blsp2_ahb_clk>,
+                        <&clock_gcc clk_gcc_blsp2_qup4_i2c_apps_clk>;
+                pinctrl-names = "i2c_active", "i2c_sleep";
+                pinctrl-0 = <&i2c_8_active>;
+                pinctrl-1 = <&i2c_8_sleep>;
+                qcom,noise-rjct-scl = <0>;
+                qcom,noise-rjct-sda = <0>;
+                qcom,master-id = <84>;
+                dmas = <&dma_blsp2 10 64 0x20000020 0x20>,
+                        <&dma_blsp2 11 32 0x20000020 0x20>;
+                dma-names = "tx", "rx";
+        };
+
+
+	usb_otg: usb@78db000 {
+		compatible = "qcom,hsusb-otg";
+		reg = <0x78db000 0x400>, <0x6c000 0x200>;
+		reg-names = "core", "phy_csr";
+
+		interrupts = <0 134 0>, <0 140 0>;
+		interrupt-names = "core_irq", "async_irq";
+
+		hsusb_vdd_dig-supply = <&pm8950_s6_level>;
+		HSUSB_1p8-supply = <&pm8950_l7>;
+		HSUSB_3p3-supply = <&pm8950_l13>;
+		vbus_otg-supply = <&smbcharger_charger_otg>;
+		qcom,vdd-voltage-level = <RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_BINNING>;
+
+		qcom,hsusb-otg-phy-init-seq =
+			<0x73 0x80 0x38 0x81 0x1b 0x82 0xffffffff>;
+		qcom,hsusb-otg-phy-type = <3>; /* SNPS Femto PHY */
+		qcom,hsusb-otg-mode = <3>; /* OTG */
+		qcom,hsusb-otg-otg-control = <2>; /* PMIC */
+		qcom,dp-manual-pullup;
+		qcom,hsusb-otg-mpm-dpsehv-int = <49>;
+		qcom,hsusb-otg-mpm-dmsehv-int = <58>;
+		qcom,boost-sysclk-with-streaming;
+		qcom,axi-prefetch-enable;
+
+		qcom,msm-bus,name = "usb2";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<87 512 0 0>,
+				<87 512 60000 0>,
+				<87 512 6000  6000>;
+
+		clocks = <&clock_gcc clk_gcc_usb_hs_ahb_clk>,
+			 <&clock_gcc clk_gcc_usb_hs_system_clk>,
+			 <&clock_gcc clk_gcc_usb2a_phy_sleep_clk>,
+			 <&clock_gcc clk_bimc_usb_clk>,
+			 <&clock_gcc clk_snoc_usb_clk>,
+			 <&clock_gcc clk_pcnoc_usb_clk>,
+			 <&clock_gcc clk_gcc_qusb2_phy_clk>,
+			 <&clock_gcc clk_gcc_usb2_hs_phy_only_clk>,
+			 <&clock_gcc clk_gcc_usb_hs_phy_cfg_ahb_clk>,
+			 <&clock_gcc clk_xo_otg_clk>;
+		clock-names = "iface_clk", "core_clk", "sleep_clk",
+				"bimc_clk", "snoc_clk", "pcnoc_clk",
+				"phy_reset_clk", "phy_por_clk", "phy_csr_clk",
+				"xo";
+		qcom,bus-clk-rate = <320000000 200000000 100000000>;
+		qcom,max-nominal-sysclk-rate = <133330000>;
+	};
+
+	android_usb: android_usb@086000c8 {
+		compatible = "qcom,android-usb";
+		reg = <0x086000c8 0xc8>;
+		qcom,pm-qos-latency = <59 150 10741>;
+	};
+
+	slim_msm: slim@c140000{
+		cell-index = <1>;
+		compatible = "qcom,slim-ngd";
+		reg = <0xc140000 0x2c000>,
+			<0xc104000 0x2a000>;
+		reg-names = "slimbus_physical", "slimbus_bam_physical";
+		interrupts = <0 163 0>, <0 180 0>;
+		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
+		qcom,apps-ch-pipes = <0x600000>;
+		qcom,ea-pc = <0x170>;
+	};
+
+	qcom,usbbam@78c4000 {
+		compatible = "qcom,usb-bam-msm";
+		reg = <0x78c4000 0x17000>;
+		reg-names = "hsusb";
+		interrupts = <0 135 0>;
+		interrupt-names = "hsusb";
+		qcom,usb-bam-num-pipes = <16>;
+		qcom,usb-bam-fifo-baseaddr = <0x08606000>;
+		qcom,ignore-core-reset-ack;
+		qcom,disable-clk-gating;
+		qcom,usb-bam-max-mbps-highspeed = <400>;
+		qcom,enable-hsusb-bam-on-boot;
+
+		qcom,pipe0 {
+			label = "hsusb-ipa-out-0";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <0>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <2>;
+			qcom,src-bam-physical-address = <0x78c4000>;
+			qcom,src-bam-pipe-index = <1>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		qcom,pipe1 {
+			label = "hsusb-ipa-in-0";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <2>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <0>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		qcom,pipe2 {
+			label = "hsusb-qdss-in-0";
+			qcom,usb-bam-mem-type = <3>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <0>;
+			qcom,peer-bam = <1>;
+			qcom,src-bam-physical-address = <0x6084000>;
+			qcom,src-bam-pipe-index = <0>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <2>;
+			qcom,data-fifo-offset = <0x0>;
+			qcom,data-fifo-size = <0xe00>;
+			qcom,descriptor-fifo-offset = <0xe00>;
+			qcom,descriptor-fifo-size = <0x200>;
+			qcom,reset-bam-on-disconnect;
+		};
+
+		/* USB BAM pipe (consumer) configuration for accelerated DPL */
+		qcom,pipe3 {
+			label = "hsusb-dpl-ipa-in-1";
+			qcom,usb-bam-mem-type = <2>;
+			qcom,bam-type = <1>;
+			qcom,dir = <1>;
+			qcom,pipe-num = <1>;
+			qcom,peer-bam = <2>;
+			qcom,dst-bam-physical-address = <0x78c4000>;
+			qcom,dst-bam-pipe-index = <3>;
+			qcom,data-fifo-size = <0x8000>;
+			qcom,descriptor-fifo-size = <0x2000>;
+			qcom,reset-bam-on-disconnect;
+		};
+	};
+
+        ipa_hw: qcom,ipa@07900000 {
+                compatible = "qcom,ipa";
+                reg = <0x07900000 0x4effc>, <0x07904000 0x26934>;
+                reg-names = "ipa-base", "bam-base";
+                interrupts = <0 228 0>,
+                             <0 230 0>;
+                interrupt-names = "ipa-irq", "bam-irq";
+                qcom,ipa-hw-ver = <6>; /* IPA core version = IPAv2.6L */
+                qcom,ipa-hw-mode = <0>; /* IPA hw type = Normal */
+                clock-names = "core_clk";
+                clocks = <&clock_gcc clk_ipa_clk>;
+                qcom,ee = <0>;
+		qcom,modem-cfg-emb-pipe-flt;
+                qcom,msm-bus,name = "ipa";
+                qcom,msm-bus,num-cases = <3>;
+                qcom,msm-bus,num-paths = <1>;
+                qcom,msm-bus,vectors-KBps =
+                <90 512 0 0>,              /* No vote (ab=0 Mbps, ib=0 Mbps ~V NO BIMC vote) */
+                <90 512 100000 800000>,    /* SVS  - (ab=100Mbps, ib=800Mbps ~V 50MHz BIMC freq) */
+                <90 512 100000 1200000>;   /* PERF - (ab=100Mbps, ib=1200Mbps ~V 75MHz BIMC freq) */
+                qcom,bus-vector-names = "MIN", "SVS", "PERF";
+        };
+
+        qcom,rmnet-ipa {
+                compatible = "qcom,rmnet-ipa";
+                qcom,rmnet-ipa-ssr;
+                qcom,ipa-loaduC;
+        };
+
+	qcom,ipc-spinlock@1905000 {
+		compatible = "qcom,ipc-spinlock-sfpb";
+		reg = <0x1905000 0x8000>;
+		qcom,num-locks = <8>;
+	};
+
+	qcom,smem@86300000 {
+		compatible = "qcom,smem";
+		reg = <0x86300000 0x100000>,
+			<0x0b011008 0x4>,
+			<0x60000 0x8000>,
+			<0x193D000 0x8>;
+		reg-names = "smem", "irq-reg-base", "aux-mem1", "smem_targ_info_reg";
+		qcom,mpu-enabled;
+
+		qcom,smd-modem {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <0>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x1000>;
+			interrupts = <0 25 1>;
+			label = "modem";
+			qcom,not-loadable;
+		};
+
+		qcom,smsm-modem {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <0>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x2000>;
+			interrupts = <0 26 1>;
+		};
+
+		qcom,smd-wcnss {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <6>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x20000>;
+			interrupts = <0 142 1>;
+			label = "wcnss";
+		};
+
+		qcom,smsm-wcnss {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <6>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x80000>;
+			interrupts = <0 144 1>;
+		};
+
+		qcom,smd-adsp {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <1>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x100>;
+			interrupts = <0 289 1>;
+			label = "adsp";
+		};
+
+		qcom,smsm-adsp {
+			compatible = "qcom,smsm";
+			qcom,smsm-edge = <1>;
+			qcom,smsm-irq-offset = <0x0>;
+			qcom,smsm-irq-bitmask = <0x200>;
+			interrupts = <0 290 1>;
+		};
+
+		qcom,smd-rpm {
+			compatible = "qcom,smd";
+			qcom,smd-edge = <15>;
+			qcom,smd-irq-offset = <0x0>;
+			qcom,smd-irq-bitmask = <0x1>;
+			interrupts = <0 168 1>;
+			label = "rpm";
+			qcom,irq-no-suspend;
+			qcom,not-loadable;
+		};
+	};
+
+	qcom,wdt@b017000 {
+		compatible = "qcom,msm-watchdog";
+		reg = <0xb017000 0x1000>;
+		reg-names = "wdt-base";
+		interrupts = <0 3 0>, <0 4 0>;
+		qcom,bark-time = <11000>;
+		qcom,pet-time = <10000>;
+		qcom,ipi-ping;
+	};
+
+	qcom,msm-rtb {
+		compatible = "qcom,msm-rtb";
+		qcom,rtb-size = <0x100000>; /* 1M EBI1 buffer */
+	};
+
+	qcom,msm-imem@8600000 {
+		compatible = "qcom,msm-imem";
+		reg = <0x08600000 0x1000>; /* Address and size of IMEM */
+		ranges = <0x0 0x08600000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		mem_dump_table@10 {
+			compatible = "qcom,msm-imem-mem_dump_table";
+			reg = <0x10 8>;
+		};
+
+		restart_reason@65c {
+			compatible = "qcom,msm-imem-restart_reason";
+			reg = <0x65c 4>;
+		};
+
+		boot_stats@6b0 {
+			compatible = "qcom,msm-imem-boot_stats";
+			reg = <0x6b0 32>;
+		};
+	};
+
+	qcom_rng: qrng@22000 {
+		compatible = "qcom,msm-rng";
+		reg = <0x22000 0x140>;
+		qcom,msm-rng-iface-clk;
+		qcom,msm-bus,name = "msm-rng-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<1 618 0 0>,            /* No vote */
+			<1 618 0 800>;          /* 100 MB/s */
+		clocks = <&clock_gcc clk_gcc_prng_ahb_clk>;
+		clock-names = "iface_clk";
+	};
+
+	qcom_tzlog: tz-log@08600720 {
+		compatible = "qcom,tz-log";
+		reg = <0x08600720 0x2000>;
+	};
+
+	qcom_crypto: qcrypto@720000 {
+		compatible = "qcom,qcrypto";
+		reg = <0x720000 0x20000>,
+		      <0x704000 0x20000>;
+		reg-names = "crypto-base","crypto-bam-base";
+		interrupts = <0 207 0>;
+		qcom,bam-pipe-pair = <2>;
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		qcom,ce-hw-shared;
+		qcom,clk-mgmt-sus-res;
+		qcom,msm-bus,name = "qcrypto-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 393600 393600>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,use-sw-aes-cbc-ecb-ctr-algo;
+		qcom,use-sw-aes-xts-algo;
+		qcom,use-sw-aes-ccm-algo;
+		qcom,use-sw-ahash-algo;
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom_cedev: qcedev@720000 {
+		compatible = "qcom,qcedev";
+		reg = <0x720000 0x20000>,
+		      <0x704000 0x20000>;
+		reg-names = "crypto-base","crypto-bam-base";
+		interrupts = <0 207 0>;
+		qcom,bam-pipe-pair = <1>;
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		qcom,ce-hw-shared;
+		qcom,msm-bus,name = "qcedev-noc";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 393600 393600>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom_seecom: qseecom@85e00000 {
+		compatible = "qcom,qseecom";
+		reg = <0x85e00000 0x500000>;
+		reg-names = "secapp-region";
+		qcom,hlos-num-ce-hw-instances = <1>;
+		qcom,hlos-ce-hw-instance = <0>;
+		qcom,qsee-ce-hw-instance = <0>;
+		qcom,msm-bus,name = "qseecom-noc";
+		qcom,disk-encrypt-pipe-pair = <2>;
+		qcom,support-fde;
+		qcom,appsbl-qseecom-support;
+		qcom,msm-bus,num-cases = <4>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,support-bus-scaling;
+		qcom,msm-bus,vectors-KBps =
+			<55 512 0 0>,
+			<55 512 0 0>,
+			<55 512 120000 1200000>,
+			<55 512 393600 3936000>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	qcom,ipc_router {
+		compatible = "qcom,ipc_router";
+		qcom,node-id = <1>;
+	};
+
+	qcom,ipc_router_modem_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "modem";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+		qcom,disable-pil-loading;
+	};
+
+	qcom,ipc_router_q6_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "adsp";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+	};
+
+	qcom,ipc_router_wcnss_xprt {
+		compatible = "qcom,ipc_router_smd_xprt";
+		qcom,ch-name = "IPCRTR";
+		qcom,xprt-remote = "wcnss";
+		qcom,xprt-linkid = <1>;
+		qcom,xprt-version = <1>;
+		qcom,fragmented-data;
+	};
+
+	qcom,smdtty {
+		compatible = "qcom,smdtty";
+
+		smdtty_apps_fm: qcom,smdtty-apps-fm {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_FM";
+		};
+
+		smdtty_apps_riva_bt_acl: smdtty-apps-riva-bt-acl {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_BT_ACL";
+		};
+
+		smdtty_apps_riva_bt_cmd: qcom,smdtty-apps-riva-bt-cmd {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_BT_CMD";
+		};
+
+		smdtty_mbalbridge: qcom,smdtty-mbalbridge {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "MBALBRIDGE";
+		};
+
+		smdtty_apps_riva_ant_cmd: smdtty-apps-riva-ant-cmd {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_ANT_CMD";
+		};
+
+		smdtty_apps_riva_ant_data: smdtty-apps-riva-ant-data {
+			qcom,smdtty-remote = "wcnss";
+			qcom,smdtty-port-name = "APPS_RIVA_ANT_DATA";
+		};
+
+		smdtty_data1: qcom,smdtty-data1 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA1";
+		};
+
+		smdtty_data4: qcom,smdtty-data4 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA4";
+		};
+
+		smdtty_data11: qcom,smdtty-data11 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA11";
+		};
+
+		smdtty_data21: qcom,smdtty-data21 {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "DATA21";
+		};
+
+		smdtty_loopback: smdtty-loopback {
+			qcom,smdtty-remote = "modem";
+			qcom,smdtty-port-name = "LOOPBACK";
+			qcom,smdtty-dev-name = "LOOPBACK_TTY";
+		};
+	};
+
+	qcom,smdpkt {
+		compatible = "qcom,smdpkt";
+
+		qcom,smdpkt-data5-cntl {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA5_CNTL";
+			qcom,smdpkt-dev-name = "smdcntl0";
+		};
+
+		qcom,smdpkt-data22 {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA22";
+			qcom,smdpkt-dev-name = "smd22";
+		};
+
+		qcom,smdpkt-data40-cntl {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "DATA40_CNTL";
+			qcom,smdpkt-dev-name = "smdcntl8";
+		};
+
+		qcom,smdpkt-apr-apps2 {
+			qcom,smdpkt-remote = "adsp";
+			qcom,smdpkt-port-name = "apr_apps2";
+			qcom,smdpkt-dev-name = "apr_apps2";
+		};
+
+		qcom,smdpkt-loopback {
+			qcom,smdpkt-remote = "modem";
+			qcom,smdpkt-port-name = "LOOPBACK";
+			qcom,smdpkt-dev-name = "smd_pkt_loopback";
+		};
+	};
+
+	qcom,iris-fm {
+		compatible = "qcom,iris_fm";
+	};
+
+	qcom,wcnss-wlan@0a000000 {
+		compatible = "qcom,wcnss_wlan";
+		reg = <0x0a000000 0x280000>,
+		      <0xb011008 0x04>,
+		      <0x0a21b000 0x3000>,
+		      <0x03204000 0x00000100>,
+		      <0x03200800 0x00000200>,
+		      <0x0a100400 0x00000200>,
+		      <0x0a205050 0x00000200>,
+		      <0x0a219000 0x00000020>,
+		      <0x0a080488 0x00000008>,
+		      <0x0a080fb0 0x00000008>,
+		      <0x0a08040c 0x00000008>,
+		      <0x0a0120a8 0x00000008>,
+		      <0x0a012448 0x00000008>,
+		      <0x0a080c00 0x00000001>;
+
+		reg-names = "wcnss_mmio", "wcnss_fiq",
+			    "pronto_phy_base", "riva_phy_base",
+			    "riva_ccu_base", "pronto_a2xb_base",
+			    "pronto_ccpu_base", "pronto_saw2_base",
+			    "wlan_tx_phy_aborts","wlan_brdg_err_source",
+			    "wlan_tx_status", "alarms_txctl",
+			    "alarms_tactl", "pronto_mcu_base";
+
+		interrupts = <0 145 0 0 146 0>;
+		interrupt-names = "wcnss_wlantx_irq", "wcnss_wlanrx_irq";
+
+		qcom,pronto-vddmx-supply = <&pm8950_s6_level_ao>;
+		qcom,pronto-vddcx-supply = <&pm8950_s2_level>;
+		qcom,pronto-vddpx-supply = <&pm8950_l5>;
+		qcom,iris-vddxo-supply   = <&pm8950_l7>;
+		qcom,iris-vddrfa-supply  = <&pm8950_l19>;
+		qcom,iris-vddpa-supply   = <&pm8950_l9>;
+		qcom,iris-vdddig-supply  = <&pm8950_l5>;
+
+		qcom,iris-vddxo-voltage-level = <1800000 0 1800000>;
+		qcom,iris-vddrfa-voltage-level = <1300000 0 1300000>;
+		qcom,iris-vddpa-voltage-level = <3300000 0 3300000>;
+		qcom,iris-vdddig-voltage-level = <1800000 0 1800000>;
+
+		qcom,vddmx-voltage-level = <RPM_SMD_REGULATOR_LEVEL_TURBO
+					RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_BINNING>;
+		qcom,vddcx-voltage-level = <RPM_SMD_REGULATOR_LEVEL_NOM
+					RPM_SMD_REGULATOR_LEVEL_NONE
+					RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		qcom,vddpx-voltage-level = <1800000 0 1800000>;
+
+		qcom,iris-vddxo-current = <10000>;
+		qcom,iris-vddrfa-current = <100000>;
+		qcom,iris-vddpa-current = <515000>;
+		qcom,iris-vdddig-current = <10000>;
+
+		qcom,pronto-vddmx-current = <0>;
+		qcom,pronto-vddcx-current = <0>;
+		qcom,pronto-vddpx-current = <0>;
+
+		pinctrl-names = "wcnss_default", "wcnss_sleep",
+				"wcnss_gpio_default";
+		pinctrl-0 = <&wcnss_default>;
+		pinctrl-1 = <&wcnss_sleep>;
+		pinctrl-2 = <&wcnss_gpio_default>;
+
+		gpios = <&msm_gpio 40 0>, <&msm_gpio 41 0>, <&msm_gpio 42 0>,
+			<&msm_gpio 43 0>, <&msm_gpio 44 0>;
+
+		clocks = <&clock_gcc clk_xo_wlan_clk>,
+			 <&clock_gcc clk_rf_clk2>,
+			 <&clock_debug clk_gcc_debug_mux>,
+			 <&clock_gcc clk_wcnss_m_clk>;
+
+		clock-names = "xo", "rf_clk", "measure", "wcnss_debug";
+
+		qcom,pc-disable-latency = <80>;
+		qcom,has-autodetect-xo;
+		qcom,is-pronto-v3;
+		qcom,has-pronto-hw;
+		qcom,has-vsys-adc-channel;
+		qcom,wcnss-adc_tm = <&pm8950_adc_tm>;
+	};
+
+	qcom,vidc@1d00000 {
+		compatible = "qcom,msm-vidc";
+		reg = <0x01d00000 0xff000>,
+			<0x000a4120 0x4>;
+		reg-names = "vidc", "efuse";
+		interrupts = <0 44 0>;
+		vdd-cx-supply = <&pm8950_s2_level_ao>;
+		venus-supply = <&gdsc_venus>;
+		venus-core0-supply = <&gdsc_venus_core0>;
+		qcom,hfi = "venus";
+		qcom,firmware-name = "venus-v1";
+
+		clocks =
+			<&clock_gcc clk_gcc_venus0_vcodec0_clk>,
+			<&clock_gcc clk_gcc_venus0_core0_vcodec0_clk>,
+			<&clock_gcc clk_gcc_venus0_ahb_clk>,
+			<&clock_gcc clk_gcc_venus0_axi_clk>;
+
+		clock-names = "core_clk", "core0_clk", "iface_clk", "bus_clk";
+		qcom,clock-configs = <0x1 0x0 0x0 0x0>;
+		qcom,sw-power-collapse;
+		qcom,reset-clock-control;
+		qcom,regulator-scaling;
+		qcom,max-hw-load = <1011840>; /* 3840 x 2176 @ 30 fps + 3840 x 2176 @ 1 fps */
+		qcom,dcvs-min-load = <734400>; /* 1920 x 1088 @ 90fps */
+		qcom,dcvs-min-mbperframe = <32400>; /* 3840 x 2160 */
+
+		qcom,load-freq-tbl =
+			<979200 466000000 0x55555555>, /* TURBO, UHD30E   */
+			<979200 400000000 0xffffffff>, /* NOM+ , UHD30D   */
+			<734400 360000000 0xffffffff>, /* NOM  , 1080p90D */
+			<734400 400000000 0x55555555>, /* NOM+ , 1080p90E */
+			<489600 228570000 0xffffffff>, /* SVS  , 1080p60D */
+			<489600 466000000 0x55555555>, /* TURBO, 1080p60E */
+			<432000 228570000 0xffffffff>, /* SVS  , 720p120D */
+			<432000 400000000 0x55555555>, /* NOM+ , 720p120E */
+			<244800 133333333 0xffffffff>, /* SVS- , 1080p30D */
+			<244800 228570000 0x55555555>, /* SVS  , 1080p30E */
+			<216000 100000000 0xffffffff>, /* SVS- , 720p60D  */
+			<216000 228570000 0x55555555>, /* SVS  , 720p60E  */
+			<108000 80000000 0xffffffff>,  /* SVS--, 720p30D  */
+			<108000 100000000 0x55555555>, /* SVS- , 720p30E  */
+			<36000 72727200 0xffffffff>,   /* SVS--, 480p30D  */
+			<36000 80000000 0x55555555>;   /* SVS--, 480p30E  */
+
+		qcom,qdss-presets =
+			<0x6025000 0x1000>,
+			<0x6026000 0x1000>,
+			<0x6021000 0x1000>,
+			<0x6002000 0x1000>,
+			<0x9180000 0x1000>,
+			<0x9181000 0x1000>;
+
+		qcom,reg-presets =
+			<0xE0020 0x05555556>,
+			<0xE0024 0x05555556>,
+			<0x80124 0x00000003>;
+
+		qcom,clock-voltage-tbl =
+			<72727200 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<80000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<100000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<133333333 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<228570000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<310667000 RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM>,
+			<400000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
+			<466000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,vp9d-clock-voltage-tbl =
+			<72727200 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<80000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<100000000 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<133333333 RPM_SMD_REGULATOR_LEVEL_SVS>,
+			<228570000 RPM_SMD_REGULATOR_LEVEL_SVS_PLUS>,
+			<310667000 RPM_SMD_REGULATOR_LEVEL_NOM>,
+			<360000000 RPM_SMD_REGULATOR_LEVEL_NOM_PLUS>,
+			<400000000 RPM_SMD_REGULATOR_LEVEL_TURBO>;
+
+		qcom,vidc-iommu-domains {
+			qcom,domain-ns {
+				qcom,vidc-domain-phandle = <&venus_domain_ns>;
+				qcom,vidc-partition-buffer-types = <0x7ff>,
+							<0x800>;
+			};
+
+			qcom,domain-sec-bs {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_bitstream>;
+				qcom,vidc-partition-buffer-types = <0x241>;
+			};
+
+			qcom,domain-sec-px {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_pixel>;
+				qcom,vidc-partition-buffer-types = <0x106>;
+			};
+
+			qcom,domain-sec-np {
+				qcom,vidc-domain-phandle = <&venus_domain_sec_non_pixel>;
+				qcom,vidc-partition-buffer-types = <0x480>;
+			};
+		};
+
+		qcom,msm-bus-clients {
+			qcom,msm-bus-client@0 {
+				qcom,msm-bus,name = "venc-ddr";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 342000 0>,  /* 480p  30 fps */
+					<63 512 342000 0>,  /* 480p  60 fps */
+					<63 512 342000 0>,  /* 720p  30 fps */
+					<63 512 677000 0>,  /* 720p  60 fps */
+					<63 512 775000 0>,  /* 1080p 30 fps */
+					<63 512 1530000 0>, /* 1080p 60 fps */
+					<63 512 1562000 0>, /* UHD   24 fps */
+					<63 512 1669000 0>, /* 4K    24 fps */
+					<63 512 1964000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0x55555555>; /* all encoders */
+			};
+
+			qcom,msm-bus-client@1 {
+				qcom,msm-bus,name = "vdec-ddr";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 252000 0>,  /* 480p  30 fps */
+					<63 512 252000 0>,  /* 480p  60 fps */
+					<63 512 252000 0>,  /* 720p  30 fps */
+					<63 512 496000 0>,  /* 720p  60 fps */
+					<63 512 574000 0>,  /* 1080p 30 fps */
+					<63 512 1148000 0>, /* 1080p 60 fps */
+					<63 512 1967000 0>, /* UHD   24 fps */
+					<63 512 2458000 0>, /* 4K    24 fps */
+					<63 512 2458000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0xffffffff>; /* all decoders */
+			};
+
+			qcom,msm-bus-client@2 {
+				qcom,msm-bus,name = "venc-ddr-lowlatency";
+				qcom,msm-bus,num-cases = <10>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 450000 0>,  /* 480p  30 fps */
+					<63 512 450000 0>,  /* 480p  60 fps */
+					<63 512 508000 0>,  /* 720p  30 fps */
+					<63 512 1010000 0>, /* 720p  60 fps */
+					<63 512 1149000 0>, /* 1080p 30 fps */
+					<63 512 2276000 0>, /* 1080p 60 fps */
+					<63 512 2159000 0>, /* UHD   24 fps */
+					<63 512 2306000 0>, /* 4K    24 fps */
+					<63 512 2688000 0>; /* UHD   30 fps */
+				qcom,bus-configs = <0x55555555>; /* all encs */
+				qcom,bus-low-latency;
+			};
+
+			qcom,msm-bus-client@3 {
+				qcom,msm-bus,name = "venus-arm9-ddr";
+				qcom,msm-bus,num-cases = <2>;
+				qcom,msm-bus,num-paths = <1>;
+				qcom,msm-bus,vectors-KBps =
+					<63 512 0 0>,
+					<63 512 1000 1000>;
+				qcom,bus-configs = <0x00000000>;
+				qcom,bus-passive;
+			};
+		};
+	};
+
+	qcom,venus@1de0000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0x1de0000 0x4000>;
+
+		vdd-supply = <&gdsc_venus>;
+		qcom,proxy-reg-names = "vdd";
+
+		clocks = <&clock_gcc clk_gcc_venus0_vcodec0_clk>,
+			 <&clock_gcc clk_gcc_venus0_ahb_clk>,
+			 <&clock_gcc clk_gcc_venus0_axi_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+
+		clock-names = "core_clk", "iface_clk", "bus_clk",
+				"scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+
+		qcom,proxy-clock-names = "core_clk", "iface_clk",
+					 "bus_clk", "scm_core_clk",
+					 "scm_iface_clk", "scm_bus_clk",
+					 "scm_core_clk_src";
+		qcom,scm_core_clk_src-freq = <80000000>;
+
+		qcom,msm-bus,name = "pil-venus";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+				<63 512 0 0>,
+				<63 512 0 304000>;
+		qcom,pas-id = <9>;
+		qcom,proxy-timeout-ms = <100>;
+		qcom,firmware-name = "venus";
+		linux,contiguous-region = <&venus_mem>;
+	};
+
+	qcom,lpass@c200000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0xc200000 0x00100>;
+		interrupts = <0 293 1>;
+
+		vdd_cx-supply = <&pm8950_s2_level>;
+		qcom,proxy-reg-names = "vdd_cx";
+		qcom,vdd_cx-uV-uA = <7 100000>;
+
+		clocks = <&clock_gcc clk_xo_pil_lpass_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+		clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+		qcom,proxy-clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				 "scm_bus_clk", "scm_core_clk_src";
+		qcom,scm_core_clk_src-freq = <80000000>;
+
+		qcom,pas-id = <1>;
+		qcom,proxy-timeout-ms = <10000>;
+		qcom,smem-id = <423>;
+		qcom,sysmon-id = <1>;
+		qcom,ssctl-instance-id = <0x14>;
+		qcom,firmware-name = "adsp";
+
+		/* GPIO inputs from lpass */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_2_in 0 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_2_in 2 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_2_in 1 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_2_in 3 0>;
+
+		/* GPIO output to lpass */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_2_out 0 0>;
+
+		linux,contiguous-region = <&reloc_mem>;
+	};
+
+        spmi_bus: qcom,spmi@200f000 {
+                compatible = "qcom,spmi-pmic-arb";
+                reg = <0x200f000 0x1000>,
+                        <0x2400000 0x800000>,
+                        <0x2c00000 0x800000>,
+                        <0x3800000 0x200000>,
+                        <0x200a000 0x2100>;
+                reg-names = "core", "chnls", "obsrvr", "intr", "cnfg";
+                interrupts = <0 190 0>;
+                qcom,pmic-arb-channel = <0>;
+                qcom,pmic-arb-max-peripherals = <256>;
+                qcom,pmic-arb-max-periph-interrupts = <224>;
+                qcom,pmic-arb-ee = <0>;
+                #interrupt-cells = <3>;
+                interrupt-controller;
+                #address-cells = <1>;
+                #size-cells = <0>;
+                cell-index = <0>;
+	};
+
+	spi_0: spi@0x78B5000 { /* BLSP1 QUP0 */
+		compatible = "qcom,spi-qup-v2";
+		reg-names = "spi_physical", "spi_bam_physical";
+		reg = <0x78B5000 0x600>,
+		      <0x7884000 0x1f000>;
+		interrupt-names = "spi_irq", "spi_bam_irq";
+		interrupts = <0 95 0>, <0 238 0>;
+		spi-max-frequency = <19200000>;
+		pinctrl-names = "spi_default", "spi_sleep";
+		pinctrl-0 = <&spi0_default &spi0_cs0_active>;
+		pinctrl-1 = <&spi0_sleep &spi0_cs0_sleep>;
+		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
+			 <&clock_gcc clk_gcc_blsp1_qup1_spi_apps_clk>;
+		clock-names = "iface_clk", "core_clk";
+		qcom,infinite-mode = <0>;
+		qcom,use-bam;
+		qcom,use-pinctrl;
+		qcom,ver-reg-exists;
+		qcom,bam-consumer-pipe-index = <4>;
+		qcom,bam-producer-pipe-index = <5>;
+		qcom,master-id = <86>;
+	};
+
+	qcom,msm-ssc-sensors {
+		compatible = "qcom,msm-ssc-sensors";
+	};
+
+	qcom,msm-pacman {
+		compatible = "qcom,msm-pacman";
+	};
+
+	test_pacman: test {
+		compatible = "qcom,msm-test-pacman";
+	};
+
+	qcom,msm-core@a0000 {
+		compatible = "qcom,apss-core-ea";
+		reg = <0xA0000 0x1000>;
+		qcom,low-hyst-temp = <10>;
+		qcom,high-hyst-temp = <5>;
+		qcom,polling-interval = <50>;
+
+		qcom,core-mapping {
+			qcom,cpu0-chars {
+				qcom,sensor = <&sensor_information9>;
+				qcom,cpu-name = <&CPU0>;
+			};
+
+			qcom,cpu1-chars {
+				qcom,sensor = <&sensor_information9>;
+				qcom,cpu-name = <&CPU1>;
+			};
+
+			qcom,cpu2-chars {
+				qcom,sensor = <&sensor_information9>;
+				qcom,cpu-name = <&CPU2>;
+			};
+
+			qcom,cpu3-chars {
+				qcom,sensor = <&sensor_information9>;
+				qcom,cpu-name = <&CPU3>;
+			};
+
+			qcom,cpu4-chars {
+				qcom,sensor = <&sensor_information4>;
+				qcom,cpu-name = <&CPU4>;
+			};
+
+			qcom,cpu5-chars {
+				qcom,sensor = <&sensor_information5>;
+				qcom,cpu-name = <&CPU5>;
+			};
+
+			qcom,cpu6-chars {
+				qcom,sensor = <&sensor_information6>;
+				qcom,cpu-name = <&CPU6>;
+			};
+
+			qcom,cpu7-chars {
+				qcom,sensor = <&sensor_information7>;
+				qcom,cpu-name = <&CPU7>;
+			};
+		};
+	};
+
+	qcom,pronto@a21b000 {
+		compatible = "qcom,pil-tz-generic";
+		reg = <0x0a21b000 0x3000>;
+		interrupts = <0 149 1>;
+
+		vdd_pronto_pll-supply = <&pm8950_l7>;
+		proxy-reg-names = "vdd_pronto_pll";
+		vdd_pronto_pll-uV-uA = <1800000 18000>;
+		clocks = <&clock_gcc clk_xo_pil_pronto_clk>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>,
+			 <&clock_gcc clk_crypto_clk_src>;
+
+		clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				"scm_bus_clk", "scm_core_clk_src";
+		qcom,proxy-clock-names = "xo", "scm_core_clk", "scm_iface_clk",
+				 "scm_bus_clk", "scm_core_clk_src";
+		qcom,scm_core_clk_src = <80000000>;
+
+		qcom,pas-id = <6>;
+		qcom,proxy-timeout-ms = <10000>;
+		qcom,smem-id = <422>;
+		qcom,sysmon-id = <6>;
+		qcom,ssctl-instance-id = <0x13>;
+		qcom,firmware-name = "wcnss";
+
+		/* GPIO inputs from wcnss */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_4_in 0 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_4_in 1 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_4_in 2 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_4_in 3 0>;
+
+                /* GPIO output to wcnss */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_4_out 0 0>;
+		linux,contiguous-region = <&reloc_mem>;
+	};
+
+	dcc: dcc@b3000 {
+		compatible = "qcom,dcc";
+		reg = <0xb3000 0x1000>,
+		      <0xb4000 0x800>;
+		reg-names = "dcc-base", "dcc-ram-base";
+
+		clocks = <&clock_gcc clk_gcc_dcc_clk>;
+		clock-names = "dcc_clk";
+
+		qcom,save-reg;
+	};
+
+	ext_codec: sound-9335 {
+		compatible = "qcom,msm8952-audio-slim-codec";
+		qcom,model = "msm8976-tasha-snd-card";
+
+		reg = <0xc051000 0x4>,
+		    <0xc051004 0x4>,
+		    <0xc055000 0x4>,
+		    <0xc056000 0x4>,
+		    <0xc052000 0x4>;
+
+		reg-names = "csr_gp_io_mux_mic_ctl",
+			"csr_gp_io_mux_spkr_ctl",
+			"csr_gp_io_lpaif_pri_pcm_pri_mode_muxsel",
+			"csr_gp_io_lpaif_sec_pcm_sec_mode_muxsel",
+			"csr_gp_io_mux_quin_ctl";
+
+		qcom,audio-routing =
+			"AIF4 VI", "MCLK",
+			"RX_BIAS", "MCLK",
+			"MADINPUT", "MCLK",
+			"AMIC2", "MIC BIAS2",
+			"MIC BIAS2", "Headset Mic",
+			"AMIC3", "MIC BIAS2",
+			"MIC BIAS2", "ANCRight Headset Mic",
+			"AMIC4", "MIC BIAS2",
+			"MIC BIAS2", "ANCLeft Headset Mic",
+			"AMIC5", "MIC BIAS3",
+			"MIC BIAS3", "Handset Mic",
+			"AMIC6", "MIC BIAS4",
+			"MIC BIAS4", "Analog Mic6",
+			"DMIC0", "MIC BIAS1",
+			"MIC BIAS1", "Digital Mic0",
+			"DMIC1", "MIC BIAS1",
+			"MIC BIAS1", "Digital Mic1",
+			"DMIC2", "MIC BIAS3",
+			"MIC BIAS3", "Digital Mic2",
+			"DMIC3", "MIC BIAS3",
+			"MIC BIAS3", "Digital Mic3",
+			"DMIC4", "MIC BIAS4",
+			"MIC BIAS4", "Digital Mic4",
+			"DMIC5", "MIC BIAS4",
+			"MIC BIAS4", "Digital Mic5",
+			"SpkrLeft IN", "SPK1 OUT",
+			"SpkrRight IN", "SPK2 OUT";
+
+		qcom,msm-gpios =
+			"us_eu_gpio";
+		qcom,pinctrl-names =
+			"all_off",
+			"us_eu_gpio_act";
+		pinctrl-names =
+			"all_off",
+			"us_eu_gpio_act";
+		pinctrl-0 = <&cross_conn_det_sus>;
+		pinctrl-1 = <&cross_conn_det_act>;
+		qcom,cdc-us-euro-gpios = <&msm_gpio 144 0>;
+
+		qcom,msm-mbhc-hphl-swh = <0>;
+		qcom,msm-mbhc-gnd-swh = <0>;
+		qcom,tasha-mclk-clk-freq = <9600000>;
+		asoc-platform = <&pcm0>, <&pcm1>, <&pcm2>, <&voip>, <&voice>,
+				<&loopback>, <&compress>, <&hostless>,
+				<&afe>, <&lsm>, <&routing>, <&cpe>, <&lpa>;
+		asoc-platform-names = "msm-pcm-dsp.0", "msm-pcm-dsp.1", "msm-pcm-dsp.2",
+				"msm-voip-dsp", "msm-pcm-voice", "msm-pcm-loopback",
+				"msm-compress-dsp", "msm-pcm-hostless", "msm-pcm-afe",
+				"msm-lsm-client", "msm-pcm-routing", "msm-cpe-lsm",
+				"msm-pcm-lpa";
+		asoc-cpu = <&dai_pri_auxpcm>, <&dai_sec_auxpcm>, <&dai_hdmi>,
+				<&dai_mi2s_hdmi>,
+				<&dai_mi2s2>, <&dai_mi2s3>, <&dai_mi2s5>,
+				<&sb_0_rx>, <&sb_0_tx>, <&sb_1_rx>, <&sb_1_tx>,
+				<&sb_2_rx>, <&sb_2_tx>, <&sb_3_rx>, <&sb_3_tx>,
+				<&sb_4_rx>, <&sb_4_tx>, <&sb_5_tx>, <&afe_pcm_rx>,
+				<&afe_pcm_tx>, <&afe_proxy_rx>, <&afe_proxy_tx>,
+				<&incall_record_rx>, <&incall_record_tx>,
+				<&incall_music_rx>, <&incall_music_2_rx>,
+				<&sb_5_rx>,  <&bt_sco_rx>,
+				<&bt_sco_tx>, <&int_fm_rx>, <&int_fm_tx>;
+		asoc-cpu-names = "msm-dai-q6-auxpcm.1", "msm-dai-q6-auxpcm.2",
+				"msm-dai-q6-hdmi.8",
+				"msm-dai-q6-mi2s-hdmi.4118",
+				"msm-dai-q6-mi2s.2",
+				"msm-dai-q6-mi2s.3", "msm-dai-q6-mi2s.5",
+				"msm-dai-q6-dev.16384", "msm-dai-q6-dev.16385",
+				"msm-dai-q6-dev.16386", "msm-dai-q6-dev.16387",
+				"msm-dai-q6-dev.16388", "msm-dai-q6-dev.16389",
+				"msm-dai-q6-dev.16390", "msm-dai-q6-dev.16391",
+				"msm-dai-q6-dev.16392", "msm-dai-q6-dev.16393",
+				"msm-dai-q6-dev.16395", "msm-dai-q6-dev.224",
+				"msm-dai-q6-dev.225", "msm-dai-q6-dev.241",
+				"msm-dai-q6-dev.240", "msm-dai-q6-dev.32771",
+				"msm-dai-q6-dev.32772", "msm-dai-q6-dev.32773",
+				"msm-dai-q6-dev.32770", "msm-dai-q6-dev.16394",
+				"msm-dai-q6-dev.12288", "msm-dai-q6-dev.12289",
+				"msm-dai-q6-dev.12292", "msm-dai-q6-dev.12293";
+		asoc-codec = <&stub_codec>;
+		asoc-codec-names = "msm-stub-codec.1";
+		qcom,max-aux-codec = <2>;
+		qcom,aux-codec = "wsa881x.20170211", "wsa881x.20170212",
+				 "wsa881x.21170213", "wsa881x.21170214";
+		qcom,aux-codec-prefix = "SpkrLeft", "SpkrRight",
+					"SpkrLeft", "SpkrRight";
+	};
+
+	wcd9xxx_intc: wcd9xxx-irq {
+		compatible = "qcom,wcd9xxx-irq";
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&msm_gpio>;
+		interrupts = <120 0>;
+		interrupt-names = "cdc-int";
+	};
+
+	wcd_rst_gpio: wcd_gpio_ctrl {
+		compatible = "qcom,wcd-gpio-ctrl";
+		qcom,cdc-rst-n-gpio = <&msm_gpio 133 0>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&cdc_reset_line_act>;
+		pinctrl-1 = <&cdc_reset_line_sus>;
+	};
+
+	clock_audio: audio_ext_clk {
+		compatible = "qcom,audio-ref-clk";
+		qcom,audio-ref-clk-gpio = <&pm8950_gpios 1 0>;
+		clock-names = "osr_clk";
+		clocks = <&clock_gcc clk_div_clk2>;
+		qcom,node_has_rpm_clock;
+		#clock-cells = <1>;
+	};
+
+	pcm0: qcom,msm-pcm {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <0>;
+	};
+
+	routing: qcom,msm-pcm-routing {
+		compatible = "qcom,msm-pcm-routing";
+	};
+
+	pcm2: qcom,msm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	pcm1: qcom,msm-pcm-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <1>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "regular";
+	};
+
+	pcm2: qcom,msm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	cpe: qcom,msm-cpe-lsm {
+		compatible = "qcom,msm-cpe-lsm";
+	};
+
+	lpa: qcom,msm-pcm-lpa {
+		compatible = "qcom,msm-pcm-lpa";
+	};
+
+	compress: qcom,msm-compress-dsp {
+		compatible = "qcom,msm-compress-dsp";
+	};
+
+	voip: qcom,msm-voip-dsp {
+		compatible = "qcom,msm-voip-dsp";
+	};
+
+	voice: qcom,msm-pcm-voice {
+		compatible = "qcom,msm-pcm-voice";
+		qcom,destroy-cvd;
+		qcom,vote-bms;
+	};
+
+	stub_codec: qcom,msm-stub-codec {
+		compatible = "qcom,msm-stub-codec";
+	};
+
+	qcom,msm-dai-fe {
+		compatible = "qcom,msm-dai-fe";
+	};
+
+	afe: qcom,msm-pcm-afe {
+		compatible = "qcom,msm-pcm-afe";
+	};
+
+	voice_svc: qcom,msm-voice-svc {
+		compatible = "qcom,msm-voice-svc";
+	};
+
+	loopback: qcom,msm-pcm-loopback {
+		compatible = "qcom,msm-pcm-loopback";
+	};
+
+	qcom,msm-dai-mi2s {
+		compatible = "qcom,msm-dai-mi2s";
+		dai_mi2s0: qcom,msm-dai-q6-mi2s-prim {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <0>;
+			qcom,msm-mi2s-rx-lines = <3>;
+			qcom,msm-mi2s-tx-lines = <0>;
+		};
+
+		dai_mi2s1: qcom,msm-dai-q6-mi2s-sec {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <1>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <0>;
+		};
+
+		dai_mi2s3: qcom,msm-dai-q6-mi2s-quat {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <3>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <2>;
+		};
+
+		dai_mi2s2: qcom,msm-dai-q6-mi2s-tert {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <2>;
+			qcom,msm-mi2s-rx-lines = <0>;
+			qcom,msm-mi2s-tx-lines = <3>;
+		};
+
+		dai_mi2s5: qcom,msm-dai-q6-mi2s-quin {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <5>;
+			qcom,msm-mi2s-rx-lines = <1>;
+			qcom,msm-mi2s-tx-lines = <2>;
+		};
+
+		dai_mi2s6: qcom,msm-dai-q6-mi2s-senary {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <6>;
+			qcom,msm-mi2s-rx-lines = <0>;
+			qcom,msm-mi2s-tx-lines = <3>;
+		};
+	};
+
+	dai_hdmi: qcom,msm-dai-q6-hdmi {
+		compatible = "qcom,msm-dai-q6-hdmi";
+		qcom,msm-dai-q6-dev-id = <8>;
+	};
+
+	dai_mi2s_hdmi: qcom,msm-dai-q6-mi2s-hdmi {
+		compatible = "qcom,msm-dai-q6-mi2s-hdmi";
+		qcom,msm-dai-q6-mi2s-dev-id = <4118>;
+	};
+
+	lsm: qcom,msm-lsm-client {
+		compatible = "qcom,msm-lsm-client";
+	};
+
+	qcom,msm-dai-q6 {
+		compatible = "qcom,msm-dai-q6";
+		sb_0_rx: qcom,msm-dai-q6-sb-0-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16384>;
+		};
+
+		sb_0_tx: qcom,msm-dai-q6-sb-0-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16385>;
+		};
+
+		sb_1_rx: qcom,msm-dai-q6-sb-1-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16386>;
+		};
+
+		sb_1_tx: qcom,msm-dai-q6-sb-1-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16387>;
+		};
+
+		sb_2_rx: qcom,msm-dai-q6-sb-2-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16388>;
+		};
+
+		sb_2_tx: qcom,msm-dai-q6-sb-2-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16389>;
+		};
+
+
+		sb_3_rx: qcom,msm-dai-q6-sb-3-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16390>;
+		};
+
+		sb_3_tx: qcom,msm-dai-q6-sb-3-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16391>;
+		};
+
+		sb_4_rx: qcom,msm-dai-q6-sb-4-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16392>;
+		};
+
+		sb_4_tx: qcom,msm-dai-q6-sb-4-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16393>;
+		};
+
+		sb_5_tx: qcom,msm-dai-q6-sb-5-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16395>;
+		};
+
+		sb_5_rx: qcom,msm-dai-q6-sb-5-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16394>;
+		};
+
+		bt_sco_rx: qcom,msm-dai-q6-bt-sco-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12288>;
+		};
+
+		bt_sco_tx: qcom,msm-dai-q6-bt-sco-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12289>;
+		};
+
+		int_fm_rx: qcom,msm-dai-q6-int-fm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12292>;
+		};
+
+		int_fm_tx: qcom,msm-dai-q6-int-fm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12293>;
+		};
+
+		afe_pcm_rx: qcom,msm-dai-q6-be-afe-pcm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <224>;
+		};
+
+		afe_pcm_tx: qcom,msm-dai-q6-be-afe-pcm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <225>;
+		};
+
+		afe_proxy_rx: qcom,msm-dai-q6-afe-proxy-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <241>;
+		};
+
+		afe_proxy_tx: qcom,msm-dai-q6-afe-proxy-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <240>;
+		};
+
+		incall_record_rx: qcom,msm-dai-q6-incall-record-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32771>;
+		};
+
+		incall_record_tx: qcom,msm-dai-q6-incall-record-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32772>;
+		};
+
+		incall_music_rx: qcom,msm-dai-q6-incall-music-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32773>;
+		};
+
+		incall_music_2_rx: qcom,msm-dai-q6-incall-music-2-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32770>;
+		};
+	};
+
+	hostless: qcom,msm-pcm-hostless {
+		compatible = "qcom,msm-pcm-hostless";
+	};
+
+	dai_pri_auxpcm: qcom,msm-pri-auxpcm {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "primary";
+	};
+
+	dai_sec_auxpcm: qcom,msm-sec-auxpcm {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "secondary";
+	};
+
+	qcom,msm-audio-ion {
+		compatible = "qcom,msm-audio-ion";
+		qcom,smmu-enabled;
+		qcom,smmu-sid = <0x1>;
+	};
+
+	qcom,adsprpc-mem {
+		compatible = "qcom,msm-adsprpc-mem-region";
+		linux,contiguous-region = <&adsp_mem>;
+	};
+
+	qcom,msm-adsp-loader {
+		compatible = "qcom,adsp-loader";
+		qcom,adsp-state = <0>;
+	};
+
+	qcom,msmapr-audio {
+		compatible = "qcom,msmapr-audio";
+		qcom,apr-dest-type = "ADSP";
+	};
+
+	qcom,avtimer@c0a300c {
+		compatible = "qcom,avtimer";
+		reg = <0x0c0a300c 0x4>,
+			<0x0c0a3010 0x4>;
+		reg-names = "avtimer_lsb_addr", "avtimer_msb_addr";
+		qcom,clk_div = <27>;
+	};
+
+	qcom,mss@4080000 {
+		compatible = "qcom,pil-q6v55-mss";
+		reg = <0x04080000 0x100>,
+		      <0x0194f000 0x010>,
+		      <0x01950000 0x008>,
+		      <0x01951000 0x008>,
+		      <0x04020000 0x040>,
+		      <0x01871000 0x004>;
+		reg-names = "qdsp6_base", "halt_q6", "halt_modem", "halt_nc",
+				 "rmb_base", "restart_reg";
+
+		interrupts = <0 24 1>;
+		vdd_mss-supply = <&pm8950_s1>;
+		vdd_cx-supply = <&pm8950_s2_level>;
+		vdd_cx-voltage = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd_mx-supply = <&pm8950_s6_level>;
+		vdd_mx-uV = <RPM_SMD_REGULATOR_LEVEL_TURBO>;
+		vdd_pll-supply = <&pm8950_l7>;
+		qcom,vdd_pll = <1800000>;
+
+		clocks = <&clock_gcc clk_xo_pil_mss_clk>,
+			 <&clock_gcc clk_gcc_mss_cfg_ahb_clk>,
+			 <&clock_gcc clk_gcc_mss_q6_bimc_axi_clk>,
+			 <&clock_gcc clk_gcc_boot_rom_ahb_clk>;
+		clock-names = "xo", "iface_clk", "bus_clk", "mem_clk";
+		qcom,proxy-clock-names = "xo";
+		qcom,active-clock-names = "iface_clk", "bus_clk", "mem_clk";
+
+		qcom,pas-id = <5>;
+		qcom,pil-mss-memsetup;
+		qcom,firmware-name = "modem";
+		qcom,pil-self-auth;
+		qcom,sysmon-id = <0>;
+		qcom,ssctl-instance-id = <0x12>;
+		qcom,qdsp6v56-1-8;
+
+		/* GPIO inputs from mss */
+		qcom,gpio-err-fatal = <&smp2pgpio_ssr_smp2p_1_in 0 0>;
+		qcom,gpio-err-ready = <&smp2pgpio_ssr_smp2p_1_in 1 0>;
+		qcom,gpio-proxy-unvote = <&smp2pgpio_ssr_smp2p_1_in 2 0>;
+		qcom,gpio-stop-ack = <&smp2pgpio_ssr_smp2p_1_in 3 0>;
+		qcom,gpio-shutdown-ack = <&smp2pgpio_ssr_smp2p_1_in 7 0>;
+
+		/* GPIO output to mss */
+		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_1_out 0 0>;
+		linux,contiguous-region = <&modem_mem>;
+	};
+
+	mcd {
+		compatible = "qcom,mcd";
+		qcom,ce-hw-instance = <0>;
+		qcom,ce-device = <0>;
+		clocks = <&clock_gcc clk_crypto_clk_src>,
+			 <&clock_gcc clk_gcc_crypto_clk>,
+			 <&clock_gcc clk_gcc_crypto_ahb_clk>,
+			 <&clock_gcc clk_gcc_crypto_axi_clk>;
+		clock-names = "core_clk_src", "core_clk",
+				"iface_clk", "bus_clk";
+		qcom,ce-opp-freq = <100000000>;
+	};
+
+	cnss_sdio: qcom,cnss_sdio {
+		compatible = "qcom,cnss_sdio";
+		subsys-name = "AR6320";
+		vdd-wlan-supply = <&rome_vreg>;
+		vdd-wlan-io-supply = <&pm8950_l5>;
+		qcom,wlan-ramdump-dynamic = <0x200000>;
+		status = "disabled";
+	};
+
+	cpu-pmu {
+		compatible = "arm,armv8-pmuv3";
+		qcom,irq-is-percpu;
+		interrupts = <1 7 0xff00>;
+	};
+};
+
+#include "msm-pm8950-rpm-regulator.dtsi"
+#include "msm-pm8950.dtsi"
+#include "msm-pmi8950.dtsi"
+#include "msm-pm8004.dtsi"
+#include "msm8976-regulator.dtsi"
+#include "msm-gdsc-8916.dtsi"
+#include "msm8976-camera.dtsi"
+
+&gdsc_venus {
+	clock-names = "bus_clk", "core_clk";
+	clocks = <&clock_gcc clk_gcc_venus0_axi_clk>,
+		 <&clock_gcc clk_gcc_venus0_vcodec0_clk>;
+	status = "okay";
+};
+
+&gdsc_venus_core0 {
+	qcom,support-hw-trigger;
+	clock-names ="core0_clk";
+	clocks = <&clock_gcc clk_gcc_venus0_core0_vcodec0_clk>;
+	status = "okay";
+};
+
+&gdsc_mdss {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_mdss_mdp_clk>,
+		 <&clock_gcc clk_gcc_mdss_axi_clk>;
+	status = "okay";
+	proxy-supply = <&gdsc_mdss>;
+	qcom,proxy-consumer-enable;
+};
+
+&gdsc_jpeg {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_camss_jpeg0_clk>,
+		 <&clock_gcc clk_gcc_camss_jpeg_axi_clk>;
+	status = "okay";
+};
+
+&gdsc_vfe {
+	clock-names = "core_clk", "bus_clk", "micro_clk",
+			"csi_clk";
+	clocks = <&clock_gcc clk_gcc_camss_vfe0_clk>,
+		 <&clock_gcc clk_gcc_camss_vfe_axi_clk>,
+		 <&clock_gcc clk_gcc_camss_micro_ahb_clk>,
+		 <&clock_gcc clk_gcc_camss_csi_vfe0_clk>;
+	status = "okay";
+};
+
+&gdsc_vfe1 {
+	clock-names = "core_clk", "bus_clk", "micro_clk",
+			"csi_clk";
+	clocks = <&clock_gcc clk_gcc_camss_vfe1_clk>,
+		 <&clock_gcc clk_gcc_camss_vfe1_axi_clk>,
+		 <&clock_gcc clk_gcc_camss_micro_ahb_clk>,
+		 <&clock_gcc clk_gcc_camss_csi_vfe1_clk>;
+	status = "okay";
+};
+
+&gdsc_cpp {
+	clock-names = "core_clk", "bus_clk";
+	clocks = <&clock_gcc clk_gcc_camss_cpp_clk>,
+		 <&clock_gcc clk_gcc_camss_cpp_axi_clk>;
+	status = "okay";
+};
+
+&gdsc_oxili_gx {
+	clock-names = "core_root_clk", "gmem_clk";
+	clocks =<&clock_gcc_gfx clk_gfx3d_clk_src>,
+		<&clock_gcc_gfx clk_gcc_oxili_gmem_clk>;
+	qcom,enable-root-clk;
+	qcom,clk-dis-wait-val = <0x5>;
+	parent-supply = <&gfx_vreg_corner>;
+	status = "okay";
+};
+
+&gdsc_oxili_cx {
+	clock-names = "core_clk";
+	clocks = <&clock_gcc_gfx clk_gcc_oxili_gfx3d_clk>;
+	status = "okay";
+};
+
+&slim_msm {
+	msm_dai_slim {
+		compatible = "qcom,msm-dai-slim";
+		elemental-addr = [ff ff ff fe 17 02];
+	};
+
+	tasha_codec {
+		compatible = "qcom,tasha-slim-pgd";
+		elemental-addr = [00 01 A0 01 17 02];
+
+		interrupt-parent = <&wcd9xxx_intc>;
+		interrupts = <0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+			17 18 19 20 21 22 23 24 25 26 27 28 29
+			30>;
+
+		cdc-vdd-buck-supply = <&eldo2_8976>;
+		qcom,cdc-vdd-buck-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-buck-current = <650000>;
+
+		cdc-buck-sido-supply = <&eldo2_8976>;
+		qcom,cdc-buck-sido-voltage = <1800000 1800000>;
+		qcom,cdc-buck-sido-current = <250000>;
+		cdc-vdd-tx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-tx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-tx-h-current = <25000>;
+
+		cdc-vdd-rx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-rx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-rx-h-current = <25000>;
+
+		cdc-vdd-px-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-px-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-px-current = <10000>;
+
+		qcom,cdc-static-supplies =
+			"cdc-vdd-buck",
+			"cdc-buck-sido",
+			"cdc-vdd-tx-h",
+			"cdc-vdd-rx-h",
+			"cdc-vdd-px";
+
+		qcom,cdc-micbias1-mv = <1800>;
+		qcom,cdc-micbias2-mv = <1800>;
+		qcom,cdc-micbias3-mv = <1800>;
+		qcom,cdc-micbias4-mv = <1800>;
+
+		qcom,cdc-mclk-clk-rate = <9600000>;
+		qcom,cdc-slim-ifd = "tasha-slim-ifd";
+		qcom,cdc-slim-ifd-elemental-addr = [00 00 A0 01 17 02];
+		qcom,cdc-dmic-sample-rate = <4800000>;
+		qcom,cdc-mad-dmic-rate = <600000>;
+
+		clock-names = "wcd_clk";
+		clocks = <&clock_audio clk_audio_pmi_clk>;
+		qcom,wcd-rst-gpio-node = <&wcd_rst_gpio>;
+	};
+};
+
+&pm8950_gpios {
+	gpio@c000 {
+		status = "ok";
+		qcom,mode = <1>;
+		qcom,pull = <5>;
+		qcom,vin-sel = <0>;
+		qcom,src-sel = <2>;
+		qcom,master-en = <1>;
+		qcom,out-strength = <2>;
+	};
+	gpio@c600 {
+		status = "ok";
+		qcom,mode = <1>;
+		qcom,pull = <5>;
+		qcom,vin-sel = <0>;
+		qcom,src-sel = <0>;
+		qcom,master-en = <1>;
+	};
+	gpio@c400 {
+		qcom,mode = <0>;
+		qcom,pull = <5>;
+		qcom,vin-sel = <2>;
+		qcom,src-sel = <2>;
+		qcom,master-en = <1>;
+		status = "okay";
+	};
+};
+
+&pm8950_1 {
+	pm8950_cajon_dig: 8952_wcd_codec@f000 {
+		compatible = "qcom,msm8x16_wcd_codec";
+		reg = <0xf000 0x100>;
+		interrupt-parent = <&spmi_bus>;
+		interrupts = <0x1 0xf0 0x0>,
+			     <0x1 0xf0 0x1>,
+			     <0x1 0xf0 0x2>,
+			     <0x1 0xf0 0x3>,
+			     <0x1 0xf0 0x4>,
+			     <0x1 0xf0 0x5>,
+			     <0x1 0xf0 0x6>,
+			     <0x1 0xf0 0x7>;
+		interrupt-names = "spk_cnp_int",
+				  "spk_clip_int",
+				  "spk_ocp_int",
+				  "ins_rem_det1",
+				  "but_rel_det",
+				  "but_press_det",
+				  "ins_rem_det",
+				  "mbhc_int";
+
+		cdc-vdda-cp-supply = <&pm8950_s4>;
+		qcom,cdc-vdda-cp-voltage = <2050000 2050000>;
+		qcom,cdc-vdda-cp-current = <500000>;
+
+		cdc-vdda-rx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdda-rx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdda-rx-h-current = <5000>;
+
+		cdc-vdda-tx-h-supply = <&pm8950_l5>;
+		qcom,cdc-vdda-tx-h-voltage = <1800000 1800000>;
+		qcom,cdc-vdda-tx-h-current = <5000>;
+
+		cdc-vdd-px-supply = <&pm8950_l5>;
+		qcom,cdc-vdd-px-voltage = <1800000 1800000>;
+		qcom,cdc-vdd-px-current = <5000>;
+
+		cdc-vdd-pa-supply = <&pm8950_s4>;
+		qcom,cdc-vdd-pa-voltage = <2050000 2050000>;
+		qcom,cdc-vdd-pa-current = <260000>;
+
+		cdc-vdd-mic-bias-supply = <&pm8950_l13>;
+		qcom,cdc-vdd-mic-bias-voltage = <3075000 3075000>;
+		qcom,cdc-vdd-mic-bias-current = <5000>;
+
+		qcom,cdc-mclk-clk-rate = <9600000>;
+
+		qcom,cdc-static-supplies = "cdc-vdda-rx-h",
+					   "cdc-vdda-tx-h",
+					   "cdc-vdd-px",
+					   "cdc-vdd-pa",
+					   "cdc-vdda-cp";
+
+		qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
+		qcom,dig-cdc-base-addr = <0xc0f0000>;
+	};
+
+	pm8950_cajon_analog: 8952_wcd_codec@f100 {
+		compatible = "qcom,msm8x16_wcd_codec";
+		reg = <0xf100 0x100>;
+		interrupt-parent = <&spmi_bus>;
+		interrupts = <0x1 0xf1 0x0>,
+			     <0x1 0xf1 0x1>,
+			     <0x1 0xf1 0x2>,
+			     <0x1 0xf1 0x3>,
+			     <0x1 0xf1 0x4>,
+			     <0x1 0xf1 0x5>;
+		interrupt-names = "ear_ocp_int",
+				  "hphr_ocp_int",
+				  "hphl_ocp_det",
+				  "ear_cnp_int",
+				  "hphr_cnp_int",
+				  "hphl_cnp_int";
+		qcom,dig-cdc-base-addr = <0xc0f0000>;
+	};
+};

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -1225,6 +1225,9 @@
 		compatible = "qcom,hsusb-otg";
 		reg = <0x78db000 0x400>, <0x6c000 0x200>;
 		reg-names = "core", "phy_csr";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
 		interrupts = <0 134 0>, <0 140 0>;
 		interrupt-names = "core_irq", "async_irq";
@@ -1277,6 +1280,7 @@
 			compatible = "qcom,usb-bam-msm";
 			reg = <0x78c4000 0x17000>;
 			reg-names = "hsusb";
+			interrupt-parent = <&intc>;
 			interrupts = <0 135 0>;
 			interrupt-names = "hsusb";
 			qcom,usb-bam-num-pipes = <16>;

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -57,6 +57,7 @@
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
+		ranges;
 
 		other_ext_mem: other_ext_region@0 {
 			linux,reserve-contiguous-region;

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -54,7 +54,7 @@
 		spi0 = &spi_0;
 	};
 
-	memory {
+	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
 

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -1272,6 +1272,82 @@
 				"xo";
 		qcom,bus-clk-rate = <320000000 200000000 100000000>;
 		qcom,max-nominal-sysclk-rate = <133330000>;
+
+		qcom,usbbam@78c4000 {
+			compatible = "qcom,usb-bam-msm";
+			reg = <0x78c4000 0x17000>;
+			reg-names = "hsusb";
+			interrupts = <0 135 0>;
+			interrupt-names = "hsusb";
+			qcom,usb-bam-num-pipes = <16>;
+			qcom,usb-bam-fifo-baseaddr = <0x08606000>;
+			qcom,ignore-core-reset-ack;
+			qcom,disable-clk-gating;
+			qcom,usb-bam-max-mbps-highspeed = <400>;
+			qcom,enable-hsusb-bam-on-boot;
+
+			qcom,pipe0 {
+				label = "hsusb-ipa-out-0";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <0>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <2>;
+				qcom,src-bam-physical-address = <0x78c4000>;
+				qcom,src-bam-pipe-index = <1>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			qcom,pipe1 {
+				label = "hsusb-ipa-in-0";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <2>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <0>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			qcom,pipe2 {
+				label = "hsusb-qdss-in-0";
+				qcom,usb-bam-mem-type = <3>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <0>;
+				qcom,peer-bam = <1>;
+				qcom,src-bam-physical-address = <0x6084000>;
+				qcom,src-bam-pipe-index = <0>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <2>;
+				qcom,data-fifo-offset = <0x0>;
+				qcom,data-fifo-size = <0xe00>;
+				qcom,descriptor-fifo-offset = <0xe00>;
+				qcom,descriptor-fifo-size = <0x200>;
+				qcom,reset-bam-on-disconnect;
+			};
+
+			/* USB BAM pipe (consumer) configuration for accelerated DPL */
+			qcom,pipe3 {
+				label = "hsusb-dpl-ipa-in-1";
+				qcom,usb-bam-mem-type = <2>;
+				qcom,bam-type = <1>;
+				qcom,dir = <1>;
+				qcom,pipe-num = <1>;
+				qcom,peer-bam = <2>;
+				qcom,dst-bam-physical-address = <0x78c4000>;
+				qcom,dst-bam-pipe-index = <3>;
+				qcom,data-fifo-size = <0x8000>;
+				qcom,descriptor-fifo-size = <0x2000>;
+				qcom,reset-bam-on-disconnect;
+			};
+		};
+
 	};
 
 	android_usb: android_usb@086000c8 {
@@ -1290,81 +1366,6 @@
 		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
 		qcom,apps-ch-pipes = <0x600000>;
 		qcom,ea-pc = <0x170>;
-	};
-
-	qcom,usbbam@78c4000 {
-		compatible = "qcom,usb-bam-msm";
-		reg = <0x78c4000 0x17000>;
-		reg-names = "hsusb";
-		interrupts = <0 135 0>;
-		interrupt-names = "hsusb";
-		qcom,usb-bam-num-pipes = <16>;
-		qcom,usb-bam-fifo-baseaddr = <0x08606000>;
-		qcom,ignore-core-reset-ack;
-		qcom,disable-clk-gating;
-		qcom,usb-bam-max-mbps-highspeed = <400>;
-		qcom,enable-hsusb-bam-on-boot;
-
-		qcom,pipe0 {
-			label = "hsusb-ipa-out-0";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <0>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <2>;
-			qcom,src-bam-physical-address = <0x78c4000>;
-			qcom,src-bam-pipe-index = <1>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		qcom,pipe1 {
-			label = "hsusb-ipa-in-0";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <2>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <0>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		qcom,pipe2 {
-			label = "hsusb-qdss-in-0";
-			qcom,usb-bam-mem-type = <3>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <0>;
-			qcom,peer-bam = <1>;
-			qcom,src-bam-physical-address = <0x6084000>;
-			qcom,src-bam-pipe-index = <0>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <2>;
-			qcom,data-fifo-offset = <0x0>;
-			qcom,data-fifo-size = <0xe00>;
-			qcom,descriptor-fifo-offset = <0xe00>;
-			qcom,descriptor-fifo-size = <0x200>;
-			qcom,reset-bam-on-disconnect;
-		};
-
-		/* USB BAM pipe (consumer) configuration for accelerated DPL */
-		qcom,pipe3 {
-			label = "hsusb-dpl-ipa-in-1";
-			qcom,usb-bam-mem-type = <2>;
-			qcom,bam-type = <1>;
-			qcom,dir = <1>;
-			qcom,pipe-num = <1>;
-			qcom,peer-bam = <2>;
-			qcom,dst-bam-physical-address = <0x78c4000>;
-			qcom,dst-bam-pipe-index = <3>;
-			qcom,data-fifo-size = <0x8000>;
-			qcom,descriptor-fifo-size = <0x2000>;
-			qcom,reset-bam-on-disconnect;
-		};
 	};
 
         ipa_hw: qcom,ipa@07900000 {


### PR DESCRIPTION
This patchset implements support for MSM8976 and MSM8956 SoC.

The base DTs are from the latest 3.10 branch supporting this SoC. Those DTs have gone through major restructuration, mainly pinctrl, to work with new drivers found in 3.18 kernel.