### PR TITLE
[UM.5.5.r1 LOIRE] Pinctrl, BAM and new msm-bus subnode

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -644,6 +644,14 @@
 		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&msm_gpio_48_def &msm_gpio_45_def>;
 		pinctrl-1 = <&msm_gpio_48_def &msm_gpio_45_def>;
+
+		qcom,msm-bus,name = "msm-bcmdhd";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<45 512 0 0>, /* None vote */
+			<45 512 500 800>, /* Low vote */
+			<45 512 500 5448000>; /* High Vote */
 	};
 
 	usb_otg: usb@78db000 {

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1337,6 +1337,8 @@
 			interrupt-parent = <&intc>;
 			interrupts = <0 135 0>;
 			interrupt-names = "hsusb";
+
+			qcom,bam-type = <1>;
 			qcom,usb-bam-num-pipes = <16>;
 			qcom,usb-bam-fifo-baseaddr = <0x08606000>;
 			qcom,ignore-core-reset-ack;
@@ -1347,7 +1349,6 @@
 			qcom,pipe0 {
 				label = "hsusb-ipa-out-0";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <0>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <2>;
@@ -1361,7 +1362,6 @@
 			qcom,pipe1 {
 				label = "hsusb-ipa-in-0";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <2>;
@@ -1375,7 +1375,6 @@
 			qcom,pipe2 {
 				label = "hsusb-qdss-in-0";
 				qcom,usb-bam-mem-type = <3>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <1>;
@@ -1394,7 +1393,6 @@
 			qcom,pipe3 {
 				label = "hsusb-dpl-ipa-in-1";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <1>;
 				qcom,peer-bam = <2>;

--- a/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pinctrl.dtsi
@@ -342,16 +342,24 @@
 
 		pmx_sdc3_clk {
 			sdc3_clk_on: sdc3_clk_on {
+				mux {
+					pins = "gpio44";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_clk";
-					drive-strength = <16>; /* 16 MA */
+					pins = "gpio44";
 					bias-disable; /* NO pull */
+					drive-strength = <16>; /* 16 MA */
 				};
 			};
 
 			sdc3_clk_off: sdc3_clk_off {
+				mux {
+					pins = "gpio44";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_clk";
+					pins = "gpio44";
 					bias-disable; /* NO pull */
 					drive-strength = <2>; /* 2 MA */
 				};
@@ -360,16 +368,24 @@
 
 		pmx_sdc3_cmd {
 			sdc3_cmd_on: sdc3_cmd_on {
+				mux {
+					pins = "gpio43";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_cmd";
+					pins = "gpio43";
 					bias-pull-up; /* pull up */
 					drive-strength = <10>; /* 10 MA */
 				};
 			};
 
 			sdc3_cmd_off: sdc3_cmd_off {
+				mux {
+					pins = "gpio43";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_cmd";
+					pins = "gpio43";
 					bias-pull-up; /* pull up */
 					drive-strength = <2>; /* 2 MA */
 				};
@@ -378,86 +394,33 @@
 
 		pmx_sdc3_data {
 			sdc3_dat_on: sdc3_data_on {
+				mux {
+					pins = "gpio39", "gpio40",
+						"gpio41", "gpio42";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_data";
+					pins = "gpio39", "gpio40",
+						"gpio41", "gpio42";
 					bias-pull-up; /* pull up */
 					drive-strength = <10>; /* 10 MA */
 				};
 			};
 
 			sdc3_dat_off: sdc3_data_off {
+				mux {
+					pins = "gpio39", "gpio40",
+						"gpio41", "gpio42";
+					function = "sdc3";
+				};
 				config {
-					pins = "sdc3_data";
+					pins = "gpio39", "gpio40",
+						"gpio41", "gpio42";
 					bias-pull-up; /* pull up */
 					drive-strength = <2>; /* 2 MA */
 				};
 			};
 		};
-/************************************************************************
-		// TODO: CHECK ME!!!!
-		pmx_sdc3_clk {
-			qcom,pins = <&gp 44>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <2>;
-			label = "sdc3_clk";
-			sdc3_clk_on: clk_on {
-				bias-disable;
-				drive-strength = <16>;
-			};
-			sdc3_clk_off: clk_off {
-				bias-disable;
-				drive-strength = <2>;
-			};
-		};
-
-		pmx_sdc3_cmd {
-			qcom,pins = <&gp 43>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <2>;
-			label = "sdc3_cmd";
-			sdc3_cmd_on: cmd_on {
-				bias-pull-up;
-				drive-strength = <10>;
-			};
-			sdc3_cmd_off: cmd_off {
-				bias-pull-up;
-				drive-strength = <2>;
-			};
-		};
-
-		pmx_sdc3_dat {
-			qcom,pins = <&gp 39>, <&gp 40>, <&gp 41>, <&gp 42>;
-			qcom,num-grp-pins = <4>;
-			qcom,pin-func = <2>;
-			label = "sdc3_dat";
-			sdc3_dat_on: dat_on {
-				bias-pull-up;
-				drive-strength = <10>;
-			};
-			sdc3_dat_off: dat_off {
-				bias-pull-up;
-				drive-strength = <2>;
-			};
-		};
-
-		sdc3_wlan_gpio {
-			qcom,pins = <&gp 34>;
-			qcom,num-grp-pins = <1>;
-			qcom,pin-func = <0>;
-			label = "wlan_en_gpio";
-			sdc3_wlan_gpio_active: sdc3_wlan_gpio_active {
-				output-high;
-				drive-strength = <8>;
-				bias-pull-up;
-			};
-			sdc3_wlan_gpio_sleep: sdc3_wlan_gpio_sleep {
-				output-low;
-				drive-strength = <2>;
-				bias-disable;
-			};
-
-		};
-***********************************************************************/
 
 		pmx_mdss: pmx_mdss {
 			mdss_dsi_active: mdss_dsi_active {

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -1284,6 +1284,8 @@
 			interrupt-parent = <&intc>;
 			interrupts = <0 135 0>;
 			interrupt-names = "hsusb";
+
+			qcom,bam-type = <1>;
 			qcom,usb-bam-num-pipes = <16>;
 			qcom,usb-bam-fifo-baseaddr = <0x08606000>;
 			qcom,ignore-core-reset-ack;
@@ -1294,7 +1296,6 @@
 			qcom,pipe0 {
 				label = "hsusb-ipa-out-0";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <0>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <2>;
@@ -1308,7 +1309,6 @@
 			qcom,pipe1 {
 				label = "hsusb-ipa-in-0";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <2>;
@@ -1322,7 +1322,6 @@
 			qcom,pipe2 {
 				label = "hsusb-qdss-in-0";
 				qcom,usb-bam-mem-type = <3>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <0>;
 				qcom,peer-bam = <1>;
@@ -1341,7 +1340,6 @@
 			qcom,pipe3 {
 				label = "hsusb-dpl-ipa-in-1";
 				qcom,usb-bam-mem-type = <2>;
-				qcom,bam-type = <1>;
 				qcom,dir = <1>;
 				qcom,pipe-num = <1>;
 				qcom,peer-bam = <2>;

--- a/drivers/pinctrl/qcom/pinctrl-msm8976.c
+++ b/drivers/pinctrl/qcom/pinctrl-msm8976.c
@@ -244,17 +244,14 @@ static const struct pinctrl_pin_desc msm8976_pins[] = {
 	PINCTRL_PIN(149, "SDC2_CLK"),
 	PINCTRL_PIN(150, "SDC2_CMD"),
 	PINCTRL_PIN(151, "SDC2_DATA"),
-	PINCTRL_PIN(152, "SDC3_CLK"),
-	PINCTRL_PIN(153, "SDC3_CMD"),
-	PINCTRL_PIN(154, "SDC3_DATA"),
-	PINCTRL_PIN(155, "QDSD_CLK"),
-	PINCTRL_PIN(156, "QDSD_CMD"),
-	PINCTRL_PIN(157, "QDSD_DATA0"),
-	PINCTRL_PIN(158, "QDSD_DATA1"),
-	PINCTRL_PIN(159, "QDSD_DATA2"),
-	PINCTRL_PIN(160, "QDSD_DATA3"),
-	PINCTRL_PIN(161, "QDSD_DATA4"),
-	PINCTRL_PIN(162, "QDSD_DATA5"),
+	PINCTRL_PIN(152, "QDSD_CLK"),
+	PINCTRL_PIN(153, "QDSD_CMD"),
+	PINCTRL_PIN(154, "QDSD_DATA0"),
+	PINCTRL_PIN(155, "QDSD_DATA1"),
+	PINCTRL_PIN(156, "QDSD_DATA2"),
+	PINCTRL_PIN(157, "QDSD_DATA3"),
+	PINCTRL_PIN(158, "QDSD_DATA4"),
+	PINCTRL_PIN(159, "QDSD_DATA5"),
 
 };
 
@@ -413,17 +410,14 @@ static const unsigned int sdc1_rclk_pins[] = { 148 };
 static const unsigned int sdc2_clk_pins[] = { 149 };
 static const unsigned int sdc2_cmd_pins[] = { 150 };
 static const unsigned int sdc2_data_pins[] = { 151 };
-static const unsigned int sdc3_clk_pins[] = { 152 };
-static const unsigned int sdc3_cmd_pins[] = { 153 };
-static const unsigned int sdc3_data_pins[] = { 154 };
-static const unsigned int qdsd_clk_pins[] = { 155 };
-static const unsigned int qdsd_cmd_pins[] = { 156 };
-static const unsigned int qdsd_data0_pins[] = { 157 };
-static const unsigned int qdsd_data1_pins[] = { 158 };
-static const unsigned int qdsd_data2_pins[] = { 159 };
-static const unsigned int qdsd_data3_pins[] = { 160 };
-static const unsigned int qdsd_data4_pins[] = { 161 };
-static const unsigned int qdsd_data5_pins[] = { 162 };
+static const unsigned int qdsd_clk_pins[] = { 152 };
+static const unsigned int qdsd_cmd_pins[] = { 153 };
+static const unsigned int qdsd_data0_pins[] = { 154 };
+static const unsigned int qdsd_data1_pins[] = { 155 };
+static const unsigned int qdsd_data2_pins[] = { 156 };
+static const unsigned int qdsd_data3_pins[] = { 157 };
+static const unsigned int qdsd_data4_pins[] = { 158 };
+static const unsigned int qdsd_data5_pins[] = { 159 };
 
 enum msm8976_functions {
 	msm_mux_gpio,
@@ -566,6 +560,7 @@ enum msm8976_functions {
 	msm_mux_wcss_bt,
 	msm_mux_atest_char2,
 	msm_mux_ebi_ch0,
+	msm_mux_sdc3,
 	msm_mux_wcss_wlan2,
 	msm_mux_wcss_wlan1,
 	msm_mux_wcss_wlan0,
@@ -1077,6 +1072,10 @@ static const char * const atest_char2_groups[] = {
 static const char * const ebi_ch0_groups[] = {
 	"gpio75",
 };
+static const char * const sdc3_groups[] = {
+	"gpio39", "gpio40", "gpio41",
+	"gpio42", "gpio43", "gpio44",
+};
 static const char * const wcss_wlan2_groups[] = {
 	"gpio40",
 };
@@ -1405,6 +1404,7 @@ static const struct msm_function msm8976_functions[] = {
 	FUNCTION(wcss_bt),
 	FUNCTION(atest_char2),
 	FUNCTION(ebi_ch0),
+	FUNCTION(sdc3),
 	FUNCTION(wcss_wlan2),
 	FUNCTION(wcss_wlan1),
 	FUNCTION(wcss_wlan0),
@@ -1539,16 +1539,18 @@ static const struct msm_pingroup msm8976_groups[] = {
 		 NA, NA, qdss_tracedata_b),
 	PINGROUP(37, NA, NA, NA, NA, NA, NA, NA, NA, qdss_tracedata_b),
 	PINGROUP(38, cci_async, NA, NA, NA, NA, NA, NA, NA, qdss_tracedata_b),
-	PINGROUP(39, NA, NA, NA, qdss_tracedata_a, NA, dac_calib5, NA, NA, NA),
-	PINGROUP(40, wcss_wlan2, NA, qdss_tracedata_a, NA, dac_calib6, NA, NA, NA, NA),
+	PINGROUP(39, NA, NA, NA, qdss_tracedata_a, NA, dac_calib5, NA,
+		 sdc3, NA),
+	PINGROUP(40, wcss_wlan2, NA, qdss_tracedata_a, NA, dac_calib6, NA, NA,
+		 sdc3, NA),
 	PINGROUP(41, wcss_wlan1, cci_timer4, blsp3_spi, gcc_gp1_clk_b, qdss_tracedata_a,
-		 NA, qdss_cti_trig_out_a0, NA, dac_calib7),
+		 NA, qdss_cti_trig_out_a0, sdc3, dac_calib7),
 	PINGROUP(42, wcss_wlan0, gcc_gp1_clk_a, qdss_tracedata_a, NA,
-		 dac_calib8, NA, NA, NA, NA),
+		 dac_calib8, NA, NA, sdc3, NA),
 	PINGROUP(43, wcss_wlan, gcc_gp2_clk_a, qdss_tracedata_a, NA,
-		 dac_calib9, NA, NA, NA, NA),
+		 dac_calib9, NA, NA, sdc3, NA),
 	PINGROUP(44, wcss_wlan, gcc_gp3_clk_a, qdss_tracedata_a, NA,
-		 dac_calib10, NA, NA, NA, NA),
+		 dac_calib10, NA, NA, sdc3, NA),
 	PINGROUP(45, NA, qdss_tracedata_a, NA, dac_calib11, NA, NA, NA, NA, NA),
 	PINGROUP(46, qdss_tracedata_a, NA, dac_calib12, NA, NA, NA, NA, NA, NA),
 	PINGROUP(47, blsp6_spi, qdss_tracedata_a, NA, dac_calib13, NA, NA, NA,
@@ -1673,9 +1675,6 @@ static const struct msm_pingroup msm8976_groups[] = {
 	SDC_QDSD_PINGROUP(sdc2_clk, 0x109000, 14, 6),
 	SDC_QDSD_PINGROUP(sdc2_cmd, 0x109000, 11, 3),
 	SDC_QDSD_PINGROUP(sdc2_data, 0x109000, 9, 0),
-	SDC_QDSD_PINGROUP(sdc3_clk, 0x108000, 14, 6),
-	SDC_QDSD_PINGROUP(sdc3_cmd, 0x108000, 11, 3),
-	SDC_QDSD_PINGROUP(sdc3_data, 0x108000, 9, 0),
 	SDC_QDSD_PINGROUP(qdsd_clk, 0x19c000, 3, 0),
 	SDC_QDSD_PINGROUP(qdsd_cmd, 0x19c000, 8, 5),
 	SDC_QDSD_PINGROUP(qdsd_data0, 0x19c000, 13, 10),


### PR DESCRIPTION
The pinctrl was HELL WRONG!!!! The SDC3 device here is in the "regular" GPIO array, not in the "extra" QDSD ones (those names may not be correct, but if you see it, you'll get it).

This was meaning that the QDSD data, clock etc pins were shifted by 3 and that was a big oops :)


Apart that, BAM was not initializing correctly, so IPA and QDSS BAM subnodes were pretty much crazy even if basically we were not experiencing anything bad in userspace, but hey. The day would have come.

Finally, the new kernel is literally IN LOVE with the msm-bus declarations here and there, so, bcmdhd: why not.