### PR TITLE
[1.3.3] arm: DT: leo: Fix video default panels

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-leo.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-leo.dtsi
@@ -73,7 +73,7 @@
 	};
 
 	dsi_default_gpio_0: somc,default_panel_0 {
-		qcom,mdss-dsi-panel-name = "default";
+		qcom,mdss-dsi-panel-name = "default video 0";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,panel-supply-entries = <&shinano_panel_power_supply>;
 		qcom,mdss-dsi-panel-destination = "display_1";
@@ -113,6 +113,8 @@
 				15 01 00 00 00 00 02 FF 10];
 		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
 				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-post-panel-on-command = [
+				39 01 00 00 00 00 01 29];
 		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
 				05 01 00 00 14 00 01 28
 				05 01 00 00 50 00 01 10];
@@ -131,7 +133,10 @@
 		qcom,mdss-dsi-bl-max-level = <255>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-tx-eot-append;
 
+		somc,mul-channel-scaling = <3>;
+		somc,dric-gpio = <&msmgpio 26 0>;
 		somc,mdss-dsi-disp-on-in-hs = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff
@@ -157,7 +162,7 @@
 	};
 
 	dsi_default_gpio_1: somc,default_panel_1 {
-		qcom,mdss-dsi-panel-name = "default";
+		qcom,mdss-dsi-panel-name = "default video 1";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,panel-supply-entries = <&shinano_panel_power_supply>;
 		qcom,mdss-dsi-panel-destination = "display_1";
@@ -197,6 +202,8 @@
 				15 01 00 00 00 00 02 FF 10];
 		qcom,mdss-dsi-on-command = [05 01 00 00 96 00 01 11
 				05 01 00 00 28 00 01 29];
+		qcom,mdss-dsi-post-panel-on-command = [
+				39 01 00 00 00 00 01 29];
 		qcom,mdss-dsi-off-command = [15 01 00 00 00 00 02 FF 10
 				05 01 00 00 14 00 01 28
 				05 01 00 00 50 00 01 10];
@@ -214,7 +221,10 @@
 		qcom,mdss-dsi-bl-max-level = <255>;
 		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+		qcom,mdss-dsi-tx-eot-append;
 
+		somc,mul-channel-scaling = <3>;
+		somc,dric-gpio = <&msmgpio 26 0>;
 		somc,mdss-dsi-disp-on-in-hs = <1>;
 		somc,mdss-dsi-wait-time-before-on-cmd = <150>;
 		somc,mdss-dsi-lane-config = [00 c2 ef 00 00 00 00 01 ff


### PR DESCRIPTION
1. Define different name between available default panels.
2. Add a generic post-panel-on DT entry and fix panel unblank actions.
3. Add missed DT entries from stock DT panel.
   - tx-eot-append
   - mul-channel-scalling
   - dric-gpio

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ie3a14412b8f68887919d97558017367d7729be05