### PR TITLE
phy-msm-usb: also set usb switch port for Suzu when OTG state is manu…

### DIFF
--- a/drivers/usb/phy/phy-msm-usb.c
+++ b/drivers/usb/phy/phy-msm-usb.c
@@ -5163,6 +5163,9 @@ static int otg_power_set_property_usb(struct power_supply *psy,
 	switch (psp) {
 	case POWER_SUPPLY_PROP_USB_OTG:
 		motg->id_state = val->intval ? USB_ID_GROUND : USB_ID_FLOAT;
+#ifdef CONFIG_MACH_SONY_SUZU
+		msm_otg_select_usb_switch(motg);
+#endif
 		queue_delayed_work(motg->otg_wq, &motg->id_status_work, 0);
 		break;
 	/* PMIC notification for DP DM state */


### PR DESCRIPTION
…ally set

As msm_otg_select_usb_switch() is called in msm_id_status_w() when OTG state is set according to the actual ground state of the ID pin, it should be also called when the state is manually set through sysfs.