### PR TITLE
[1.3.3] sched: avoid unnecessary multiplication and division

### DIFF
--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -985,8 +985,10 @@ static inline u64 scale_load_to_cpu(u64 task_load, int cpu)
 {
 	u64 lsf = cpu_load_scale_factor(cpu);
 
-	task_load *= (u64)lsf;
-	task_load /= 1024;
+	if (lsf != 1024) {
+		task_load *= (u64)lsf;
+		task_load /= 1024;
+	}
 
 	return task_load;
 }


### PR DESCRIPTION
Avoid unnecessary multiplication and division when load scaling factor
is 1024.

Change-Id: If3cb63a77feaf49cc69ddec7f41cc3c1cabbfc5a
Signed-off-by: Joonwoo Park <joonwoop@codeaurora.org>
[Port to LA.BR.1.3.3_rb2.14]
Signed-off-by: RyTek <rytek1128@outlook.com>