### PR TITLE
clk: qcom: clock-gcc-8976: Add BCR reg for block reset of USB

### DIFF
--- a/drivers/clk/qcom/clock-gcc-8976.c
+++ b/drivers/clk/qcom/clock-gcc-8976.c
@@ -2761,6 +2761,7 @@ static struct branch_clk gcc_usb_fs_ic_clk = {
 
 static struct branch_clk gcc_usb_fs_system_clk = {
 	.cbcr_reg = USB_FS_SYSTEM_CBCR,
+	.bcr_reg  = USB_FS_BCR,
 	.has_sibling = 0,
 	.base = &virt_bases[GCC_BASE],
 	.c = {


### PR DESCRIPTION
BCR register is required to reset FSUSB controller. So, add support
for the same.

Change-Id: Ibbf71adc97fcd22ddc5dd7e2f4618074c9e0a0af
Signed-off-by: Vijayavardhan Vennapusa <vvreddy@codeaurora.org>