### PR TITLE
[UM.5.5.r1] drivers: soc: qcom: Remove unused variable

### DIFF
--- a/drivers/soc/qcom/cpu_pwr_ctl.c
+++ b/drivers/soc/qcom/cpu_pwr_ctl.c
@@ -58,7 +58,7 @@ struct msm_l2ccc_of_info {
 static int kick_l2spm(struct device_node *l2ccc_node,
 				struct device_node *vctl_node)
 {
-	struct resource res, acinactm_res;
+	struct resource res;
 	int val;
 	int timeout = 10, ret = 0;
 	void __iomem *l2spm_base = of_iomap(vctl_node, 0);


### PR DESCRIPTION
Fix build.

Signed-off-by: Humberto Borba <humberos@gmail.com>