### PR TITLE
[UM.5.5.r1] ARM: dts: msm: Route to sw crypto for hmac and aead on msm8996

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996.dtsi
@@ -2454,6 +2454,8 @@
 		qcom,use-sw-aes-xts-algo;
 		qcom,use-sw-aes-ccm-algo;
 		qcom,use-sw-ahash-algo;
+		qcom,use-sw-hmac-algo;
+		qcom,use-sw-aead-algo;
 	};
 
 	qcom_cedev: qcedev@660000 {


### PR DESCRIPTION
For crypto operations, kernel applications request for tfm by
using crypto_alloc with algorithm name, which ever algorithm
was registered first those will be used for completing the
requested process. HW crypto driver has different algorithm
names to use HW crypto calls instead of SW crypto. Two flags
has been missed on this targets which leads all the crypto
calls to HW crypto, for smaller size packets its not advisable
to use HW crypto. This patch adds dtsi flags to route all the
calls to SW instead HW for hmac and aead alogs. If app wants
to use HW crypto then it should append "qcom-" to the name
of crypto algorithms.

Change-Id: I6b361eadbc5830fa7d513b62c44fe99cb8a75fc8
Signed-off-by: AnilKumar Chimata <anilc@codeaurora.org>
Signed-off-by: Mallikarjuna Reddy Amireddy <mamire@codeaurora.org>