### PR TITLE
[1.3.3] tulip: sdcard

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -685,6 +685,10 @@
 	};
 };
 
+&sdhc_2 {
+	cd-gpios = <&msm_gpio 38 0>;
+};
+
 &sdc2_cd_off {
 	bias-pull-up;
 };


### PR DESCRIPTION
I added it here for to not modify the source msm8939-mtp.dtsi from qcom

[    8.544390] mmc1: new ultra high speed SDR104 SDHC card at address 59b4
[    8.544695] mmcblk1: mmc1:59b4 USDU1 29.5 GiB