### PR TITLE
[1.3.3] sound: soc: loire: Fix FM audio routing

### DIFF
--- a/sound/soc/msm/msm8952-dai-links.c
+++ b/sound/soc/msm/msm8952-dai-links.c
@@ -1191,6 +1191,20 @@ static struct snd_soc_dai_link msm8952_common_be_dai[] = {
 		.ignore_pmdown_time = 1, /* dai link has playback support */
 		.ignore_suspend = 1,
 	},
+	/* Temporary patch for FM Capture link */
+	{
+		.name = LPASS_BE_QUIN_MI2S_TX,
+		.stream_name = "Quinary MI2S Capture",
+		.cpu_dai_name = "msm-dai-q6-mi2s.5",
+		.platform_name = "msm-pcm-routing",
+		.codec_dai_name = "snd-soc-dummy-dai",
+		.codec_name = "snd-soc-dummy",
+		.no_pcm = 1,
+		.be_id = MSM_BACKEND_DAI_QUINARY_MI2S_TX,
+		.be_hw_params_fixup = msm_be_hw_params_fixup,
+		.ops = &msm8952_quin_mi2s_be_ops,
+		.ignore_suspend = 1,
+	},
 };
 
 static struct snd_soc_aux_dev msm895x_aux_dev[] = {


### PR DESCRIPTION
<3>[   82.178178] msm8952-slimbus-wcd c051000.sound-9335: ASoC: can't get capture BE for Quinary MI2S Capture
<3>[   82.186560]  MSM8X16 Media1: ASoC: no BE found for Quinary MI2S Capture
<3>[   82.245939]  MSM8X16 Media2: ASoC: no backend DAIs enabled for MSM8X16 Media2
<3>[   82.252377] q6asm_callback: cmd = 0x10bcd returned error = 0x1
<3>[   82.258011] __q6asm_cmd: DSP returned error[-1] opcode 68557

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I46d5ff34ba040a0bdbb256ca5678caa784d6ca0e