### PR TITLE
satsuki: DT: switch max-brightness-level to 8 bit

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-auo-4k2k-cmd-ID6.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-auo-4k2k-cmd-ID6.dtsi
@@ -58,7 +58,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		somc,mdss-dsi-disp-on-in-hs = <0>;
@@ -491,7 +491,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		somc,mdss-dsi-lane-config = [02 00 EF 00 20 00 00 01 FF
 				02 00 EF 00 40 00 00 01 FF

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-auo-4k2k-cmd-ID9.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-auo-4k2k-cmd-ID9.dtsi
@@ -58,7 +58,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		somc,mdss-dsi-disp-on-in-hs = <0>;
@@ -516,7 +516,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		somc,mdss-dsi-lane-config = [02 00 EF 00 20 00 00 01 FF
 				02 00 EF 00 40 00 00 01 FF

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-jdi-4k2k-cmd-ID4.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-jdi-4k2k-cmd-ID4.dtsi
@@ -131,7 +131,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
@@ -223,7 +223,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-compression = "fbc";
 		qcom,mdss-dsi-fbc-enable;

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-jdi-4k2k-cmd-ID5.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-jdi-4k2k-cmd-ID5.dtsi
@@ -133,7 +133,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
@@ -225,7 +225,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-compression = "fbc";
 		qcom,mdss-dsi-fbc-enable;

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-sharp-4k2k-cmd-ID3.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-sharp-4k2k-cmd-ID3.dtsi
@@ -58,7 +58,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		somc,mdss-dsi-disp-on-in-hs = <0>;
@@ -538,7 +538,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		somc,mdss-dsi-lane-config = [02 00 EF 00 20 00 00 01 FF
 				02 00 EF 00 40 00 00 01 FF

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-sharp-4k2k-cmd-ID8.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-novatek-sharp-4k2k-cmd-ID8.dtsi
@@ -58,7 +58,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		somc,mdss-dsi-disp-on-in-hs = <0>;
@@ -566,7 +566,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		somc,mdss-dsi-lane-config = [02 00 EF 00 20 00 00 01 FF
 				02 00 EF 00 40 00 00 01 FF

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-satsuki.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-satsuki.dtsi
@@ -210,7 +210,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
@@ -313,7 +313,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-compression = "fbc";
 		qcom,mdss-dsi-fbc-enable;
@@ -418,7 +418,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 
 		qcom,mdss-dsi-compression = "fbc";
@@ -521,7 +521,7 @@
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
-		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <255>;
 
 		qcom,mdss-dsi-compression = "fbc";
 		qcom,mdss-dsi-fbc-enable;


### PR DESCRIPTION
following kernel 1.2.2 and take as reference commit: 96d2c9dc752a65fc7ce6d6a6cb7bcf07ccc9b90a

Signed-off-by: David Viteri <davidteri91@gmail.com>