### PR TITLE
[1.3.3] drivers: regulator: loire: Add setteling delay for FTS2.5

### DIFF
--- a/drivers/regulator/spm-regulator.c
+++ b/drivers/regulator/spm-regulator.c
@@ -101,6 +101,12 @@ static const struct voltage_range ult_hf_range1 = {750000, 750000, 1525000,
 #define QPNP_FTS2_STEP_MARGIN_NUM	4
 #define QPNP_FTS2_STEP_MARGIN_DEN	5
 
+#if defined(CONFIG_ARCH_SONY_LOIRE)
+/* Adding setteling delay for FTS2.5 */
+/* warm-up=20uS, 0-10% & 90-100% V-ramp = 50uS */
+#define FTS2P5_SETTLING_DELAY_US 70
+#endif
+
 /* VSET value to decide the range of ULT SMPS */
 #define ULT_SMPS_RANGE_SPLIT 0x60
 
@@ -183,6 +189,14 @@ static int _spm_regulator_set_voltage(struct regulator_dev *rdev)
 		/* Wait for voltage stepping to complete. */
 		udelay(DIV_ROUND_UP(vreg->uV - vreg->last_set_uV,
 					vreg->step_rate));
+#if defined(CONFIG_ARCH_SONY_LOIRE)
+		if (vreg->regulator_type == QPNP_TYPE_FTS2p5)
+			udelay(FTS2P5_SETTLING_DELAY_US);
+	} else if (vreg->regulator_type == QPNP_TYPE_FTS2p5) {
+			/* add the ramp-down delay */
+			udelay(DIV_ROUND_UP(vreg->last_set_uV - vreg->uV,
+				vreg->step_rate));
+#endif
 	}
 
 	if ((vreg->regulator_type == QPNP_TYPE_FTS2)


### PR DESCRIPTION
warm-up=20uS, 0-10% & 90-100% V-ramp = 50uS

extracted from 38.1.A.0.289F

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I71f147c4be696ba7672b88c51711e205cd8533ec