### PR TITLE
[1.3.3] BT/FM implementation

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -122,26 +122,6 @@
 		status = "okay";
 	};
 
-	bluesleep {
-		compatible = "qcom,bluesleep";
-		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
-		bt_ext_wake = <&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
-		interrupt-parent = <&msm_gpio>;
-		interrupts = <17 0>;
-		interrupt-names = "host_wake";
-		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_18_def>;
-		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_18_def>;
-	};
-
-	bcm43xx {
-		compatible = "bcm,bcm43xx";
-		bcm,reg-on-gpio = <&msm_gpio 19 0x00>; /* BT_REG_ON */
-		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_19_def>;
-		pinctrl-1 = <&msm_gpio_19_def>;
-	};
-
         /*I2C : BLSP2 */
         i2c@7af6000 {
                 nfc@28 {

--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -137,22 +137,20 @@
 		compatible = "qcom,bluesleep";
 		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
 		bt_ext_wake = <&msm_gpio 27 0x00>; /* BT_DEV_WAKE */
-		bt_reg_on = <&msm_gpio 36 0x00>; /* BT_REG_ON */
 		interrupt-parent = <&msm_gpio>;
 		interrupts = <17 0>;
 		interrupt-names = "host_wake";
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_36_def &msm_gpio_17_act &msm_gpio_27_def>;
-		pinctrl-1 = <&msm_gpio_36_def &msm_gpio_17_sus &msm_gpio_27_def>;
+		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_27_def>;
+		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_27_def>;
 	};
 
 	bcm43xx {
 		compatible = "bcm,bcm43xx";
-		gpios = <&msm_gpio 36 0x00>, /* BT_REG_ON */
-			<&msm_gpio 27 0x00>; /* BT_DEV_WAKE */
+		bcm,reg-on-gpio = <&msm_gpio 36 0x00>; /* BT_REG_ON */
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_36_def &msm_gpio_27_def>;
-		pinctrl-1 = <&msm_gpio_36_def &msm_gpio_27_def>;
+		pinctrl-0 = <&msm_gpio_36_def>;
+		pinctrl-1 = <&msm_gpio_36_def>;
 	};
 
 	qcom,sensor-information {

--- a/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
@@ -18,6 +18,27 @@
  */
 
 &soc {
+
+	bluesleep {
+		compatible = "qcom,bluesleep";
+		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
+		bt_ext_wake = <&msm_gpio 18 0x00>; /* BT_DEV_WAKE */
+		interrupt-parent = <&msm_gpio>;
+		interrupts = <17 0>;
+		interrupt-names = "host_wake";
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_18_def>;
+		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_18_def>;
+	};
+
+	bcm43xx {
+		compatible = "bcm,bcm43xx";
+		bcm,reg-on-gpio = <&msm_gpio 19 0x00>; /* BT_REG_ON */
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&msm_gpio_19_def>;
+		pinctrl-1 = <&msm_gpio_19_def>;
+	};
+
 	usb_otg: usb@78db000 {
 		qcom,hsusb-otg-phy-init-seq =
 			<0x74 0x80 0x6f 0x81 0x3f 0x82 0x33 0x83 0xffffffff>;

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2582,10 +2582,6 @@
 		compatible = "qcom,msm-pcm-hostless";
 	};
 
-	bcmbt_ldisc {
-		compatible = "bcmbt_ldisc";
-	};
-
 	dai_pri_auxpcm: qcom,msm-pri-auxpcm {
 		compatible = "qcom,msm-auxpcm-dev";
 		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;

--- a/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8974pro-ab-shinano_common.dtsi
@@ -70,10 +70,6 @@
 		status = "ok";
 	};
 
-	bcmbt_ldisc {
-		compatible = "bcmbt_ldisc";
-	};
-
 	bcm43xx {
 		compatible = "bcm,bcm43xx";
 		bcm,reg-on-gpio = <&pm8941_gpios 16 0>; /* BT_REG_ON */

--- a/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8994-kitakami_common.dtsi
@@ -440,10 +440,6 @@
 		/delete-property/ qcom,android-usb-uicc-nluns;
 	};
 
-        bcmbt_ldisc {
-		compatible = "bcmbt_ldisc";
-        };
-
 	sim_detect {
 		compatible = "sim-detect";
 		interrupt-parent = <&msm_gpio>;

--- a/arch/arm/mach-msm/board-8974.c
+++ b/arch/arm/mach-msm/board-8974.c
@@ -115,6 +115,16 @@ static void __init msm8974_map_io(void)
 	msm_map_8974_io();
 }
 
+#if defined(CONFIG_MACH_SONY_SHINANO)
+static struct platform_device bcm_ldisc_device = {
+	.name = "bcm_ldisc",
+	.id = -1,
+	.dev = {
+
+	},
+};
+#endif
+
 void __init msm8974_init(void)
 {
 	struct of_dev_auxdata *adata = msm8974_auxdata_lookup;
@@ -135,6 +145,9 @@ void __init msm8974_init(void)
 	msm_8974_init_gpiomux();
 	regulator_has_full_constraints();
 	msm8974_add_drivers();
+#if defined(CONFIG_MACH_SONY_SHINANO)
+	platform_device_register(&bcm_ldisc_device);
+#endif
 }
 
 static const char *msm8974_dt_match[] __initconst = {

--- a/arch/arm64/kernel/setup.c
+++ b/arch/arm64/kernel/setup.c
@@ -570,6 +570,16 @@ void arch_setup_pdev_archdata(struct platform_device *pdev)
 int msm8994_req_tlbi_wa = 1;
 #define SOC_MAJOR_REV(val) (((val) & 0xF00) >> 8)
 
+#if defined(CONFIG_ARCH_SONY_KITAKAMI) || defined(CONFIG_ARCH_SONY_LOIRE)
+static struct platform_device bcm_ldisc_device = {
+	.name = "bcm_ldisc",
+	.id = -1,
+	.dev = {
+
+	},
+};
+#endif
+
 static int __init msm8994_check_tlbi_workaround(void)
 {
 	void __iomem *addr;
@@ -587,6 +597,9 @@ static int __init msm8994_check_tlbi_workaround(void)
 		msm8994_req_tlbi_wa = 0;
 	}
 
+#if defined(CONFIG_ARCH_SONY_KITAKAMI) || defined(CONFIG_ARCH_SONY_LOIRE)
+	platform_device_register(&bcm_ldisc_device);
+#endif
 	return 0;
 }
 arch_initcall_sync(msm8994_check_tlbi_workaround);

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -41,7 +41,7 @@
 *****************************************************************************/
 
 #ifndef N_BRCM_HCI
-#define N_BRCM_HCI      25
+#define N_BRCM_HCI      26
 #endif
 
 /* Ioctls */

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
@@ -2356,7 +2356,6 @@ static int bcmbt_ldisc_probe(struct platform_device *pdev)
     struct hci_uart *hu;
     printk("%s\n",  __func__);
     BT_LDISC_DBG(V4L2_DBG_INIT, "%s", __func__);
-    mutex_init(&cmd_credit);
 
     if ((pdev->id != -1) && (pdev->id < MAX_BRCM_DEVICES)) {
         /* multiple devices could exist */
@@ -2403,15 +2402,6 @@ static int bcmbt_ldisc_remove(struct platform_device *pdev)
 {
     struct hci_uart* hu;
     BT_LDISC_DBG(V4L2_DBG_INIT, "bcmbt_ldisc_remove() unloading ");
-    mutex_destroy(&cmd_credit);
-#if V4L2_SNOOP_ENABLE
-    if(ldisc_snoop_enable_param)
-    {
-        /* stop hci snoop to hcidump */
-        if(nl_sk_hcisnoop)
-            netlink_kernel_release(nl_sk_hcisnoop);
-    }
-#endif
     hu = dev_get_drvdata(&pdev->dev);
     sysfs_remove_group(&pdev->dev.kobj, &uim_attr_grp);
     brcm_hci_uart_exit(hu);
@@ -2419,11 +2409,6 @@ static int bcmbt_ldisc_remove(struct platform_device *pdev)
     hu  = NULL;
     return 0;
 }
-
-static const struct of_device_id bcmbt_ldisc_dt_ids[] = {
-    { .compatible = "bcmbt_ldisc"},
-    {}
-};
 
 /* Sys_fs entry bcm_ldisc. The Line discipline driver sets this to 1 when bluedroid performs open on BT
   * protocol driver or application performs open on FM v4l2 driver */
@@ -2435,11 +2420,33 @@ static struct platform_driver bcmbt_ldisc_platform_driver = {
     .driver = {
            .name = "bcm_ldisc",
            .owner = THIS_MODULE,
-           .of_match_table = bcmbt_ldisc_dt_ids,
            },
 };
 
-module_platform_driver(bcmbt_ldisc_platform_driver);
+static int __init bcmbt_ldisc_init(void)
+{
+    platform_driver_register(&bcmbt_ldisc_platform_driver);
+    mutex_init(&cmd_credit);
+    return 0;
+}
+
+static void __exit bcmbt_ldisc_exit(void)
+{
+    platform_driver_unregister(&bcmbt_ldisc_platform_driver);
+    mutex_destroy(&cmd_credit);
+
+#if V4L2_SNOOP_ENABLE
+    if(ldisc_snoop_enable_param)
+    {
+        /* stop hci snoop to hcidump */
+        if(nl_sk_hcisnoop)
+            netlink_kernel_release(nl_sk_hcisnoop);
+    }
+#endif
+}
+
+module_init(bcmbt_ldisc_init);
+module_exit(bcmbt_ldisc_exit);
 
 
 /*****************************************************************************


### PR DESCRIPTION
1. Implements a generic way for ldisc driver.
2. Bring back the ldisc port value from 25 to 26.