### PR TITLE
amami: Correct fcc-mah in DT

### DIFF
--- a/arch/arm/boot/dts/qcom/batterydata-rhine-amami.dtsi
+++ b/arch/arm/boot/dts/qcom/batterydata-rhine-amami.dtsi
@@ -16,7 +16,7 @@
  */
 
 qcom,amami-batterydata {
-	qcom,fcc-mah = <3140>;
+	qcom,fcc-mah = <2420>;
 	qcom,default-rbatt-mohm = <100>;
 	qcom,rbatt-capacitive-mohm = <0>;
 	qcom,flat-ocv-threshold-uv = <3800000>;


### PR DESCRIPTION
Commit ae463afda7d5 ("arm: DT: Rhine: Implement DT battery data") ported the
battery data to DT and accidentally used the same value as honami.
Use correct value from C removed in commit 0af12f52b182 ("arm: mach-msm:
Remove C-form batterydata for Shinano and Rhine").