### PR TITLE
drivers: ldisc: Set 25 for N_BRCM_HCI

### DIFF
--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -41,7 +41,7 @@
 *****************************************************************************/
 
 #ifndef N_BRCM_HCI
-#define N_BRCM_HCI      26
+#define N_BRCM_HCI      25
 #endif
 
 /* Ioctls */


### PR DESCRIPTION
Use the same AOSP value for UART ioctl line discipline (N_BRCM_HCI).

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I2bfc6f3e890fc3074f13c2a70d22db9a42c74614