### PR TITLE
[UM.5.5.r1] Bluetooth reverts

### DIFF
--- a/drivers/bluetooth/bcm43xx.c
+++ b/drivers/bluetooth/bcm43xx.c
@@ -27,6 +27,9 @@
 #include <linux/platform_device.h>
 #include <linux/rfkill.h>
 #include <linux/slab.h>
+#ifdef CONFIG_BT_MSM_SLEEP
+#include <net/bluetooth/bluesleep.h>
+#endif
 
 #define D_BCM_BLUETOOTH_CONFIG_MATCH_TABLE   "bcm,bcm43xx"
 
@@ -61,6 +64,9 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 1);
 
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+		bluesleep_start(1);
+#endif
 	} else {
 		if (!regOnGpio) {
 			pr_debug("Bluetooth device is already power off:%d\n",
@@ -69,6 +75,9 @@ static int bcm43xx_bt_rfkill_set_power(void *data, bool blocked)
 		}
 		gpio_set_value(bcm43xx_my_data->reg_on_gpio, 0);
 
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+		bluesleep_stop();
+#endif
 	}
 	bt_enabled = !blocked;
 

--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -311,14 +311,14 @@ static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 	switch (cmd) {
 	case MSM_ENABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_on(&msm_uport->uport);
-#if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+#ifdef CONFIG_BT_MSM_SLEEP
 		bluesleep_outgoing_data();
 #endif
 		break;
 	}
 	case MSM_DISABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_off(&msm_uport->uport);
-#if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+#ifdef CONFIG_BT_MSM_SLEEP
 		bluesleep_tx_allow_sleep();
 #endif
 		break;
@@ -1441,6 +1441,11 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	/* Set 1 second timeout */
 	mod_timer(&tx->tx_timeout_timer,
 		jiffies + msecs_to_jiffies(MSEC_PER_SEC));
+
+	/* Notify the bluesleep driver of outgoing data, if available. */
+#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
+	bluesleep_outgoing_data();
+#endif
 
 	MSM_HS_DBG("%s:Enqueue Tx Cmd, ret %d\n", __func__, ret);
 }


### PR DESCRIPTION
This patch reverts bluesleep driver to the 3.10 way

Also this requires IOCTL as BT power communication
https://github.com/sonyxperiadev/device-sony-tone/pull/25

It is necessary to fix UART clock request as following:

[   66.395108] Unable to handle kernel NULL pointer dereference at virtual address 00000538
[   66.395122] pgd = ffffffc064a71000
[   66.395127] [00000538] *pgd=00000000c70dc003, *pud=00000000c70dc003, *pmd=0000000000000000
[   66.395143] Internal error: Oops: 96000006 [#1] PREEMPT SMP
[   66.395153] CPU: 0 PID: 1520 Comm: bluetooth wake Not tainted 3.18.31-perf-gfd1084e #5
[   66.395158] Hardware name: SoMC Kagura-ROW (DT)
[   66.395164] task: ffffffc03e045400 ti: ffffffc03e07c000 task.ti: ffffffc03e07c000
[   66.395176] PC is at mutex_locj+0x10/0x48
[   66.395184] LR is at msm_hs_request_clock_on+0x24/0x98
[   66.395189] pc : [<ffffffc000cbd98c>] lr : [<ffffffc000564ba8>] pstate: 20000145
[   66.395193] sp : ffffffc03e07fd10
[   66.395198] x29: ffffffc03e07fd10x28: ffffffc03e07c000 
[   66.395207] x27: ffffffc00020b000 x26: 0000000000000004 
[   66.395215] x25: 0000000000000182 x24: 0000000000000011 
[   66.395224] x23: 0000000000000001 x22: 00000000d4c70463 
[   66.395232] x21: 0000000000000538 x20: 0000000000000000 
[   66.395240] x19: 0000000000000538 x18: 0000000000000000 
[   66.395247] x17: 0000000000000000 x16: ffffffc0002e0760 
[   66.395255] x15: 0000000000000000 x14: 00000000ee1e0b99 
[   66.395263] x13: 00000000d4c70458 x12: 00000000d4c708d8 
[   66.395270] x11: 00000000e5a865d4 x10: 00000000e5a86528 
[   66.395278] x9 : 00000000d4c704c0 x8 : 0000000000000000 
[   66.395286] x7 : 0000000000000000 x6 : 0000000000000001 
[   66.395294] x5 : 0000000000000001 x4 : 0000000000000001 
[   66.395302] x3 : ffffffc0766f7200 x2 : 0000000000000001 
[   66.395310] x1 : 0000000000000000 x0 : 0000000000000538 
