### PR TITLE
[1.3.3] qdsp6v2 optimize size

### DIFF
--- a/drivers/misc/qcom/qdsp6v2/Makefile
+++ b/drivers/misc/qcom/qdsp6v2/Makefile
@@ -3,3 +3,4 @@ obj-$(CONFIG_MSM_QDSP6V2_CODECS) += audio_wma.o audio_wmapro.o audio_aac.o audio
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += q6audio_v2.o q6audio_v2_aio.o
 obj-$(CONFIG_MSM_QDSP6V2_CODECS)  += audio_mp3.o audio_amrnb.o audio_amrwb.o audio_amrwbplus.o audio_evrc.o audio_qcelp.o amrwb_in.o audio_hwacc_effects.o
 obj-$(CONFIG_MSM_ULTRASOUND) += ultrasound/
+ccflags-y := -Os

--- a/drivers/soc/qcom/qdsp6v2/Makefile
+++ b/drivers/soc/qcom/qdsp6v2/Makefile
@@ -1,3 +1,4 @@
 obj-$(CONFIG_MSM_QDSP6_APRV2) += apr.o apr_v2.o apr_v3.o apr_tal.o voice_svc.o
 obj-$(CONFIG_SND_SOC_MSM_QDSP6V2_INTF) += msm_audio_ion.o
 obj-$(CONFIG_MSM_ADSP_LOADER) += adsp-loader.o
+ccflags-y := -Os

--- a/sound/soc/Makefile
+++ b/sound/soc/Makefile
@@ -33,3 +33,4 @@ obj-$(CONFIG_SND_SOC)	+= sh/
 obj-$(CONFIG_SND_SOC)	+= tegra/
 obj-$(CONFIG_SND_SOC)	+= txx9/
 obj-$(CONFIG_SND_SOC)	+= ux500/
+ccflags-y := -Os

--- a/sound/soc/msm/qdsp6v2/Makefile
+++ b/sound/soc/msm/qdsp6v2/Makefile
@@ -18,3 +18,4 @@ obj-y += audio_calibration.o audio_cal_utils.o q6adm.o q6afe.o q6asm.o \
 	q6audio-v2.o q6voice.o q6core.o rtac.o q6lsm.o audio_slimslave.o
 ocmem-audio-objs += audio_ocmem.o
 obj-$(CONFIG_AUDIO_OCMEM) += ocmem-audio.o
+ccflags-y := -Os


### PR DESCRIPTION
- Reduce kernel size (Z3 with this is 8.6MB)
- Compile arm / arm64 ok 
- Tested on Z3
