### PR TITLE
[LA.UM.5.5.r1] ARM: dts: msm: Add hyp log to tz log driver for msm8956

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1511,6 +1511,9 @@
 	qcom_tzlog: tz-log@08600720 {
 		compatible = "qcom,tz-log";
 		reg = <0x08600720 0x2000>;
+		qcom,hyplog-enabled;
+		hyplog-address-offset = <0x410>; /* 0x066BFB30 */
+		hyplog-size-offset = <0x414>;    /* 0x066BFB34 */
 	};
 
 	qcom_crypto: qcrypto@720000 {


### PR DESCRIPTION
Add hypervisor log device tree parameters to tz-log driver
to enable hypervisor log service.

Signed-off-by: Humberto Borba <humberos@gmail.com>