### PR TITLE
[UM.5.5.r1] drivers: bluetooth: Fix unbalanced irq

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -668,9 +668,13 @@ static int bluesleep_probe(struct platform_device *pdev)
 		goto free_bt_ext_wake;
 	}
 
+#if defined(CONFIG_LINE_DISCIPLINE_DRIVER)
 	bsi->uport = msm_hs_get_uart_port(BT_PORT_ID);
-
 	atomic_set(&bsi->wakeup_irq_disabled, 1);
+#else
+	enable_wakeup_irq(0);
+#endif
+
 	return 0;
 
 free_bt_ext_wake:


### PR DESCRIPTION
[   84.261515] WARNING: CPU: 0 PID: 3551 at ../../../../../..\
        /kernel/sony/msm8996/kernel/irq/manage.c:448 __enable_irq+0x40/0x88()
[   84.261520] Unbalanced enable for IRQ 351

Change-Id: I32c85e5fdfbb783916f686a39f0065332db4dd51
Signed-off-by: Humberto Borba <humberos@gmail.com>