### PR TITLE
[LA.UM.5.5.r1] ARM: dts: msm8956: Add large-address-bus to sdhci-msm

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -916,6 +916,7 @@
 		interrupts = <0 123 0>, <0 138 0>;
 		interrupt-names = "hc_irq", "pwr_irq";
 
+		qcom,large-address-bus;
 		qcom,bus-width = <8>;
 
 		qcom,cpu-dma-latency-us = <60 340 900>;
@@ -960,6 +961,7 @@
 		interrupts = <0 125 0>, <0 221 0>;
 		interrupt-names = "hc_irq", "pwr_irq";
 
+		qcom,large-address-bus;
 		qcom,bus-width = <4>;
 
 		qcom,cpu-dma-latency-us = <701>;


### PR DESCRIPTION
Mask 64-bit support for controller with 32-bit address bus so that
smaller descriptor size will be used and improve memory consumption.

Signed-off-by: Humberto Borba <humberos@gmail.com>