### PR TITLE
arm64: MSM8956: DT: fix msm-ssc-sensors typo

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2170,7 +2170,7 @@
 		qcom,master-id = <86>;
 	};
 
-	qcom,,msm-ssc-sensors {
+	qcom,msm-ssc-sensors {
 		compatible = "qcom,msm-ssc-sensors";
 	};
 


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>