### PR TITLE
[5.5.R1] Fix PCC color calibration for v1.7 hardware

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-v3.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-v3.dtsi
@@ -118,7 +118,7 @@
 
 			qcom,speed-bin = <0>;
 
-			qcom,initial-pwrlevel = <5>;
+			qcom,initial-pwrlevel = <6>;
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
@@ -191,7 +191,7 @@
 
 			qcom,speed-bin = <1>;
 
-			qcom,initial-pwrlevel = <3>;
+			qcom,initial-pwrlevel = <4>;
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
@@ -248,7 +248,7 @@
 
 			qcom,speed-bin = <2>;
 
-			qcom,initial-pwrlevel = <4>;
+			qcom,initial-pwrlevel = <5>;
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -334,6 +334,8 @@ static void msm_restart_prepare(const char *cmd)
 		} else {
 			__raw_writel(0x77665501, restart_reason);
 		}
+	} else {
+		__raw_writel(0x776655AA, restart_reason);
 	}
 
 	flush_cache_all();

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -1615,6 +1615,13 @@ static int mdss_dsi_unblank(struct mdss_panel_data *pdata)
 	}
 
 	ctrl_pdata->ctrl_state |= CTRL_STATE_PANEL_INIT;
+#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
+	ret = ctrl_pdata->spec_pdata->unblank(ctrl_pdata);
+	if (ret){
+		pr_err("%s: Unblank specific commands failed.\n", __func__);
+		goto error;
+	}
+#endif
 
 error:
 	mdss_dsi_clk_ctrl(ctrl_pdata, ctrl_pdata->dsi_clk_handle,

--- a/drivers/video/msm/mdss/mdss_dsi.c
+++ b/drivers/video/msm/mdss/mdss_dsi.c
@@ -3304,8 +3304,9 @@ static int mdss_dsi_ctrl_probe(struct platform_device *pdev)
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
 	if (ctrl_pdata->panel_data.panel_info.cont_splash_enabled &&
 		ctrl_pdata->spec_pdata->pcc_data.pcc_sts & PCC_STS_UD) {
-		ctrl_pdata->spec_pdata->pcc_setup(&ctrl_pdata->panel_data);
-		ctrl_pdata->spec_pdata->pcc_data.pcc_sts &= ~PCC_STS_UD;
+		rc = ctrl_pdata->spec_pdata->pcc_setup(&ctrl_pdata->panel_data);
+		if (rc == 0)
+			ctrl_pdata->spec_pdata->pcc_data.pcc_sts &= ~PCC_STS_UD;
 	}
 #endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -1346,6 +1346,16 @@ error:
 	return -ENODEV;
 }
 
+static int mdss_dsi_panel_unblank(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
+{
+	if (ctrl_pdata->spec_pdata->pcc_data.pcc_sts & PCC_STS_UD) {
+		ctrl_pdata->spec_pdata->pcc_setup(&ctrl_pdata->panel_data);
+		ctrl_pdata->spec_pdata->pcc_data.pcc_sts &= ~PCC_STS_UD;
+	}
+
+	return 0;
+}
+
 static int mdss_dsi_panel_on(struct mdss_panel_data *pdata)
 {
 	struct mipi_panel_info *mipi;
@@ -1376,11 +1386,11 @@ static int mdss_dsi_panel_on(struct mdss_panel_data *pdata)
 
 	lcm_first_boot = 0;
 
-	if (spec_pdata->pcc_data.pcc_sts & PCC_STS_UD) {
+/*	if (spec_pdata->pcc_data.pcc_sts & PCC_STS_UD) {
 		mdss_dsi_panel_pcc_setup(pdata);
 		spec_pdata->pcc_data.pcc_sts &= ~PCC_STS_UD;
 	}
-
+*/
 	if (pdata->panel_info.dsi_master != pdata->panel_info.pdest)
 		goto end;
 

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -2088,7 +2088,7 @@ static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata)
 		pcc_data->color_tbl[pcc_data->tbl_idx].b_data);
 
 exit:
-	return 0;
+	return ret;
 }
 
 #define PA_V2_BASIC_FEAT_ENB (MDP_PP_PA_HUE_ENABLE | MDP_PP_PA_SAT_ENABLE | \

--- a/drivers/video/msm/mdss/somc_panel/panel_driver.c
+++ b/drivers/video/msm/mdss/somc_panel/panel_driver.c
@@ -1979,6 +1979,10 @@ static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata)
 	int ret;
 	u32 copyback;
 	struct mdp_pcc_cfg_data pcc_config;
+	struct mdp_pcc_data_v1_7 pcc_payload;
+	struct mdp_pp_feature_version pcc_version = {
+		.pp_feature = PCC,
+	};
 
 	if (pdata == NULL) {
 		pr_err("%s: Invalid input data\n", __func__);
@@ -2012,8 +2016,6 @@ static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata)
 								 __func__);
 	}
 
-	memset(&pcc_config, 0, sizeof(struct mdp_pcc_cfg_data));
-
 	pinfo = &ctrl_pdata->panel_data.panel_info;
 	if (pinfo->rev_u[1] != 0) {
 		if (pinfo->rev_u[0] == 0)
@@ -2032,6 +2034,7 @@ static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata)
 			pcc_data->v_data = pcc_data->v_data - pinfo->rev_v[1];
 	}
 
+	memset(&pcc_config, 0, sizeof(struct mdp_pcc_cfg_data));
 	ret = find_color_area(&pcc_config, pcc_data);
 	if (ret) {
 		pr_err("%s: Can't find color area!!!!\n", __func__);
@@ -2039,8 +2042,21 @@ static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata)
 	}
 
 	if (pcc_data->color_tbl[pcc_data->tbl_idx].color_type != UNUSED) {
+		ret = mdss_mdp_pp_get_version(&pcc_version);
+		if (ret) {
+			pr_err("%s: FAIL: Cannot get PP version.\n", __func__);
+			goto exit;
+		}
+		memset(&pcc_payload, 0, sizeof(struct mdp_pcc_data_v1_7));
+		pcc_config.cfg_payload = &pcc_payload;
+		pcc_config.version = pcc_version.version_info;
 		pcc_config.block = MDP_LOGICAL_BLOCK_DISP_0;
 		pcc_config.ops = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE;
+
+		pcc_payload.r.r = pcc_config.r.r;
+		pcc_payload.g.g = pcc_config.g.g;
+		pcc_payload.b.b = pcc_config.b.b;
+
 		ret = mdss_mdp_pcc_config(mfd, &pcc_config, &copyback);
 		if (ret != 0)
 			pr_err("%s: Failed setting PCC data\n", __func__);
@@ -4599,6 +4615,7 @@ int mdss_dsi_panel_init(struct device_node *node,
 	spec_pdata->reset = mdss_dsi_panel_reset_seq;
 	spec_pdata->disp_on = mdss_dsi_panel_disp_on;
 	spec_pdata->update_fps = mdss_dsi_panel_fps_data_update;
+	spec_pdata->unblank = mdss_dsi_panel_unblank;
 
 	ctrl_pdata->on = mdss_dsi_panel_on;
 	ctrl_pdata->post_panel_on = mdss_dsi_post_panel_on;

--- a/drivers/video/msm/mdss/somc_panel/somc_panel_exts.h
+++ b/drivers/video/msm/mdss/somc_panel/somc_panel_exts.h
@@ -113,6 +113,7 @@ struct mdss_panel_specific_pdata {
 	int (*update_panel) (struct mdss_panel_data *pdata);
 	int (*update_fps) (struct msm_fb_data_type *mfd);
 	int (*reset) (struct mdss_panel_data *pdata, int enable);
+	int (*unblank) (struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 
 	int (*panel_power_ctrl) (struct mdss_panel_data *pdata, int enable);
 	int (*panel_power_on)	(struct mdss_panel_data *pdata);


### PR DESCRIPTION
This fixes display color calibration on v1.7 hardware.
This includes MSM8996, MSM8998 (/pro)