### PR TITLE
[UM 5.5.r1] Fixup MDSS 20nm PLL code for 3.18 kernel

### DIFF
--- a/drivers/clk/msm/mdss/mdss-dsi-20nm-pll-util.c
+++ b/drivers/clk/msm/mdss/mdss-dsi-20nm-pll-util.c
@@ -505,7 +505,7 @@ static bool pll_20nm_is_pll_locked(struct mdss_pll_resources *dsi_pll_res)
 	bool pll_locked;
 
 	/* poll for PLL ready status */
-	if (readl_poll_timeout_noirq((dsi_pll_res->pll_base +
+	if (readl_poll_timeout_atomic((dsi_pll_res->pll_base +
 			MMSS_DSI_PHY_PLL_RESET_SM),
 			status,
 			((status & BIT(5)) > 0),
@@ -513,7 +513,7 @@ static bool pll_20nm_is_pll_locked(struct mdss_pll_resources *dsi_pll_res)
 			DSI_PLL_POLL_TIMEOUT_US)) {
 		pr_debug("DSI PLL status=%x failed to Lock\n", status);
 		pll_locked = false;
-	} else if (readl_poll_timeout_noirq((dsi_pll_res->pll_base +
+	} else if (readl_poll_timeout_atomic((dsi_pll_res->pll_base +
 				MMSS_DSI_PHY_PLL_RESET_SM),
 				status,
 				((status & BIT(6)) > 0),

--- a/drivers/clk/msm/mdss/mdss-hdmi-pll-20nm.c
+++ b/drivers/clk/msm/mdss/mdss-hdmi-pll-20nm.c
@@ -411,7 +411,7 @@ static int hdmi_20nm_pll_lock_status(struct mdss_pll_resources *io)
 	pr_debug("%s: Waiting for PHY Ready\n", __func__);
 
 	/* poll for PLL ready status */
-	if (!readl_poll_timeout_noirq(
+	if (!readl_poll_timeout_atomic(
 		(io->pll_base + QSERDES_COM_RESET_SM),
 		status, status & BIT(6),
 		HDMI_PLL_POLL_MAX_READS,
@@ -424,7 +424,7 @@ static int hdmi_20nm_pll_lock_status(struct mdss_pll_resources *io)
 	}
 
 	/* poll for PHY ready status */
-	if (pll_locked && !readl_poll_timeout_noirq(
+	if (pll_locked && !readl_poll_timeout_atomic(
 		(io->phy_base + HDMI_PHY_STATUS),
 		status, status & BIT(0),
 		HDMI_PLL_POLL_MAX_READS,


### PR DESCRIPTION
In this 3.10 snapshot, we were using readl_poll_timeout_noirq
which was an early API which was not accepted on mainline.
On the current (3.18) kernel, the API got refined and
accepted, but the call is now named readl_poll_timeout_atomic.
