### PR TITLE
[LA.UM.5.5.r1] drivers: soc: loire: Fix boot process

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -929,7 +929,7 @@
 
 &pm8950_vadc {
 	chan@13 { /* case_therm */
-		qcom,scale-function = <15>; /* 100K_PULLUP_DECI */
+		qcom,scale-function = <17>; /* 100K_PULLUP_DECI */
 	};
 };
 
@@ -940,7 +940,7 @@
 		qcom,decimation = <0>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <15>; /* 100K_PULLUP_DECI */
+		qcom,scale-function = <17>; /* 100K_PULLUP_DECI */
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2214,6 +2214,7 @@
 		/* GPIO output to mss */
 		qcom,gpio-force-stop = <&smp2pgpio_ssr_smp2p_1_out 0 0>;
 		memory-region = <&modem_mem>;
+		qcom,mem-protect-id = <0xF>;
 	};
 
 	cpu-pmu {


### PR DESCRIPTION
Add missed DT entry and #ifdef soc driver to match with DT