### PR TITLE
arm: irq: drop "IRQx no longer affine to CPUn" print to pr_debug()

### DIFF
--- a/arch/arm/kernel/irq.c
+++ b/arch/arm/kernel/irq.c
@@ -183,7 +183,7 @@ void migrate_irqs(void)
 		raw_spin_unlock(&desc->lock);
 
 		if (affinity_broken && printk_ratelimit())
-			pr_warning("IRQ%u no longer affine to CPU%u\n", i,
+			pr_debug("IRQ%u no longer affine to CPU%u\n", i,
 				smp_processor_id());
 	}
 


### PR DESCRIPTION
On devices where hotplug is used for power savings or thermal
mitigation, it's not uncommon for hotplug events to be relatively
frequent and their latency to matter.

If a serial console is enabled, the "IRQ no longer affine to CPU"
informational prints can be one of the most significant contributors
to hotplug latency. For example, on msm8994, 10 lines of this format
are normally printed on each hotplug. At 115200/8/N/1 baud, that
printing takes a minimum of 42.5ms.

On production devices where a serial console is not enabled, the time
takes is negligible (a few microseconds at most), but the prints do
still clutter the logs and are worth silencing since they are
typically of no concern.

Signed-off-by: Matt Wagantall <mwagantall@cyngn.com>

@kholk muted the logspam for arm64, but not for arm, so this commit (partially) fixes this logspam https://github.com/sonyxperiadev/kernel/issues/1259