### PR TITLE
[1.3.3] arm64: DT: loire: Cleanup/update as3668 leds entries

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -288,21 +288,21 @@
 			somc,max_current_uA = <0 12000 5000 4000 4000 8000 8000>;
 			somc,rgb_blue {
 				label = "rgb";
-				linux,name = "as3668:blue";
+				linux,name = "led:rgb_blue";
 				somc,pattern_frame_mask = <0>;
 				somc,pattern_frame_delay = <0>;
 				linux,default-trigger = "none";
 			};
 			somc,rgb_red {
 				label = "rgb";
-				linux,name = "as3668:red";
+				linux,name = "led:rgb_red";
 				somc,pattern_frame_mask = <0>;
 				somc,pattern_frame_delay = <0>;
 				linux,default-trigger = "none";
 			};
 			somc,rgb_green {
 				label = "rgb";
-				linux,name = "as3668:green";
+				linux,name = "led:rgb_green";
 				somc,pattern_frame_mask = <0>;
 				somc,pattern_frame_delay = <0>;
 				linux,default-trigger = "none";

--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -115,21 +115,7 @@
 			fusb301,use-try-snk-emulation;
 		};
 		as3668@42 {
-                        somc,rgb_blue {
-                                linux,name = "led:rgb_blue";
-                                somc,max_single_current_uA = <12000>;
-                                somc,max_mix_current_uA = <4500>;
-                        };
-                        somc,rgb_red {
-                                linux,name = "led:rgb_red";
-                                somc,max_single_current_uA = <2700>;
-                                somc,max_mix_current_uA = <900>;
-                        };
-                        somc,rgb_green {
-                                linux,name = "led:rgb_green";
-                                somc,max_single_current_uA = <2000>;
-                                somc,max_mix_current_uA = <2000>;
-                        };
+			somc,max_current_uA = <0 12000 4500 2700 900 2000 2000>;
 		};
 	};
 

--- a/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
@@ -38,21 +38,7 @@
 	/* I2C : BLSP6 */
 	i2c@7af6000 { /* BLSP2 QUP1 */
 		as3668@42 {
-			somc,rgb_blue {
-				linux,name = "led:rgb_blue";
-				somc,max_single_current_uA = <12000>;
-				somc,max_mix_current_uA = <4000>;
-			};
-			somc,rgb_red {
-				linux,name = "led:rgb_red";
-				somc,max_single_current_uA = <5000>;
-				somc,max_mix_current_uA = <5000>;
-			};
-			somc,rgb_green {
-				linux,name = "led:rgb_green";
-				somc,max_single_current_uA = <8000>;
-				somc,max_mix_current_uA = <8000>;
-			};
+			somc,max_current_uA = <0 12000 4000 5000 5000 8000 8000>;
 		};
 	};
 };


### PR DESCRIPTION
Update DT entries to match with driver update.
Also clean up duplicate DT entries between loire devices.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ia1eaf520a6c1b54c3cb098f8190f59a53190f96a