### PR TITLE
arm64: MSM8956: DT: remove VMBMS feature

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2469,7 +2469,6 @@
 	voice: qcom,msm-pcm-voice {
 		compatible = "qcom,msm-pcm-voice";
 		qcom,destroy-cvd;
-		qcom,vote-bms;
 	};
 
 	stub_codec: qcom,msm-stub-codec {


### PR DESCRIPTION
Following 475b8cdd22ea0dde19202e983a6c6a438b9891b4

Signed-off-by: David Viteri <davidteri91@gmail.com>