### PR TITLE
[UM.5.5.r1] drivers: bluetooth: brcm: Fix reinit_completion call

### DIFF
--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -152,7 +152,7 @@ struct hci_uart {
     unsigned char    protos_registered;
     spinlock_t lock;
 
-    struct completion cmd_rcvd, *ldisc_installed, ldisc_patchram_complete,
+    struct completion cmd_rcvd, ldisc_installed, ldisc_patchram_complete,
                 uim_baudrate_set_complete;
     char resp_buffer[30];
     struct platform_device *brcm_pdev;
@@ -170,7 +170,7 @@ struct hci_uart {
     spinlock_t hcisnoop_lock;
     spinlock_t hcisnoop_write_lock;
 #endif
-    struct completion *tty_close_complete;
+    struct completion tty_close_complete;
 };
 
 typedef struct {

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
@@ -1692,7 +1692,7 @@ long brcm_sh_ldisc_stop(struct hci_uart *hu)
 {
     long err = 0;
 
-    reinit_completion(hu->ldisc_installed);
+    reinit_completion(&hu->ldisc_installed);
 
     brcm_btsleep_stop(sleep);
     hu->ldisc_install = V4L2_STATUS_OFF;
@@ -1729,7 +1729,7 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
 
     do {
         brcm_btsleep_start(sleep);
-        reinit_completion(hu->ldisc_installed);
+        reinit_completion(&hu->ldisc_installed);
         /* send notification to UIM */
         hu->ldisc_install = V4L2_STATUS_ON;
         BT_LDISC_DBG(V4L2_DBG_INIT, "ldisc_install = %c",\
@@ -1742,7 +1742,7 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
                 msecs_to_jiffies(LDISC_TIME));
         if (!err) { /* timeout */
             pr_err("line disc installation timed out ");
-            reinit_completion(hu->tty_close_complete);
+            reinit_completion(&hu->tty_close_complete);
             err = brcm_sh_ldisc_stop(hu);
             cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
                     msecs_to_jiffies(TTY_CLOSE_TIME));
@@ -1757,7 +1757,7 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
             err = download_patchram(hu);
             if (err != 0) {
                 pr_err("patchram download failed");
-                reinit_completion(hu->tty_close_complete);
+                reinit_completion(&hu->tty_close_complete);
                 brcm_sh_ldisc_stop(hu);
                 cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
                         msecs_to_jiffies(TTY_CLOSE_TIME));


### PR DESCRIPTION
Preserve the header and change only the new implementation
of INIT_COMPLETION@3.10 which now is reinit_completion@3.18.

Signed-off-by: Humberto Borba <humberos@gmail.com>