### PR TITLE
[1.3.3] Fix rhine jack

### DIFF
--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -202,7 +202,7 @@ static struct wcd9xxx_mbhc_config mbhc_cfg = {
 	.micbias_enable_flags = 1 << MBHC_MICBIAS_ENABLE_THRESHOLD_HEADSET,
 	.insert_detect = true,
 	.swap_gnd_mic = NULL,
-#ifdef CONFIG_MACH_SONY_SHINANO
+#if defined (CONFIG_MACH_SONY_SHINANO) || defined (CONFIG_MACH_SONY_RHINE)
 	.cs_enable_flags = 0,
 #else
 	.cs_enable_flags = (1 << MBHC_CS_ENABLE_POLLING |

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -1929,6 +1929,15 @@ void *def_taiko_mbhc_cal(void)
 	btn_high = wcd9xxx_mbhc_cal_btn_det_mp(btn_cfg,
 					       MBHC_BTN_DET_V_BTN_HIGH);
 	btn_low[0] = -30;
+#ifdef CONFIG_MACH_SONY_RHINE
+	btn_high[0] = 887;
+	btn_low[1] = 888;
+	btn_high[1] = 1009;
+	btn_low[2] = 1010;
+	btn_high[2] = 1189;
+	btn_low[3] = 1190;
+	btn_high[3] = 1411;
+#else
 	btn_high[0] = 50;
 	btn_low[1] = 51;
 	btn_high[1] = 336;
@@ -1936,6 +1945,7 @@ void *def_taiko_mbhc_cal(void)
 	btn_high[2] = 680;
 	btn_low[3] = 681;
 	btn_high[3] = 1207;
+#endif
 	n_ready = wcd9xxx_mbhc_cal_btn_det_mp(btn_cfg, MBHC_BTN_DET_N_READY);
 	n_ready[0] = 80;
 	n_ready[1] = 68;

--- a/sound/soc/msm/msm8974.c
+++ b/sound/soc/msm/msm8974.c
@@ -1904,8 +1904,13 @@ void *def_taiko_mbhc_cal(void)
 	S(t_ins_retry, 200);
 #undef S
 #define S(X, Y) ((WCD9XXX_MBHC_CAL_PLUG_TYPE_PTR(taiko_cal)->X) = (Y))
+#ifdef CONFIG_MACH_SONY_RHINE
+	S(v_no_mic, 900);
+	S(v_hs_max, 2600);
+#else
 	S(v_no_mic, 50);
 	S(v_hs_max, 2550);
+#endif
 #undef S
 #define S(X, Y) ((WCD9XXX_MBHC_CAL_BTN_DET_PTR(taiko_cal)->X) = (Y))
 	S(c[0], 62);


### PR DESCRIPTION
Disable enable flags and use values that are marked as "noise dumping jack". It would make sense to use non-noise dumping values and they are actually used, but they are wrong. Detection does not work and all headphones are detected as 4-pole ones which results in not working phone mic (phone tries to use not existing headphones one) and phantom button presses.

Also correct values for headset buttons that are also wrong - all buttons act as one button - you can't change volume.