### PR TITLE
[UM.5.5.r1] drivers: bluetooth: tone: Fix bluesleep wakelock

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2727,7 +2727,7 @@ static int msm_hs_startup(struct uart_port *uport)
 
 
 	spin_lock_irqsave(&uport->lock, flags);
-#ifndef CONFIG_LINE_DISCIPLINE_DRIVER
+#ifdef CONFIG_BT_MSM_SLEEP
 	atomic_set(&msm_uport->client_count, 0);
 	atomic_set(&msm_uport->client_req_state, 0);
 #endif


### PR DESCRIPTION
Current driver is causing wakelock on tone devices which will not
able to going to sleep properly.

So, this patch uses the same logic developed for ldisc targets (tx timer)
and now tone devices should be able to sleep as expected.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ia619bd8d83e049cabb082b2a668101bd6d856799