### PR TITLE
qcom: clock-mmss-8974: Add missing 37.5MHz freq for cci_clk_src

### DIFF
--- a/arch/arm/mach-msm/clock-mmss-8974.c
+++ b/arch/arm/mach-msm/clock-mmss-8974.c
@@ -601,6 +601,7 @@ static struct rcg_clk mdp_clk_src = {
 
 static struct clk_freq_tbl ftbl_camss_cci_cci_clk[] = {
 	F_MM(19200000,    cxo,   1,   0,   0),
+	F_MM(37500000,  gpll0,  16,   0,   0),
 	F_END
 };
 


### PR DESCRIPTION
needed by commit 0c978e9037ca176f35ac028f06d611471f380a3d

Signed-off-by: David Viteri <davidteri91@gmail.com>