### PR TITLE
[1.3.3] power: quickwakeup: initial driver

### DIFF
--- a/include/linux/quickwakeup.h
+++ b/include/linux/quickwakeup.h
@@ -1,0 +1,46 @@
+/* include/linux/quickwakeup.h
+ *
+ * Copyright (C) 2014 Motorola Mobility LLC.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef _QUICKWAKEUP_H_
+#define _QUICKWAKEUP_H_
+
+#ifdef __KERNEL__
+
+struct quickwakeup_ops {
+	struct list_head list;
+	char *name;
+	int (*qw_execute)(void *data);
+	int (*qw_check)(void *data);
+	int execute;
+	void *data;  /* arbitrary data passed back to user */
+};
+
+#ifdef CONFIG_QUICK_WAKEUP
+
+int quickwakeup_register(struct quickwakeup_ops *ops);
+void quickwakeup_unregister(struct quickwakeup_ops *ops);
+bool quickwakeup_suspend_again(void);
+
+#else
+
+static inline int quickwakeup_register(struct quickwakeup_ops *ops) { return 0; };
+static inline void quickwakeup_unregister(struct quickwakeup_ops *ops) {};
+static inline bool quickwakeup_suspend_again(void) { return 0; };
+
+#endif /* CONFIG_QUICK_WAKEUP */
+
+#endif /* __KERNEL__ */
+
+#endif /* _QUICKWAKEUP_H_ */

--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -289,6 +289,14 @@ config SUSPEND_TIME
 	  keeps statistics on the time spent in suspend in
 	  /sys/kernel/debug/suspend_time
 
+config QUICK_WAKEUP
+	bool "Quick wakeup"
+	depends on SUSPEND
+	default y
+	---help---
+	  Allow kernel driver to do periodic jobs without resuming the full system
+	  This option can increase battery life on android powered smartphone.
+	  
 config DEDUCE_WAKEUP_REASONS
 	bool
 	default n
@@ -304,4 +312,3 @@ config PARTIALRESUME
 	  Partial resume will occur only if all wakeup sources have
 	  partial-resume handlers associated with them, and they all return
 	  true.
-

--- a/kernel/power/Makefile
+++ b/kernel/power/Makefile
@@ -13,6 +13,7 @@ obj-$(CONFIG_PM_AUTOSLEEP)	+= autosleep.o
 obj-$(CONFIG_PM_WAKELOCKS)	+= wakelock.o
 obj-$(CONFIG_SUSPEND_TIME)	+= suspend_time.o
 
+obj-$(CONFIG_QUICK_WAKEUP)	+= quickwakeup.o
 obj-$(CONFIG_MAGIC_SYSRQ)	+= poweroff.o
 
 obj-$(CONFIG_SUSPEND)	+= wakeup_reason.o

--- a/kernel/power/quickwakeup.c
+++ b/kernel/power/quickwakeup.c
@@ -1,0 +1,104 @@
+/* kernel/power/quickwakeup.c
+ *
+ * Copyright (C) 2014 Motorola Mobility LLC.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include <linux/kernel.h>
+#include <linux/list.h>
+#include <linux/mutex.h>
+#include <linux/quickwakeup.h>
+
+static LIST_HEAD(qw_head);
+static DEFINE_MUTEX(list_lock);
+
+int quickwakeup_register(struct quickwakeup_ops *ops)
+{
+	mutex_lock(&list_lock);
+	list_add(&ops->list, &qw_head);
+	mutex_unlock(&list_lock);
+
+	return 0;
+}
+
+void quickwakeup_unregister(struct quickwakeup_ops *ops)
+{
+	mutex_lock(&list_lock);
+	list_del(&ops->list);
+	mutex_unlock(&list_lock);
+}
+
+static int quickwakeup_check(void)
+{
+	int check = 0;
+	struct quickwakeup_ops *index;
+
+	mutex_lock(&list_lock);
+
+	list_for_each_entry(index, &qw_head, list) {
+		int ret = index->qw_check(index->data);
+		index->execute = ret;
+		check |= ret;
+		pr_debug("%s: %s votes for %s\n", __func__, index->name,
+			ret ? "execute" : "dont care");
+	}
+
+	mutex_unlock(&list_lock);
+
+	return check;
+}
+
+/* return 1 => suspend again
+   return 0 => continue wakeup
+ */
+static int quickwakeup_execute(void)
+{
+	int suspend_again = 0;
+	int final_vote = 1;
+	struct quickwakeup_ops *index;
+
+	mutex_lock(&list_lock);
+
+	list_for_each_entry(index, &qw_head, list) {
+		if (index->execute) {
+			int ret = index->qw_execute(index->data);
+			index->execute = 0;
+			final_vote &= ret;
+			suspend_again = final_vote;
+			pr_debug("%s: %s votes for %s\n", __func__, index->name,
+				ret ? "suspend again" : "wakeup");
+		}
+	}
+
+	mutex_unlock(&list_lock);
+
+	pr_debug("%s: %s\n", __func__,
+		suspend_again ? "suspend again" : "wakeup");
+
+	return suspend_again;
+}
+
+/* return 1 => suspend again
+   return 0 => continue wakeup
+ */
+bool quickwakeup_suspend_again(void)
+{
+	int ret = 0;
+
+	if (quickwakeup_check())
+		ret = quickwakeup_execute();
+
+	pr_debug("%s- returning %d %s\n", __func__, ret,
+		ret ? "suspend again" : "wakeup");
+
+	return ret;
+}


### PR DESCRIPTION
This driver allows clients to register code to be called upon wakeup
so that clients can perform specific checks and vote to drop the system
back into suspend without fully resuming if the wake reason was a special
quick wakeup event.

Propagation of (CR)

Signed-off-by: James Wylder <jwylder1@motorola.com>
Signed-off-by: Jared Suttles <jsuttles@motorola.com>
Signed-off-by: Joe Swantek <w98568@motorola.com>
Reviewed-on: http://gerrit.mot.com/648051
SLTApproved: Slta Waiver <sltawvr@motorola.com>
Tested-by: Jira Key <jirakey@motorola.com>
Reviewed-by: Joseph Swantek <jswantek@motorola.com>
Submit-Approved: Jira Key <jirakey@motorola.com>
Reviewed-by: Patrick Auchter <auchter@motorola.com>
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>