### PR TITLE
ARM: dts: msm: Add bus vectors in cpp node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -390,7 +390,14 @@
 			"camss_vfe_cpp_clk","micro_iface_clk", "camss_ahb_clk";
 		qcom,clock-rates = <0 240000000 0 0 240000000 0 0>;
 		qcom,min-clock-rate = <160000000>;
-		bus_master = <1>;
+		qcom,bus-master = <1>;
+		qcom,msm-bus,name = "msm_camera_cpp";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<106 512 0 0>,
+			<106 512 0 0>;
+			qcom,msm-bus-vector-dyn-vote;
 		qcom,cpp-fw-payload-info {
 			qcom,stripe-base = <156>;
 			qcom,plane-base = <141>;


### PR DESCRIPTION
Add bus vector in cpp node for independent
AB/IB voting. Previously this was being done
via isp.

Change-Id: I3804a72d705295645ef5321d995a8dcab6e395a9
Signed-off-by: Krupal Divvela <kdivvela@codeaurora.org>
Signed-off-by: Neelam Abhinav Karthik <aneelam@codeaurora.org>