### PR TITLE
binder: prevent kptr leak by using %pK format specifier

### DIFF
--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -3429,7 +3429,7 @@ static void print_binder_node(struct seq_file *m, struct binder_node *node)
 
 static void print_binder_ref(struct seq_file *m, struct binder_ref *ref)
 {
-	seq_printf(m, "  ref %d: desc %d %snode %d s %d w %d d %p\n",
+	seq_printf(m, "  ref %d: desc %d %snode %d s %d w %d d %pK\n",
 		   ref->debug_id, ref->desc, ref->node->proc ? "" : "dead ",
 		   ref->node->debug_id, ref->strong, ref->weak, ref->death);
 }


### PR DESCRIPTION
Works in conjunction with kptr_restrict.
Bug: 30143283
Change-Id: I2b3ce22f4e206e74614d51453a1d59b7080ab05a
Git-repo: https://android.googlesource.com/kernel/msm.git
Git-commit: b884cbf06200b18e660514a30293931a61126ef5
Signed-off-by: Dennis Cagle <d-cagle@codeaurora.org>
Signed-off-by: Pradosh Das <prados@codeaurora.org>