### PR TITLE
msm: msm_bus: Fix memory corruption in alloc_handle_lst

### DIFF
--- a/drivers/platform/msm/msm_bus/msm_bus_arb_adhoc.c
+++ b/drivers/platform/msm/msm_bus/msm_bus_arb_adhoc.c
@@ -919,7 +919,7 @@ static int alloc_handle_lst(int size)
 	} else {
 		t_cl_list = krealloc(handle_list.cl_list,
 				sizeof(struct msm_bus_client *) *
-				handle_list.num_entries + NUM_CL_HANDLES,
+				(handle_list.num_entries + NUM_CL_HANDLES),
 				GFP_KERNEL);
 		if (ZERO_OR_NULL_PTR(t_cl_list)) {
 			ret = -ENOMEM;
@@ -928,8 +928,9 @@ static int alloc_handle_lst(int size)
 			goto exit_alloc_handle_lst;
 		}
 
-		memset(&handle_list.cl_list[handle_list.num_entries], 0,
+		memset(&t_cl_list[handle_list.num_entries], 0,
 			NUM_CL_HANDLES * sizeof(struct msm_bus_client *));
+
 		handle_list.num_entries += NUM_CL_HANDLES;
 		handle_list.cl_list = t_cl_list;
 	}


### PR DESCRIPTION
There are two issues when registering already existing
bus handle.

1. Realloc size is not correct.
2. Assuming that pointer returned in krealloc will be the
same is not correct. There is no guarantee for that.

Issue is reproducible in camera usecase on take picture,
since there are multiple instances of jpeg encoder
registering for same bus handle.

Change-Id: I6868311cab36f71c6abe1d06a3d9c15cb64bf5fd
Signed-off-by: Gjorgji Rosikopulos <grosikopulos@mm-sol.com>
Acked-by: Laurent Pinchart <laurent.pinchart@linaro.org>
Acked-by: Sandeep Patil <sspatil@google.com>
Tested-by: Sandeep Patil <sspatil@google.com>
Signed-off-by: Greg Kroah-Hartman <gregkh@google.com>
Signed-off-by: Sandeep Patil <sspatil@google.com>