### PR TITLE
arm64: DT: MSM8996: Rename thermal sensor-information child nodes

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -618,14 +618,14 @@
 			qcom,alias-name = "bl_therm";
 		};
 
-		sensor_information100: qcom,sensor-information@100 {
+		sensor_information100: qcom,sensor-information-100 {
 			qcom,sensor-type = "adc";
 			qcom,sensor-name = "bms";
 			qcom,alias-name = "batt_therm";
 			qcom,scaling-factor = <1000>;
 		};
 
-		sensor_information101: qcom,sensor-information@101 {
+		sensor_information101: qcom,sensor-information-101 {
 			qcom,sensor-type = "adc";
 			qcom,sensor-name = "flash_therm";
 			qcom,scaling-factor = <10>;


### PR DESCRIPTION
Following 2d62a489a6cf0cea206060ee788562d1022599a0

Signed-off-by: David Viteri <davidteri91@gmail.com>