### PR TITLE
ARM: dts: msm: Increase secure_mem heap size for MSM8956/76

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -90,7 +90,7 @@
 
 		secure_mem: secure_region@0 {
 			linux,reserve-contiguous-region;
-			reg = <0x0 0x0 0x0 0x7A00000>;
+			reg = <0x0 0x0 0x0 0x8100000>;
 			label = "secure_mem";
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8976.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976.dtsi
@@ -91,7 +91,7 @@
 
 		secure_mem: secure_region@0 {
 			linux,reserve-contiguous-region;
-			reg = <0x0 0x0 0x0 0x7A00000>;
+			reg = <0x0 0x0 0x0 0x8100000>;
 			label = "secure_mem";
 		};
 


### PR DESCRIPTION
To support WFD + WV free rotation, we need to take into
account rotation of multiple input layers. This needs
additional 7 MB of memory and hence increasing
secure_mem heap size from 122 MB to 129 MB.

Change-Id: Ib6833edc8fd55b18fad5fee50bcaa584cccf2462
Signed-off-by: Ramakant Singh <ramaka@codeaurora.org>