### PR TITLE
[1.3.3] drivers: bluetooth: Fix ttyHS0 wakelocks

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -91,6 +91,7 @@ enum {
 	DEBUG_SUSPEND = 1U << 1,
 	DEBUG_BTWAKE = 1U << 2,
 	DEBUG_VERBOSE = 1U << 3,
+	DEBUG_BTWRITE = 1U << 4,
 };
 
 static int debug_mask = DEBUG_USER_STATE;
@@ -131,8 +132,8 @@ DECLARE_DELAYED_WORK(sleep_workqueue, bluesleep_sleep_work);
 #define bluesleep_rx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
 #define bluesleep_tx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
 
-/* 5 second timeout */
-#define TX_TIMER_INTERVAL  5
+/* 1 second timeout */
+#define RX_TIMER_INTERVAL  1
 
 /* state variable names and bit positions */
 #define BT_PROTO	0x01
@@ -140,24 +141,18 @@ DECLARE_DELAYED_WORK(sleep_workqueue, bluesleep_sleep_work);
 #define BT_ASLEEP	0x04
 #define BT_EXT_WAKE	0x08
 #define BT_SUSPEND	0x10
+#define BT_RXTIMER	0x20
 
 #define PROC_BTWAKE	0
 #define PROC_HOSTWAKE	1
 #define PROC_PROTO	2
 #define PROC_ASLEEP	3
-#if BT_BLUEDROID_SUPPORT
 #define PROC_LPM	4
 #define PROC_BTWRITE	5
-#endif
 
 #define MSM_HSUART_BT	0
 
-#if BT_BLUEDROID_SUPPORT
 static bool has_lpm_enabled;
-#else
-/* global pointer to a single hci device. */
-static struct hci_dev *bluesleep_hdev;
-#endif
 
 static struct platform_device *bluesleep_uart_dev;
 static struct bluesleep_info *bsi;
@@ -168,10 +163,6 @@ static atomic_t open_count = ATOMIC_INIT(1);
 /*
  * Local function prototypes
  */
-#if !BT_BLUEDROID_SUPPORT
-static int bluesleep_hci_event(struct notifier_block *this,
-			unsigned long event, void *data);
-#endif
 static int bluesleep_start(void);
 static void bluesleep_stop(void);
 
@@ -185,20 +176,13 @@ static unsigned long flags;
 /** Tasklet to respond to change in hostwake line */
 static struct tasklet_struct hostwake_task;
 
-/** Transmission timer */
-static void bluesleep_tx_timer_expire(unsigned long data);
-static DEFINE_TIMER(tx_timer, bluesleep_tx_timer_expire, 0, 0);
+/** Reception timer */
+static void bluesleep_rx_timer_expire(unsigned long data);
+static DEFINE_TIMER(rx_timer, bluesleep_rx_timer_expire, 0, 0);
 
 /** Lock for state transitions */
 static spinlock_t rw_lock;
 static struct rfkill *bt_rfkill;
-
-#if !BT_BLUEDROID_SUPPORT
-/** Notifier block for HCI events */
-struct notifier_block hci_event_nblock = {
-	.notifier_call = bluesleep_hci_event,
-};
-#endif
 
 struct proc_dir_entry *bluetooth_dir, *sleep_dir;
 
@@ -229,27 +213,8 @@ int bluesleep_can_sleep(void)
 {
 	/* check if WAKE_BT_GPIO and BT_WAKE_GPIO are both deasserted */
 	return ((gpio_get_value(bsi->host_wake) != bsi->irq_polarity) &&
-		(test_bit(BT_EXT_WAKE, &flags)) &&
+		(test_bit(BT_EXT_WAKE, &flags)) && (!test_bit(BT_RXTIMER, &flags)) &&
 		(bsi->uport != NULL));
-}
-
-void bluesleep_sleep_wakeup(void)
-{
-	if (test_bit(BT_ASLEEP, &flags)) {
-		if (debug_mask & DEBUG_SUSPEND)
-			pr_info("waking up...\n");
-		wake_lock(&bsi->wake_lock);
-		/* Start the timer */
-		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
-		if (debug_mask & DEBUG_BTWAKE)
-			pr_info("BT WAKE: set to wake\n");
-		if (bsi->has_ext_wake == 1)
-			gpio_set_value(bsi->ext_wake, 0);
-		clear_bit(BT_EXT_WAKE, &flags);
-		clear_bit(BT_ASLEEP, &flags);
-		/*Activating UART */
-		hsuart_power(HS_UART_ON);
-	}
 }
 
 static int bluesleep_rfkill_set_power(void *data, bool blocked)
@@ -334,19 +299,25 @@ static void bluesleep_sleep_work(struct work_struct *work)
 			 */
 			wake_lock_timeout(&bsi->wake_lock, HZ / 2);
 		} else {
-			mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
+			pr_err("This should never happen.\n");
 			return;
 		}
-	} else if (test_bit(BT_EXT_WAKE, &flags)
-			&& !test_bit(BT_ASLEEP, &flags)) {
-		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
-		if (debug_mask & DEBUG_BTWAKE)
-			pr_info("BT WAKE: set to wake\n");
-		if (bsi->has_ext_wake == 1)
-			gpio_set_value(bsi->ext_wake, 0);
-		clear_bit(BT_EXT_WAKE, &flags);
+	} else if (test_bit(BT_ASLEEP, &flags)) {
+		/* Can not sleep but UART has already sleep */
+		if (debug_mask & DEBUG_SUSPEND)
+			pr_err("waking up...\n");
+		wake_lock(&bsi->wake_lock);
+		clear_bit(BT_ASLEEP, &flags);
+
+		/* Add a timer to make sure that UART
+		 * would not be turned on&off very frequentently
+		 */
+		mod_timer(&rx_timer, jiffies + (RX_TIMER_INTERVAL * HZ));
+
+		set_bit(BT_RXTIMER, &flags);
+		hsuart_power(HS_UART_ON);
 	} else {
-		bluesleep_sleep_wakeup();
+		pr_err("default branch, do nothing.\n");
 	}
 }
 
@@ -376,100 +347,65 @@ static void bluesleep_hostwake_task(unsigned long data)
 static void bluesleep_outgoing_data(void)
 {
 	unsigned long irq_flags;
+	int power_on_uart = 0;
 
 	spin_lock_irqsave(&rw_lock, irq_flags);
-
-	/* log data passing by */
-	set_bit(BT_TXDATA, &flags);
-
-	spin_unlock_irqrestore(&rw_lock, irq_flags);
 
 	/* if the tx side is sleeping... */
 	if (test_bit(BT_EXT_WAKE, &flags)) {
 		if (debug_mask & DEBUG_SUSPEND)
 			pr_info("tx was sleeping\n");
-		bluesleep_sleep_wakeup();
-	}
-}
-
-
-#if !BT_BLUEDROID_SUPPORT
-/**
- * Handles HCI device events.
- * @param this Not used.
- * @param event The event that occurred.
- * @param data The HCI device associated with the event.
- * @return <code>NOTIFY_DONE</code>.
- */
-static int bluesleep_hci_event(struct notifier_block *this,
-				unsigned long event, void *data)
-{
-	struct hci_dev *hdev = (struct hci_dev *) data;
-	struct hci_uart *hu;
-	struct uart_state *state;
-
-	if (!hdev)
-		return NOTIFY_DONE;
-
-	switch (event) {
-	case HCI_DEV_REG:
-		if (!bluesleep_hdev) {
-			bluesleep_hdev = hdev;
-			hu  = (struct hci_uart *) hdev->driver_data;
-			state = (struct uart_state *) hu->tty->driver_data;
-			bsi->uport = state->uart_port;
-			/* if bluetooth started, start bluesleep*/
-			bluesleep_start();
-		}
-		break;
-	case HCI_DEV_UNREG:
-		bluesleep_stop();
-		bluesleep_hdev = NULL;
-		bsi->uport = NULL;
-		/* if bluetooth stopped, stop bluesleep also */
-		break;
-	case HCI_DEV_WRITE:
-		bluesleep_outgoing_data();
-		break;
+		if (bsi->has_ext_wake == 1)
+			gpio_set_value(bsi->ext_wake, 0);
+		clear_bit(BT_EXT_WAKE, &flags);
 	}
 
-	return NOTIFY_DONE;
+	if (test_bit(BT_ASLEEP, &flags)) {
+		if (debug_mask & DEBUG_SUSPEND)
+			pr_err("waking up...\n");
+		wake_lock(&bsi->wake_lock);
+		clear_bit(BT_ASLEEP, &flags);
+		power_on_uart = 1;
+	}
+
+	spin_unlock_irqrestore(&rw_lock, irq_flags);
+
+	if (power_on_uart == 1)
+		hsuart_power(HS_UART_ON);
 }
-#endif
 
 /**
- * Handles transmission timer expiration.
- * @param data Not used.
+ * Function to check wheather bluetooth can sleep when btwrite was deasserted
+ * by bluedroid.
  */
-static void bluesleep_tx_timer_expire(unsigned long data)
+static void bluesleep_tx_allow_sleep(void)
 {
 	unsigned long irq_flags;
 
 	if (debug_mask & DEBUG_VERBOSE)
-		pr_info("Tx timer expired\n");
+		pr_err("%s\n", __FUNCTION__);
+	if (debug_mask & DEBUG_SUSPEND)
+		pr_err("Tx has been idle\n");
 
 	spin_lock_irqsave(&rw_lock, irq_flags);
 
-	/* were we silent during the last timeout? */
-	if (!test_bit(BT_TXDATA, &flags)) {
-		if (debug_mask & DEBUG_SUSPEND)
-			pr_info("Tx has been idle\n");
-		if (debug_mask & DEBUG_BTWAKE)
-			pr_info("BT WAKE: set to sleep\n");
-		if (bsi->has_ext_wake == 1)
-			gpio_set_value(bsi->ext_wake, 1);
-		set_bit(BT_EXT_WAKE, &flags);
-		bluesleep_tx_idle();
-	} else {
-		if (debug_mask & DEBUG_SUSPEND)
-			pr_info("Tx data during last period\n");
-		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL*HZ));
-	}
-
-	/* clear the incoming data flag */
-	clear_bit(BT_TXDATA, &flags);
+	if (bsi->has_ext_wake == 1)
+		gpio_set_value(bsi->ext_wake, 1);
+	set_bit(BT_EXT_WAKE, &flags);
+	bluesleep_tx_idle();
 
 	spin_unlock_irqrestore(&rw_lock, irq_flags);
+}
+
+/**
+ * Handles reception timer expiration.
+ * Clear BT_RXTIMER.
+ * @param data Not used.
+ */
+static void bluesleep_rx_timer_expire(unsigned long data)
+{
+	clear_bit(BT_RXTIMER, &flags);
+	bluesleep_rx_idle();
 }
 
 /**
@@ -509,23 +445,21 @@ static int bluesleep_start(void)
 		return -EBUSY;
 	}
 
-	/* start the timer */
-
-	mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL*HZ));
-
-	hsuart_power(HS_UART_ON);
-	BT_INFO("msm_hs_request_clock_on ... done");
+	spin_lock_irqsave(&rw_lock, irq_flags);
 
 	/* assert BT_WAKE */
 	if (debug_mask & DEBUG_BTWAKE)
-		pr_info("BT WAKE: set to wake\n");
+		pr_err("BT WAKE: set to wake\n");
 	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 0);
 	clear_bit(BT_EXT_WAKE, &flags);
+	clear_bit(BT_ASLEEP, &flags);
+	spin_unlock_irqrestore(&rw_lock, irq_flags);
+
 #if BT_ENABLE_IRQ_WAKE
 	retval = enable_irq_wake(bsi->host_wake_irq);
 	if (retval < 0) {
-		BT_ERR("Couldn't enable BT_HOST_WAKE as wakeup interrupt");
+		pr_err("Couldn't enable BT_HOST_WAKE as wakeup interrupt");
 		goto fail;
 	}
 #endif
@@ -533,7 +467,7 @@ static int bluesleep_start(void)
 	wake_lock(&bsi->wake_lock);
 	return 0;
 fail:
-	del_timer(&tx_timer);
+	del_timer(&rx_timer);
 	atomic_inc(&open_count);
 
 	return retval;
@@ -555,11 +489,11 @@ static void bluesleep_stop(void)
 
 	/* assert BT_WAKE */
 	if (debug_mask & DEBUG_BTWAKE)
-		pr_info("BT WAKE: set to wake\n");
+		pr_err("BT WAKE: set to wake\n");
 	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 0);
 	clear_bit(BT_EXT_WAKE, &flags);
-	del_timer(&tx_timer);
+	del_timer(&rx_timer);
 	clear_bit(BT_PROTO, &flags);
 
 	if (test_bit(BT_ASLEEP, &flags)) {
@@ -574,7 +508,7 @@ static void bluesleep_stop(void)
 
 #if BT_ENABLE_IRQ_WAKE
 	if (disable_irq_wake(bsi->host_wake_irq))
-		BT_ERR("Couldn't disable hostwake IRQ wakeup mode");
+		pr_err("Couldn't disable hostwake IRQ wakeup mode");
 #endif
 	wake_lock_timeout(&bsi->wake_lock, HZ / 2);
 }
@@ -591,7 +525,7 @@ static int bluesleep_populate_dt_pinfo(struct platform_device *pdev)
 
 	tmp = of_get_named_gpio(np, "bt_host_wake", 0);
 	if (tmp < 0) {
-		BT_ERR("couldn't find host_wake gpio");
+		pr_err("couldn't find host_wake gpio");
 		return -ENODEV;
 	}
 	bsi->host_wake = tmp;
@@ -626,11 +560,10 @@ static int bluesleep_populate_pinfo(struct platform_device *pdev)
 	res = platform_get_resource_byname(pdev, IORESOURCE_IO,
 				"gpio_host_wake");
 	if (!res) {
-		BT_ERR("couldn't find host_wake gpio");
+		pr_err("couldn't find host_wake gpio");
 		return -ENODEV;
 	}
 	bsi->host_wake = res->start;
-
 	res = platform_get_resource_byname(pdev, IORESOURCE_IO,
 				"gpio_ext_wake");
 	if (!res)
@@ -640,7 +573,6 @@ static int bluesleep_populate_pinfo(struct platform_device *pdev)
 
 	if (bsi->has_ext_wake)
 		bsi->ext_wake = res->start;
-
 	return 0;
 }
 
@@ -709,13 +641,13 @@ static int bluesleep_probe(struct platform_device *pdev)
 	if (pdev->dev.of_node) {
 		ret = bluesleep_populate_dt_pinfo(pdev);
 		if (ret < 0) {
-			BT_ERR("couldn't populate info from dt");
+			pr_err("couldn't populate info from dt");
 			return ret;
 		}
 	} else {
 		ret = bluesleep_populate_pinfo(pdev);
 		if (ret < 0) {
-			BT_ERR("couldn't populate info");
+			pr_err("couldn't populate info");
 			return ret;
 		}
 	}
@@ -723,19 +655,19 @@ static int bluesleep_probe(struct platform_device *pdev)
 	/* configure host_wake as input */
 	ret = gpio_request_one(bsi->host_wake, GPIOF_IN, "bt_host_wake");
 	if (ret < 0) {
-		BT_ERR("failed to configure input direction for GPIO %d err %d",
+		pr_err("failed to configure input direction for GPIO %d err %d",
 				bsi->host_wake, ret);
 		goto free_bsi;
 	}
 
 	if (debug_mask & DEBUG_BTWAKE)
-		pr_info("BT WAKE: set to wake\n");
+		pr_err("BT WAKE: set to wake\n");
 	if (bsi->has_ext_wake) {
 		/* configure ext_wake as output mode*/
 		ret = gpio_request_one(bsi->ext_wake,
-				GPIOF_OUT_INIT_LOW, "bt_ext_wake");
+				GPIOF_OUT_INIT_HIGH, "bt_ext_wake");
 		if (ret < 0) {
-			BT_ERR("failed to configure output direction for GPIO %d err %d",
+			pr_err("failed to configure output direction for GPIO %d err %d",
 					bsi->ext_wake, ret);
 			goto free_bt_host_wake;
 		}
@@ -765,11 +697,11 @@ static int bluesleep_probe(struct platform_device *pdev)
 			bsi->irq_polarity);
 
 	ret = request_irq(bsi->host_wake_irq, bluesleep_hostwake_isr,
-			IRQF_DISABLED | IRQF_TRIGGER_FALLING,
+			IRQF_DISABLED | IRQF_TRIGGER_FALLING | IRQF_TRIGGER_RISING,
 			"bluetooth hostwake", NULL);
 
 	if (ret  < 0) {
-		BT_ERR("Couldn't acquire BT_HOST_WAKE IRQ");
+		pr_err("Couldn't acquire BT_HOST_WAKE IRQ");
 		goto free_bt_ext_wake;
 	}
 
@@ -806,7 +738,6 @@ free_bsi:
 
 static int bluesleep_remove(struct platform_device *pdev)
 {
-
 	int ret;
 	
 	if (pinctrl_data->has_pinctl){
@@ -879,20 +810,15 @@ static struct platform_driver bluesleep_driver = {
 static int bluesleep_proc_show(struct seq_file *m, void *v)
 {
 	switch ((long)m->private) {
-	case PROC_BTWAKE:
-		seq_printf(m, "btwake:%u\n", test_bit(BT_EXT_WAKE, &flags));
+	case PROC_LPM:
+		seq_printf(m, "lpm: %u\n",
+				test_bit(has_lpm_enabled, &flags) ? 1 : 0);
 		break;
-	case PROC_HOSTWAKE:
-		seq_printf(m, "hostwake: %u\n", gpio_get_value(bsi->host_wake));
+	case PROC_BTWRITE:
+		seq_printf(m, "btwrite: %u\n",
+				test_bit(BT_TXDATA, &flags) ? 1 : 0);
 		break;
-	case PROC_PROTO:
-		seq_printf(m, "proto: %u\n",
-				test_bit(BT_PROTO, &flags) ? 1 : 0);
-		break;
-	case PROC_ASLEEP:
-		seq_printf(m, "asleep: %u\n",
-				test_bit(BT_ASLEEP, &flags) ? 1 : 0);
-		break;
+
 	default:
 		return 0;
 	}
@@ -913,27 +839,6 @@ static ssize_t bluesleep_proc_write(struct file *file, const char *buf,
 	lbuf[count] = 0;
 
 	switch ((long)data) {
-	case PROC_BTWAKE:
-		if (lbuf[0] == '0') {
-			if (debug_mask & DEBUG_BTWAKE)
-				pr_info("BT WAKE: set to wake\n");
-			if (bsi->has_ext_wake == 1)
-				gpio_set_value(bsi->ext_wake, 0);
-			clear_bit(BT_EXT_WAKE, &flags);
-		} else if (buf[0] == '1') {
-			if (debug_mask & DEBUG_BTWAKE)
-				pr_info("BT WAKE: set to sleep\n");
-			if (bsi->has_ext_wake == 1)
-				gpio_set_value(bsi->ext_wake, 1);
-			set_bit(BT_EXT_WAKE, &flags);
-		}
-		break;
-	case PROC_PROTO:
-		if (lbuf[0] == '0')
-			bluesleep_stop();
-		else
-			bluesleep_start();
-		break;
 	case PROC_LPM:
 		if (lbuf[0] == '0') {
 			/* HCI_DEV_UNREG */
@@ -951,9 +856,10 @@ static ssize_t bluesleep_proc_write(struct file *file, const char *buf,
 		}
 		break;
 	case PROC_BTWRITE:
-		/* HCI_DEV_WRITE */
 		if (lbuf[0] != '0')
 			bluesleep_outgoing_data();
+		else
+			bluesleep_tx_allow_sleep();
 		break;
 	default:
 		return 0;
@@ -993,80 +899,39 @@ static int __init bluesleep_init(void)
 	int retval;
 	struct proc_dir_entry *ent;
 
-	BT_INFO("BlueSleep Mode Driver Ver %s", VERSION);
+	pr_err("BlueSleep Mode Driver Ver %s", VERSION);
 
 	retval = platform_driver_register(&bluesleep_driver);
-	if (retval)
+	if (retval) {
+		pr_err("\n:retval = %d",retval);
 		return retval;
+	}
 
-	if (bsi == NULL)
+	if (bsi == NULL) {
+		pr_err("bsi is NULL.");
 		return 0;
+	}
 
 	bt_enabled = false;
 
-#if !BT_BLUEDROID_SUPPORT
-	bluesleep_hdev = NULL;
-#endif
-
 	bluetooth_dir = proc_mkdir("bluetooth", NULL);
 	if (bluetooth_dir == NULL) {
-		BT_ERR("Unable to create /proc/bluetooth directory");
+		pr_err("Unable to create /proc/bluetooth directory");
 		return -ENOMEM;
 	}
 
 	sleep_dir = proc_mkdir("sleep", bluetooth_dir);
 	if (sleep_dir == NULL) {
-		BT_ERR("Unable to create /proc/%s directory", PROC_DIR);
+		pr_err("Unable to create /proc/%s directory", PROC_DIR);
 		return -ENOMEM;
 	}
 
-	/* Creating read/write "btwake" entry */
-	ent = proc_create_data("btwake", S_IRUGO | S_IWUSR | S_IWGRP,
-			sleep_dir, &bluesleep_proc_readwrite_fops,
-			(void *)PROC_BTWAKE);
-	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/btwake entry", PROC_DIR);
-		retval = -ENOMEM;
-		goto fail;
-	}
-
-	/* read only proc entries */
-	ent = proc_create_data("hostwake", S_IRUGO, sleep_dir,
-				&bluesleep_proc_read_fops,
-				(void *)PROC_HOSTWAKE);
-	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/hostwake entry", PROC_DIR);
-		retval = -ENOMEM;
-		goto fail;
-	}
-
-	/* read/write proc entries */
-	ent = proc_create_data("proto", S_IRUGO | S_IWUSR | S_IWGRP,
-			sleep_dir, &bluesleep_proc_readwrite_fops,
-			(void *)PROC_PROTO);
-	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/proto entry", PROC_DIR);
-		retval = -ENOMEM;
-		goto fail;
-	}
-
-	/* read only proc entries */
-	ent = proc_create_data("asleep", S_IRUGO,
-			sleep_dir, &bluesleep_proc_read_fops,
-			(void *)PROC_ASLEEP);
-	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/asleep entry", PROC_DIR);
-		retval = -ENOMEM;
-		goto fail;
-	}
-
-#if BT_BLUEDROID_SUPPORT
 	/* read/write proc entries */
 	ent = proc_create_data("lpm", S_IRUGO | S_IWUSR | S_IWGRP,
 			sleep_dir, &bluesleep_proc_readwrite_fops,
 			(void *)PROC_LPM);
 	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/lpm entry", PROC_DIR);
+		pr_err("Unable to create /proc/%s/lpm entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
@@ -1076,12 +941,10 @@ static int __init bluesleep_init(void)
 			sleep_dir, &bluesleep_proc_readwrite_fops,
 			(void *)PROC_BTWRITE);
 	if (ent == NULL) {
-		BT_ERR("Unable to create /proc/%s/btwrite entry", PROC_DIR);
+		pr_err("Unable to create /proc/%s/btwrite entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
-
-#endif
 
 	flags = 0; /* clear all status bits */
 
@@ -1089,34 +952,25 @@ static int __init bluesleep_init(void)
 	spin_lock_init(&rw_lock);
 
 	/* Initialize timer */
-	init_timer(&tx_timer);
-	tx_timer.function = bluesleep_tx_timer_expire;
-	tx_timer.data = 0;
+	init_timer(&rx_timer);
+	rx_timer.function = bluesleep_rx_timer_expire;
+	rx_timer.data = 0;
 
 	/* initialize host wake tasklet */
 	tasklet_init(&hostwake_task, bluesleep_hostwake_task, 0);
 
 	/* assert bt wake */
 	if (debug_mask & DEBUG_BTWAKE)
-		pr_info("BT WAKE: set to wake\n");
+		pr_err("BT WAKE: set to wake\n");
 	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 0);
 	clear_bit(BT_EXT_WAKE, &flags);
-#if !BT_BLUEDROID_SUPPORT
-	hci_register_notifier(&hci_event_nblock);
-#endif
 
 	return 0;
 
 fail:
-#if BT_BLUEDROID_SUPPORT
 	remove_proc_entry("btwrite", sleep_dir);
 	remove_proc_entry("lpm", sleep_dir);
-#endif
-	remove_proc_entry("asleep", sleep_dir);
-	remove_proc_entry("proto", sleep_dir);
-	remove_proc_entry("hostwake", sleep_dir);
-	remove_proc_entry("btwake", sleep_dir);
 	remove_proc_entry("sleep", bluetooth_dir);
 	remove_proc_entry("bluetooth", 0);
 	return retval;
@@ -1136,26 +990,17 @@ static void __exit bluesleep_exit(void)
 	clear_bit(BT_EXT_WAKE, &flags);
 	if (test_bit(BT_PROTO, &flags)) {
 		if (disable_irq_wake(bsi->host_wake_irq))
-			BT_ERR("Couldn't disable hostwake IRQ wakeup mode");
+			pr_err("Couldn't disable hostwake IRQ wakeup mode");
 		free_irq(bsi->host_wake_irq, NULL);
-		del_timer(&tx_timer);
+		del_timer(&rx_timer);
 		if (test_bit(BT_ASLEEP, &flags))
 			hsuart_power(HS_UART_ON);
 	}
 
-#if !BT_BLUEDROID_SUPPORT
-	hci_unregister_notifier(&hci_event_nblock);
-#endif
 	platform_driver_unregister(&bluesleep_driver);
 
-#if BT_BLUEDROID_SUPPORT
 	remove_proc_entry("btwrite", sleep_dir);
 	remove_proc_entry("lpm", sleep_dir);
-#endif
-	remove_proc_entry("asleep", sleep_dir);
-	remove_proc_entry("proto", sleep_dir);
-	remove_proc_entry("hostwake", sleep_dir);
-	remove_proc_entry("btwake", sleep_dir);
 	remove_proc_entry("sleep", bluetooth_dir);
 	remove_proc_entry("bluetooth", 0);
 }

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -317,7 +317,8 @@ static void bluesleep_sleep_work(struct work_struct *work)
 		set_bit(BT_RXTIMER, &flags);
 		hsuart_power(HS_UART_ON);
 	} else {
-		pr_err("default branch, do nothing.\n");
+		if (debug_mask & DEBUG_SUSPEND)
+			pr_err("default branch, do nothing.\n");
 	}
 }
 


### PR DESCRIPTION
First of all, this change will affect only LOIRE platform.

For some reason bluetooth will not start without clock vote
during rfkill initialization. This is necessary and it works even
with the kernel warning about "unregistered wakeup source".
But it should be called only once, otherwise it will break
"deep sleep" state, consequently causing kernel wakelock.

The clock vote should be done after enabled/disabled bt_reg_on.
Also, the new msm_serial_hs implementation is no necessary anymore.

This patch fixes "deep sleep" state and it improves BT [re]connecting.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ia6059d6f0cd14a12503d1bae44566417b43dce1c