### PR TITLE
[UM.5.5.r1] arm64: kernel: Fix typo

### DIFF
--- a/arch/arm64/kernel/perf_event.c
+++ b/arch/arm64/kernel/perf_event.c
@@ -1669,7 +1669,7 @@ static struct notifier_block perf_cpu_idle_nb = {
  */
 static const struct of_device_id armpmu_of_device_ids[] = {
 	{.compatible = "arm,armv8-pmuv3"},
-#ifdef CONFIG_MACH_MSM8996
+#ifdef CONFIG_ARCH_MSM8996
 	{.compatible = "qcom,kryo-pmuv3", .data = kryo_pmu_init},
 #endif
 	{},


### PR DESCRIPTION
Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I582732597b55fc1de9e7e381d54d118d45ca21a7