### PR TITLE
dts: loire: kugo: set correct function for gpio18 and gpio19

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -276,7 +276,7 @@
 	msm_gpio_18_def: msm_gpio_18def {
 		mux {
 			pins = "gpio18";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio18";
@@ -291,7 +291,7 @@
 	msm_gpio_18_sus: msm_gpio_18sus {
 		mux {
 			pins = "gpio18";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio18";
@@ -304,7 +304,7 @@
 	msm_gpio_18_act: msm_gpio_18act {
 		mux {
 			pins = "gpio18";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio18";
@@ -317,7 +317,7 @@
 	msm_gpio_19_def: msm_gpio_19def {
 		mux {
 			pins = "gpio19";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio19";
@@ -332,7 +332,7 @@
 	msm_gpio_19_sus: msm_gpio_19sus {
 		mux {
 			pins = "gpio19";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio19";
@@ -345,7 +345,7 @@
 	msm_gpio_19_act: msm_gpio_19act {
 		mux {
 			pins = "gpio19";
-			function = "blsp_i2c5";
+			function = "blsp_i2c8";
 		};
 		config {
 			pins = "gpio19";


### PR DESCRIPTION
according to msm8976-pinctrl.dtsi, i2c8 is the function for gpio18 and
gpio19. This resolves the warning:
[    0.322351] ------------[ cut here ]------------
[    0.322380] WARNING: CPU: 2 PID: 1 at
drivers/pinctrl/qcom/pinctrl-msm.c:162 msm_pinmux_set_mux+0x74/0xf4()
[    0.322393] CPU: 2 PID: 1 Comm: swapper/0 Not tainted
3.18.31-perf-gb5c8693-dirty #8
[    0.322399] Hardware name: SoMC Kugo-ROW (DT)
[    0.322406] Call trace:
[    0.322420] [<ffffffc000206218>] dump_backtrace+0x0/0x214
[    0.322431] [<ffffffc000206440>] show_stack+0x14/0x1c
[    0.322443] [<ffffffc000cb19e0>] dump_stack+0x88/0xac
[    0.322455] [<ffffffc00021bbe0>] warn_slowpath_common+0x84/0xac
[    0.322466] [<ffffffc00021bcfc>] warn_slowpath_null+0x18/0x20
[    0.322476] [<ffffffc000436e18>] msm_pinmux_set_mux+0x74/0xf4
[    0.322488] [<ffffffc000434c98>] pinmux_enable_setting+0x1a8/0x220
[    0.322498] [<ffffffc00043349c>] pinctrl_select_state+0x84/0x12c
[    0.322507] [<ffffffc000438034>] somc_pinctrl_probe+0x68/0x128
[    0.322521] [<ffffffc0005d24c4>] platform_drv_probe+0x38/0x84
[    0.322532] [<ffffffc0005d1078>] driver_probe_device+0xd4/0x224
[    0.322541] [<ffffffc0005d11f4>] __device_attach+0x2c/0x4c
[    0.322551] [<ffffffc0005cfcd8>] bus_for_each_drv+0x70/0x8c
[    0.322560] [<ffffffc0005d1314>] device_attach+0x70/0x9c
[    0.322570] [<ffffffc0005cfe9c>] bus_probe_device+0x2c/0xa0
[    0.322580] [<ffffffc0005cdf54>] device_add+0x47c/0x540
[    0.322593] [<ffffffc000949a10>] of_device_add+0x38/0x40
[    0.322602] [<ffffffc00094a2f8>]
of_platform_device_create_pdata+0x98/0xd8
[    0.322612] [<ffffffc00094a568>] of_platform_bus_create+0x230/0x2c4
[    0.322622] [<ffffffc00094a5b0>] of_platform_bus_create+0x278/0x2c4
[    0.322632] [<ffffffc00094a750>] of_platform_populate+0x70/0xac
[    0.322646] [<ffffffc001403980>] arm64_device_init+0x20/0x2c
[    0.322657] [<ffffffc001400a44>] do_one_initcall+0xf4/0x184
[    0.322667] [<ffffffc001400c98>] kernel_init_freeable+0x1c4/0x260
[    0.322679] [<ffffffc000cacd98>] kernel_init+0x14/0xd8
[    0.322702] ---[ end trace 3cfb2baf4639642d ]---