### PR TITLE
sdcardfs: fix external storage exporting incorrect uid

### DIFF
--- a/fs/sdcardfs/main.c
+++ b/fs/sdcardfs/main.c
@@ -274,7 +274,7 @@ static int sdcardfs_read_super(struct super_block *sb, const char *dev_name,
 					sb_info->options.fs_low_uid,
 					sb_info->options.fs_low_gid, 00755);*/
 	} else {
-		setup_derived_state(sb->s_root->d_inode, PERM_ROOT, sb_info->options.fs_low_uid, AID_ROOT, false);
+		setup_derived_state(sb->s_root->d_inode, PERM_ROOT, sb_info->options.fs_user_id, AID_ROOT, false);
 		snprintf(sb_info->obbpath_s, PATH_MAX, "%s/Android/obb", dev_name);
 	}
 	fix_derived_permission(sb->s_root->d_inode);


### PR DESCRIPTION
Symptom: App cannot write into per-app folder
Root Cause: sdcardfs exports incorrect uid
Solution: fix uid
Project: All
Note:
Test done by RD: passed

Change-Id: Iff64f6f40ba4c679f07f4426d3db6e6d0db7e3ca