### PR TITLE
arm64: Kconfig: Increase UI responsiveness

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -595,6 +595,7 @@ config SWP_EMULATE
 
 config HZ
 	int
+	default 300 if ARCH_MSM8916 || ARCH_MSM8994
 	default 100
 
 config ARCH_HAS_HOLES_MEMORYMODEL


### PR DESCRIPTION
following angler see:
                 https://android.googlesource.com/kernel/msm/+/521ae588c433b7b50b868eb61858d62fd6022998
                 https://android.googlesource.com/kernel/msm/+/9837c5a44098ccdcca58707c16cf39be1f2fbdb1

set 300HZ for ARCH_MSM8916 (tulip - suzu - kugo) and ARCH_MSM8994 (kitakami)

Signed-off-by: David Viteri <davidteri91@gmail.com>