### PR TITLE
[UM 5.5.r1] video: somc_panel: Add paranoid NULL pointer checks for reset sequences

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -303,6 +303,12 @@ static void mdss_dsi_panel_set_gpio_seq(
 {
 	int i, rc;
 
+	if (unlikely(seq == NULL)) {
+		pr_err("%s: WARNING: Reset sequence is NULL! Bailing out.\n",
+			__func__);
+		return;
+	}
+
 	rc = gpio_direction_output(gpio, seq[0]);
 	if (rc) {
 		pr_err("%s: FATAL: Cannot set direction for reset GPIO %d\n",
@@ -432,9 +438,22 @@ static int mdss_dsi_panel_reset_seq(struct mdss_panel_data *pdata, int enable)
 			gpio_set_value(spec_pdata->disp_p5, 0);
 			usleep_range(10000, 10000);
 		}
-	} else
+	} else {
+		if (unlikely(pw_seq->rst_seq == NULL)) {
+			pr_err("FATAL: power%s reset sequence is NULL!!\n",
+				enable ? "on" : "off");
+			return 0;
+		}
+
+		if (unlikely(pw_seq->seq_num < 0 || pw_seq->seq_num > 20)) {
+			pr_err("FATAL: Invalid number of entries for "\
+				"power%s sequence!!\n", enable ? "on" : "off");
+			return 0;
+		};
+
 		mdss_dsi_panel_set_gpio_seq(ctrl_pdata->rst_gpio,
 			pw_seq->seq_num, pw_seq->rst_seq);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
While porting devices to somc_panel driver, sometimes some DT
property gets mistakenly named or unsupported or whatever.
Make debugging more comfortable: add paranoid NULL pointer
checks for reset sequences, optimized with very unlikely
branches declarations.

The branches for those checks should be NEVER triggered, but
it is sane to add this (if optimized!) because those eventual
errors will NOT make the device unstable in a situation where
it can produce loss of data: panic'ing the kernel instead can
so avoid panics at every cost.

Take in mind that this commit is done for debugging purposes
and NOT to solve real problems: those have to be solved in
their own place as soon as possible.