### PR TITLE
[UM.5.5.r1] Global actuator fix

### DIFF
--- a/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
@@ -2235,9 +2235,11 @@ static int32_t msm_actuator_platform_probe(struct platform_device *pdev)
 		rc = msm_camera_pinctrl_init(
 			&(msm_actuator_t->pinctrl_info), &(pdev->dev));
 		if (rc < 0) {
-			pr_err("ERR:%s: Error in reading actuator pinctrl\n",
+			pr_err("%s: Error in reading actuator pinctrl. \
+				Not fatal, going on.\n",
 				__func__);
 			msm_actuator_t->cam_pinctrl_status = 0;
+			rc = 0;
 		}
 	}
 


### PR DESCRIPTION
The fact that we need a GPIO (or pinctrl handle) for the actuator(s)
is not necessarily true... at least for us: we manage power by only
using regulator controls and we shut it down completely when we
don't need it.