### PR TITLE
arm64: MSM8956: DT: fix avtimer clock prop name

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2737,7 +2737,7 @@
 		reg = <0x0c0a300c 0x4>,
 			<0x0c0a3010 0x4>;
 		reg-names = "avtimer_lsb_addr", "avtimer_msb_addr";
-		qcom,clk_div = <27>;
+		qcom,clk-div = <27>;
 	};
 
 	mcd {


### PR DESCRIPTION
changed in commit 030de8d429f64c30b5a5fc6557a8c0609bad3a74

Signed-off-by: David Viteri <davidteri91@gmail.com>