### PR TITLE
[5.5] Fix UART clk turning on after resume.

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -710,13 +710,14 @@ static int bluesleep_resume(struct platform_device *pdev)
 	if (test_bit(BT_SUSPEND, &flags)) {
 		if (debug_mask & DEBUG_SUSPEND)
 			pr_info("bluesleep resuming...\n");
+		clear_bit(BT_SUSPEND, &flags);
+
 		if (atomic_read(&open_count) == 1 &&
 			(gpio_get_value(bsi->host_wake) == bsi->irq_polarity)) {
 			if (debug_mask & DEBUG_SUSPEND)
 				pr_info("bluesleep resume from BT event...\n");
 			hsuart_power(HS_UART_ON);
 		}
-		clear_bit(BT_SUSPEND, &flags);
 	}
 	return 0;
 }


### PR DESCRIPTION
In I50eb35b6af93f6bebb2122b3f80061f04b120998, the UART clock turn on
code in the resume function was modified to use the hsuart_power
function to avoid code duplication. The latter method checks the
BT_SUSPEND flag and does nothing if it is not set. Due to the fact that
the flag is cleared only after the invocation of hsuart_power, the clock
is not turned on as it was previously. Hence, move the code to clear the
flag before the invocation of the hsuart_power function to restore the
orignal behavior.

Change-Id: Icaf781433bd3641c52a2a2f98007ea9ba721ba38
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>