### PR TITLE
ion: adjust system heap pool orders

### DIFF
--- a/drivers/staging/android/ion/ion_system_heap.c
+++ b/drivers/staging/android/ion/ion_system_heap.c
@@ -35,7 +35,7 @@ static gfp_t high_order_gfp_flags = (GFP_HIGHUSER | __GFP_NOWARN |
 static gfp_t low_order_gfp_flags  = (GFP_HIGHUSER | __GFP_NOWARN);
 
 #ifndef CONFIG_ALLOC_BUFFERS_IN_4K_CHUNKS
-static const unsigned int orders[] = {9, 8, 4, 0};
+static const unsigned int orders[] = {4, 0};
 #else
 static const unsigned int orders[] = {0};
 #endif


### PR DESCRIPTION
As part of the change to fix unmovable block migration over time, we
need to reduce the orders requested by ion to under order-5
allocations. In a future CL, we can add fixed-size larger-order pools
to improve performance when allocating large buffers.

bug 26916944

Change-Id: I1ca336c8057b984987a5a5c28a86ab36488e08ea