### PR TITLE
Revert "[DWC3] Add missing return at the end of function dwc3_chg_det…

### DIFF
--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -1796,7 +1796,6 @@ static void dwc3_chg_detect_work(struct work_struct *w)
 			chg_to_string(mdwc->charger.chg_type));
 		mdwc->charger.notify_detection_complete(mdwc->otg_xceiv->otg,
 								&mdwc->charger);
-								return;
 	default:
 		pm_runtime_put_sync(mdwc->dev);
 		return;


### PR DESCRIPTION
…ect_work"

This reverts commit b27cb0a9d95e7295104cf5499c2da01703c4c0de.

This commit introduced a bug where a wakelock would get stuck on amami (probably all 8974 devices, can't personally test any others though). After booting the phone, connecting it to a charger (either ac or usb) and the disconnecting it resulted in an msm_dwc3 wakelock getting stuck. Reverting it fixes the problem.