### PR TITLE
Fix FM Audio path for Shinano

### DIFF
--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_config.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_config.h
@@ -46,9 +46,11 @@
 
 /* Set default Audio path */
 #ifndef DEF_V4L2_FM_AUDIO_PATH
+#ifndef CONFIG_MACH_SONY_SHINANO
 #define DEF_V4L2_FM_AUDIO_PATH FM_AUDIO_I2S
 #else
 #define DEF_V4L2_FM_AUDIO_PATH FM_AUDIO_DAC
+#endif
 #endif
 
 /*Make this TRUE if FM I2S audio to be routed over */


### PR DESCRIPTION
 Shinano FM Radio sound only works if FM-Audio path is FM_AUDIO_DAC