### PR TITLE
[UM.5.5.r1] ASoC: msm8952: Fix loire sound

### DIFF
--- a/sound/soc/msm/msm8952-dai-links.c
+++ b/sound/soc/msm/msm8952-dai-links.c
@@ -24,6 +24,7 @@
 enum TASHA_LITE_DEVICE {
 	MSM8952_TASHA_LITE = 0,
 	MSM8953_TASHA_LITE,
+	MSM8976_TASHA_LITE,
 	NUM_OF_TASHA_LITE_DEVICE,
 };
 
@@ -315,6 +316,7 @@ static struct snd_soc_dai_link msm8952_tasha_be_dai[] = {
 		.ops = &msm8952_slimbus_be_ops,
 		.ignore_suspend = 1,
 	},
+#ifndef CONFIG_ARCH_SONY_LOIRE
 	{
 		.name = LPASS_BE_SLIMBUS_6_RX,
 		.stream_name = "Slimbus6 Playback",
@@ -331,6 +333,7 @@ static struct snd_soc_dai_link msm8952_tasha_be_dai[] = {
 		.ignore_pmdown_time = 1,
 		.ignore_suspend = 1,
 	},
+#endif
 };
 
 static struct snd_soc_dai_link msm8952_tomtom_fe_dai[] = {
@@ -1573,7 +1576,8 @@ struct snd_soc_card *populate_snd_card_dailinks(struct device *dev)
 	enum codec_variant codec_ver = 0;
 	const char *tasha_lite[NUM_OF_TASHA_LITE_DEVICE] = {
 		"msm8952-tashalite-snd-card",
-		"msm8953-tashalite-snd-card"
+		"msm8953-tashalite-snd-card",
+		"msm8976-tashalite-snd-card"
 	};
 
 	card->dev = dev;
@@ -1607,6 +1611,8 @@ struct snd_soc_card *populate_snd_card_dailinks(struct device *dev)
 				card->name = tasha_lite[MSM8952_TASHA_LITE];
 			else if (!strcmp(card->name, "msm8953-tasha-snd-card"))
 				card->name = tasha_lite[MSM8953_TASHA_LITE];
+			else if (!strcmp(card->name, "msm8976-tasha-snd-card"))
+				card->name = tasha_lite[MSM8976_TASHA_LITE];
 		}
 
 		len1 = ARRAY_SIZE(msm8952_common_fe_dai);

--- a/sound/soc/msm/msm8952-slimbus.c
+++ b/sound/soc/msm/msm8952-slimbus.c
@@ -2350,6 +2350,19 @@ static int msm8952_codec_event_cb(struct snd_soc_codec *codec,
 	}
 }
 
+static int msm8976_tasha_codec_event_cb(struct snd_soc_codec *codec,
+					enum wcd9335_codec_event codec_event)
+{
+	switch (codec_event) {
+	case WCD9335_CODEC_EVENT_CODEC_UP:
+		return msm8952_wcd93xx_codec_up(codec);
+	default:
+		pr_err("%s: UnSupported codec event %d\n",
+			__func__, codec_event);
+		return -EINVAL;
+	}
+}
+
 int msm_audrx_init(struct snd_soc_pcm_runtime *rtd)
 {
 	int err;
@@ -2549,6 +2562,8 @@ int msm_audrx_init(struct snd_soc_pcm_runtime *rtd)
 
 	if (!strcmp(dev_name(codec_dai->dev), "tomtom_codec"))
 		tomtom_event_register(msm8952_codec_event_cb, rtd->codec);
+	else if (!strcmp(dev_name(codec_dai->dev), "tasha_codec"))
+		tasha_event_register(msm8976_tasha_codec_event_cb, rtd->codec);
 
 	codec_reg_done = true;
 


### PR DESCRIPTION
Add missed 8976 tasha card config/codecs and remove
msm-dai-q6-dev.16396 dai link.

Signed-off-by: Humberto Borba <humberos@gmail.com>