### PR TITLE
[5.5 R1] video: msm: somc_panel: Force full-incell SP state at first poweroff

### DIFF
--- a/drivers/video/msm/mdss/somc_panel/panel_incell.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_incell.c
@@ -1654,12 +1654,10 @@ int incell_power_lock_ctrl(incell_pw_lock lock,
 
 	pr_debug("%s: status:%d --->\n", __func__, ((int)(incell->state)));
 
-	if (hybrid_incell) {
-		if (incell->state == INCELL_STATE_SLE000_P0 &&
-				!sp_panel_forced) {
-			incell_force_sp_on();
-			sp_panel_forced = true;
-		}
+	if (incell->state == INCELL_STATE_SLE000_P0 &&
+			!sp_panel_forced) {
+		incell_force_sp_on();
+		sp_panel_forced = true;
 	}
 
 	if (lock == INCELL_DISPLAY_POWER_LOCK)


### PR DESCRIPTION
The hybrid incell panel already had this because of the required
GPIO stuff to reset the touchscreen, but the full incell supposedly
didn't require this.

Unfortunately, suppositions were wrong, since we do NOT kickstart
the touchscreen from userspace, but from kernel (which is THE
proper way).

Set SP ON for also full incell at first poweroff (incell state is
SLE000_P0, meaning "everything OFF") because bootloader actually
initializes the incell regulator and powers on both display and
TS rails.

The main issue here was that bootloader will not pass incell state
to the kernel driver, hence this hack is needed.