### PR TITLE
[WIP] BT/FMRadio using the broadcom ldisc driver

### DIFF
--- a/drivers/bluetooth/bcm43xx.c
+++ b/drivers/bluetooth/bcm43xx.c
@@ -64,7 +64,7 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 1);
 
-#ifdef CONFIG_BT_MSM_SLEEP
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 		bluesleep_start(1);
 #endif
 	} else {
@@ -75,7 +75,7 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 0);
 
-#ifdef CONFIG_BT_MSM_SLEEP
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 		bluesleep_stop();
 #endif
 	}

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -450,16 +450,17 @@ int bluesleep_start(bool is_clock_enabled)
 	clear_bit(BT_TXDATA, &flags);
 #endif
 
+	clear_bit(BT_ASLEEP, &flags);
+
+	spin_unlock_irqrestore(&rw_lock, irq_flags);
+
 	// For ldisc-controlled BT, the clock is enabled by upper layers, so
 	// make bluesleep aware of this state.
-	clear_bit(BT_ASLEEP, &flags);
 	if(is_clock_enabled) {
 		atomic_set(&uart_is_on, 1);
 	} else {
 		hsuart_power(HS_UART_ON);
 	}
-
-	spin_unlock_irqrestore(&rw_lock, irq_flags);
 
 	enable_wakeup_irq(1);
 	set_bit(BT_PROTO, &flags);

--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -1444,7 +1444,7 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 		jiffies + msecs_to_jiffies(MSEC_PER_SEC));
 
 	/* Notify the bluesleep driver of outgoing data, if available. */
-#ifdef CONFIG_BT_MSM_SLEEP
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	bluesleep_outgoing_data();
 #endif
 
@@ -2730,8 +2730,10 @@ static int msm_hs_startup(struct uart_port *uport)
 
 
 	spin_lock_irqsave(&uport->lock, flags);
+#ifndef CONFIG_LINE_DISCIPLINE_DRIVER
 	atomic_set(&msm_uport->client_count, 0);
 	atomic_set(&msm_uport->client_req_state, 0);
+#endif
 	LOG_USR_MSG(msm_uport->ipc_msm_hs_pwr_ctxt,
 			"%s: Client_Count 0\n", __func__);
 	msm_hs_start_rx_locked(uport);


### PR DESCRIPTION
These commits allow us to use the broadcom ldisc driver for BT/FMRadio without any changes to libbt etc. The only additional requirements are some few changes to the device tree:
- "#define HCILP_INCLUDED false" in bdroid_buildcfg.h
- "UartPort = /dev/brcm_bt_dev" in bt_vendor.conf
- "UimUartPort = /dev/ttyHS0" in bt_vendor.conf (for msm_serial_hs)

The PR consists of 2 commits:
- A bugfix.
- The actual commit which intercepts configuration HCI commands from libbt with few related changes.

Bug List:
- Bug (1)
  BT may not be enabled automatically after startup (Toggling the BT switch enables it).
- Bug (2)
  If BT is switched to disabled once, and the device enters the "Deep Sleep" state, FMRadio does not work afterwards, EXCEPT if the FMRadio app was launched after setting BT to disabled before the device enters "Deep Sleep".
- Bug (3)
  See comment 1
- Bug (4)
  Kernel panic when disabling BT after "Deep Sleep" from the lockscreen. See comment 3