### PR TITLE
[LA.UM.5.5.r1] ARM: dts: msm8956: Limit qseecom reserved memory to 32-bit

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -96,6 +96,7 @@
 
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
 			reusable;
 			alignment = <0 0x400000>;
 			size = <0 0x1000000>;


### PR DESCRIPTION
Qseecom reserved memory needs to be in the 32-bit addressable range.
Use the alloc-ranges property to provide the limits.

Signed-off-by: Humberto Borba <humberos@gmail.com>