### PR TITLE
ARM: dts: tone: Fix bluetooth

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -117,8 +117,8 @@
 		compatible = "bcm,bcm43xx";
 		bcm,reg-on-gpio = <&tlmm 83 0x00>; /* BT_REG_ON */
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_83 &msm_gpio_81>;
-		pinctrl-1 = <&msm_gpio_83 &msm_gpio_81>;
+		pinctrl-0 = <&msm_gpio_83>;
+		pinctrl-1 = <&msm_gpio_83>;
 	};
 
 	/* UART: BLSP3 : NC */


### PR DESCRIPTION
Use only one pinctrl (REG_ON) for rfkill.

Signed-off-by: Humberto Borba <humberos@gmail.com>