### PR TITLE
arm64: DT: Enable regulator in VFE node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8952-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8952-camera.dtsi
@@ -151,8 +151,9 @@
 		interrupts = <0 55 0>;
 		interrupt-names = "ispif";
 		qcom,num-isps = <0x2>;
-		vfe0_vdd_supply = <&gdsc_vfe>;
-		vfe1_vdd_supply = <&gdsc_vfe1>;
+		vfe0-vdd-supply = <&gdsc_vfe>;
+		vfe1-vdd-supply = <&gdsc_vfe1>;
+		qcom,vdd-names = "vfe0-vdd", "vfe1-vdd";
 		clocks = <&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
 			<&clock_gcc clk_csi0_clk_src>,
 			<&clock_gcc clk_gcc_camss_csi0_clk>,

--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -145,6 +145,7 @@
 		qcom,num-isps = <0x2>;
 		vfe0-vdd-supply = <&gdsc_vfe>;
 		vfe1-vdd-supply = <&gdsc_vfe1>;
+		qcom,vdd-names = "vfe0-vdd", "vfe1-vdd";
 		clocks = <&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
 			<&clock_gcc clk_csi0_clk_src>,
 			<&clock_gcc clk_gcc_camss_csi0_clk>,


### PR DESCRIPTION
following commit 953a0b772770ac51fc9474428514ea14ffe842f1
VFE clocks need VFE regulators to be enabled to turn on clocks

Signed-off-by: David Viteri <davidteri91@gmail.com>