### PR TITLE
CHROMIUM: power_supply: Add types for USB Type C and PD chargers

### DIFF
--- a/drivers/power/power_supply_sysfs.c
+++ b/drivers/power/power_supply_sysfs.c
@@ -46,9 +46,9 @@ static ssize_t power_supply_show_property(struct device *dev,
 					  char *buf) {
 	static char *type_text[] = {
 		"Unknown", "Battery", "UPS", "Mains", "USB",
-		"USB_DCP", "USB_CDP", "USB_ACA",
-		"USB_HVDCP", "USB_HVDCP_3", "Wireless", "BMS", "USB_Parallel",
-		"Wipower", "Retry_Detection"
+		"USB_DCP", "USB_CDP", "USB_ACA", "USB_C",
+		"USB_PD", "USB_PD_DRP", "USB_HVDCP", "USB_HVDCP_3",
+		"Wireless", "BMS", "USB_Parallel", "Wipower", "Retry_Detection"
 	};
 	static char *status_text[] = {
 		"Unknown", "Charging", "Discharging", "Not charging", "Full"

--- a/include/linux/power_supply.h
+++ b/include/linux/power_supply.h
@@ -246,6 +246,9 @@ enum power_supply_type {
 	POWER_SUPPLY_TYPE_USB_DCP,	/* Dedicated Charging Port */
 	POWER_SUPPLY_TYPE_USB_CDP,	/* Charging Downstream Port */
 	POWER_SUPPLY_TYPE_USB_ACA,	/* Accessory Charger Adapters */
+	POWER_SUPPLY_TYPE_USB_TYPE_C,	/* Type C Port */
+	POWER_SUPPLY_TYPE_USB_PD,	/* Type C Power Delivery Port */
+	POWER_SUPPLY_TYPE_USB_PD_DRP,	/* Type C PD Dual Role Port */
 	POWER_SUPPLY_TYPE_USB_HVDCP,	/* High Voltage DCP */
 	POWER_SUPPLY_TYPE_USB_HVDCP_3,	/* Efficient High Voltage DCP */
 	POWER_SUPPLY_TYPE_WIRELESS,	/* Accessory Charger Adapters */


### PR DESCRIPTION
This adds power supply types for USB chargers defined in
the USB Type-C Specification 1.1 and in the
USB Power Delivery Specification Revision 2.0 V1.1.

The following are added :
POWER_SUPPLY_TYPE_USB_TYPE_C,	/* Type C Port */
POWER_SUPPLY_TYPE_USB_PD,	/* Type C Power Delivery Port */
POWER_SUPPLY_TYPE_USB_PD_DRP,	/* Type C PD Dual Role Port */

Signed-off-by: Benson Leung <bleung@chromium.org>

BUG=chrome-os-partner:45222,chromium:531628
TEST=Attach the system to a plain SDP Type A host.
cat /sys/class/power_supply/CROS_USB_PD_CHARGER0/type
Check that the return value is 'USB'
Attach to a port that supports charging, or a wall wart.
Check that the type is 'Mains'

Change-Id: I6d9fd441ec6d7a155fa754d68e8283a5516d68c6
Reviewed-on: https://chromium-review.googlesource.com/304660
Commit-Ready: Benson Leung <bleung@chromium.org>
Tested-by: Benson Leung <bleung@chromium.org>
Reviewed-by: Alec Berg <alecaberg@chromium.org>
Reviewed-by: Vincent Palatin <vpalatin@chromium.org>
Reviewed-by: Todd Broch <tbroch@chromium.org>