### PR TITLE
msm: dma_test: Initialize newly allocated memory

### DIFF
--- a/arch/arm/mach-msm/dma_test.c
+++ b/arch/arm/mach-msm/dma_test.c
@@ -99,7 +99,7 @@ static int buffer_req(struct msm_dma_alloc_req *req)
 	if (i >= MAX_TEST_BUFFERS)
 		goto error;
 
-	buffers[i] = kmalloc(req->size, GFP_KERNEL | __GFP_DMA);
+	buffers[i] = kzalloc(req->size, GFP_KERNEL | __GFP_DMA);
 	if (buffers[i] == 0)
 		goto error;
 	sizes[i] = req->size;

--- a/arch/arm64/mm/dma-mapping.c
+++ b/arch/arm64/mm/dma-mapping.c
@@ -88,6 +88,7 @@ static void *__alloc_from_pool(size_t size, struct page **ret_page)
 	if (pageno < pool->nr_pages) {
 		bitmap_set(pool->bitmap, pageno, count);
 		ptr = pool->vaddr + PAGE_SIZE * pageno;
+		memset(ptr, 0, size);
 		*ret_page = pool->pages[pageno];
 	} else {
 		pr_err_once("ERROR: %u KiB atomic DMA coherent pool is too small!\n"
@@ -208,6 +209,7 @@ static void *arm64_swiotlb_alloc_coherent(struct device *dev, size_t size,
 
 		page = pfn_to_page(pfn);
 		addr = page_address(page);
+		memset(addr, 0, size);
 
 		if (dma_get_attr(DMA_ATTR_NO_KERNEL_MAPPING, attrs) ||
 		    dma_get_attr(DMA_ATTR_STRONGLY_ORDERED, attrs)) {


### PR DESCRIPTION
The MSM_DMA_IOALLOC ioctl command allocates kernel memory and
this memory can be read back using the MSM_DMA_IORBUF ioctl command.
This memory is not zero-initialized and may contain sensitive data.

Change-Id: I8c55d6fe500e7607690b89806715893783eecf9c
Signed-off-by: Srinivasarao P <spathi@codeaurora.org>