### PR TITLE
drivers: bluesleep: Fix BT FMRadio kernel panic.

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -141,7 +141,7 @@ static struct platform_device *bluesleep_uart_dev;
 static struct bluesleep_info *bsi;
 
 /* module usage */
-static atomic_t open_count = ATOMIC_INIT(1);
+static atomic_t open_count = ATOMIC_INIT(0);
 
 /*
  * Global variables
@@ -188,10 +188,16 @@ static void hsuart_power(int on)
 	} else if (!on && atomic_read(&uart_is_on) == 1) {
 		msm_hs_set_mctrl(bsi->uport, 0);
 		ret = msm_hs_request_clock_off(bsi->uport);
-		if (unlikely(ret))
+		if (unlikely(ret)) {
+			if(ret == -EPERM) {
+				// Decrease the uart clk indicator in the error case: clock was turned
+				// off already.
+				atomic_set(&uart_is_on, 0);
+			}
 			pr_err("Turning UART clock off failed (%d)\n", ret);
-		else
-			atomic_dec(&uart_is_on);
+		} else {
+			atomic_set(&uart_is_on, 0);
+		}
 	} else {
 		pr_err("Inconsistent UART clock request state.\n");
 	}
@@ -304,8 +310,7 @@ void bluesleep_outgoing_data(void)
 	spin_lock_irqsave(&rw_lock, irq_flags);
 
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
-	if (!test_bit(BT_TXDATA, &flags))
-		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
+	mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
 	set_bit(BT_TXDATA, &flags);
 #endif
 
@@ -422,30 +427,17 @@ int bluesleep_start(bool is_clock_enabled)
 {
 	unsigned long irq_flags;
 
+	if (atomic_read(&open_count) != 0) {
+		return -EBUSY;
+	}
+	atomic_inc(&open_count);
+
 	spin_lock_irqsave(&rw_lock, irq_flags);
 
 	if (test_bit(BT_PROTO, &flags)) {
 		spin_unlock_irqrestore(&rw_lock, irq_flags);
 		return 0;
 	}
-
-	spin_unlock_irqrestore(&rw_lock, irq_flags);
-
-	// For ldisc-controlled BT, the clock is enabled by upper layers, so
-	// make bluesleep aware of this state.
-	if(is_clock_enabled) {
-		atomic_set(&uart_is_on, 1);
-		clear_bit(BT_ASLEEP, &flags);
-	} else {
-		set_bit(BT_ASLEEP, &flags);
-	}
-
-	if (!atomic_dec_and_test(&open_count)) {
-		atomic_inc(&open_count);
-		return -EBUSY;
-	}
-
-	spin_lock_irqsave(&rw_lock, irq_flags);
 
 	/* assert BT_WAKE */
 	if (debug_mask & DEBUG_BTWAKE)
@@ -457,6 +449,15 @@ int bluesleep_start(bool is_clock_enabled)
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	clear_bit(BT_TXDATA, &flags);
 #endif
+
+	// For ldisc-controlled BT, the clock is enabled by upper layers, so
+	// make bluesleep aware of this state.
+	clear_bit(BT_ASLEEP, &flags);
+	if(is_clock_enabled) {
+		atomic_set(&uart_is_on, 1);
+	} else {
+		hsuart_power(HS_UART_ON);
+	}
 
 	spin_unlock_irqrestore(&rw_lock, irq_flags);
 
@@ -491,8 +492,6 @@ void bluesleep_stop(void)
 
 #if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	del_timer(&tx_timer);
-
-	atomic_set(&uart_is_on, 0);
 #endif
 
 	if (!test_bit(BT_ASLEEP, &flags)) {
@@ -503,7 +502,11 @@ void bluesleep_stop(void)
 		spin_unlock_irqrestore(&rw_lock, irq_flags);
 	}
 
-	atomic_inc(&open_count);
+#if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+	atomic_set(&uart_is_on, 0);
+#endif
+
+	atomic_dec(&open_count);
 
 	enable_wakeup_irq(0);
 	wake_lock_timeout(&bsi->wake_lock, HZ / 2);
@@ -698,7 +701,7 @@ static int bluesleep_resume(struct platform_device *pdev)
 	if (test_bit(BT_SUSPEND, &flags)) {
 		if (debug_mask & DEBUG_SUSPEND)
 			pr_info("bluesleep resuming...\n");
-		if (atomic_read(&open_count) == 0 &&
+		if (atomic_read(&open_count) == 1 &&
 			(gpio_get_value(bsi->host_wake) == bsi->irq_polarity)) {
 			if (debug_mask & DEBUG_SUSPEND)
 				pr_info("bluesleep resume from BT event...\n");

--- a/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.c
+++ b/drivers/bluetooth/broadcom/bt_protocol_driver/brcm_bt_drv.c
@@ -201,7 +201,7 @@ static int brcm_bt_drv_open(struct inode *inode, struct file *filp)
         BT_DRV_ERR("failed to get ST write func pointer");
 
         /* Undo registration with ST */
-        err = brcm_sh_ldisc_unregister(PROTO_SH_BT);
+        err = brcm_sh_ldisc_unregister(PROTO_SH_BT, err != -EBUSY);
         if (err < 0)
             BT_DRV_ERR("st_unregister failed %d", err);
 
@@ -267,7 +267,7 @@ static int brcm_bt_drv_close(struct inode *i, struct file *f)
 
     /* Unregister from ST layer */
     if (test_and_clear_bit(BT_ST_REGISTERED, &bt_dev_p->flags)) {
-        err = brcm_sh_ldisc_unregister(PROTO_SH_BT);
+        err = brcm_sh_ldisc_unregister(PROTO_SH_BT, 1);
         if (err != 0) {
             BT_DRV_ERR("%s st_unregister failed %d", __func__, err);
             err = -EBUSY;

--- a/drivers/bluetooth/broadcom/include/brcm_ldisc_sh.h
+++ b/drivers/bluetooth/broadcom/include/brcm_ldisc_sh.h
@@ -67,7 +67,7 @@ enum sleep_type {
 
 
 void brcm_btsleep_wake( enum sleep_type type);
-void brcm_btsleep_start(enum sleep_type type);
+int brcm_btsleep_start(enum sleep_type type);
 void brcm_btsleep_stop(enum sleep_type type);
 
 
@@ -117,6 +117,6 @@ struct sh_proto_s {
 *******************************************************************************/
 
 extern long brcm_sh_ldisc_register(struct sh_proto_s *);
-extern long brcm_sh_ldisc_unregister(enum proto_type);
+extern long brcm_sh_ldisc_unregister(enum proto_type, bool btsleep_open);
 
 #endif /* LDISC_H */

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_bluesleep.c
@@ -47,12 +47,13 @@ void brcm_btsleep_wake( enum sleep_type type)
 /**
  * Starts the Sleep-Mode Protocol on the Host.
 **/
-void brcm_btsleep_start(enum sleep_type type)
+int brcm_btsleep_start(enum sleep_type type)
 {
 #ifdef LPM_BLUESLEEP
     if(type == SLEEP_BLUESLEEP)
-        bluesleep_start(0);
+        return bluesleep_start(0);
 #endif
+    return 0;
 }
 /**
  * Stops the Sleep-Mode Protocol on the Host.

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -214,7 +214,7 @@ long brcm_sh_ldisc_write(struct sk_buff *);
 /* ask for reference from KIM */
 void hu_ref(struct hci_uart **, int);
 long brcm_sh_ldisc_start(struct hci_uart *hu);
-long brcm_sh_ldisc_stop(struct hci_uart *hu);
+long brcm_sh_ldisc_stop(struct hci_uart *hu, bool btsleep_open);
 
 #ifdef CONFIG_BT_HCIUART_H4
 int h4_init(void);

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
@@ -1212,7 +1212,7 @@ long brcm_sh_ldisc_register(struct sh_proto_s *new_proto)
                 (test_bit(LDISC_REG_PENDING, &hu->sh_ldisc_state))) {
                 pr_err(" ldisc registration failed ");
             }
-            return -EINVAL;
+            return err == -EBUSY ? err : -EINVAL;
         }
 
         BT_LDISC_DBG(V4L2_DBG_OPEN, "clearing flag LDISC_REG_IN_PROGRESS");
@@ -1270,7 +1270,7 @@ EXPORT_SYMBOL(brcm_sh_ldisc_register);
 ** Returns - 0 if success; errno otherwise
 **
 *******************************************************************************/
-long brcm_sh_ldisc_unregister(enum proto_type type)
+long brcm_sh_ldisc_unregister(enum proto_type type, bool btsleep_open)
 {
     long err = 0;
     unsigned long flags;
@@ -1318,7 +1318,7 @@ long brcm_sh_ldisc_unregister(enum proto_type type)
         }
 
         /* all chnl_ids now unregistered */
-        brcm_sh_ldisc_stop(hu);
+        brcm_sh_ldisc_stop(hu, btsleep_open);
     }
 
     return err;
@@ -1688,13 +1688,14 @@ error_state:
 /**
  * brcm_sh_ldisc_stop - called  on the last un-registration */
 
-long brcm_sh_ldisc_stop(struct hci_uart *hu)
+long brcm_sh_ldisc_stop(struct hci_uart *hu, bool btsleep_open)
 {
     long err = 0;
 
     INIT_COMPLETION(hu->ldisc_installed);
 
-    brcm_btsleep_stop(sleep);
+    if(btsleep_open)
+        brcm_btsleep_stop(sleep);
     hu->ldisc_install = V4L2_STATUS_OFF;
 
     /* send uninstall notification to UIM */
@@ -1728,7 +1729,9 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
     BT_LDISC_DBG(V4L2_DBG_INIT, " %p",tty);
 
     do {
-        brcm_btsleep_start(sleep);
+        if(brcm_btsleep_start(sleep) == -EBUSY)
+            return -EBUSY;
+
         INIT_COMPLETION(hu->ldisc_installed);
         /* send notification to UIM */
         hu->ldisc_install = V4L2_STATUS_ON;
@@ -1743,7 +1746,7 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
         if (!err) { /* timeout */
             pr_err("line disc installation timed out ");
             INIT_COMPLETION(hu->tty_close_complete);
-            err = brcm_sh_ldisc_stop(hu);
+            err = brcm_sh_ldisc_stop(hu, 1);
             cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
                     msecs_to_jiffies(TTY_CLOSE_TIME));
             if (!cl_err) { /* timeout */
@@ -1758,7 +1761,7 @@ long brcm_sh_ldisc_start(struct hci_uart *hu)
             if (err != 0) {
                 pr_err("patchram download failed");
                 INIT_COMPLETION(hu->tty_close_complete);
-                brcm_sh_ldisc_stop(hu);
+                brcm_sh_ldisc_stop(hu, 1);
                 cl_err = wait_for_completion_timeout(&hu->tty_close_complete,
                         msecs_to_jiffies(TTY_CLOSE_TIME));
                 if (!cl_err) { /* timeout */

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.c
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv_main.c
@@ -110,7 +110,6 @@ struct region_info region_configs[] = {
      },
 };
 
-
 #if V4L2_FM_DEBUG
 #define V4L2_FM_DRV_DBG(flag, fmt, arg...) \
         do { \
@@ -1494,7 +1493,7 @@ int fmc_prepare(struct fmdrv_ops *fmdev)
 
     /* Register with the shared line discipline */
     ret = brcm_sh_ldisc_register(&fm_st_proto);
-    if (ret == -1) {
+    if (ret < 0) {
         pr_err("(fmdrv): brcm_sh_ldisc_register failed %d", ret);
         ret = -EAGAIN;
         return ret;
@@ -1508,7 +1507,7 @@ int fmc_prepare(struct fmdrv_ops *fmdev)
     }
     else {
         V4L2_FM_DRV_ERR("(fmdrv): Failed to get shared ldisc write func pointer");
-        ret = brcm_sh_ldisc_unregister(PROTO_SH_FM);
+        ret = brcm_sh_ldisc_unregister(PROTO_SH_FM, 1);
         if (ret < 0)
             V4L2_FM_DRV_ERR("(fmdrv): brcm_sh_ldisc_unregister failed %d", ret);
             ret = -EAGAIN;
@@ -1574,7 +1573,7 @@ int fmc_release(struct fmdrv_ops *fmdev)
     cancel_work_sync(&fmdev->tx_workqueue);
     cancel_work_sync(&fmdev->rx_workqueue);
 
-    ret = brcm_sh_ldisc_unregister(PROTO_SH_FM);
+    ret = brcm_sh_ldisc_unregister(PROTO_SH_FM, 1);
     if (ret < 0)
         V4L2_FM_DRV_ERR("(fmdrv): Failed to de-register FM from HCI LDisc - %d", ret);
     else


### PR DESCRIPTION
Instead of relying on the bluesleep worker function, power up UART
directly from bluesleep_start. This avoids inconsistent states that lead
to kernel panics most times when the FMRadio app is opened.
Further shift the clock power up further below to avoid crashes when
opening FMRadio while BT is still on.

In addition, some following changes have been made to get the FMRadio to
operate close to what is expected. The current limitations are that BT
and FMRadio cannot be activated simultaneously, and a playback pause of
some seconds that occurs when turning the device on again via the power
button while the FMRadio is playing.
In particular, these changes include:
* bluesleep: open_count: invert the open count logic to actually reflect
opening (start) of the bluesleep driver.
* bluesleep: hsuart_power: if turning off the uart clock fails due to
already turned off clocks (via calls from other modules), also decrase
the uart_clock state counter.
* bluesleep: bluesleep_outgoing_data: always reset the tx timer, if
outgoing data is delivered (robustness).
* bluesleep: bluesleep_stop: place the uart state counter correctly to
avoid erroneous behavior when hsuart_power is called.
* brcm_bluesleep: brcm_btsleep_start: return the return value from 
bluesleep_start. Needed for the FMRadio driver.
* brcom_ldisc_sh: brcm_sh_ldisc_unregister: Add a flag to determine
whether the bluesleep module could be started successfully before
unregistering.
* brcom_ldisc_sh: brcm_sh_ldisc_start: Do not initialize the ldisc if
bluesleep is already opened (by BT). Workaround until the migration to
the standard ldisc driver.

Change-Id: I4e534f8b54832914b661b08c7505a958cd363ed2
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>