### PR TITLE
media: msm: venus_hfi: Do not enable packetization in fw load for 8939

### DIFF
--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -4637,7 +4637,8 @@ static int __load_fw(struct venus_hfi_device *device)
 	/* kholk: Legacy SoCs cannot initialize packetization
 	 *        in firmware load path because old bootloader
 	 */
-	if (!of_machine_is_compatible("qcom,msm8956") &&
+	if (!of_machine_is_compatible("qcom,msm8939") &&
+	    !of_machine_is_compatible("qcom,msm8956") &&
 	    !of_machine_is_compatible("qcom,msm8976") &&
 	    !of_machine_is_compatible("qcom,msm8974") &&
 	    !of_machine_is_compatible("qcom,msm8994") &&


### PR DESCRIPTION
tulip will need this too
Following 030b26985660e99e0ca144b8b186c3fbef5539cc

Signed-off-by: David Viteri <davidteri91@gmail.com>