### PR TITLE
[1.3.3] Revert "ANDROID: mmc: move to a SCHED_FIFO thread"

### DIFF
--- a/drivers/mmc/card/queue.c
+++ b/drivers/mmc/card/queue.c
@@ -19,7 +19,6 @@
 
 #include <linux/mmc/card.h>
 #include <linux/mmc/host.h>
-#include <linux/sched/rt.h>
 #include "queue.h"
 
 #define MMC_QUEUE_BOUNCESZ	65536
@@ -149,11 +148,6 @@ static int mmc_queue_thread(void *d)
 	struct mmc_queue *mq = d;
 	struct request_queue *q = mq->queue;
 	struct mmc_card *card = mq->card;
-
-	struct sched_param scheduler_params = {0};
-	scheduler_params.sched_priority = 1;
-
-	sched_setscheduler(current, SCHED_FIFO, &scheduler_params);
 
 	current->flags |= PF_MEMALLOC;
 	if (card->host->wakeup_on_idle)


### PR DESCRIPTION
This reverts commit e423578d2857a7bb83857f8d7bae4e9ba11f1af7.
As a part of above commit, mmcqd thread's priority was
modified to sched_fifo making it a RT task. This resulted
in starving other tasks like watchdog and starting hiting
watchdog bite error. This is expected if there are too
many requests to SD card and since it is fast enough to
serve the requests, it may starve other tasks.

Hence reverting the change to avoid such issues.

Change-Id: I620b674a990b9e2e76027a7419e1275679fa4eb0
Signed-off-by: Sayali Lokhande <sayalil@codeaurora.org>