### PR TITLE
[UM.5.5.r1] drivers: bluetooth: Add missed rfkill build

### DIFF
--- a/drivers/bluetooth/Makefile
+++ b/drivers/bluetooth/Makefile
@@ -20,6 +20,7 @@ obj-$(CONFIG_BT_MRVL)		+= btmrvl.o
 obj-$(CONFIG_BT_MRVL_SDIO)	+= btmrvl_sdio.o
 obj-$(CONFIG_BT_WILINK)		+= btwilink.o
 obj-$(CONFIG_MSM_BT_POWER)	+= bluetooth-power.o
+obj-$(CONFIG_BT_BCM43XX)	+= bcm43xx.o
 obj-$(CONFIG_BT_MSM_SLEEP)	+= msm_bt_sleep.o
 msm_bt_sleep-objs		:= bluesleep.o
 


### PR DESCRIPTION
Welcome back bluetooth!

Signed-off-by: Humberto Borba <humberos@gmail.com>