### PR TITLE
kernel: bootlogo: amami: set correct config name

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_splash_logo.c
+++ b/drivers/video/msm/mdss/mdss_mdp_splash_logo.c
@@ -36,7 +36,7 @@
 #elif defined(CONFIG_MACH_SONY_SEAGULL) || \
       defined(CONFIG_MACH_SONY_TIANCHI) || \
       defined(CONFIG_MACH_SONY_TULIP) || \
-      defined(CONFIG_MACH_SONY_AMAMI) || \
+      defined(CONFIG_MACH_SONY_AMAMI_ROW) || \
       defined(CONFIG_MACH_SONY_ARIES) || \
       defined(CONFIG_MACH_SONY_SUZURAN) || \
       defined(CONFIG_MACH_SONY_KUGO)


### PR DESCRIPTION
CONFIG_MACH_SONY_AMAMI does not exist and bootlogo used for amami builds is very big (480 instead of 320)
fix this changing CONFIG_MACH_SONY_AMAMI to CONFIG_MACH_SONY_AMAMI_ROW which is expected
see https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BR.1.3.3_rb2.14/arch/arm/boot/dts/qcom/Makefile#L46

Signed-off-by: David Viteri <davidteri91@gmail.com>