### PR TITLE
[UM.5.5.r1] drivers: bluetooth: brcm: Fix v4l2 device creation

### DIFF
--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
@@ -33,6 +33,7 @@
 #include <linux/timer.h>
 #include <linux/version.h>
 #include <linux/videodev2.h>
+#include <media/v4l2-device.h>
 
 /*******************************************************************************
 **  Constants & Macros
@@ -213,6 +214,7 @@ struct fm_device_info {
 /* FM driver operation structure */
 struct fmdrv_ops {
     struct video_device *radio_dev;   /* V4L2 video device pointer */
+    struct v4l2_device v4l2_dev;      /* V4L2 top level struct */
     spinlock_t resp_skb_lock;         /* To protect access to received SKB */
     spinlock_t rds_cbuff_lock;        /* To protect access to RDS Circular buffer */
 


### PR DESCRIPTION
Welcome back /dev/radio0

Add v4l2 device creation before video register.
This implementation is required at 3.18 kernel

Fix:
[    1.232089] (fmdrv): FM driver version 1.01
[    1.232097] ------------[ cut here ]------------
[    1.232109] WARNING: CPU: 5 PID: 1 at ../../../../../../../../../home/humberos/android/aosp-7.1.1/kernel/sony/msm/drivers/media/v4l2-core/v4l2-dev.c:802 __video_register_device+0x64/0xe54()
[    1.232114] Modules linked in:
[    1.232123] CPU: 5 PID: 1 Comm: swapper/0 Not tainted 3.18.31-g35e1a03-dirty #7
[    1.232128] Hardware name: SoMC Suzu-ROW (DT)
[    1.232133] Call trace:
[    1.232141] [<ffffffc000089814>] dump_backtrace+0x0/0x248
[    1.232147] [<ffffffc000089a70>] show_stack+0x14/0x1c
[    1.232154] [<ffffffc000ca78d4>] dump_stack+0x80/0xa4
[    1.232161] [<ffffffc0000a26a0>] warn_slowpath_common+0x8c/0xb0
[    1.232166] [<ffffffc0000a278c>] warn_slowpath_null+0x18/0x20
[    1.232172] [<ffffffc0007225fc>] __video_register_device+0x64/0xe54
[    1.232178] [<ffffffc00082059c>] fm_v4l2_init_video_device+0x7c/0xec
[    1.232183] [<ffffffc001403a40>] fm_drv_init+0xe4/0x198
[    1.232189] [<ffffffc0000829d4>] do_one_initcall+0x10c/0x19c
[    1.232195] [<ffffffc0013c5b10>] kernel_init_freeable+0x1c4/0x260
[    1.232200] [<ffffffc000ca1db8>] kernel_init+0x14/0xd8
[    1.232220] ---[ end trace 0888f93d3e6f350d ]---

Signed-off-by: Humberto Borba <humberos@gmail.com>