### PR TITLE
ALSA: usb-audio: revert erroneous change on dBmin/dBmax calculation

### DIFF
--- a/sound/usb/mixer.c
+++ b/sound/usb/mixer.c
@@ -994,9 +994,9 @@ static int get_min_max_with_quirks(struct usb_mixer_elem_info *cval,
 	 * while ALSA TLV contains in 1/100 dB unit
 	 */
 	cval->dBmin =
-		(convert_signed_value(cval, cval->min) * 100) / (cval->res);
+		(convert_signed_value(cval, cval->min) * 100) / 256;
 	cval->dBmax =
-		(convert_signed_value(cval, cval->max) * 100) / (cval->res);
+		(convert_signed_value(cval, cval->max) * 100) / 256;
 	if (cval->dBmin > cval->dBmax) {
 		/* something is wrong; assume it's either from/to 0dB */
 		if (cval->dBmin < 0)


### PR DESCRIPTION
Commit c234ff1 ("ALSA: usb-audio: Fix the mixer control range limiting issue") wrongly changed the calculations of dBmin/dBmax to use the device-reported volume resolution (cval->res) instead of the scale defined in the USB audio class specification (1 = 1/256dB).

This results in wrong calculated limits. For example, if a device has a lower volume limit of -55.00dB and volume resolution of 0.5dB, dBmin would be doubled to -110.00dB (-11000 instead of -5500).

It would be only correct if cval->res will be converted to a value in ALSA scale (or dB) as cval->min and cval->max were. For example, if cval->res is 128, it indicates that the device supports volume stepping of 0.5dB (128 / 256). The corresponding value in ALSA scale would be 50.

Only that would allow ALSA to be aware of the proper volume stepping. And that makes it illogical to calculate dBmin/dBmax with cval->res.

Note that ALSA does not have a fixed volume stepping (of 100, i.e. 1dB). Neither is it the reason to have dBmin/dBmax derived. The calculation is performed only because the limits are represented different scales in ALSA and in the USB Audio Class specification respectively (1:100dB vs 1:256dB). It has always been clearly stated in the comment above the code as well. So I have no idea how the commit could have been signed off.

Neither does the original commit message ("In USB mixer while calculating the dBmin/dBmax values resolution factor is hardcoded to 256") make sense at all.

P.S. Apparently the original commit never made its way to upstream.