### PR TITLE
[LA.UM.5.5.r1] Avoid leaking kernel addresses

### DIFF
--- a/drivers/gpu/msm/adreno_debugfs.c
+++ b/drivers/gpu/msm/adreno_debugfs.c
@@ -138,7 +138,7 @@ static void sync_event_print(struct seq_file *s,
 		break;
 	}
 	case KGSL_CMD_SYNCPOINT_TYPE_FENCE:
-		seq_printf(s, "sync: [%p] %s", sync_event->handle,
+		seq_printf(s, "sync: [%pK] %s", sync_event->handle,
 		(sync_event->handle && sync_event->handle->fence)
 				? sync_event->handle->fence->name : "NULL");
 		break;

--- a/drivers/gpu/msm/kgsl.c
+++ b/drivers/gpu/msm/kgsl.c
@@ -3890,9 +3890,8 @@ int kgsl_device_platform_probe(struct kgsl_device *device)
 	disable_irq(device->pwrctrl.interrupt_num);
 
 	KGSL_DRV_INFO(device,
-		"dev_id %d regs phys 0x%08lx size 0x%08x virt %p\n",
-		device->id, device->reg_phys, device->reg_len,
-		device->reg_virt);
+		"dev_id %d regs phys 0x%08lx size 0x%08x\n",
+		device->id, device->reg_phys, device->reg_len);
 
 	rwlock_init(&device->context_lock);
 

--- a/drivers/gpu/msm/kgsl_cffdump.c
+++ b/drivers/gpu/msm/kgsl_cffdump.c
@@ -513,10 +513,6 @@ EXPORT_SYMBOL(kgsl_cffdump_waitirq);
 static int subbuf_start_handler(struct rchan_buf *buf,
 	void *subbuf, void *prev_subbuf, size_t prev_padding)
 {
-	pr_debug("kgsl: cffdump: subbuf_start_handler(subbuf=%p, prev_subbuf"
-		"=%p, prev_padding=%08zx)\n", subbuf, prev_subbuf,
-		 prev_padding);
-
 	if (relay_buf_full(buf)) {
 		if (!suspended) {
 			suspended = 1;
@@ -572,9 +568,6 @@ static struct rchan_callbacks relay_callbacks = {
 static struct rchan *create_channel(unsigned subbuf_size, unsigned n_subbufs)
 {
 	struct rchan *chan;
-
-	pr_info("kgsl: cffdump: relay: create_channel: subbuf_size %u, "
-		"n_subbufs %u, dir 0x%p\n", subbuf_size, n_subbufs, dir);
 
 	chan = relay_open("cpu", dir, subbuf_size,
 			  n_subbufs, &relay_callbacks, NULL);

--- a/drivers/gpu/msm/kgsl_cmdbatch.c
+++ b/drivers/gpu/msm/kgsl_cmdbatch.c
@@ -80,7 +80,7 @@ void kgsl_dump_syncpoints(struct kgsl_device *device,
 		}
 		case KGSL_CMD_SYNCPOINT_TYPE_FENCE:
 			if (event->handle)
-				dev_err(device->dev, "  fence: [%p] %s\n",
+				dev_err(device->dev, "  fence: [%pK] %s\n",
 					event->handle->fence,
 					event->handle->name);
 			else

--- a/drivers/gpu/msm/kgsl_iommu.c
+++ b/drivers/gpu/msm/kgsl_iommu.c
@@ -323,8 +323,8 @@ static int _iommu_map_sync_pc(struct kgsl_pagetable *pt,
 	_unlock_if_secure_mmu(memdesc, pt->mmu);
 
 	if (ret) {
-		KGSL_CORE_ERR("map err: %p, 0x%016llX, 0x%llx, 0x%x, %d\n",
-			iommu_pt->domain, gpuaddr, size, flags, ret);
+		KGSL_CORE_ERR("map err: 0x%016llX, 0x%llx, 0x%x, %d\n",
+			gpuaddr, size, flags, ret);
 		return -ENODEV;
 	}
 
@@ -351,8 +351,8 @@ static int _iommu_unmap_sync_pc(struct kgsl_pagetable *pt,
 	_unlock_if_secure_mmu(memdesc, pt->mmu);
 
 	if (unmapped != size) {
-		KGSL_CORE_ERR("unmap err: %p, 0x%016llx, 0x%llx, %zd\n",
-			iommu_pt->domain, addr, size, unmapped);
+		KGSL_CORE_ERR("unmap err: 0x%016llx, 0x%llx, %zd\n",
+			addr, size, unmapped);
 		return -ENODEV;
 	}
 
@@ -421,8 +421,8 @@ static int _iommu_map_sg_offset_sync_pc(struct kgsl_pagetable *pt,
 	if (size != 0) {
 		/* Cleanup on error */
 		_iommu_unmap_sync_pc(pt, memdesc, addr, mapped);
-		KGSL_CORE_ERR("map err: %p, 0x%016llX, %d, %x, %zd\n",
-			iommu_pt->domain, addr, nents, flags, mapped);
+		KGSL_CORE_ERR("map err: 0x%016llX, %d, %x, %zd\n",
+			addr, nents, flags, mapped);
 		return  -ENODEV;
 	}
 
@@ -451,8 +451,8 @@ static int _iommu_map_sg_sync_pc(struct kgsl_pagetable *pt,
 	_unlock_if_secure_mmu(memdesc, pt->mmu);
 
 	if (mapped == 0) {
-		KGSL_CORE_ERR("map err: %p, 0x%016llX, %d, %x, %zd\n",
-			iommu_pt->domain, addr, nents, flags, mapped);
+		KGSL_CORE_ERR("map err: 0x%016llX, %d, %x, %zd\n",
+			addr, nents, flags, mapped);
 		return  -ENODEV;
 	}
 

--- a/drivers/gpu/msm/kgsl_snapshot.c
+++ b/drivers/gpu/msm/kgsl_snapshot.c
@@ -1074,9 +1074,6 @@ void kgsl_snapshot_save_frozen_objs(struct work_struct *work)
 		goto done;
 
 	snapshot->mempool = vmalloc(size);
-	if (snapshot->mempool != NULL)
-		KGSL_DRV_ERR(device, "snapshot: mempool address %p, size %zx\n",
-				snapshot->mempool, size);
 
 	ptr = snapshot->mempool;
 	snapshot->mempool_size = 0;

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp40.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp40.c
@@ -1015,8 +1015,8 @@ static int msm_vfe40_start_fetch_engine(struct vfe_device *vfe_dev,
 		rc = vfe_dev->buf_mgr->ops->get_buf_by_index(
 			vfe_dev->buf_mgr, bufq_handle, fe_cfg->buf_idx, &buf);
 		if (rc < 0 || !buf) {
-			pr_err("%s: No fetch buffer rc= %d buf= %p\n",
-				__func__, rc, buf);
+			pr_err("%s: No fetch buffer rc= %d\n",
+				__func__, rc);
 			return -EINVAL;
 		}
 		mapped_info = buf->mapped_info[0];
@@ -1072,7 +1072,7 @@ static int msm_vfe40_start_fetch_engine_multi_pass(struct vfe_device *vfe_dev,
 		rc = vfe_dev->buf_mgr->ops->get_buf_by_index(
 			vfe_dev->buf_mgr, bufq_handle, fe_cfg->buf_idx, &buf);
 		if (rc < 0 || !buf) {
-			pr_err("%s: No fetch buffer rc= %d buf= %p\n",
+			pr_err("%s: No fetch buffer rc= %d buf= %pK\n",
 				__func__, rc, buf);
 			return -EINVAL;
 		}

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp_axi_util.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp_axi_util.c
@@ -1670,8 +1670,8 @@ int msm_isp_cfg_offline_ping_pong_address(struct vfe_device *vfe_dev,
 		rc = vfe_dev->buf_mgr->ops->get_buf_by_index(
 			vfe_dev->buf_mgr, bufq_handle, buf_idx, &buf);
 		if (rc < 0 || !buf) {
-			pr_err("%s: No fetch buffer rc= %d buf= %p\n",
-				__func__, rc, buf);
+			pr_err("%s: No fetch buffer rc= %d\n",
+				__func__, rc);
 			return -EINVAL;
 		}
 

--- a/drivers/misc/qcom/qdsp6v2/amrwb_in.c
+++ b/drivers/misc/qcom/qdsp6v2/amrwb_in.c
@@ -1,4 +1,5 @@
-/* Copyright (c) 2011-2012, 2014 The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2012, 2014, 2016 The Linux Foundation. All rights
+ * reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -307,7 +308,7 @@ static int amrwb_in_open(struct inode *inode, struct file *file)
 				(void *)audio);
 
 	if (!audio->ac) {
-		pr_err("%s:audio[%p]: Could not allocate memory for audio"
+		pr_err("%s:audio[%pK]: Could not allocate memory for audio"
 			"client\n", __func__, audio);
 		kfree(audio->enc_cfg);
 		kfree(audio);

--- a/drivers/misc/qcom/qdsp6v2/audio_aac.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_aac.c
@@ -221,10 +221,10 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 		if (rc)
-			pr_err("%s[%p]:Failed in utils_ioctl: %d\n",
+			pr_err("%s[%pK]:Failed in utils_ioctl: %d\n",
 				__func__, audio, rc);
 	}
 	}
@@ -328,10 +328,10 @@ static long audio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_compat_ioctl(file, cmd, arg);
 		if (rc)
-			pr_err("%s[%p]:Failed in utils_ioctl: %d\n",
+			pr_err("%s[%pK]:Failed in utils_ioctl: %d\n",
 				__func__, audio, rc);
 	}
 	}

--- a/drivers/misc/qcom/qdsp6v2/audio_alac.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_alac.c
@@ -52,7 +52,7 @@ static long audio_ioctl_shared(struct file *file, unsigned int cmd,
 					__func__, audio->pcm_cfg.channel_count);
 		}
 
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */

--- a/drivers/misc/qcom/qdsp6v2/audio_amrnb.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_amrnb.c
@@ -33,7 +33,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -62,7 +62,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default:
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 	}
 	return rc;

--- a/drivers/misc/qcom/qdsp6v2/audio_amrwb.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_amrwb.c
@@ -34,7 +34,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -65,7 +65,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default:
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 	}
 	return rc;

--- a/drivers/misc/qcom/qdsp6v2/audio_amrwbplus.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_amrwbplus.c
@@ -55,7 +55,7 @@ static long audio_ioctl_shared(struct file *file, unsigned int cmd,
 
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_err("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_err("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 			audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -162,7 +162,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 		break;
 	}
@@ -274,7 +274,7 @@ static long audio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_compat_ioctl(file, cmd, arg);
 		break;
 	}

--- a/drivers/misc/qcom/qdsp6v2/audio_ape.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_ape.c
@@ -39,7 +39,7 @@ static long audio_ioctl_shared(struct file *file, unsigned int cmd,
 	case AUDIO_START: {
 		struct asm_ape_cfg ape_cfg;
 		struct msm_audio_ape_config *ape_config;
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -133,7 +133,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);
@@ -229,7 +229,7 @@ static long audio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_compat_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);

--- a/drivers/misc/qcom/qdsp6v2/audio_evrc.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_evrc.c
@@ -34,7 +34,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -65,7 +65,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default:
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 	}
 	return rc;

--- a/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
@@ -99,7 +99,7 @@ static void audio_effects_event_handler(uint32_t opcode, uint32_t token,
 	struct q6audio_effects *effects;
 
 	if (!payload || !priv) {
-		pr_err("%s: invalid data to handle events, payload: %p, priv: %p\n",
+		pr_err("%s: invalid data to handle events, payload: %pK, priv: %pK\n",
 			__func__, payload, priv);
 		return;
 	}
@@ -703,7 +703,7 @@ static int audio_effects_release(struct inode *inode, struct file *file)
 				__func__);
 		rc = q6asm_cmd(effects->ac, CMD_CLOSE);
 		if (rc < 0)
-			pr_err("%s[%p]:Failed to close the session rc=%d\n",
+			pr_err("%s[%pK]:Failed to close the session rc=%d\n",
 				__func__, effects, rc);
 		effects->opened = 0;
 		effects->started = 0;

--- a/drivers/misc/qcom/qdsp6v2/audio_mp3.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_mp3.c
@@ -33,7 +33,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	int rc = 0;
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -69,7 +69,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default:
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 	}
 	return rc;

--- a/drivers/misc/qcom/qdsp6v2/audio_qcelp.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_qcelp.c
@@ -36,7 +36,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 	switch (cmd) {
 	case AUDIO_START: {
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -67,7 +67,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default:
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 	}
 	return rc;

--- a/drivers/misc/qcom/qdsp6v2/audio_utils.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_utils.c
@@ -744,7 +744,7 @@ ssize_t audio_in_read(struct file *file,
 			count -= bytes_to_copy;
 			buf += bytes_to_copy;
 		} else {
-			pr_err("%s:session id %d: short read data[%p] bytesavail[%d]bytesrequest[%zd]\n",
+			pr_err("%s:session id %d: short read data[%pK] bytesavail[%d]bytesrequest[%zd]\n",
 				__func__,
 				audio->ac->session,
 				data, size, count);
@@ -883,7 +883,7 @@ ssize_t audio_in_write(struct file *file,
 		buf += xfer;
 	}
 	mutex_unlock(&audio->write_lock);
-	pr_debug("%s:session id %d: eos_condition 0x%x buf[0x%p] start[0x%p]\n",
+	pr_debug("%s:session id %d: eos_condition 0x%x buf[0x%pK] start[0x%pK]\n",
 				__func__, audio->ac->session,
 				nflags, buf, start);
 	if (nflags & AUD_EOS_SET) {

--- a/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_utils_aio.c
@@ -83,7 +83,7 @@ int insert_eos_buf(struct q6audio_aio *audio,
 		struct audio_aio_buffer_node *buf_node)
 {
 	struct dec_meta_out *eos_buf = buf_node->kvaddr;
-	pr_debug("%s[%p]:insert_eos_buf\n", __func__, audio);
+	pr_debug("%s[%pK]:insert_eos_buf\n", __func__, audio);
 	eos_buf->num_of_frames = 0xFFFFFFFF;
 	eos_buf->meta_out_dsp[0].offset_to_frame = 0x0;
 	eos_buf->meta_out_dsp[0].nflags = AUDIO_DEC_EOS_SET;
@@ -131,14 +131,14 @@ static int audio_aio_ion_lookup_vaddr(struct q6audio_aio *audio, void *addr,
 	}
 
 	if (match_count > 1) {
-		pr_err("%s[%p]:multiple hits for vaddr %p, len %ld\n",
+		pr_err("%s[%pK]:multiple hits for vaddr %pK, len %ld\n",
 			__func__, audio, addr, len);
 		list_for_each_entry(region_elt, &audio->ion_region_queue,
 					list) {
 			if (addr >= region_elt->vaddr &&
 			addr < region_elt->vaddr + region_elt->len &&
 			addr + len <= region_elt->vaddr + region_elt->len)
-				pr_err("\t%s[%p]:%p, %ld --> %pa\n",
+				pr_err("\t%s[%pK]:%pK, %ld --> %pK\n",
 					__func__, audio,
 					region_elt->vaddr,
 					region_elt->len,
@@ -158,7 +158,7 @@ static phys_addr_t audio_aio_ion_fixup(struct q6audio_aio *audio, void *addr,
 
 	ret = audio_aio_ion_lookup_vaddr(audio, addr, len, &region);
 	if (ret) {
-		pr_err("%s[%p]:lookup (%p, %ld) failed\n",
+		pr_err("%s[%pK]:lookup (%pK, %ld) failed\n",
 				__func__, audio, addr, len);
 		return 0;
 	}
@@ -166,7 +166,7 @@ static phys_addr_t audio_aio_ion_fixup(struct q6audio_aio *audio, void *addr,
 		region->ref_cnt++;
 	else
 		region->ref_cnt--;
-	pr_debug("%s[%p]:found region %p ref_cnt %d\n",
+	pr_debug("%s[%pK]:found region %pK ref_cnt %d\n",
 			__func__, audio, region, region->ref_cnt);
 	paddr = region->paddr + (addr - region->vaddr);
 	/* provide kernel virtual address for accessing meta information */
@@ -179,26 +179,26 @@ static int audio_aio_pause(struct q6audio_aio  *audio)
 {
 	int rc = -EINVAL;
 
-	pr_debug("%s[%p], enabled = %d\n", __func__, audio,
+	pr_debug("%s[%pK], enabled = %d\n", __func__, audio,
 			audio->enabled);
 	if (audio->enabled) {
 		rc = q6asm_cmd(audio->ac, CMD_PAUSE);
 		if (rc < 0)
-			pr_err("%s[%p]: pause cmd failed rc=%d\n",
+			pr_err("%s[%pK]: pause cmd failed rc=%d\n",
 				__func__, audio, rc);
 
 		if (rc == 0) {
 			/* Send suspend only if pause was successful */
 			rc = q6asm_cmd(audio->ac, CMD_SUSPEND);
 			if (rc < 0)
-				pr_err("%s[%p]: suspend cmd failed rc=%d\n",
+				pr_err("%s[%pK]: suspend cmd failed rc=%d\n",
 					__func__, audio, rc);
 		} else
-			pr_err("%s[%p]: not sending suspend since pause failed\n",
+			pr_err("%s[%pK]: not sending suspend since pause failed\n",
 				__func__, audio);
 
 	} else
-		pr_err("%s[%p]: Driver not enabled\n", __func__, audio);
+		pr_err("%s[%pK]: Driver not enabled\n", __func__, audio);
 	return rc;
 }
 
@@ -212,7 +212,7 @@ static int audio_aio_flush(struct q6audio_aio  *audio)
 		if (!(audio->drv_status & ADRV_STATUS_PAUSE)) {
 			rc = audio_aio_pause(audio);
 			if (rc < 0)
-				pr_err("%s[%p}: pause cmd failed rc=%d\n",
+				pr_err("%s[%pK}: pause cmd failed rc=%d\n",
 					__func__, audio,
 					rc);
 			else
@@ -220,13 +220,13 @@ static int audio_aio_flush(struct q6audio_aio  *audio)
 		}
 		rc = q6asm_cmd(audio->ac, CMD_FLUSH);
 		if (rc < 0)
-			pr_err("%s[%p]: flush cmd failed rc=%d\n",
+			pr_err("%s[%pK]: flush cmd failed rc=%d\n",
 				__func__, audio, rc);
 		/* Not in stop state, reenable the stream */
 		if (audio->stopped == 0) {
 			rc = audio_aio_enable(audio);
 			if (rc)
-				pr_err("%s[%p]:audio re-enable failed\n",
+				pr_err("%s[%pK]:audio re-enable failed\n",
 					__func__, audio);
 			else {
 				audio->enabled = 1;
@@ -235,9 +235,9 @@ static int audio_aio_flush(struct q6audio_aio  *audio)
 			}
 		}
 	}
-	pr_debug("%s[%p]:in_bytes %d\n",
+	pr_debug("%s[%pK]:in_bytes %d\n",
 			__func__, audio, atomic_read(&audio->in_bytes));
-	pr_debug("%s[%p]:in_samples %d\n",
+	pr_debug("%s[%pK]:in_samples %d\n",
 			__func__, audio, atomic_read(&audio->in_samples));
 	atomic_set(&audio->in_bytes, 0);
 	atomic_set(&audio->in_samples, 0);
@@ -250,7 +250,7 @@ static int audio_aio_outport_flush(struct q6audio_aio *audio)
 
 	rc = q6asm_cmd(audio->ac, CMD_OUT_FLUSH);
 	if (rc < 0)
-		pr_err("%s[%p}: output port flush cmd failed rc=%d\n",
+		pr_err("%s[%pK}: output port flush cmd failed rc=%d\n",
 			__func__, audio, rc);
 	return rc;
 }
@@ -278,19 +278,19 @@ void audio_aio_async_write_ack(struct q6audio_aio *audio, uint32_t token,
 	if (token == used_buf->token) {
 		list_del(&used_buf->list);
 		spin_unlock_irqrestore(&audio->dsp_lock, flags);
-		pr_debug("%s[%p]:consumed buffer\n", __func__, audio);
+		pr_debug("%s[%pK]:consumed buffer\n", __func__, audio);
 		event_payload.aio_buf = used_buf->buf;
 		audio_aio_post_event(audio, AUDIO_EVENT_WRITE_DONE,
 					event_payload);
 		kfree(used_buf);
 		if (list_empty(&audio->out_queue) &&
 			(audio->drv_status & ADRV_STATUS_FSYNC)) {
-			pr_debug("%s[%p]: list is empty, reached EOS in Tunnel\n",
+			pr_debug("%s[%pK]: list is empty, reached EOS in Tunnel\n",
 				 __func__, audio);
 			wake_up(&audio->write_wait);
 		}
 	} else {
-		pr_err("%s[%p]:expected=%x ret=%x\n",
+		pr_err("%s[%pK]:expected=%x ret=%x\n",
 			__func__, audio, used_buf->token, token);
 		spin_unlock_irqrestore(&audio->dsp_lock, flags);
 	}
@@ -304,13 +304,13 @@ void audio_aio_async_out_flush(struct q6audio_aio *audio)
 	union msm_audio_event_payload payload;
 	unsigned long flags;
 
-	pr_debug("%s[%p}\n", __func__, audio);
+	pr_debug("%s[%pK}\n", __func__, audio);
 	/* EOS followed by flush, EOS response not guranteed, free EOS i/p
 	buffer */
 	spin_lock_irqsave(&audio->dsp_lock, flags);
 
 	if (audio->eos_flag && (audio->eos_write_payload.aio_buf.buf_addr)) {
-		pr_debug("%s[%p]: EOS followed by flush received,acknowledge"\
+		pr_debug("%s[%pK]: EOS followed by flush received,acknowledge"
 			" eos i/p buffer immediately\n", __func__, audio);
 		audio_aio_post_event(audio, AUDIO_EVENT_WRITE_DONE,
 				audio->eos_write_payload);
@@ -324,7 +324,7 @@ void audio_aio_async_out_flush(struct q6audio_aio *audio)
 		payload.aio_buf = buf_node->buf;
 		audio_aio_post_event(audio, AUDIO_EVENT_WRITE_DONE, payload);
 		kfree(buf_node);
-		pr_debug("%s[%p]: Propagate WRITE_DONE during flush\n",
+		pr_debug("%s[%pK]: Propagate WRITE_DONE during flush\n",
 				__func__, audio);
 	}
 }
@@ -335,14 +335,14 @@ void audio_aio_async_in_flush(struct q6audio_aio *audio)
 	struct list_head *ptr, *next;
 	union msm_audio_event_payload payload;
 
-	pr_debug("%s[%p]\n", __func__, audio);
+	pr_debug("%s[%pK]\n", __func__, audio);
 	list_for_each_safe(ptr, next, &audio->in_queue) {
 		buf_node = list_entry(ptr, struct audio_aio_buffer_node, list);
 		list_del(&buf_node->list);
 		/* Forcefull send o/p eos buffer after flush, if no eos response
 		 * received by dsp even after sending eos command */
 		if ((audio->eos_rsp != 1) && audio->eos_flag) {
-			pr_debug("%s[%p]: send eos on o/p buffer during flush\n",
+			pr_debug("%s[%pK]: send eos on o/p buffer during flush\n",
 				 __func__, audio);
 			payload.aio_buf = buf_node->buf;
 			payload.aio_buf.data_len =
@@ -355,7 +355,7 @@ void audio_aio_async_in_flush(struct q6audio_aio *audio)
 		}
 		audio_aio_post_event(audio, AUDIO_EVENT_READ_DONE, payload);
 		kfree(buf_node);
-		pr_debug("%s[%p]: Propagate READ_DONE during flush\n",
+		pr_debug("%s[%pK]: Propagate READ_DONE during flush\n",
 				__func__, audio);
 	}
 }
@@ -373,19 +373,19 @@ int audio_aio_disable(struct q6audio_aio *audio)
 	if (audio->opened) {
 		audio->enabled = 0;
 		audio->opened = 0;
-		pr_debug("%s[%p]: inbytes[%d] insamples[%d]\n", __func__,
+		pr_debug("%s[%pK]: inbytes[%d] insamples[%d]\n", __func__,
 			audio, atomic_read(&audio->in_bytes),
 			atomic_read(&audio->in_samples));
 		/* Close the session */
 		rc = q6asm_cmd(audio->ac, CMD_CLOSE);
 		if (rc < 0)
-			pr_err("%s[%p]:Failed to close the session rc=%d\n",
+			pr_err("%s[%pK]:Failed to close the session rc=%d\n",
 				__func__, audio, rc);
 		audio->stopped = 1;
 		wake_up(&audio->write_wait);
 		wake_up(&audio->cmd_wait);
 	}
-	pr_debug("%s[%p]:enabled[%d]\n", __func__, audio, audio->enabled);
+	pr_debug("%s[%pK]:enabled[%d]\n", __func__, audio, audio->enabled);
 	return rc;
 }
 
@@ -434,16 +434,16 @@ static void audio_aio_unmap_ion_region(struct q6audio_aio *audio)
 	struct list_head *ptr, *next;
 	int rc = -EINVAL;
 
-	pr_debug("%s[%p]:\n", __func__, audio);
+	pr_debug("%s[%pK]:\n", __func__, audio);
 	list_for_each_safe(ptr, next, &audio->ion_region_queue) {
 		region = list_entry(ptr, struct audio_aio_ion_region, list);
 		if (region != NULL) {
-			pr_debug("%s[%p]: phy_address = 0x%pa\n",
+			pr_debug("%s[%pK]: phy_address = 0x%pK\n",
 				__func__, audio, &region->paddr);
 			rc = q6asm_memory_unmap(audio->ac,
 						region->paddr, IN);
 			if (rc < 0)
-				pr_err("%s[%p]: memory unmap failed\n",
+				pr_err("%s[%pK]: memory unmap failed\n",
 					__func__, audio);
 		}
 	}
@@ -460,20 +460,20 @@ static void audio_aio_listner(u32 evt_id, union auddev_evt_data *evt_payload,
 	switch (evt_id) {
 	case AUDDEV_EVT_STREAM_VOL_CHG:
 		audio->volume = evt_payload->session_vol;
-		pr_debug("%s[%p]: AUDDEV_EVT_STREAM_VOL_CHG, stream vol %d, enabled = %d\n",
+		pr_debug("%s[%pK]: AUDDEV_EVT_STREAM_VOL_CHG, stream vol %d, enabled = %d\n",
 			__func__, audio, audio->volume, audio->enabled);
 		if (audio->enabled == 1) {
 			if (audio->ac) {
 				rc = q6asm_set_volume(audio->ac, audio->volume);
 				if (rc < 0) {
-					pr_err("%s[%p]: Send Volume command failed rc=%d\n",
+					pr_err("%s[%pK]: Send Volume command failed rc=%d\n",
 						__func__, audio, rc);
 				}
 			}
 		}
 		break;
 	default:
-		pr_err("%s[%p]:ERROR:wrong event\n", __func__, audio);
+		pr_err("%s[%pK]:ERROR:wrong event\n", __func__, audio);
 		break;
 	}
 }
@@ -490,7 +490,7 @@ int register_volume_listener(struct q6audio_aio *audio)
 					audio_aio_listner,
 					(void *)audio);
 	if (rc < 0) {
-		pr_err("%s[%p]: Event listener failed\n", __func__, audio);
+		pr_err("%s[%pK]: Event listener failed\n", __func__, audio);
 		rc = -EACCES;
 	}
 	return rc;
@@ -508,7 +508,7 @@ int enable_volume_ramp(struct q6audio_aio *audio)
 
 	if (audio->ac == NULL)
 		return -EINVAL;
-	pr_debug("%s[%p]\n", __func__, audio);
+	pr_debug("%s[%pK]\n", __func__, audio);
 	softpause.enable = SOFT_PAUSE_ENABLE;
 	softpause.period = SOFT_PAUSE_PERIOD;
 	softpause.step = SOFT_PAUSE_STEP;
@@ -568,7 +568,7 @@ int enable_volume_ramp(struct q6audio_aio *audio)
 int audio_aio_release(struct inode *inode, struct file *file)
 {
 	struct q6audio_aio *audio = file->private_data;
-	pr_debug("%s[%p]\n", __func__, audio);
+	pr_debug("%s[%pK]\n", __func__, audio);
 	mutex_lock(&audio->lock);
 	audio->wflush = 1;
 	if (audio->wakelock_voted &&
@@ -624,56 +624,56 @@ int audio_aio_fsync(struct file *file, loff_t start, loff_t end, int datasync)
 	audio->drv_status |= ADRV_STATUS_FSYNC;
 	mutex_unlock(&audio->lock);
 
-	pr_debug("%s[%p]:\n", __func__, audio);
+	pr_debug("%s[%pK]:\n", __func__, audio);
 
 	audio->eos_rsp = 0;
 
-	pr_debug("%s[%p]Wait for write done from DSP\n", __func__, audio);
+	pr_debug("%s[%pK]Wait for write done from DSP\n", __func__, audio);
 	rc = wait_event_interruptible(audio->write_wait,
 					(list_empty(&audio->out_queue)) ||
 					audio->wflush || audio->stopped);
 
 	if (audio->stopped || audio->wflush) {
-		pr_debug("%s[%p]: Audio Flushed or Stopped,this is not EOS\n"
+		pr_debug("%s[%pK]: Audio Flushed or Stopped,this is not EOS\n"
 			, __func__, audio);
 		audio->wflush = 0;
 		rc = -EBUSY;
 	}
 
 	if (rc < 0) {
-		pr_err("%s[%p]: wait event for list_empty failed, rc = %d\n",
+		pr_err("%s[%pK]: wait event for list_empty failed, rc = %d\n",
 			__func__, audio, rc);
 		goto done;
 	}
 
 	rc = q6asm_cmd(audio->ac, CMD_EOS);
-	pr_debug("%s[%p]: EOS cmd sent to DSP\n", __func__, audio);
+	pr_debug("%s[%pK]: EOS cmd sent to DSP\n", __func__, audio);
 
 	if (rc < 0)
-		pr_err("%s[%p]: q6asm_cmd failed, rc = %d",
+		pr_err("%s[%pK]: q6asm_cmd failed, rc = %d",
 			__func__, audio, rc);
 
-	pr_debug("%s[%p]: wait for RENDERED_EOS from DSP\n"
+	pr_debug("%s[%pK]: wait for RENDERED_EOS from DSP\n"
 		, __func__, audio);
 	rc = wait_event_interruptible(audio->write_wait,
 					(audio->eos_rsp || audio->wflush ||
 					audio->stopped));
 
 	if (rc < 0) {
-		pr_err("%s[%p]: wait event for eos_rsp failed, rc = %d\n",
+		pr_err("%s[%pK]: wait event for eos_rsp failed, rc = %d\n",
 			__func__, audio, rc);
 		goto done;
 	}
 
 	if (audio->stopped || audio->wflush) {
 		audio->wflush = 0;
-		pr_debug("%s[%p]: Audio Flushed or Stopped,this is not EOS\n"
+		pr_debug("%s[%pK]: Audio Flushed or Stopped,this is not EOS\n"
 			, __func__, audio);
 		rc = -EBUSY;
 	}
 
 	if (audio->eos_rsp == 1)
-		pr_debug("%s[%p]: EOS\n", __func__, audio);
+		pr_debug("%s[%pK]: EOS\n", __func__, audio);
 
 
 done:
@@ -744,21 +744,21 @@ static long audio_aio_process_event_req_common(struct q6audio_aio *audio,
 		usr_evt->event_payload = drv_evt->payload;
 		list_add_tail(&drv_evt->list, &audio->free_event_queue);
 	} else {
-		pr_err("%s[%p]:Unexpected path\n", __func__, audio);
+		pr_err("%s[%pK]:Unexpected path\n", __func__, audio);
 		spin_unlock_irqrestore(&audio->event_queue_lock, flags);
 		return -EPERM;
 	}
 	spin_unlock_irqrestore(&audio->event_queue_lock, flags);
 
 	if (drv_evt->event_type == AUDIO_EVENT_WRITE_DONE) {
-		pr_debug("%s[%p]:posted AUDIO_EVENT_WRITE_DONE to user\n",
+		pr_debug("%s[%pK]:posted AUDIO_EVENT_WRITE_DONE to user\n",
 			__func__, audio);
 		mutex_lock(&audio->write_lock);
 		audio_aio_ion_fixup(audio, drv_evt->payload.aio_buf.buf_addr,
 		drv_evt->payload.aio_buf.buf_len, 0, 0);
 		mutex_unlock(&audio->write_lock);
 	} else if (drv_evt->event_type == AUDIO_EVENT_READ_DONE) {
-		pr_debug("%s[%p]:posted AUDIO_EVENT_READ_DONE to user\n",
+		pr_debug("%s[%pK]:posted AUDIO_EVENT_READ_DONE to user\n",
 			__func__, audio);
 		mutex_lock(&audio->read_lock);
 		audio_aio_ion_fixup(audio, drv_evt->payload.aio_buf.buf_addr,
@@ -770,7 +770,7 @@ static long audio_aio_process_event_req_common(struct q6audio_aio *audio,
 	 * Once EOS indicated
 	 */
 	if (audio->eos_rsp && !list_empty(&audio->in_queue)) {
-		pr_debug("%s[%p]:Send flush command to release read buffers"\
+		pr_debug("%s[%pK]:Send flush command to release read buffers"
 			" held up in DSP\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		audio_aio_flush(audio);
@@ -913,7 +913,7 @@ static int audio_aio_ion_check(struct q6audio_aio *audio,
 	list_for_each_entry(region_elt, &audio->ion_region_queue, list) {
 		if (CONTAINS(region_elt, &t) || CONTAINS(&t, region_elt) ||
 			OVERLAPS(region_elt, &t)) {
-			pr_err("%s[%p]:region (vaddr %p len %ld) clashes with registered region (vaddr %p paddr %pa len %ld)\n",
+			pr_err("%s[%pK]:region (vaddr %pK len %ld) clashes with registered region (vaddr %pK paddr %pK len %ld)\n",
 				__func__, audio, vaddr, len,
 				region_elt->vaddr,
 				&region_elt->paddr, region_elt->len);
@@ -935,7 +935,7 @@ static int audio_aio_ion_add(struct q6audio_aio *audio,
 	unsigned long ionflag;
 	void *kvaddr = NULL;
 
-	pr_debug("%s[%p]:\n", __func__, audio);
+	pr_debug("%s[%pK]:\n", __func__, audio);
 	region = kmalloc(sizeof(*region), GFP_KERNEL);
 
 	if (!region) {
@@ -964,14 +964,14 @@ static int audio_aio_ion_add(struct q6audio_aio *audio,
 	region->kvaddr = kvaddr;
 	region->len = len;
 	region->ref_cnt = 0;
-	pr_debug("%s[%p]:add region paddr %pa vaddr %p, len %lu kvaddr %p\n",
+	pr_debug("%s[%pK]:add region paddr %pK vaddr %pK, len %lu kvaddr %pK\n",
 		__func__, audio,
 		&region->paddr, region->vaddr, region->len,
 		region->kvaddr);
 	list_add_tail(&region->list, &audio->ion_region_queue);
 	rc = q6asm_memory_map(audio->ac,  paddr, IN, len, 1);
 	if (rc < 0) {
-		pr_err("%s[%p]: memory map failed\n", __func__, audio);
+		pr_err("%s[%pK]: memory map failed\n", __func__, audio);
 		goto mmap_error;
 	} else {
 		goto end;
@@ -993,7 +993,7 @@ static int audio_aio_ion_remove(struct q6audio_aio *audio,
 	struct list_head *ptr, *next;
 	int rc = -EINVAL;
 
-	pr_debug("%s[%p]:info fd %d vaddr %p\n",
+	pr_debug("%s[%pK]:info fd %d vaddr %pK\n",
 		__func__, audio, info->fd, info->vaddr);
 
 	list_for_each_safe(ptr, next, &audio->ion_region_queue) {
@@ -1002,17 +1002,17 @@ static int audio_aio_ion_remove(struct q6audio_aio *audio,
 		if ((region->fd == info->fd) &&
 			(region->vaddr == info->vaddr)) {
 			if (region->ref_cnt) {
-				pr_debug("%s[%p]:region %p in use ref_cnt %d\n",
+				pr_debug("%s[%pK]:region %pK in use ref_cnt %d\n",
 					__func__, audio, region,
 					region->ref_cnt);
 				break;
 			}
-			pr_debug("%s[%p]:remove region fd %d vaddr %p\n",
+			pr_debug("%s[%pK]:remove region fd %d vaddr %pK\n",
 				__func__, audio, info->fd, info->vaddr);
 			rc = q6asm_memory_unmap(audio->ac,
 						region->paddr, IN);
 			if (rc < 0)
-				pr_err("%s[%p]: memory unmap failed\n",
+				pr_err("%s[%pK]: memory unmap failed\n",
 					__func__, audio);
 
 			list_del(&region->list);
@@ -1035,15 +1035,15 @@ static int audio_aio_async_write(struct q6audio_aio *audio,
 	struct audio_aio_write_param param;
 
 	if (!audio || !buf_node) {
-		pr_err("%s NULL pointer audio=[0x%p], buf_node=[0x%p]\n",
+		pr_err("%s NULL pointer audio=[0x%pK], buf_node=[0x%pK]\n",
 			__func__, audio, buf_node);
 		return -EINVAL;
 	}
-	pr_debug("%s[%p]: Send write buff %p phy %pa len %d meta_enable = %d\n",
+	pr_debug("%s[%pK]: Send write buff %pK phy %pK len %d meta_enable = %d\n",
 		__func__, audio, buf_node, &buf_node->paddr,
 		buf_node->buf.data_len,
 		audio->buf_cfg.meta_info_enable);
-	pr_debug("%s[%p]: flags = 0x%x\n", __func__, audio,
+	pr_debug("%s[%pK]: flags = 0x%x\n", __func__, audio,
 		buf_node->meta_info.meta_in.nflags);
 
 	ac = audio->ac;
@@ -1072,7 +1072,7 @@ static int audio_aio_async_write(struct q6audio_aio *audio,
 	buf_node->token = ac->session;
 	rc = q6asm_async_write(ac, &param);
 	if (rc < 0)
-		pr_err("%s[%p]:failed\n", __func__, audio);
+		pr_err("%s[%pK]:failed\n", __func__, audio);
 	return rc;
 }
 
@@ -1091,8 +1091,6 @@ void audio_aio_post_event(struct q6audio_aio *audio, int type,
 	} else {
 		e_node = kmalloc(sizeof(struct audio_aio_event), GFP_ATOMIC);
 		if (!e_node) {
-			pr_err("%s[%p]:No mem to post event %d\n",
-				__func__, audio, type);
 			spin_unlock_irqrestore(&audio->event_queue_lock, flags);
 			return;
 		}
@@ -1113,7 +1111,7 @@ static int audio_aio_async_read(struct q6audio_aio *audio,
 	struct audio_aio_read_param param;
 	int rc;
 
-	pr_debug("%s[%p]: Send read buff %p phy %pa len %d\n",
+	pr_debug("%s[%pK]: Send read buff %pK phy %pK len %d\n",
 		__func__, audio, buf_node,
 		&buf_node->paddr, buf_node->buf.buf_len);
 	ac = audio->ac;
@@ -1127,7 +1125,7 @@ static int audio_aio_async_read(struct q6audio_aio *audio,
 	buf_node->token = param.paddr;
 	rc = q6asm_async_read(ac, &param);
 	if (rc < 0)
-		pr_err("%s[%p]:failed\n", __func__, audio);
+		pr_err("%s[%pK]:failed\n", __func__, audio);
 	return rc;
 }
 
@@ -1136,7 +1134,7 @@ static int audio_aio_buf_add_shared(struct q6audio_aio *audio, u32 dir,
 {
 	unsigned long flags;
 	int ret = 0;
-	pr_debug("%s[%p]:node %p dir %x buf_addr %p buf_len %d data_len %d\n",
+	pr_debug("%s[%pK]:node %pK dir %x buf_addr %pK buf_len %d data_len %d\n",
 		 __func__, audio, buf_node, dir, buf_node->buf.buf_addr,
 		buf_node->buf.buf_len, buf_node->buf.data_len);
 	buf_node->paddr = audio_aio_ion_fixup(audio, buf_node->buf.buf_addr,
@@ -1161,7 +1159,7 @@ static int audio_aio_buf_add_shared(struct q6audio_aio *audio, u32 dir,
 		} else if (buf_node->meta_info.meta_in.nflags
 				   & AUDIO_DEC_EOS_SET) {
 			if (!audio->wflush) {
-				pr_debug("%s[%p]:Send EOS cmd at i/p\n",
+				pr_debug("%s[%pK]:Send EOS cmd at i/p\n",
 					__func__, audio);
 				/* Driver will forcefully post writedone event
 				 * once eos ack recived from DSP
@@ -1207,7 +1205,7 @@ static int audio_aio_buf_add_shared(struct q6audio_aio *audio, u32 dir,
 			event_payload.aio_buf = buf_node->buf;
 			event_payload.aio_buf.data_len =
 				insert_eos_buf(audio, buf_node);
-			pr_debug("%s[%p]: propagate READ_DONE as EOS done\n",\
+			pr_debug("%s[%pK]: propagate READ_DONE as EOS done\n",
 				__func__, audio);
 			audio_aio_post_event(audio, AUDIO_EVENT_READ_DONE,
 					event_payload);
@@ -1276,7 +1274,8 @@ void audio_aio_ioport_reset(struct q6audio_aio *audio)
 		 * abort due to flush
 		 */
 		if (audio->drv_status & ADRV_STATUS_FSYNC) {
-			pr_debug("%s[%p]:fsync in progress\n", __func__, audio);
+			pr_debug("%s[%pK]:fsync in progress\n",
+				 __func__, audio);
 			audio->drv_ops.out_flush(audio);
 		} else
 			audio->drv_ops.out_flush(audio);
@@ -1303,13 +1302,13 @@ int audio_aio_open(struct q6audio_aio *audio, struct file *file)
 
 	/* Only AIO interface */
 	if (file->f_flags & O_NONBLOCK) {
-		pr_debug("%s[%p]:set to aio interface\n", __func__, audio);
+		pr_debug("%s[%pK]:set to aio interface\n", __func__, audio);
 		audio->drv_status |= ADRV_STATUS_AIO_INTF;
 		audio->drv_ops.out_flush = audio_aio_async_out_flush;
 		audio->drv_ops.in_flush = audio_aio_async_in_flush;
 		q6asm_set_io_mode(audio->ac, ASYNC_IO_MODE);
 	} else {
-		pr_err("%s[%p]:SIO interface not supported\n",
+		pr_err("%s[%pK]:SIO interface not supported\n",
 			__func__, audio);
 		rc = -EACCES;
 		goto fail;
@@ -1341,7 +1340,7 @@ int audio_aio_open(struct q6audio_aio *audio, struct file *file)
 		if (e_node)
 			list_add_tail(&e_node->list, &audio->free_event_queue);
 		else {
-			pr_err("%s[%p]:event pkt alloc failed\n",
+			pr_err("%s[%pK]:event pkt alloc failed\n",
 				__func__, audio);
 			rc = -ENOMEM;
 			goto cleanup;
@@ -1353,7 +1352,7 @@ int audio_aio_open(struct q6audio_aio *audio, struct file *file)
 		rc = -ENOMEM;
 		goto cleanup;
 	}
-	pr_debug("Ion client create in audio_aio_open %p", audio->client);
+	pr_debug("Ion client create in audio_aio_open %pK", audio->client);
 
 	rc = register_volume_listener(audio);
 	if (rc < 0)
@@ -1387,11 +1386,11 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_OUTPORT_FLUSH: {
-		pr_debug("%s[%p]:AUDIO_OUTPORT_FLUSH\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_OUTPORT_FLUSH\n", __func__, audio);
 		mutex_lock(&audio->read_lock);
 		rc = audio_aio_outport_flush(audio);
 		if (rc < 0) {
-			pr_err("%s[%p]: AUDIO_OUTPORT_FLUSH failed\n",
+			pr_err("%s[%pK]: AUDIO_OUTPORT_FLUSH failed\n",
 				__func__, audio);
 			rc = -EINTR;
 		}
@@ -1399,13 +1398,13 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_STOP: {
-		pr_debug("%s[%p]: AUDIO_STOP session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_STOP session_id[%d]\n", __func__,
 				audio, audio->ac->session);
 		mutex_lock(&audio->lock);
 		audio->stopped = 1;
 		rc = audio_aio_flush(audio);
 		if (rc < 0) {
-			pr_err("%s[%p]:Audio Stop procedure failed rc=%d\n",
+			pr_err("%s[%pK]:Audio Stop procedure failed rc=%d\n",
 				__func__, audio, rc);
 			mutex_unlock(&audio->lock);
 			break;
@@ -1413,7 +1412,7 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		audio->enabled = 0;
 		audio->drv_status &= ~ADRV_STATUS_PAUSE;
 		if (audio->drv_status & ADRV_STATUS_FSYNC) {
-			pr_debug("%s[%p] Waking up the audio_aio_fsync\n",
+			pr_debug("%s[%pK] Waking up the audio_aio_fsync\n",
 					__func__, audio);
 			wake_up(&audio->write_wait);
 		}
@@ -1421,12 +1420,12 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_PAUSE: {
-		pr_debug("%s[%p]:AUDIO_PAUSE %ld\n", __func__, audio, arg);
+		pr_debug("%s[%pK]:AUDIO_PAUSE %ld\n", __func__, audio, arg);
 		mutex_lock(&audio->lock);
 		if (arg == 1) {
 			rc = audio_aio_pause(audio);
 			if (rc < 0) {
-				pr_err("%s[%p]: pause FAILED rc=%d\n",
+				pr_err("%s[%pK]: pause FAILED rc=%d\n",
 					__func__, audio, rc);
 				mutex_unlock(&audio->lock);
 				break;
@@ -1436,7 +1435,7 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 			if (audio->drv_status & ADRV_STATUS_PAUSE) {
 				rc = audio_aio_enable(audio);
 				if (rc)
-					pr_err("%s[%p]: audio enable failed\n",
+					pr_err("%s[%pK]: audio enable failed\n",
 					__func__, audio);
 				else {
 					audio->drv_status &= ~ADRV_STATUS_PAUSE;
@@ -1448,13 +1447,13 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_FLUSH: {
-		pr_debug("%s[%p]: AUDIO_FLUSH sessionid[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_FLUSH sessionid[%d]\n", __func__,
 			audio, audio->ac->session);
 		mutex_lock(&audio->lock);
 		audio->rflush = 1;
 		audio->wflush = 1;
 		if (audio->drv_status & ADRV_STATUS_FSYNC) {
-			pr_debug("%s[%p] Waking up the audio_aio_fsync\n",
+			pr_debug("%s[%pK] Waking up the audio_aio_fsync\n",
 				__func__, audio);
 			wake_up(&audio->write_wait);
 		}
@@ -1463,7 +1462,7 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 		/* Flush input / Output buffer in software*/
 		audio_aio_ioport_reset(audio);
 		if (rc < 0) {
-			pr_err("%s[%p]:AUDIO_FLUSH interrupted\n",
+			pr_err("%s[%pK]:AUDIO_FLUSH interrupted\n",
 				__func__, audio);
 			rc = -EINTR;
 		} else {
@@ -1493,12 +1492,12 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 	case AUDIO_PM_AWAKE: {
 		if ((audio->audio_ws_mgr ==  NULL) ||
 				(audio->miscdevice == NULL)) {
-			pr_err("%s[%p]: invalid ws_mgr or miscdevice",
+			pr_err("%s[%pK]: invalid ws_mgr or miscdevice",
 					__func__, audio);
 			rc = -EACCES;
 			break;
 		}
-		pr_debug("%s[%p]:AUDIO_PM_AWAKE\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_PM_AWAKE\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (!audio->wakelock_voted) {
 			audio->wakelock_voted = true;
@@ -1513,12 +1512,12 @@ static long audio_aio_shared_ioctl(struct file *file, unsigned int cmd,
 	case AUDIO_PM_RELAX: {
 		if ((audio->audio_ws_mgr ==  NULL) ||
 				(audio->miscdevice == NULL)) {
-			pr_err("%s[%p]: invalid ws_mgr or miscdevice",
+			pr_err("%s[%pK]: invalid ws_mgr or miscdevice",
 					__func__, audio);
 			rc = -EACCES;
 			break;
 		}
-		pr_debug("%s[%p]:AUDIO_PM_RELAX\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_PM_RELAX\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (audio->wakelock_voted) {
 			audio->wakelock_voted = false;
@@ -1577,7 +1576,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_GET_EVENT: {
-		pr_debug("%s[%p]:AUDIO_GET_EVENT\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_GET_EVENT\n", __func__, audio);
 		if (mutex_trylock(&audio->get_event_lock)) {
 			rc = audio_aio_process_event_req(audio,
 						(void __user *)arg);
@@ -1617,7 +1616,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 		memset(&cfg, 0, sizeof(cfg));
 		cfg.buffer_size = audio->str_cfg.buffer_size;
 		cfg.buffer_count = audio->str_cfg.buffer_count;
-		pr_debug("%s[%p]:GET STREAM CFG %d %d\n",
+		pr_debug("%s[%pK]:GET STREAM CFG %d %d\n",
 			__func__, audio, cfg.buffer_size, cfg.buffer_count);
 		if (copy_to_user((void *)arg, &cfg, sizeof(cfg))) {
 			pr_err(
@@ -1630,7 +1629,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 	}
 	case AUDIO_SET_STREAM_CONFIG: {
 		struct msm_audio_stream_config cfg;
-		pr_debug("%s[%p]:SET STREAM CONFIG\n", __func__, audio);
+		pr_debug("%s[%pK]:SET STREAM CONFIG\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (copy_from_user(&cfg, (void *)arg, sizeof(cfg))) {
 			pr_err(
@@ -1660,7 +1659,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 	}
 	case AUDIO_SET_CONFIG: {
 		struct msm_audio_config config;
-		pr_err("%s[%p]:AUDIO_SET_CONFIG\n", __func__, audio);
+		pr_err("%s[%pK]:AUDIO_SET_CONFIG\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (copy_from_user(&config, (void *)arg, sizeof(config))) {
 			pr_err(
@@ -1671,7 +1670,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 			break;
 		}
 		if (audio->feedback != NON_TUNNEL_MODE) {
-			pr_err("%s[%p]:Not sufficient permission to change the playback mode\n",
+			pr_err("%s[%pK]:Not sufficient permission to change the playback mode\n",
 				 __func__, audio);
 			rc = -EACCES;
 			mutex_unlock(&audio->lock);
@@ -1711,14 +1710,14 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 		}
 
 		audio->buf_cfg.meta_info_enable = cfg.meta_info_enable;
-		pr_debug("%s[%p]:session id %d: Set-buf-cfg: meta[%d]",
+		pr_debug("%s[%pK]:session id %d: Set-buf-cfg: meta[%d]",
 				__func__, audio,
 				audio->ac->session, cfg.meta_info_enable);
 		mutex_unlock(&audio->lock);
 		break;
 	}
 	case AUDIO_GET_BUF_CFG: {
-		pr_debug("%s[%p]:session id %d: Get-buf-cfg: meta[%d] framesperbuf[%d]\n",
+		pr_debug("%s[%pK]:session id %d: Get-buf-cfg: meta[%d] framesperbuf[%d]\n",
 			 __func__, audio,
 			audio->ac->session, audio->buf_cfg.meta_info_enable,
 			audio->buf_cfg.frames_per_buf);
@@ -1736,7 +1735,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 	}
 	case AUDIO_REGISTER_ION: {
 		struct msm_audio_ion_info info;
-		pr_debug("%s[%p]:AUDIO_REGISTER_ION\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_REGISTER_ION\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (copy_from_user(&info, (void *)arg, sizeof(info))) {
 			pr_err(
@@ -1752,7 +1751,7 @@ static long audio_aio_ioctl(struct file *file, unsigned int cmd,
 	case AUDIO_DEREGISTER_ION: {
 		struct msm_audio_ion_info info;
 		mutex_lock(&audio->lock);
-		pr_debug("%s[%p]:AUDIO_DEREGISTER_ION\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_DEREGISTER_ION\n", __func__, audio);
 		if (copy_from_user(&info, (void *)arg, sizeof(info))) {
 			pr_err(
 				"%s: copy_from_user for AUDIO_DEREGISTER_ION failed\n",
@@ -1868,7 +1867,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_GET_EVENT_32: {
-		pr_debug("%s[%p]:AUDIO_GET_EVENT\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_GET_EVENT\n", __func__, audio);
 		if (mutex_trylock(&audio->get_event_lock)) {
 			rc = audio_aio_process_event_req_compat(audio,
 						(void __user *)arg);
@@ -1908,7 +1907,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		memset(&cfg, 0, sizeof(cfg));
 		cfg.buffer_size = audio->str_cfg.buffer_size;
 		cfg.buffer_count = audio->str_cfg.buffer_count;
-		pr_debug("%s[%p]:GET STREAM CFG %d %d\n",
+		pr_debug("%s[%pK]:GET STREAM CFG %d %d\n",
 			__func__, audio, cfg.buffer_size, cfg.buffer_count);
 		if (copy_to_user((void *)arg, &cfg, sizeof(cfg))) {
 			pr_err("%s: copy_to_user for AUDIO_GET_STREAM_CONFIG_32 failed\n",
@@ -1921,7 +1920,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 	case AUDIO_SET_STREAM_CONFIG_32: {
 		struct msm_audio_stream_config32 cfg_32;
 		struct msm_audio_stream_config cfg;
-		pr_debug("%s[%p]:SET STREAM CONFIG\n", __func__, audio);
+		pr_debug("%s[%pK]:SET STREAM CONFIG\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (copy_from_user(&cfg_32, (void *)arg, sizeof(cfg_32))) {
 			pr_err("%s: copy_from_user for AUDIO_SET_STREAM_CONFIG_32 failed\n",
@@ -1965,13 +1964,13 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		mutex_lock(&audio->lock);
 
 		if (audio->feedback != NON_TUNNEL_MODE) {
-			pr_err("%s[%p]:Not sufficient permission to change the playback mode\n",
+			pr_err("%s[%pK]:Not sufficient permission to change the playback mode\n",
 				 __func__, audio);
 			rc = -EACCES;
 			mutex_unlock(&audio->lock);
 			break;
 		}
-		pr_err("%s[%p]:AUDIO_SET_CONFIG\n", __func__, audio);
+		pr_err("%s[%pK]:AUDIO_SET_CONFIG\n", __func__, audio);
 		if (copy_from_user(&config_32, (void *)arg,
 					sizeof(config_32))) {
 			pr_err("%s: copy_from_user for AUDIO_SET_CONFIG_32 failed\n",
@@ -2025,7 +2024,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		}
 
 		audio->buf_cfg.meta_info_enable = cfg.meta_info_enable;
-		pr_debug("%s[%p]:session id %d: Set-buf-cfg: meta[%d]",
+		pr_debug("%s[%pK]:session id %d: Set-buf-cfg: meta[%d]",
 				__func__, audio,
 				audio->ac->session, cfg.meta_info_enable);
 		mutex_unlock(&audio->lock);
@@ -2033,7 +2032,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 	}
 	case AUDIO_GET_BUF_CFG_32: {
 		struct msm_audio_buf_cfg32 cfg_32;
-		pr_debug("%s[%p]:session id %d: Get-buf-cfg: meta[%d] framesperbuf[%d]\n",
+		pr_debug("%s[%pK]:session id %d: Get-buf-cfg: meta[%d] framesperbuf[%d]\n",
 			 __func__, audio,
 			audio->ac->session, audio->buf_cfg.meta_info_enable,
 			audio->buf_cfg.frames_per_buf);
@@ -2053,7 +2052,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 	case AUDIO_REGISTER_ION_32: {
 		struct msm_audio_ion_info32 info_32;
 		struct msm_audio_ion_info info;
-		pr_debug("%s[%p]:AUDIO_REGISTER_ION\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_REGISTER_ION\n", __func__, audio);
 		mutex_lock(&audio->lock);
 		if (copy_from_user(&info_32, (void *)arg, sizeof(info_32))) {
 			pr_err("%s: copy_from_user for AUDIO_REGISTER_ION_32 failed\n",
@@ -2071,7 +2070,7 @@ static long audio_aio_compat_ioctl(struct file *file, unsigned int cmd,
 		struct msm_audio_ion_info32 info_32;
 		struct msm_audio_ion_info info;
 		mutex_lock(&audio->lock);
-		pr_debug("%s[%p]:AUDIO_DEREGISTER_ION\n", __func__, audio);
+		pr_debug("%s[%pK]:AUDIO_DEREGISTER_ION\n", __func__, audio);
 		if (copy_from_user(&info_32, (void *)arg, sizeof(info_32))) {
 			pr_err("%s: copy_from_user for	AUDIO_DEREGISTER_ION_32 failed\n",
 				__func__);

--- a/drivers/misc/qcom/qdsp6v2/audio_wma.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_wma.c
@@ -40,7 +40,7 @@ static long audio_ioctl_shared(struct file *file, unsigned int cmd,
 	case AUDIO_START: {
 		struct asm_wma_cfg wma_cfg;
 		struct msm_audio_wma_config_v2 *wma_config;
-		pr_debug("%s[%p]: AUDIO_START session_id[%d]\n", __func__,
+		pr_debug("%s[%pK]: AUDIO_START session_id[%d]\n", __func__,
 						audio, audio->ac->session);
 		if (audio->feedback == NON_TUNNEL_MODE) {
 			/* Configure PCM output block */
@@ -122,7 +122,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);
@@ -209,7 +209,7 @@ static long audio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_compat_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);

--- a/drivers/misc/qcom/qdsp6v2/audio_wmapro.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_wmapro.c
@@ -173,7 +173,7 @@ static long audio_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);
@@ -281,7 +281,7 @@ static long audio_compat_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	default: {
-		pr_debug("%s[%p]: Calling utils ioctl\n", __func__, audio);
+		pr_debug("%s[%pK]: Calling utils ioctl\n", __func__, audio);
 		rc = audio->codec_compat_ioctl(file, cmd, arg);
 		if (rc)
 			pr_err("Failed in utils_ioctl: %d\n", rc);

--- a/drivers/misc/qcom/qdsp6v2/q6audio_v2_aio.c
+++ b/drivers/misc/qcom/qdsp6v2/q6audio_v2_aio.c
@@ -54,18 +54,18 @@ void audio_aio_cb(uint32_t opcode, uint32_t token,
 
 	switch (opcode) {
 	case ASM_DATA_EVENT_WRITE_DONE_V2:
-		pr_debug("%s[%p]:ASM_DATA_EVENT_WRITE_DONE token = 0x%x\n",
+		pr_debug("%s[%pK]:ASM_DATA_EVENT_WRITE_DONE token = 0x%x\n",
 			__func__, audio, token);
 		audio_aio_async_write_ack(audio, token, payload);
 		break;
 	case ASM_DATA_EVENT_READ_DONE_V2:
-		pr_debug("%s[%p]:ASM_DATA_EVENT_READ_DONE token = 0x%x\n",
+		pr_debug("%s[%pK]:ASM_DATA_EVENT_READ_DONE token = 0x%x\n",
 			__func__, audio, token);
 		audio_aio_async_read_ack(audio, token, payload);
 		break;
 	case ASM_DATA_EVENT_RENDERED_EOS:
 		/* EOS Handle */
-		pr_debug("%s[%p]:ASM_DATA_CMDRSP_EOS\n", __func__, audio);
+		pr_debug("%s[%pK]:ASM_DATA_CMDRSP_EOS\n", __func__, audio);
 		if (audio->feedback) { /* Non-Tunnel mode */
 			audio->eos_rsp = 1;
 			/* propagate input EOS i/p buffer,
@@ -87,16 +87,16 @@ void audio_aio_cb(uint32_t opcode, uint32_t token,
 		break;
 	case ASM_DATA_CMD_MEDIA_FMT_UPDATE_V2:
 	case ASM_STREAM_CMD_SET_ENCDEC_PARAM:
-		pr_debug("%s[%p]:payload0[%x] payloa1d[%x]opcode= 0x%x\n",
+		pr_debug("%s[%pK]:payload0[%x] payloa1d[%x]opcode= 0x%x\n",
 			__func__, audio, payload[0], payload[1], opcode);
 		break;
 	case ASM_DATA_EVENT_SR_CM_CHANGE_NOTIFY:
 	case ASM_DATA_EVENT_ENC_SR_CM_CHANGE_NOTIFY:
-		pr_debug("%s[%p]: ASM_DATA_EVENT_SR_CM_CHANGE_NOTIFY, payload[0]-sr = %d, payload[1]-chl = %d, payload[2] = %d, payload[3] = %d\n",
+		pr_debug("%s[%pK]: ASM_DATA_EVENT_SR_CM_CHANGE_NOTIFY, payload[0]-sr = %d, payload[1]-chl = %d, payload[2] = %d, payload[3] = %d\n",
 					 __func__, audio, payload[0],
 					 payload[1], payload[2], payload[3]);
 
-		pr_debug("%s[%p]: ASM_DATA_EVENT_SR_CM_CHANGE_NOTIFY, sr(prev) = %d, chl(prev) = %d,",
+		pr_debug("%s[%pK]: ASM_DATA_EVENT_SR_CM_CHANGE_NOTIFY, sr(prev) = %d, chl(prev) = %d,",
 		__func__, audio, audio->pcm_cfg.sample_rate,
 		audio->pcm_cfg.channel_count);
 
@@ -130,7 +130,7 @@ void extract_meta_out_info(struct q6audio_aio *audio,
 		else
 			memset(&buf_node->meta_info.meta_in,
 			0, sizeof(struct dec_meta_in));
-		pr_debug("%s[%p]:i/p: msw_ts 0x%d lsw_ts 0x%d nflags 0x%8x\n",
+		pr_debug("%s[%pK]:i/p: msw_ts 0x%d lsw_ts 0x%d nflags 0x%8x\n",
 			__func__, audio,
 			buf_node->meta_info.meta_in.ntimestamp.highpart,
 			buf_node->meta_info.meta_in.ntimestamp.lowpart,
@@ -145,7 +145,7 @@ void extract_meta_out_info(struct q6audio_aio *audio,
 				meta_data->meta_out_dsp[0].lsw_ts;
 		meta_data->meta_out_dsp[0].lsw_ts = temp;
 
-		pr_debug("%s[%p]:o/p: msw_ts 0x%d lsw_ts 0x%d nflags 0x%8x, num_frames = %d\n",
+		pr_debug("%s[%pK]:o/p: msw_ts 0x%d lsw_ts 0x%d nflags 0x%8x, num_frames = %d\n",
 		__func__, audio,
 		((struct dec_meta_out *)buf_node->kvaddr)->\
 			meta_out_dsp[0].msw_ts,
@@ -201,7 +201,7 @@ void audio_aio_async_read_ack(struct q6audio_aio *audio, uint32_t token,
 							 = payload[9];
 			event_payload.aio_buf.data_len = payload[4]\
 				 + payload[5] + sizeof(struct dec_meta_out);
-			pr_debug("%s[%p]:nr of frames 0x%8x len=%d\n",
+			pr_debug("%s[%pK]:nr of frames 0x%8x len=%d\n",
 				__func__, audio,
 				filled_buf->meta_info.meta_out.num_of_frames,
 				event_payload.aio_buf.data_len);
@@ -213,7 +213,7 @@ void audio_aio_async_read_ack(struct q6audio_aio *audio, uint32_t token,
 					event_payload);
 		kfree(filled_buf);
 	} else {
-		pr_err("%s[%p]:expected=%x ret=%x\n",
+		pr_err("%s[%pK]:expected=%x ret=%x\n",
 			__func__, audio, filled_buf->token, token);
 		spin_unlock_irqrestore(&audio->dsp_lock, flags);
 	}

--- a/drivers/misc/qcom/qdsp6v2/ultrasound/q6usm.c
+++ b/drivers/misc/qcom/qdsp6v2/ultrasound/q6usm.c
@@ -208,7 +208,7 @@ static int q6usm_us_client_buf_free(unsigned int dir,
 
 	rc = q6usm_memory_unmap(port->phys, dir, usc->session,
 				*((uint32_t *)port->ext));
-	pr_debug("%s: data[%p]phys[%llx][%p]\n", __func__,
+	pr_debug("%s: data[%pK]phys[%llx][%pK]\n", __func__,
 		 (void *)port->data, (u64)port->phys, (void *)&port->phys);
 
 	msm_audio_ion_free(port->client, port->handle);
@@ -248,7 +248,7 @@ int q6usm_us_param_buf_free(unsigned int dir,
 
 	rc = q6usm_memory_unmap(port->param_phys, dir, usc->session,
 				*((uint32_t *)port->param_buf_mem_handle));
-	pr_debug("%s: data[%p]phys[%llx][%p]\n", __func__,
+	pr_debug("%s: data[%pK]phys[%llx][%pK]\n", __func__,
 		 (void *)port->param_buf, (u64)port->param_phys,
 		 (void *)&port->param_phys);
 
@@ -362,7 +362,7 @@ struct us_client *q6usm_us_client_alloc(
 		spin_lock_init(&usc->port[lcnt].dsp_lock);
 		usc->port[lcnt].ext = (void *)p_mem_handle++;
 		usc->port[lcnt].param_buf_mem_handle = (void *)p_mem_handle++;
-		pr_err("%s: usc->port[%d].ext=%p;\n",
+		pr_err("%s: usc->port[%d].ext=%pK;\n",
 		       __func__, lcnt, usc->port[lcnt].ext);
 	}
 	atomic_set(&usc->cmd_state, 0);
@@ -417,7 +417,7 @@ int q6usm_us_client_buf_alloc(unsigned int dir,
 
 	port->buf_cnt = bufcnt;
 	port->buf_size = bufsz;
-	pr_debug("%s: data[%p]; phys[%llx]; [%p]\n", __func__,
+	pr_debug("%s: data[%pK]; phys[%llx]; [%pK]\n", __func__,
 		 (void *)port->data,
 		 (u64)port->phys,
 		 (void *)&port->phys);
@@ -482,7 +482,7 @@ int q6usm_us_param_buf_alloc(unsigned int dir,
 	}
 
 	port->param_buf_size = bufsz;
-	pr_debug("%s: param_buf[%p]; param_phys[%llx]; [%p]\n", __func__,
+	pr_debug("%s: param_buf[%pK]; param_phys[%llx]; [%pK]\n", __func__,
 		 (void *)port->param_buf,
 		 (u64)port->param_phys,
 		 (void *)&port->param_phys);
@@ -1335,7 +1335,7 @@ int q6usm_set_us_detection(struct us_client *usc,
 	if ((usc == NULL) ||
 	    (detect_info_size == 0) ||
 	    (detect_info == NULL)) {
-		pr_err("%s: wrong input: usc=0x%p, inf_size=%d; info=0x%p",
+		pr_err("%s: wrong input: usc=0x%pK, inf_size=%d; info=0x%pK",
 		       __func__,
 		       usc,
 		       detect_info_size,

--- a/drivers/misc/qcom/qdsp6v2/ultrasound/usfcdev.c
+++ b/drivers/misc/qcom/qdsp6v2/ultrasound/usfcdev.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2013, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2013, 2016 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -170,7 +170,7 @@ static int usfcdev_connect(struct input_handler *handler, struct input_dev *dev,
 	}
 	usfc_handle->dev = dev;
 	ret = input_register_handle(usfc_handle);
-	pr_debug("%s: name=[%s]; ind=%d; dev=0x%p\n",
+	pr_debug("%s: name=[%s]; ind=%d; dev=0x%pK\n",
 		 __func__,
 		dev->name,
 		ind,
@@ -259,7 +259,7 @@ bool usfcdev_register(
 	bool rc = false;
 
 	if ((event_type_ind >= MAX_EVENT_TYPE_NUM) || !match_cb) {
-		pr_err("%s: wrong input: event_type_ind=%d; match_cb=0x%p\n",
+		pr_err("%s: wrong input: event_type_ind=%d; match_cb=0x%pK\n",
 			__func__,
 			event_type_ind,
 			match_cb);

--- a/drivers/soc/qcom/scm.c
+++ b/drivers/soc/qcom/scm.c
@@ -662,10 +662,6 @@ int scm_call2(u32 fn_id, struct scm_desc *desc)
 
 		desc->ret[0] = desc->ret[1] = desc->ret[2] = 0;
 
-		pr_debug("scm_call: func id %#llx, args: %#x, %#llx, %#llx, %#llx, %#llx\n",
-			x0, desc->arginfo, desc->args[0], desc->args[1],
-			desc->args[2], desc->x5);
-
 		trace_scm_call_start(x0, desc);
 
 		if (scm_version == SCM_ARMV8_64)
@@ -695,10 +691,8 @@ int scm_call2(u32 fn_id, struct scm_desc *desc)
 	}  while (ret == SCM_V2_EBUSY && (retry_count++ < SCM_EBUSY_MAX_RETRY));
 
 	if (ret < 0)
-		pr_err("scm_call failed: func id %#llx, arginfo: %#x, args: %#llx, %#llx, %#llx, %#llx, ret: %d, syscall returns: %#llx, %#llx, %#llx\n",
-			x0, desc->arginfo, desc->args[0], desc->args[1],
-			desc->args[2], desc->x5, ret, desc->ret[0],
-			desc->ret[1], desc->ret[2]);
+		pr_err("scm_call failed: func id %#llx, ret: %d, syscall returns: %#llx, %#llx, %#llx\n",
+			x0, ret, desc->ret[0], desc->ret[1], desc->ret[2]);
 
 	if (arglen > N_REGISTER_ARGS)
 		kfree(desc->extra_arg_buf);

--- a/drivers/staging/android/binder.c
+++ b/drivers/staging/android/binder.c
@@ -3355,7 +3355,7 @@ static void print_binder_node(struct seq_file *m, struct binder_node *node)
 
 static void print_binder_ref(struct seq_file *m, struct binder_ref *ref)
 {
-	seq_printf(m, "  ref %d: desc %d %snode %d s %d w %d d %p\n",
+	seq_printf(m, "  ref %d: desc %d %snode %d s %d w %d d %pK\n",
 		   ref->debug_id, ref->desc, ref->node->proc ? "" : "dead ",
 		   ref->node->debug_id, ref->strong, ref->weak, ref->death);
 }

--- a/drivers/staging/android/ion/ion.c
+++ b/drivers/staging/android/ion/ion.c
@@ -1201,7 +1201,7 @@ static void ion_vm_open(struct vm_area_struct *vma)
 	mutex_lock(&buffer->lock);
 	list_add(&vma_list->list, &buffer->vmas);
 	mutex_unlock(&buffer->lock);
-	pr_debug("%s: adding %p\n", __func__, vma);
+	pr_debug("%s: adding %pK\n", __func__, vma);
 }
 
 static void ion_vm_close(struct vm_area_struct *vma)
@@ -1216,7 +1216,7 @@ static void ion_vm_close(struct vm_area_struct *vma)
 			continue;
 		list_del(&vma_list->list);
 		kfree(vma_list);
-		pr_debug("%s: deleting %p\n", __func__, vma);
+		pr_debug("%s: deleting %pK\n", __func__, vma);
 		break;
 	}
 	mutex_unlock(&buffer->lock);

--- a/drivers/staging/android/ion/ion_cma_heap.c
+++ b/drivers/staging/android/ion/ion_cma_heap.c
@@ -94,7 +94,7 @@ static int ion_cma_allocate(struct ion_heap *heap, struct ion_buffer *buffer,
 
 	/* keep this for memory release */
 	buffer->priv_virt = info;
-	dev_dbg(dev, "Allocate buffer %p\n", buffer);
+	dev_dbg(dev, "Allocate buffer %pK\n", buffer);
 	return 0;
 
 err:
@@ -107,7 +107,7 @@ static void ion_cma_free(struct ion_buffer *buffer)
 	struct device *dev = buffer->heap->priv;
 	struct ion_cma_buffer_info *info = buffer->priv_virt;
 
-	dev_dbg(dev, "Release buffer %p\n", buffer);
+	dev_dbg(dev, "Release buffer %pK\n", buffer);
 	/* release memory */
 	dma_free_coherent(dev, buffer->size, info->cpu_addr, info->handle);
 	sg_free_table(info->table);
@@ -123,7 +123,7 @@ static int ion_cma_phys(struct ion_heap *heap, struct ion_buffer *buffer,
 	struct device *dev = heap->priv;
 	struct ion_cma_buffer_info *info = buffer->priv_virt;
 
-	dev_dbg(dev, "Return buffer %p physical address %pa\n", buffer,
+	dev_dbg(dev, "Return buffer %pK physical address %pa\n", buffer,
 		&info->handle);
 
 	*addr = info->handle;

--- a/drivers/staging/android/ion/ion_cma_secure_heap.c
+++ b/drivers/staging/android/ion/ion_cma_secure_heap.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) Linaro 2012
  * Author: <benjamin.gaignard@linaro.org> for ST-Ericsson.
- * Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2016, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -501,7 +501,7 @@ retry:
 
 	/* keep this for memory release */
 	buffer->priv_virt = info;
-	dev_dbg(sheap->dev, "Allocate buffer %p\n", buffer);
+	dev_dbg(sheap->dev, "Allocate buffer %pK\n", buffer);
 	return info;
 
 err:
@@ -634,7 +634,7 @@ retry:
 		sg = sg_next(sg);
 	}
 	buffer->priv_virt = info;
-	dev_dbg(sheap->dev, "Allocate buffer %p\n", buffer);
+	dev_dbg(sheap->dev, "Allocate buffer %pK\n", buffer);
 	return info;
 
 err2:
@@ -721,7 +721,7 @@ static void ion_secure_cma_free(struct ion_buffer *buffer)
 	struct ion_secure_cma_buffer_info *info = buffer->priv_virt;
 	int ret = 0;
 
-	dev_dbg(sheap->dev, "Release buffer %p\n", buffer);
+	dev_dbg(sheap->dev, "Release buffer %pK\n", buffer);
 	if (msm_secure_v2_is_supported())
 		ret = msm_unsecure_table(info->table);
 	atomic_sub(buffer->size, &sheap->total_allocated);
@@ -743,8 +743,8 @@ static int ion_secure_cma_phys(struct ion_heap *heap, struct ion_buffer *buffer,
 		container_of(heap, struct ion_cma_secure_heap, heap);
 	struct ion_secure_cma_buffer_info *info = buffer->priv_virt;
 
-	dev_dbg(sheap->dev, "Return buffer %p physical address 0x%pa\n", buffer,
-		&info->phys);
+	dev_dbg(sheap->dev, "Return buffer %pK physical address 0x%pa\n",
+		buffer, &info->phys);
 
 	*addr = info->phys;
 	*len = buffer->size;

--- a/drivers/staging/android/ion/msm/msm_ion.c
+++ b/drivers/staging/android/ion/msm/msm_ion.c
@@ -705,7 +705,7 @@ long msm_ion_custom_ioctl(struct ion_client *client,
 		} else {
 			handle = ion_import_dma_buf(client, data.flush_data.fd);
 			if (IS_ERR(handle)) {
-				pr_info("%s: Could not import handle: %p\n",
+				pr_info("%s: Could not import handle: %pK\n",
 					__func__, handle);
 				return -EINVAL;
 			}
@@ -718,7 +718,7 @@ long msm_ion_custom_ioctl(struct ion_client *client,
 			+ data.flush_data.length;
 
 		if (start && check_vaddr_bounds(start, end)) {
-			pr_err("%s: virtual address %p is out of bounds\n",
+			pr_err("%s: virtual address %pK is out of bounds\n",
 				__func__, data.flush_data.vaddr);
 			ret = -EINVAL;
 		} else {

--- a/kernel/cgroup.c
+++ b/kernel/cgroup.c
@@ -5566,7 +5566,7 @@ static int cgroup_css_links_read(struct seq_file *seq, void *v)
 		struct task_struct *task;
 		int count = 0;
 
-		seq_printf(seq, "css_set %p\n", cset);
+		seq_printf(seq, "css_set %pK\n", cset);
 
 		list_for_each_entry(task, &cset->tasks, cg_list) {
 			if (count++ > MAX_TASKS_SHOWN_PER_CSS)

--- a/net/rmnet_data/rmnet_data_vnd.c
+++ b/net/rmnet_data/rmnet_data_vnd.c
@@ -929,7 +929,7 @@ int rmnet_vnd_add_tc_flow(uint32_t id, uint32_t map_flow, uint32_t tc_flow)
 	list_add(&(itm->list), &(dev_conf->flow_head));
 	write_unlock_irqrestore(&dev_conf->flow_map_lock, flags);
 
-	LOGD("Created flow mapping [%s][0x%08X][0x%08X]@%p",
+	LOGD("Created flow mapping [%s][0x%08X][0x%08X]@%pK",
 	     dev->name, itm->map_flow_id, itm->tc_flow_id[0], itm);
 
 	return RMNET_CONFIG_OK;

--- a/sound/soc/codecs/msm8x16-wcd.c
+++ b/sound/soc/codecs/msm8x16-wcd.c
@@ -6203,7 +6203,7 @@ static int msm8x16_wcd_spmi_probe(struct spmi_device *spmi)
 	}
 
 
-	dev_dbg(&spmi->dev, "%s(%d):start addr = 0x%pa\n",
+	dev_dbg(&spmi->dev, "%s(%d):start addr = 0x%pK\n",
 		__func__, __LINE__,  &wcd_resource->start);
 
 	if (wcd_resource->start != TOMBAK_CORE_0_SPMI_ADDR)

--- a/sound/soc/codecs/wcd-mbhc-v2.c
+++ b/sound/soc/codecs/wcd-mbhc-v2.c
@@ -2349,7 +2349,7 @@ int wcd_mbhc_start(struct wcd_mbhc *mbhc,
 			schedule_delayed_work(&mbhc->mbhc_firmware_dwork,
 				      usecs_to_jiffies(FW_READ_TIMEOUT));
 		else
-			pr_err("%s: Skipping to read mbhc fw, 0x%p %p\n",
+			pr_err("%s: Skipping to read mbhc fw, 0x%pK %pK\n",
 				 __func__, mbhc->mbhc_fw, mbhc->mbhc_cal);
 	}
 	pr_debug("%s: leave %d\n", __func__, rc);

--- a/sound/soc/codecs/wcd9320.c
+++ b/sound/soc/codecs/wcd9320.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2014, 2016 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -4786,7 +4786,7 @@ static int taiko_set_channel_map(struct snd_soc_dai *dai,
 	struct taiko_priv *taiko = snd_soc_codec_get_drvdata(dai->codec);
 	struct wcd9xxx *core = dev_get_drvdata(dai->codec->dev->parent);
 	if (!tx_slot || !rx_slot) {
-		pr_err("%s: Invalid tx_slot=%p, rx_slot=%p\n", __func__,
+		pr_err("%s: Invalid tx_slot=%pK, rx_slot=%pK\n", __func__,
 			tx_slot, rx_slot);
 		return -EINVAL;
 	}

--- a/sound/soc/codecs/wcd9330.c
+++ b/sound/soc/codecs/wcd9330.c
@@ -5314,7 +5314,7 @@ static int tomtom_set_channel_map(struct snd_soc_dai *dai,
 	struct tomtom_priv *tomtom = snd_soc_codec_get_drvdata(dai->codec);
 	struct wcd9xxx *core = dev_get_drvdata(dai->codec->dev->parent);
 	if (!tx_slot || !rx_slot) {
-		pr_err("%s: Invalid tx_slot=%p, rx_slot=%p\n",
+		pr_err("%s: Invalid tx_slot=%pK, rx_slot=%pK\n",
 			__func__, tx_slot, rx_slot);
 		return -EINVAL;
 	}
@@ -5359,7 +5359,7 @@ static int tomtom_get_channel_map(struct snd_soc_dai *dai,
 	case AIF2_PB:
 	case AIF3_PB:
 		if (!rx_slot || !rx_num) {
-			pr_err("%s: Invalid rx_slot %p or rx_num %p\n",
+			pr_err("%s: Invalid rx_slot %pK or rx_num %pK\n",
 				 __func__, rx_slot, rx_num);
 			return -EINVAL;
 		}
@@ -5378,7 +5378,7 @@ static int tomtom_get_channel_map(struct snd_soc_dai *dai,
 	case AIF4_VIFEED:
 	case AIF4_MAD_TX:
 		if (!tx_slot || !tx_num) {
-			pr_err("%s: Invalid tx_slot %p or tx_num %p\n",
+			pr_err("%s: Invalid tx_slot %pK or tx_num %pK\n",
 				 __func__, tx_slot, tx_num);
 			return -EINVAL;
 		}
@@ -8068,7 +8068,7 @@ static void tomtom_compute_impedance(struct wcd9xxx_mbhc *mbhc, s16 *l, s16 *r,
 	struct tomtom_priv *tomtom;
 
 	if (!mbhc) {
-		pr_err("%s: Invalid parameters mbhc = %p\n",
+		pr_err("%s: Invalid parameters mbhc = %pK\n",
 			__func__,  mbhc);
 		return;
 	}
@@ -8127,7 +8127,7 @@ static void tomtom_zdet_error_approx(struct wcd9xxx_mbhc *mbhc, uint32_t *zl,
 	const int shift = TOMTOM_ZDET_ERROR_APPROX_SHIFT;
 
 	if (!zl || !zr || !mbhc) {
-		pr_err("%s: Invalid parameters zl = %p zr = %p, mbhc = %p\n",
+		pr_err("%s: Invalid parameters zl = %pK zr = %pK, mbhc = %pK\n",
 			__func__, zl, zr, mbhc);
 		return;
 	}
@@ -8444,7 +8444,7 @@ static int tomtom_codec_fll_enable(struct snd_soc_codec *codec,
 	struct wcd9xxx *wcd9xxx;
 
 	if (!codec || !codec->control_data) {
-		pr_err("%s: Invalid codec handle, %p\n",
+		pr_err("%s: Invalid codec handle, %pK\n",
 		       __func__, codec);
 		return -EINVAL;
 	}

--- a/sound/soc/codecs/wcd9335.c
+++ b/sound/soc/codecs/wcd9335.c
@@ -10830,7 +10830,7 @@ static int tasha_get_channel_map(struct snd_soc_dai *dai,
 #endif
 	case AIF_MIX1_PB:
 		if (!rx_slot || !rx_num) {
-			pr_err("%s: Invalid rx_slot %p or rx_num %p\n",
+			pr_err("%s: Invalid rx_slot %pK or rx_num %pK\n",
 				 __func__, rx_slot, rx_num);
 			return -EINVAL;
 		}
@@ -10849,7 +10849,7 @@ static int tasha_get_channel_map(struct snd_soc_dai *dai,
 	case AIF4_MAD_TX:
 	case AIF4_VIFEED:
 		if (!tx_slot || !tx_num) {
-			pr_err("%s: Invalid tx_slot %p or tx_num %p\n",
+			pr_err("%s: Invalid tx_slot %pK or tx_num %pK\n",
 				 __func__, tx_slot, tx_num);
 			return -EINVAL;
 		}
@@ -10887,7 +10887,7 @@ static int tasha_set_channel_map(struct snd_soc_dai *dai,
 	core = dev_get_drvdata(dai->codec->dev->parent);
 
 	if (!tx_slot || !rx_slot) {
-		pr_err("%s: Invalid tx_slot=%p, rx_slot=%p\n",
+		pr_err("%s: Invalid tx_slot=%pK, rx_slot=%pK\n",
 			__func__, tx_slot, rx_slot);
 		return -EINVAL;
 	}

--- a/sound/soc/codecs/wcd9xxx-mbhc.c
+++ b/sound/soc/codecs/wcd9xxx-mbhc.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -4700,7 +4700,7 @@ int wcd9xxx_mbhc_start(struct wcd9xxx_mbhc *mbhc,
 			schedule_delayed_work(&mbhc->mbhc_firmware_dwork,
 					     usecs_to_jiffies(FW_READ_TIMEOUT));
 		else
-			pr_debug("%s: Skipping to read mbhc fw, 0x%p %p\n",
+			pr_debug("%s: Skipping to read mbhc fw, 0x%pK %pK\n",
 				 __func__, mbhc->mbhc_fw, mbhc->mbhc_cal);
 	}
 
@@ -5098,7 +5098,7 @@ static int wcd9xxx_remeasure_z_values(struct wcd9xxx_mbhc *mbhc,
 	right = !!(r);
 
 	dev_dbg(codec->dev, "%s: Remeasuring impedance values\n", __func__);
-	dev_dbg(codec->dev, "%s: l: %p, r: %p, left=%d, right=%d\n", __func__,
+	dev_dbg(codec->dev, "%s: l: %pK, r: %pK, left=%d, right=%d\n", __func__,
 		 l, r, left, right);
 
 	/* Remeasure V2 values */

--- a/sound/soc/codecs/wcd_cpe_core.c
+++ b/sound/soc/codecs/wcd_cpe_core.c
@@ -473,7 +473,7 @@ static int wcd_cpe_load_fw(struct wcd_cpe_core *core,
 	bool load_segment;
 
 	if (!core || !core->cpe_handle) {
-		pr_err("%s: Error CPE core %p\n", __func__,
+		pr_err("%s: Error CPE core %pK\n", __func__,
 		       core);
 		return -EINVAL;
 	}

--- a/sound/soc/codecs/wsa881x.c
+++ b/sound/soc/codecs/wsa881x.c
@@ -905,7 +905,7 @@ int wsa881x_set_channel_map(struct snd_soc_codec *codec, u8 *port, u8 num_port,
 	if (!port || !ch_mask || !ch_rate ||
 		(num_port > WSA881X_MAX_SWR_PORTS)) {
 		dev_err(codec->dev,
-			"%s: Invalid port=%p, ch_mask=%p, ch_rate=%p\n",
+			"%s: Invalid port=%pK, ch_mask=%pK, ch_rate=%pK\n",
 			__func__, port, ch_mask, ch_rate);
 		return -EINVAL;
 	}

--- a/sound/soc/msm/msm-cpe-lsm.c
+++ b/sound/soc/msm/msm-cpe-lsm.c
@@ -506,7 +506,7 @@ static int msm_cpe_lab_buf_alloc(struct snd_pcm_substream *substream,
 		pcm_buf[count].mem = pcm_buf[0].mem + (count * bufsz);
 		pcm_buf[count].phys = pcm_buf[0].phys + (count * bufsz);
 		dev_dbg(rtd->dev,
-			"%s: pcm_buf[%d].mem %p pcm_buf[%d].phys %pa\n",
+			"%s: pcm_buf[%d].mem %pK pcm_buf[%d].phys %pK\n",
 			 __func__, count,
 			(void *)pcm_buf[count].mem,
 			count, &(pcm_buf[count].phys));
@@ -733,7 +733,7 @@ static int msm_cpe_lab_thread(void *data)
 			cur_buf = &lab_d->pcm_buf[buf_count % prd_cnt];
 			next_buf = &lab_d->pcm_buf[(buf_count + 2) % prd_cnt];
 			dev_dbg(rtd->dev,
-				"%s: Cur buf.mem = %p Next Buf.mem = %p\n"
+				"%s: Cur buf.mem = %pK Next Buf.mem = %pK\n"
 				" buf count = 0x%x\n", __func__,
 				cur_buf->mem, next_buf->mem, buf_count);
 		} else {
@@ -1548,7 +1548,7 @@ static int msm_cpe_lsm_lab_start(struct snd_pcm_substream *substream,
 	int rc;
 
 	if (!substream || !substream->private_data) {
-		pr_err("%s: invalid substream (%p)\n",
+		pr_err("%s: invalid substream (%pK)\n",
 			__func__, substream);
 		return -EINVAL;
 	}
@@ -1638,7 +1638,7 @@ static bool msm_cpe_lsm_is_valid_stream(struct snd_pcm_substream *substream,
 	struct wcd_cpe_lsm_ops *lsm_ops;
 
 	if (!substream || !substream->private_data) {
-		pr_err("%s: invalid substream (%p)\n",
+		pr_err("%s: invalid substream (%pK)\n",
 			func, substream);
 		return false;
 	}
@@ -2079,7 +2079,7 @@ static int msm_cpe_lsm_ioctl(struct snd_pcm_substream *substream,
 	struct wcd_cpe_lsm_ops *lsm_ops;
 
 	if (!substream || !substream->private_data) {
-		pr_err("%s: invalid substream (%p)\n",
+		pr_err("%s: invalid substream (%pK)\n",
 			__func__, substream);
 		return -EINVAL;
 	}
@@ -2351,7 +2351,7 @@ static int msm_cpe_lsm_ioctl_compat(struct snd_pcm_substream *substream,
 	struct wcd_cpe_lsm_ops *lsm_ops;
 
 	if (!substream || !substream->private_data) {
-		pr_err("%s: invalid substream (%p)\n",
+		pr_err("%s: invalid substream (%pK)\n",
 			__func__, substream);
 		return -EINVAL;
 	}
@@ -3001,7 +3001,7 @@ static int msm_cpe_lsm_copy(struct snd_pcm_substream *substream, int a,
 	if (lab_d->buf_idx >= (lsm_d->hw_params.period_count))
 		lab_d->buf_idx = 0;
 	pcm_buf = (lab_d->pcm_buf[lab_d->buf_idx].mem);
-	pr_debug("%s: Buf IDX = 0x%x pcm_buf %p\n",
+	pr_debug("%s: Buf IDX = 0x%x pcm_buf %pK\n",
 		 __func__,  lab_d->buf_idx, pcm_buf);
 	if (pcm_buf) {
 		if (copy_to_user(buf, pcm_buf, fbytes)) {


### PR DESCRIPTION
Print format %p displays the kernel address while bypassing the
kptr_restrict sysctl settings.

Change the print format for addresses from %p to %pK. If
kptr_restrict is enabled, addresses are printed as zeroes. To view
the actual addresses, disable kptr_restrict by:
echo 0 > /proc/sys/kernel/kptr_restrict