### PR TITLE
[UM.5.5.r1] [DO NOT MERGE] arm64: DT: msm8956/76 Update wcd9335 sound DT entries

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -476,7 +476,7 @@
 
 		tasha_codec {
 			swr_master {
-				wsa881x@20170212 {
+				wsa881x_212: wsa881x@20170212 {
 					qcom,spkr-sd-n-gpio = <&msm_gpio 101 0>;
 				};
 			};

--- a/arch/arm/boot/dts/qcom/msm8956-loire_pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire_pinctrl.dtsi
@@ -1559,6 +1559,19 @@
 
 	/delete-node/ pri-tlmm-lines;
 
+	wsa_spkr_sd: spkr_lines {
+		mux {
+			pins = "gpio132", "gpio101";
+			function = "gpio";
+		};
+		config {
+			pins = "gpio132";
+			drive-strength = <2>;
+			output-high;
+			bias-pull-down;
+		};
+	};
+
 	wsa_spkr_sd_act: spkr_lines_on {
 		mux {
 			pins = "gpio132", "gpio101";

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2323,7 +2323,7 @@
 		qcom,wsa-max-devs = <2>;
 		qcom,wsa-devs = <&wsa881x_211>, <&wsa881x_212>,
 				<&wsa881x_213>, <&wsa881x_214>;
-		qcom,aux-codec-prefix = "SpkrLeft", "SpkrRight",
+		qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrRight",
 					"SpkrLeft", "SpkrRight";
 	};
 

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -2334,10 +2334,10 @@
 				"msm-dai-q6-dev.12292", "msm-dai-q6-dev.12293";
 		asoc-codec = <&stub_codec>;
 		asoc-codec-names = "msm-stub-codec.1";
-		qcom,max-aux-codec = <2>;
-		qcom,aux-codec = "wsa881x.20170211", "wsa881x.20170212",
-				 "wsa881x.21170213", "wsa881x.21170214";
-		qcom,aux-codec-prefix = "SpkrLeft", "SpkrRight",
+		qcom,wsa-max-devs = <2>;
+		qcom,wsa-devs = <&wsa881x_211>, <&wsa881x_212>,
+				<&wsa881x_213>, <&wsa881x_214>;
+		qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrRight",
 					"SpkrLeft", "SpkrRight";
 	};
 
@@ -2346,8 +2346,7 @@
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&msm_gpio>;
-		interrupts = <120 0>;
-		interrupt-names = "cdc-int";
+		qcom,gpio-connect = <&msm_gpio 120 0>;
 	};
 
 	wcd_rst_gpio: wcd_gpio_ctrl {


### PR DESCRIPTION
Driver probe is ok!
[    5.524285] tasha_codec tasha_codec: tasha_probe: Tasha driver probe done

Although sound driver is probing but it still broken at 3.18

[    5.533845] msm8952-slimbus-wcd c051000.sound-9335: msm8952_init_wsa_dev: found 2 wsa881x devices registered with ALSA core
[    5.534232] msm8952-slimbus-wcd c051000.sound-9335: ASoC: CPU DAI msm-dai-q6-dev.16396 not registered
[    5.534259] msm8952-slimbus-wcd c051000.sound-9335: snd_soc_register_card failed (-517)
[    5.535620] swr-wcd tasha_swr_ctrl: swrm_get_logical_dev_num: device id 0x0 does not match with 0x21170213
[    5.535627] swr_get_logical_dev_num: Error -22 to get logical addr for device 21170213
[    5.541491] swr-wcd tasha_swr_ctrl: swrm_get_logical_dev_num: device id 0x0 does not match with 0x21170214
[    5.541498] swr_get_logical_dev_num: Error -22 to get logical addr for device 21170214
[    5.546794] msm8952-slimbus-wcd c051000.sound-9335: msm8952_init_wsa_dev: found 2 wsa881x devices registered with ALSA core
[    5.547160] msm8952-slimbus-wcd c051000.sound-9335: ASoC: CPU DAI msm-dai-q6-dev.16396 not registered
[    5.547187] msm8952-slimbus-wcd c051000.sound-9335: snd_soc_register_card failed (-517)
