### PR TITLE
[LA.UM.5.5.r1] CVE-2016-3868 - msm-core: debug: Fix the number of arguments for sysfs nodes

### DIFF
--- a/drivers/power/qcom/debug_core.c
+++ b/drivers/power/qcom/debug_core.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -22,6 +22,8 @@
 #include "soc/qcom/msm-core.h"
 
 #define MAX_PSTATES 50
+#define NUM_OF_PENTRY 3 /* number of variables for ptable node */
+#define NUM_OF_EENTRY 2 /* number of variables for enable node */
 
 enum arg_offset {
 	CPU_OFFSET,
@@ -146,7 +148,9 @@ static int split_ptable_args(char *line, unsigned int *arg, uint32_t n)
 	int i;
 	int ret = 0;
 
-	for (i = 0; line; i++) {
+	for (i = 0; i < n; i++) {
+		if (!line)
+			break;
 		args = strsep(&line, " ");
 		ret = kstrtouint(args, 10, &arg[i]);
 		if (ret)
@@ -174,7 +178,7 @@ static ssize_t msm_core_ptable_write(struct file *file,
 		goto done;
 	}
 	kbuf[len] = '\0';
-	ret = split_ptable_args(kbuf, arg);
+	ret = split_ptable_args(kbuf, arg, NUM_OF_PENTRY);
 	if (!ret) {
 		add_to_ptable(arg);
 		ret = len;
@@ -238,7 +242,7 @@ static ssize_t msm_core_enable_write(struct file *file,
 		goto done;
 	}
 	kbuf[len] = '\0';
-	ret = split_ptable_args(kbuf, arg);
+	ret = split_ptable_args(kbuf, arg, NUM_OF_EENTRY);
 	if (ret)
 		goto done;
 	cpu = arg[CPU_OFFSET];


### PR DESCRIPTION
Ptable and enable node parses the input arguments incorrectly. Parse the
input message into exact number of arguments that are required for the
respective nodes.

CRs-fixed: 1032875
Change-Id: I881f18217b703a497efa4799288dee39a28ea8ab
Signed-off-by: Archana Sathyakumar <asathyak@codeaurora.org>