### PR TITLE
Fixup Deep Sleep in combination with bluesleep.

### DIFF
--- a/drivers/bluetooth/bcm43xx.c
+++ b/drivers/bluetooth/bcm43xx.c
@@ -27,6 +27,9 @@
 #include <linux/platform_device.h>
 #include <linux/rfkill.h>
 #include <linux/slab.h>
+#ifdef CONFIG_BT_MSM_SLEEP
+#include <net/bluetooth/bluesleep.h>
+#endif
 
 #define D_BCM_BLUETOOTH_CONFIG_MATCH_TABLE   "bcm,bcm43xx"
 
@@ -60,6 +63,10 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 			return 0;
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 1);
+
+#ifdef CONFIG_BT_MSM_SLEEP
+		bluesleep_start(1);
+#endif
 	} else {
 		if (!regOnGpio) {
 			pr_debug("Bluetooth device is already power off:%d\n",
@@ -67,6 +74,10 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 			return 0;
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 0);
+
+#ifdef CONFIG_BT_MSM_SLEEP
+		bluesleep_stop();
+#endif
 	}
 	bt_enabled = !blocked;
 

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -58,6 +58,7 @@
 #include <linux/serial_core.h>
 #include <linux/platform_data/msm_serial_hs.h>
 
+#include <net/bluetooth/bluesleep.h>
 #include <net/bluetooth/bluetooth.h>
 #include <net/bluetooth/hci_core.h> /* event notifications */
 #include "hci_uart.h"
@@ -143,12 +144,6 @@ static struct bluesleep_info *bsi;
 static atomic_t open_count = ATOMIC_INIT(1);
 
 /*
- * Local function prototypes
- */
-int bluesleep_start(void);
-void bluesleep_stop(void);
-
-/*
  * Global variables
  */
 
@@ -167,6 +162,9 @@ static DEFINE_TIMER(tx_timer, bluesleep_tx_timer_expire, 0, 0);
 /** Lock for state transitions */
 static spinlock_t rw_lock;
 
+/** State variable: whether uart clock is turned on by bluesleep. */
+static atomic_t uart_is_on = ATOMIC_INIT(0);
+
 struct proc_dir_entry *bluetooth_dir, *sleep_dir;
 
 /*
@@ -179,16 +177,23 @@ static void hsuart_power(int on)
 
 	if (test_bit(BT_SUSPEND, &flags))
 		return;
-	if (on) {
+	if (on && atomic_read(&uart_is_on) == 0) {
 		ret = msm_hs_request_clock_on(bsi->uport);
 		if (unlikely(ret))
 			pr_err("Turning UART clock on failed (%d)\n", ret);
-		msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
-	} else {
+		else {
+			msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
+			atomic_inc(&uart_is_on);
+		}
+	} else if (!on && atomic_read(&uart_is_on) == 1) {
 		msm_hs_set_mctrl(bsi->uport, 0);
 		ret = msm_hs_request_clock_off(bsi->uport);
 		if (unlikely(ret))
 			pr_err("Turning UART clock off failed (%d)\n", ret);
+		else
+			atomic_dec(&uart_is_on);
+	} else {
+		pr_err("Inconsistent UART clock request state.\n");
 	}
 }
 
@@ -334,7 +339,7 @@ EXPORT_SYMBOL(bluesleep_outgoing_data);
  * Function to check wheather bluetooth can sleep when btwrite was deasserted
  * by bluedroid.
  */
-static void bluesleep_tx_allow_sleep(void)
+void bluesleep_tx_allow_sleep(void)
 {
 	unsigned long irq_flags;
 
@@ -345,13 +350,20 @@ static void bluesleep_tx_allow_sleep(void)
 
 	spin_lock_irqsave(&rw_lock, irq_flags);
 
+#ifdef CONFIG_LINE_DISCIPLINE_DRIVER
+	mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL*HZ));
+	clear_bit(BT_TXDATA, &flags);
+#else
 	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 0);
 	set_bit(BT_EXT_WAKE, &flags);
+
 	bluesleep_tx_idle();
+#endif
 
 	spin_unlock_irqrestore(&rw_lock, irq_flags);
 }
+EXPORT_SYMBOL(bluesleep_tx_allow_sleep);
 
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 /**
@@ -406,7 +418,7 @@ static irqreturn_t bluesleep_hostwake_isr(int irq, void *dev_id)
  * @return On success, 0. On error, -1, and <code>errno</code> is set
  * appropriately.
  */
-int bluesleep_start(void)
+int bluesleep_start(bool is_clock_enabled)
 {
 	unsigned long irq_flags;
 
@@ -418,6 +430,15 @@ int bluesleep_start(void)
 	}
 
 	spin_unlock_irqrestore(&rw_lock, irq_flags);
+
+	// For ldisc-controlled BT, the clock is enabled by upper layers, so
+	// make bluesleep aware of this state.
+	if(is_clock_enabled) {
+		atomic_set(&uart_is_on, 1);
+		clear_bit(BT_ASLEEP, &flags);
+	} else {
+		set_bit(BT_ASLEEP, &flags);
+	}
 
 	if (!atomic_dec_and_test(&open_count)) {
 		atomic_inc(&open_count);
@@ -432,10 +453,11 @@ int bluesleep_start(void)
 	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 1);
 	clear_bit(BT_EXT_WAKE, &flags);
-	set_bit(BT_ASLEEP, &flags);
+
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	clear_bit(BT_TXDATA, &flags);
 #endif
+
 	spin_unlock_irqrestore(&rw_lock, irq_flags);
 
 	enable_wakeup_irq(1);
@@ -469,6 +491,8 @@ void bluesleep_stop(void)
 
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	del_timer(&tx_timer);
+
+	atomic_set(&uart_is_on, 0);
 #endif
 
 	if (!test_bit(BT_ASLEEP, &flags)) {
@@ -671,8 +695,6 @@ static int bluesleep_remove(struct platform_device *pdev)
 
 static int bluesleep_resume(struct platform_device *pdev)
 {
-	int ret = 0;
-
 	if (test_bit(BT_SUSPEND, &flags)) {
 		if (debug_mask & DEBUG_SUSPEND)
 			pr_info("bluesleep resuming...\n");
@@ -680,11 +702,7 @@ static int bluesleep_resume(struct platform_device *pdev)
 			(gpio_get_value(bsi->host_wake) == bsi->irq_polarity)) {
 			if (debug_mask & DEBUG_SUSPEND)
 				pr_info("bluesleep resume from BT event...\n");
-			ret = msm_hs_request_clock_on(bsi->uport);
-			if (unlikely(ret))
-				pr_err("Turning UART clock on failed (%d)\n",
-						ret);
-			msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
+			hsuart_power(HS_UART_ON);
 		}
 		clear_bit(BT_SUSPEND, &flags);
 	}
@@ -754,7 +772,7 @@ static ssize_t bluesleep_proc_write(struct file *file, const char *buf,
 			bluesleep_stop();
 		} else {
 			/* HCI_DEV_REG */
-			bluesleep_start();
+			bluesleep_start(0);
 		}
 		break;
 	case PROC_BTWRITE:

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
@@ -29,9 +29,7 @@
 #include "../include/brcm_ldisc_sh.h"
 
 #ifdef LPM_BLUESLEEP
-    extern void bluesleep_outgoing_data(void);
-    extern int bluesleep_start(void);
-    extern void bluesleep_stop(void);
+#include <net/bluetooth/bluesleep.h>
 #endif
 
 /**
@@ -53,7 +51,7 @@ void brcm_btsleep_start(enum sleep_type type)
 {
 #ifdef LPM_BLUESLEEP
     if(type == SLEEP_BLUESLEEP)
-        bluesleep_start();
+        bluesleep_start(0);
 #endif
 }
 /**

--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -67,6 +67,10 @@
 #include <linux/platform_data/msm_serial_hs.h>
 #include <linux/msm-bus.h>
 
+#ifdef CONFIG_BT_MSM_SLEEP
+#include <net/bluetooth/bluesleep.h>
+#endif
+
 #include "msm_serial_hs_hwreg.h"
 #define UART_SPS_CONS_PERIPHERAL 0
 #define UART_SPS_PROD_PERIPHERAL 1
@@ -308,10 +312,16 @@ static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 	switch (cmd) {
 	case MSM_ENABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_on(&msm_uport->uport);
+#ifdef CONFIG_BT_MSM_SLEEP
+		bluesleep_outgoing_data();
+#endif
 		break;
 	}
 	case MSM_DISABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_off(&msm_uport->uport);
+#ifdef CONFIG_BT_MSM_SLEEP
+		bluesleep_tx_allow_sleep();
+#endif
 		break;
 	}
 	case MSM_GET_UART_CLOCK_STATUS: {
@@ -1432,6 +1442,11 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	/* Set 1 second timeout */
 	mod_timer(&tx->tx_timeout_timer,
 		jiffies + msecs_to_jiffies(MSEC_PER_SEC));
+
+	/* Notify the bluesleep driver of outgoing data, if available. */
+#ifdef CONFIG_BT_MSM_SLEEP
+	bluesleep_outgoing_data();
+#endif
 
 	MSM_HS_DBG("%s:Enqueue Tx Cmd, ret %d\n", __func__, ret);
 }

--- a/include/net/bluetooth/bluesleep.h
+++ b/include/net/bluetooth/bluesleep.h
@@ -1,0 +1,35 @@
+/*
+   Bluesleep - Bluetooth Sleep Mode protocol for Linux
+
+   Provides prototypes to drivers that interact with the sleep/wake behavior of
+   the bluetooth / bluesleep system, e.g. serial drivers handling ioctls.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License version 2 as
+   published by the Free Software Foundation;
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+   IN NO EVENT SHALL THE COPYRIGHT HOLDER(S) AND AUTHOR(S) BE LIABLE FOR ANY
+   CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+   ALL LIABILITY, INCLUDING LIABILITY FOR INFRINGEMENT OF ANY PATENTS,
+   COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS, RELATING TO USE OF THIS
+   SOFTWARE IS DISCLAIMED.
+*/
+
+#ifndef _LINUX_BLUESLEEP_H
+#define _LINUX_BLUESLEEP_H
+
+int bluesleep_can_sleep(void);
+void bluesleep_outgoing_data(void);
+void bluesleep_tx_allow_sleep(void);
+
+int bluesleep_start(bool is_clock_enabled);
+void bluesleep_stop(void);
+
+#endif // _BLUESLEEP_H


### PR DESCRIPTION
Due to the inclusion of FMRadio, the wake mechanism in the userspace
moved from using the procfs to the ioctl assertion mechanism. This
commit makes the bluesleep and the msm uart driver fully aware of the
ioctl assertion mechanism. The basic idea is to trigger the bluesleep
functions that are called during assertion/deassertion via the procfs
from the msm_serial_hs driver whenever an assert/deassert ioctl is
delivered.

NOTE: This change requires modifications to the libbt configuration
to operate correctly (remove the wake via procfs).

In particular, the following changes have been made:

* Create a bluesleep header file to allow the msm_serial_hs driver to
access the bluesleep assert/deassert functions.

* msm_serial_hs: Make the msm_serial_hs driver to call the bluesleep
start/stop functions upon registration/deregistration. Also call the
assert/deassert functions (bluesleep_outgoing_data() /
bluesleep_tx_allow_sleep()) when the corresponding ioctl commands are
received.

* bluesleep: Make the bluesleep_tx_allow_sleep function externally
accessible.

* bluesleep: Introduce a state tracker variable for uart clock on/off
requests and use it in the hsuart_power method. Further, remove any
direct invocations of msm_hs_request_clock_on/off.

* bluesleep: Add a state flag to the bluesleep_start function to signal
the context from which the bluesleep driver is called: 0 indicates that
no clock has been asserted before, while 1 signals the opposite. This
flag is required to correctly set the initial state which enables deep
sleep and FMRadio with the current limitations. This flag should be no
longer needer once the FMRadio driver uses the standard ldisc.

Change-Id: I50eb35b6af93f6bebb2122b3f80061f04b120998
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>