### PR TITLE
[1.3.3] drivers: bluesleep: Fix ttyHS0 wakelocks

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2376,30 +2376,31 @@ void msm_hs_request_clock_on(struct uart_port *uport)
 }
 EXPORT_SYMBOL(msm_hs_request_clock_on);
 
-void msm_hs_set_clock(int port_index, int on)
+int msm_hs_set_clock(struct uart_port *uport, int on)
 {
-	struct uart_port *uport = msm_hs_get_uart_port(port_index);
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	int rc = atomic_read(&msm_uport->clk_count);
 
 	// Check if there is a registered wakeup source
 	if (!msm_uport->ws.name) {
-		pr_debug("%s there is no registered WS source:\n", __func__);
-		return;
+		pr_debug("%s there is no registered wakeup source:\n", __func__);
+		return 0;
 	}
 
-	pr_debug("%s /dev/ttyHS%d clock: %s\n", __func__,
-		port_index, on ? "ON" : "OFF");
+	pr_info("%s: %s\n", __func__, on ? "ON" : "OFF");
 
 	if (on) {
 		msm_hs_request_clock_on(uport);
 		msm_hs_set_mctrl(uport, TIOCM_RTS);
+		return 1;
 	} else {
 		if (rc > 0) {
 			msm_hs_set_mctrl(uport, 0);
 			msm_hs_request_clock_off(uport);
+			return 1;
 		}
 	}
+	return 0;
 }
 EXPORT_SYMBOL(msm_hs_set_clock);
 

--- a/include/linux/platform_data/msm_serial_hs.h
+++ b/include/linux/platform_data/msm_serial_hs.h
@@ -61,5 +61,5 @@ void msm_hs_request_clock_on(struct uart_port *uport);
 struct uart_port *msm_hs_get_uart_port(int port_index);
 void msm_hs_set_mctrl(struct uart_port *uport,
 				    unsigned int mctrl);
-void msm_hs_set_clock(int port_index, int on);
+int msm_hs_set_clock(struct uart_port *uport, int on);
 #endif


### PR DESCRIPTION
Rfkill requires clock vote ON only one time (during its initialization) then
the bluesleep driver will do the clock control for BT uart by itself.

Also, bring back the uart port enabled/disabled control and avoid the
racing condition during clock vote by bluesleep driver.

This patch fixes the deep sleep state and it improves
bluetooth [re]connection speed.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I549d0d8c205b59dcb1e0636bc74675ae02b03778