### PR TITLE
[1.3.3] mmc: core: Avoid frequent enable/disable of Auto BKOPS

### DIFF
--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -4344,8 +4344,6 @@ static void mmc_blk_shutdown(struct mmc_card *card)
 		mmc_rpm_hold(card->host, &card->dev);
 		mmc_claim_host(card->host);
 		mmc_stop_bkops(card);
-		if (mmc_card_doing_auto_bkops(card))
-			mmc_set_auto_bkops(card, false);
 		mmc_release_host(card->host);
 		mmc_send_pon(card);
 		mmc_rpm_release(card->host, &card->dev);

--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -1921,13 +1921,7 @@ reinit:
 		 * Ignore the return value of setting auto bkops.
 		 * If it failed, will run in backward compatible mode.
 		 */
-		err = mmc_set_auto_bkops(card, true);
-		if (err)
-			pr_err("%s: %s: Failed to enable auto-bkops: err: %d\n",
-			       mmc_hostname(card->host), __func__, err);
-		else
-			printk_once("%s: %s: Enabled auto-bkops on device\n",
-				    mmc_hostname(card->host), __func__);
+		(void)mmc_set_auto_bkops(card, true);
 	}
 
 	if (card->ext_csd.cmdq_support && (card->host->caps2 &
@@ -2118,15 +2112,6 @@ static int _mmc_suspend(struct mmc_host *host, bool is_suspend)
 	 * as to avoid clock scaling decisions kicking in during this window.
 	 */
 	mmc_disable_clk_scaling(host);
-
-	if (mmc_card_doing_auto_bkops(host->card)) {
-		err = mmc_set_auto_bkops(host->card, false);
-		if (err) {
-			pr_err("%s: %s: failed to stop auto-bkops: %d\n",
-			       mmc_hostname(host), __func__, err);
-			goto out;
-		}
-	}
 
 	err = mmc_cache_ctrl(host, 0);
 	if (err)


### PR DESCRIPTION
Extracted from:
https://github.com/sonyxperiadev/kernel/commit/b42af0ea55492e2be89b5834d266e5fb07c982ed

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ib963c209113b6db959c982ab811763adc0f75b84