### PR TITLE
[UM 5.5.r1] gpu: msm: kgsl: Add additional gtbu1 clock for MSM8976 A510

### DIFF
--- a/drivers/gpu/msm/kgsl_iommu.h
+++ b/drivers/gpu/msm/kgsl_iommu.h
@@ -73,7 +73,7 @@ enum kgsl_iommu_reg_map {
 };
 
 /* Max number of iommu clks per IOMMU unit */
-#define KGSL_IOMMU_MAX_CLKS 5
+#define KGSL_IOMMU_MAX_CLKS 6
 
 enum kgsl_iommu_context_id {
 	KGSL_IOMMU_CONTEXT_USER = 0,

--- a/drivers/gpu/msm/kgsl_pwrctrl.c
+++ b/drivers/gpu/msm/kgsl_pwrctrl.c
@@ -51,6 +51,12 @@
 #define KGSL_L2PC_CPU_TIMEOUT	(80 * 1000)
 
 /* Order deeply matters here because reasons. New entries go on the end */
+/* kholk: Not because reasons. This is because they wanted to
+ *        set clocks through this array by hardcoding the array position
+ *        in the damn calls. It looks like the last clock to worry about
+ *        is rbbmtimer_clk, so after that one it should be safe to add
+ *        our clocks in our favourite order.
+ */
 static const char * const clocks[] = {
 	"src_clk",
 	"core_clk",
@@ -64,7 +70,8 @@ static const char * const clocks[] = {
 	"gtcu_iface_clk",
 	"alwayson_clk",
 	"isense_clk",
-	"rbcpr_clk"
+	"rbcpr_clk",
+	"gtbu1_clk"
 };
 
 static unsigned int ib_votes[KGSL_MAX_BUSLEVELS];

--- a/drivers/gpu/msm/kgsl_pwrctrl.h
+++ b/drivers/gpu/msm/kgsl_pwrctrl.h
@@ -25,7 +25,7 @@
 
 #define KGSL_PWR_ON	0xFFFF
 
-#define KGSL_MAX_CLKS 13
+#define KGSL_MAX_CLKS 14
 #define KGSL_MAX_REGULATORS 2
 
 #define KGSL_MAX_PWRLEVELS 10


### PR DESCRIPTION
MSM8976 with Adreno A510 GPU has two TBUs with their own
clocks.

To manage enablement and disablement of both TBUs, we need
to implement a new clock in the driver, corresponding to
the additional block in 8976's A510.

Without this change, unexpected behaviors will happen,
including GPU faults, IOMMU faults and kernel lockups.