### PR TITLE
[LA.BR.1.3.3_rb2.14] CAF Security Advisories - April 14-17, 2017

### DIFF
--- a/drivers/gpu/msm/kgsl.c
+++ b/drivers/gpu/msm/kgsl.c
@@ -533,20 +533,17 @@ void kgsl_context_dump(struct kgsl_context *context)
 EXPORT_SYMBOL(kgsl_context_dump);
 
 /* Allocate a new context ID */
-int _kgsl_get_context_id(struct kgsl_device *device,
-		struct kgsl_context *context)
+int _kgsl_get_context_id(struct kgsl_device *device)
 {
 	int id;
 
 	idr_preload(GFP_KERNEL);
 	write_lock(&device->context_lock);
-	id = idr_alloc(&device->context_idr, context, 1,
+	/* Allocate the slot but don't put a pointer in it yet */
+	id = idr_alloc(&device->context_idr, NULL, 1,
 		KGSL_MEMSTORE_MAX, GFP_NOWAIT);
 	write_unlock(&device->context_lock);
 	idr_preload_end();
-
-	if (id > 0)
-		context->id = id;
 
 	return id;
 }
@@ -571,7 +568,7 @@ int kgsl_context_init(struct kgsl_device_private *dev_priv,
 	char name[64];
 	int ret = 0, id;
 
-	id = _kgsl_get_context_id(device, context);
+	id = _kgsl_get_context_id(device);
 	if (id == -ENOSPC) {
 		/*
 		 * Before declaring that there are no contexts left try
@@ -580,7 +577,7 @@ int kgsl_context_init(struct kgsl_device_private *dev_priv,
 		 */
 
 		flush_workqueue(device->events_wq);
-		id = _kgsl_get_context_id(device, context);
+		id = _kgsl_get_context_id(device);
 	}
 
 	if (id < 0) {
@@ -591,6 +588,8 @@ int kgsl_context_init(struct kgsl_device_private *dev_priv,
 
 		return id;
 	}
+
+	context->id = id;
 
 	kref_init(&context->refcount);
 	/*
@@ -1806,6 +1805,12 @@ long kgsl_ioctl_drawctxt_create(struct kgsl_device_private *dev_priv,
 		goto done;
 	}
 	trace_kgsl_context_create(dev_priv->device, context, param->flags);
+
+	/* Commit the pointer to the context in context_idr */
+	write_lock(&device->context_lock);
+	idr_replace(&device->context_idr, context, context->id);
+	write_unlock(&device->context_lock);
+
 	param->drawctxt_id = context->id;
 done:
 	return result;

--- a/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2014, 2016-2017, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -28,6 +28,8 @@ struct q6audio_effects {
 
 	struct audio_client             *ac;
 	struct msm_hwacc_effects_config  config;
+
+	struct mutex			lock;
 
 	atomic_t			in_count;
 	atomic_t			out_count;
@@ -230,8 +232,11 @@ static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
 		uint32_t idx = 0;
 		uint32_t size = 0;
 
+		mutex_lock(&effects->lock);
+
 		if (!effects->started) {
 			rc = -EFAULT;
+			mutex_unlock(&effects->lock);
 			goto ioctl_fail;
 		}
 
@@ -241,11 +246,13 @@ static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
 		if (!rc) {
 			pr_err("%s: write wait_event_timeout\n", __func__);
 			rc = -EFAULT;
+			 mutex_unlock(&effects->lock);
 			goto ioctl_fail;
 		}
 		if (!atomic_read(&effects->out_count)) {
 			pr_err("%s: pcm stopped out_count 0\n", __func__);
 			rc = -EFAULT;
+			mutex_unlock(&effects->lock);
 			goto ioctl_fail;
 		}
 
@@ -254,6 +261,7 @@ static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
 			if (copy_from_user(bufptr, (void *)arg,
 					effects->config.buf_cfg.output_len)) {
 				rc = -EFAULT;
+				mutex_unlock(&effects->lock);
 				goto ioctl_fail;
 			}
 			rc = q6asm_write(effects->ac,
@@ -261,6 +269,7 @@ static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
 					 0, 0, NO_TIMESTAMP);
 			if (rc < 0) {
 				rc = -EFAULT;
+				mutex_unlock(&effects->lock);
 				goto ioctl_fail;
 			}
 			atomic_dec(&effects->out_count);
@@ -268,6 +277,7 @@ static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
 			pr_err("%s: AUDIO_EFFECTS_WRITE: Buffer dropped\n",
 				__func__);
 		}
+		mutex_unlock(&effects->lock);
 		break;
 	}
 	case AUDIO_EFFECTS_READ: {
@@ -464,6 +474,7 @@ static long audio_effects_ioctl(struct file *file, unsigned int cmd,
 		break;
 	}
 	case AUDIO_EFFECTS_SET_BUF_LEN: {
+		mutex_lock(&effects->lock);
 		if (copy_from_user(&effects->config.buf_cfg, (void *)arg,
 				   sizeof(effects->config.buf_cfg))) {
 			pr_err("%s: copy from user for AUDIO_EFFECTS_SET_BUF_LEN failed\n",
@@ -473,6 +484,7 @@ static long audio_effects_ioctl(struct file *file, unsigned int cmd,
 		pr_debug("%s: write buf len: %d, read buf len: %d\n",
 			 __func__, effects->config.buf_cfg.output_len,
 			 effects->config.buf_cfg.input_len);
+		mutex_unlock(&effects->lock);
 		break;
 	}
 	case AUDIO_EFFECTS_GET_BUF_AVAIL: {
@@ -717,6 +729,7 @@ static int audio_effects_release(struct inode *inode, struct file *file)
 	}
 	q6asm_audio_client_free(effects->ac);
 
+	mutex_destroy(&effects->lock);
 	kfree(effects);
 
 	pr_debug("%s: close session success\n", __func__);
@@ -747,6 +760,7 @@ static int audio_effects_open(struct inode *inode, struct file *file)
 
 	init_waitqueue_head(&effects->read_wait);
 	init_waitqueue_head(&effects->write_wait);
+	mutex_init(&effects->lock);
 
 	effects->opened = 0;
 	effects->started = 0;

--- a/drivers/net/ethernet/msm/rndis_ipa.c
+++ b/drivers/net/ethernet/msm/rndis_ipa.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013-2015, 2017 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -132,29 +132,6 @@ enum rndis_ipa_operation {
 	RNDIS_IPA_DEBUG("Driver state: %s\n",\
 	rndis_ipa_state_string(ctx->state));
 
-/**
- * struct rndis_loopback_pipe - hold all information needed for
- *  pipe loopback logic
- */
-struct rndis_loopback_pipe {
-	struct sps_pipe          *ipa_sps;
-	struct ipa_sps_params ipa_sps_connect;
-	struct ipa_connect_params ipa_connect_params;
-
-	struct sps_pipe          *dma_sps;
-	struct sps_connect        dma_connect;
-
-	struct sps_alloc_dma_chan dst_alloc;
-	struct sps_dma_chan       ipa_sps_channel;
-	enum sps_mode mode;
-	u32 ipa_peer_bam_hdl;
-	u32 peer_pipe_index;
-	u32 ipa_drv_ep_hdl;
-	u32 ipa_pipe_index;
-	enum ipa_client_type ipa_client;
-	ipa_notify_cb ipa_callback;
-	struct ipa_ep_cfg *ipa_ep_cfg;
-};
 
 /**
  * struct rndis_ipa_dev - main driver context parameters
@@ -169,13 +146,9 @@ struct rndis_loopback_pipe {
  * @rx_dump_enable: dump all Rx packets
  * @icmp_filter: allow all ICMP packet to pass through the filters
  * @rm_enable: flag that enable/disable Resource manager request prior to Tx
- * @loopback_enable:  flag that enable/disable USB stub loopback
  * @deaggregation_enable: enable/disable IPA HW deaggregation logic
  * @during_xmit_error: flags that indicate that the driver is in a middle
  *  of error handling in Tx path
- * @usb_to_ipa_loopback_pipe: usb to ipa (Rx) pipe representation for loopback
- * @ipa_to_usb_loopback_pipe: ipa to usb (Tx) pipe representation for loopback
- * @bam_dma_hdl: handle representing bam-dma, used for loopback logic
  * @directory: holds all debug flags used by the driver to allow cleanup
  *  for driver unload
  * @eth_ipv4_hdr_hdl: saved handle for ipv4 header-insertion table
@@ -205,12 +178,8 @@ struct rndis_ipa_dev {
 	u32 rx_dump_enable;
 	u32 icmp_filter;
 	u32 rm_enable;
-	bool loopback_enable;
 	u32 deaggregation_enable;
 	u32 during_xmit_error;
-	struct rndis_loopback_pipe usb_to_ipa_loopback_pipe;
-	struct rndis_loopback_pipe ipa_to_usb_loopback_pipe;
-	u32 bam_dma_hdl;
 	struct dentry *directory;
 	uint32_t eth_ipv4_hdr_hdl;
 	uint32_t eth_ipv6_hdr_hdl;
@@ -274,31 +243,12 @@ static int resource_request(struct rndis_ipa_dev *rndis_ipa_ctx);
 static void resource_release(struct rndis_ipa_dev *rndis_ipa_ctx);
 static netdev_tx_t rndis_ipa_start_xmit(struct sk_buff *skb,
 					struct net_device *net);
-static int rndis_ipa_loopback_pipe_create(
-		struct rndis_ipa_dev *rndis_ipa_ctx,
-		struct rndis_loopback_pipe *loopback_pipe);
-static void rndis_ipa_destroy_loopback_pipe(
-		struct rndis_loopback_pipe *loopback_pipe);
-static int rndis_ipa_create_loopback(struct rndis_ipa_dev *rndis_ipa_ctx);
-static void rndis_ipa_destroy_loopback(struct rndis_ipa_dev *rndis_ipa_ctx);
-static int rndis_ipa_setup_loopback(bool enable,
-		struct rndis_ipa_dev *rndis_ipa_ctx);
-static int rndis_ipa_debugfs_loopback_open(struct inode *inode,
-		struct file *file);
 static int rndis_ipa_debugfs_atomic_open(struct inode *inode,
 		struct file *file);
 static int rndis_ipa_debugfs_aggr_open(struct inode *inode,
 		struct file *file);
 static ssize_t rndis_ipa_debugfs_aggr_write(struct file *file,
 		const char __user *buf, size_t count, loff_t *ppos);
-static ssize_t rndis_ipa_debugfs_loopback_write(struct file *file,
-		const char __user *buf, size_t count, loff_t *ppos);
-static ssize_t rndis_ipa_debugfs_enable_write(struct file *file,
-		const char __user *buf, size_t count, loff_t *ppos);
-static ssize_t rndis_ipa_debugfs_enable_read(struct file *file,
-		char __user *ubuf, size_t count, loff_t *ppos);
-static ssize_t rndis_ipa_debugfs_loopback_read(struct file *file,
-		char __user *ubuf, size_t count, loff_t *ppos);
 static ssize_t rndis_ipa_debugfs_atomic_read(struct file *file,
 		char __user *ubuf, size_t count, loff_t *ppos);
 static void rndis_ipa_dump_skb(struct sk_buff *skb);
@@ -331,12 +281,6 @@ static const struct net_device_ops rndis_ipa_netdev_ops = {
 const struct file_operations rndis_ipa_debugfs_atomic_ops = {
 	.open = rndis_ipa_debugfs_atomic_open,
 	.read = rndis_ipa_debugfs_atomic_read,
-};
-
-const struct file_operations rndis_ipa_loopback_ops = {
-		.open = rndis_ipa_debugfs_loopback_open,
-		.read = rndis_ipa_debugfs_loopback_read,
-		.write = rndis_ipa_debugfs_loopback_write,
 };
 
 const struct file_operations rndis_ipa_aggr_ops = {
@@ -2188,14 +2132,6 @@ static int rndis_ipa_debugfs_init(struct rndis_ipa_dev *rndis_ipa_ctx)
 		goto fail_file;
 	}
 
-	file = debugfs_create_file("loopback_enable", flags_read_write,
-				rndis_ipa_ctx->directory,
-				rndis_ipa_ctx, &rndis_ipa_loopback_ops);
-	if (!file) {
-		RNDIS_IPA_ERROR("could not create outstanding file\n");
-		goto fail_file;
-	}
-
 	file = debugfs_create_u8("state", flags_read_only,
 			rndis_ipa_ctx->directory, (u8 *)&rndis_ipa_ctx->state);
 	if (!file) {
@@ -2351,59 +2287,6 @@ static ssize_t rndis_ipa_debugfs_aggr_write(struct file *file,
 	return count;
 }
 
-static int rndis_ipa_debugfs_loopback_open(struct inode *inode,
-		struct file *file)
-{
-	struct rndis_ipa_dev *rndis_ipa_ctx = inode->i_private;
-	file->private_data = rndis_ipa_ctx;
-
-	return 0;
-}
-
-static ssize_t rndis_ipa_debugfs_loopback_read(struct file *file,
-		char __user *ubuf, size_t count, loff_t *ppos)
-{
-	int cnt;
-	struct rndis_ipa_dev *rndis_ipa_ctx = file->private_data;
-
-	file->private_data = &rndis_ipa_ctx->loopback_enable;
-
-	cnt = rndis_ipa_debugfs_enable_read(file,
-			ubuf, count, ppos);
-
-	return cnt;
-}
-
-static ssize_t rndis_ipa_debugfs_loopback_write(struct file *file,
-		const char __user *buf, size_t count, loff_t *ppos)
-{
-	int retval;
-	int cnt;
-	struct rndis_ipa_dev *rndis_ipa_ctx = file->private_data;
-	bool old_state = rndis_ipa_ctx->loopback_enable;
-
-	file->private_data = &rndis_ipa_ctx->loopback_enable;
-
-	cnt = rndis_ipa_debugfs_enable_write(file,
-			buf, count, ppos);
-
-	RNDIS_IPA_DEBUG("loopback_enable was set to:%d->%d\n",
-			old_state, rndis_ipa_ctx->loopback_enable);
-
-	if (old_state == rndis_ipa_ctx->loopback_enable) {
-		RNDIS_IPA_ERROR("NOP - same state\n");
-		return cnt;
-	}
-
-	retval = rndis_ipa_setup_loopback(
-				rndis_ipa_ctx->loopback_enable,
-				rndis_ipa_ctx);
-	if (retval)
-		rndis_ipa_ctx->loopback_enable = old_state;
-
-	return cnt;
-}
-
 static int rndis_ipa_debugfs_atomic_open(struct inode *inode, struct file *file)
 {
 	struct rndis_ipa_dev *rndis_ipa_ctx = inode->i_private;
@@ -2432,319 +2315,6 @@ static ssize_t rndis_ipa_debugfs_atomic_read(struct file *file,
 	RNDIS_IPA_LOG_EXIT();
 
 	return simple_read_from_buffer(ubuf, count, ppos, atomic_str, nbytes);
-}
-
-static ssize_t rndis_ipa_debugfs_enable_read(struct file *file,
-		char __user *ubuf, size_t count, loff_t *ppos)
-{
-	int nbytes;
-	int size = 0;
-	int ret;
-	loff_t pos;
-	u8 enable_str[sizeof(char)*3] = {0};
-	bool *enable = file->private_data;
-	pos = *ppos;
-	nbytes = scnprintf(enable_str, sizeof(enable_str), "%d\n", *enable);
-	ret = simple_read_from_buffer(ubuf, count, ppos, enable_str, nbytes);
-	if (ret < 0) {
-		RNDIS_IPA_ERROR("simple_read_from_buffer problem\n");
-		return ret;
-	}
-	size += ret;
-	count -= nbytes;
-	*ppos = pos + size;
-	return size;
-}
-
-static ssize_t rndis_ipa_debugfs_enable_write(struct file *file,
-		const char __user *buf, size_t count, loff_t *ppos)
-{
-	unsigned long missing;
-	char input;
-	bool *enable = file->private_data;
-	if (count != sizeof(input) + 1) {
-		RNDIS_IPA_ERROR("wrong input length(%zd)\n", count);
-		return -EINVAL;
-	}
-	if (!buf) {
-		RNDIS_IPA_ERROR("Bad argument\n");
-		return -EINVAL;
-	}
-	missing = copy_from_user(&input, buf, 1);
-	if (missing)
-		return -EFAULT;
-	RNDIS_IPA_DEBUG("input received %c\n", input);
-	*enable = input - '0';
-	RNDIS_IPA_DEBUG("value was set to %d\n", *enable);
-	return count;
-}
-
-/**
- * Connects IPA->BAMDMA
- * This shall simulate the path from IPA to USB
- * Allowing the driver TX path
- */
-static int rndis_ipa_loopback_pipe_create(
-		struct rndis_ipa_dev *rndis_ipa_ctx,
-		struct rndis_loopback_pipe *loopback_pipe)
-{
-	int retval;
-
-	RNDIS_IPA_LOG_ENTRY();
-
-	/* SPS pipe has two side handshake
-	 * This is the first handshake of IPA->BAMDMA,
-	 * This is the IPA side
-	 */
-	loopback_pipe->ipa_connect_params.client = loopback_pipe->ipa_client;
-	loopback_pipe->ipa_connect_params.client_bam_hdl =
-			rndis_ipa_ctx->bam_dma_hdl;
-	loopback_pipe->ipa_connect_params.client_ep_idx =
-		loopback_pipe->peer_pipe_index;
-	loopback_pipe->ipa_connect_params.desc_fifo_sz = BAM_DMA_DESC_FIFO_SIZE;
-	loopback_pipe->ipa_connect_params.data_fifo_sz = BAM_DMA_DATA_FIFO_SIZE;
-	loopback_pipe->ipa_connect_params.notify = loopback_pipe->ipa_callback;
-	loopback_pipe->ipa_connect_params.priv = rndis_ipa_ctx;
-	loopback_pipe->ipa_connect_params.ipa_ep_cfg =
-		*(loopback_pipe->ipa_ep_cfg);
-
-	/* loopback_pipe->ipa_sps_connect is out param */
-	retval = ipa_connect(&loopback_pipe->ipa_connect_params,
-			&loopback_pipe->ipa_sps_connect,
-			&loopback_pipe->ipa_drv_ep_hdl);
-	if (retval) {
-		RNDIS_IPA_ERROR("ipa_connect() fail (%d)", retval);
-		return retval;
-	}
-	RNDIS_IPA_DEBUG("ipa_connect() succeeded, ipa_drv_ep_hdl=%d",
-			loopback_pipe->ipa_drv_ep_hdl);
-
-	/* SPS pipe has two side handshake
-	 * This is the second handshake of IPA->BAMDMA,
-	 * This is the BAMDMA side
-	 */
-	loopback_pipe->dma_sps = sps_alloc_endpoint();
-	if (!loopback_pipe->dma_sps) {
-		RNDIS_IPA_ERROR("sps_alloc_endpoint() failed ");
-		retval = -ENOMEM;
-		goto fail_sps_alloc;
-	}
-
-	retval = sps_get_config(loopback_pipe->dma_sps,
-		&loopback_pipe->dma_connect);
-	if (retval) {
-		RNDIS_IPA_ERROR("sps_get_config() failed (%d)", retval);
-		goto fail_get_cfg;
-	}
-
-	/* Start setting the non IPA ep for SPS driver*/
-	loopback_pipe->dma_connect.mode = loopback_pipe->mode;
-
-	/* SPS_MODE_DEST: DMA end point is the dest (consumer) IPA->DMA */
-	if (loopback_pipe->mode == SPS_MODE_DEST) {
-
-		loopback_pipe->dma_connect.source =
-				loopback_pipe->ipa_sps_connect.ipa_bam_hdl;
-		loopback_pipe->dma_connect.src_pipe_index =
-				loopback_pipe->ipa_sps_connect.ipa_ep_idx;
-		loopback_pipe->dma_connect.destination =
-				rndis_ipa_ctx->bam_dma_hdl;
-		loopback_pipe->dma_connect.dest_pipe_index =
-				loopback_pipe->peer_pipe_index;
-
-	/* SPS_MODE_SRC: DMA end point is the source (producer) DMA->IPA */
-	} else {
-
-		loopback_pipe->dma_connect.source =
-				rndis_ipa_ctx->bam_dma_hdl;
-		loopback_pipe->dma_connect.src_pipe_index =
-				loopback_pipe->peer_pipe_index;
-		loopback_pipe->dma_connect.destination =
-				loopback_pipe->ipa_sps_connect.ipa_bam_hdl;
-		loopback_pipe->dma_connect.dest_pipe_index =
-				loopback_pipe->ipa_sps_connect.ipa_ep_idx;
-
-	}
-
-	loopback_pipe->dma_connect.desc = loopback_pipe->ipa_sps_connect.desc;
-	loopback_pipe->dma_connect.data = loopback_pipe->ipa_sps_connect.data;
-	loopback_pipe->dma_connect.event_thresh = 0x10;
-	/* BAM-to-BAM */
-	loopback_pipe->dma_connect.options = SPS_O_AUTO_ENABLE;
-
-	RNDIS_IPA_DEBUG("doing sps_connect() with - ");
-	RNDIS_IPA_DEBUG("src bam_hdl:0x%lx, src_pipe#:%d",
-			loopback_pipe->dma_connect.source,
-			loopback_pipe->dma_connect.src_pipe_index);
-	RNDIS_IPA_DEBUG("dst bam_hdl:0x%lx, dst_pipe#:%d",
-			loopback_pipe->dma_connect.destination,
-			loopback_pipe->dma_connect.dest_pipe_index);
-
-	retval = sps_connect(loopback_pipe->dma_sps,
-		&loopback_pipe->dma_connect);
-	if (retval) {
-		RNDIS_IPA_ERROR("sps_connect() fail for BAMDMA side (%d)",
-			retval);
-		goto fail_sps_connect;
-	}
-
-	RNDIS_IPA_LOG_EXIT();
-
-	return 0;
-
-fail_sps_connect:
-fail_get_cfg:
-	sps_free_endpoint(loopback_pipe->dma_sps);
-fail_sps_alloc:
-	ipa_disconnect(loopback_pipe->ipa_drv_ep_hdl);
-	return retval;
-}
-
-static void rndis_ipa_destroy_loopback_pipe(
-		struct rndis_loopback_pipe *loopback_pipe)
-{
-	sps_disconnect(loopback_pipe->dma_sps);
-	sps_free_endpoint(loopback_pipe->dma_sps);
-}
-
-/**
- * rndis_ipa_create_loopback() - create a BAM-DMA loopback
- *  in order to replace the USB core
- */
-static int rndis_ipa_create_loopback(struct rndis_ipa_dev *rndis_ipa_ctx)
-{
-	/* The BAM handle should be use as
-	 * source/destination in the sps_connect()
-	 */
-	int retval;
-
-	RNDIS_IPA_LOG_ENTRY();
-
-
-	retval = sps_ctrl_bam_dma_clk(true);
-	if (retval) {
-		RNDIS_IPA_ERROR("fail on enabling BAM-DMA clocks");
-		return -ENODEV;
-	}
-
-	/* Get BAM handle instead of USB handle */
-	rndis_ipa_ctx->bam_dma_hdl = sps_dma_get_bam_handle();
-	if (!rndis_ipa_ctx->bam_dma_hdl) {
-		RNDIS_IPA_ERROR("sps_dma_get_bam_handle() failed");
-		return -ENODEV;
-	}
-	RNDIS_IPA_DEBUG("sps_dma_get_bam_handle() succeeded (0x%x)",
-			rndis_ipa_ctx->bam_dma_hdl);
-
-	/* IPA<-BAMDMA, NetDev Rx path (BAMDMA is the USB stub) */
-	rndis_ipa_ctx->usb_to_ipa_loopback_pipe.ipa_client =
-	IPA_CLIENT_USB_PROD;
-	rndis_ipa_ctx->usb_to_ipa_loopback_pipe.peer_pipe_index =
-		FROM_USB_TO_IPA_BAMDMA;
-	/*DMA EP mode*/
-	rndis_ipa_ctx->usb_to_ipa_loopback_pipe.mode = SPS_MODE_SRC;
-	rndis_ipa_ctx->usb_to_ipa_loopback_pipe.ipa_ep_cfg =
-		&usb_to_ipa_ep_cfg_deaggr_en;
-	rndis_ipa_ctx->usb_to_ipa_loopback_pipe.ipa_callback =
-			rndis_ipa_packet_receive_notify;
-	RNDIS_IPA_DEBUG("setting up IPA<-BAMDAM pipe (RNDIS_IPA RX path)");
-	retval = rndis_ipa_loopback_pipe_create(rndis_ipa_ctx,
-			&rndis_ipa_ctx->usb_to_ipa_loopback_pipe);
-	if (retval) {
-		RNDIS_IPA_ERROR("fail to close IPA->BAMDAM pipe");
-		goto fail_to_usb;
-	}
-	RNDIS_IPA_DEBUG("IPA->BAMDAM pipe successfully connected (TX path)");
-
-	/* IPA->BAMDMA, NetDev Tx path (BAMDMA is the USB stub)*/
-	rndis_ipa_ctx->ipa_to_usb_loopback_pipe.ipa_client =
-		IPA_CLIENT_USB_CONS;
-	/*DMA EP mode*/
-	rndis_ipa_ctx->ipa_to_usb_loopback_pipe.mode = SPS_MODE_DEST;
-	rndis_ipa_ctx->ipa_to_usb_loopback_pipe.ipa_ep_cfg = &ipa_to_usb_ep_cfg;
-	rndis_ipa_ctx->ipa_to_usb_loopback_pipe.peer_pipe_index =
-		FROM_IPA_TO_USB_BAMDMA;
-	rndis_ipa_ctx->ipa_to_usb_loopback_pipe.ipa_callback =
-			rndis_ipa_tx_complete_notify;
-	RNDIS_IPA_DEBUG("setting up IPA->BAMDAM pipe (RNDIS_IPA TX path)");
-	retval = rndis_ipa_loopback_pipe_create(rndis_ipa_ctx,
-			&rndis_ipa_ctx->ipa_to_usb_loopback_pipe);
-	if (retval) {
-		RNDIS_IPA_ERROR("fail to close IPA<-BAMDAM pipe");
-		goto fail_from_usb;
-	}
-	RNDIS_IPA_DEBUG("IPA<-BAMDAM pipe successfully connected(RX path)");
-
-	RNDIS_IPA_LOG_EXIT();
-
-	return 0;
-
-fail_from_usb:
-	rndis_ipa_destroy_loopback_pipe(
-			&rndis_ipa_ctx->usb_to_ipa_loopback_pipe);
-fail_to_usb:
-
-	return retval;
-}
-
-static void rndis_ipa_destroy_loopback(struct rndis_ipa_dev *rndis_ipa_ctx)
-{
-	rndis_ipa_destroy_loopback_pipe(
-			&rndis_ipa_ctx->ipa_to_usb_loopback_pipe);
-	rndis_ipa_destroy_loopback_pipe(
-			&rndis_ipa_ctx->usb_to_ipa_loopback_pipe);
-	sps_dma_free_bam_handle(rndis_ipa_ctx->bam_dma_hdl);
-	if (sps_ctrl_bam_dma_clk(false))
-		RNDIS_IPA_ERROR("fail to disable BAM-DMA clocks");
-}
-
-/**
- * rndis_ipa_setup_loopback() - create/destroy a loopback on IPA HW
- *  (as USB pipes loopback) and notify RNDIS_IPA netdev for pipe connected
- * @enable: flag that determines if the loopback should be created or destroyed
- * @rndis_ipa_ctx: driver main context
- *
- * This function is the main loopback logic.
- * It shall create/destory the loopback by using BAM-DMA and notify
- * the netdev accordingly.
- */
-static int rndis_ipa_setup_loopback(bool enable,
-		struct rndis_ipa_dev *rndis_ipa_ctx)
-{
-	int retval;
-
-	if (!enable) {
-		rndis_ipa_destroy_loopback(rndis_ipa_ctx);
-		RNDIS_IPA_DEBUG("loopback destroy done");
-		retval = rndis_ipa_pipe_disconnect_notify(rndis_ipa_ctx);
-		if (retval) {
-			RNDIS_IPA_ERROR("connect notify fail");
-			return -ENODEV;
-		}
-		return 0;
-	}
-
-	RNDIS_IPA_DEBUG("creating loopback (instead of USB core)");
-	retval = rndis_ipa_create_loopback(rndis_ipa_ctx);
-	RNDIS_IPA_DEBUG("creating loopback- %s", (retval ? "FAIL" : "OK"));
-	if (retval) {
-		RNDIS_IPA_ERROR("Fail to connect loopback");
-		return -ENODEV;
-	}
-	retval = rndis_ipa_pipe_connect_notify(
-			rndis_ipa_ctx->usb_to_ipa_loopback_pipe.ipa_drv_ep_hdl,
-			rndis_ipa_ctx->ipa_to_usb_loopback_pipe.ipa_drv_ep_hdl,
-			BAM_DMA_DATA_FIFO_SIZE,
-			15,
-			BAM_DMA_DATA_FIFO_SIZE - rndis_ipa_ctx->net->mtu,
-			rndis_ipa_ctx);
-	if (retval) {
-		RNDIS_IPA_ERROR("connect notify fail");
-		return -ENODEV;
-	}
-
-	return 0;
-
 }
 
 static int rndis_ipa_init_module(void)

--- a/drivers/platform/msm/avtimer.c
+++ b/drivers/platform/msm/avtimer.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2015, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
 
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License version 2 and
@@ -331,9 +331,17 @@ static long avtimer_ioctl(struct file *file, unsigned int ioctl_num,
 	switch (ioctl_num) {
 	case IOCTL_GET_AVTIMER_TICK:
 	{
-		uint64_t avtimer_tick;
+		uint64_t avtimer_tick = 0;
+		int rc;
 
-		avcs_core_query_timer(&avtimer_tick);
+		rc = avcs_core_query_timer(&avtimer_tick);
+
+		if (rc) {
+			pr_err("%s: Error: Invalid AV Timer tick, rc = %d\n",
+				__func__, rc);
+			return rc;
+		}
+
 		pr_debug_ratelimited("%s: AV Timer tick: time %llx\n",
 		__func__, avtimer_tick);
 		if (copy_to_user((void *) ioctl_param, &avtimer_tick,

--- a/drivers/platform/msm/avtimer.c
+++ b/drivers/platform/msm/avtimer.c
@@ -305,7 +305,8 @@ int avcs_core_query_timer(uint64_t *avtimer_tick)
 			| avtimer_lsw;
 	res = do_div(avtimer_tick_temp, avtimer.clk_div);
 	*avtimer_tick = avtimer_tick_temp;
-	pr_debug("%s:Avtimer: msw: %u, lsw: %u, tick: %llu\n", __func__,
+	pr_debug_ratelimited("%s:Avtimer: msw: %u, lsw: %u, tick: %llu\n",
+			__func__,
 			avtimer_msw, avtimer_lsw, *avtimer_tick);
 	return 0;
 }
@@ -330,21 +331,11 @@ static long avtimer_ioctl(struct file *file, unsigned int ioctl_num,
 	switch (ioctl_num) {
 	case IOCTL_GET_AVTIMER_TICK:
 	{
-		uint32_t avtimer_msw_1st = 0, avtimer_lsw = 0;
-		uint32_t avtimer_msw_2nd = 0;
 		uint64_t avtimer_tick;
-		do {
-			avtimer_msw_1st = ioread32(avtimer.p_avtimer_msw);
-			avtimer_lsw = ioread32(avtimer.p_avtimer_lsw);
-			avtimer_msw_2nd = ioread32(avtimer.p_avtimer_msw);
-		} while (avtimer_msw_1st != avtimer_msw_2nd);
 
-		avtimer_lsw = avtimer_lsw/avtimer.clk_div;
-		avtimer_tick =
-		((uint64_t) avtimer_msw_1st << 32) | avtimer_lsw;
-
-		pr_debug("%s: AV Timer tick: msw: %x, lsw: %x time %llx\n",
-		__func__, avtimer_msw_1st, avtimer_lsw, avtimer_tick);
+		avcs_core_query_timer(&avtimer_tick);
+		pr_debug_ratelimited("%s: AV Timer tick: time %llx\n",
+		__func__, avtimer_tick);
 		if (copy_to_user((void *) ioctl_param, &avtimer_tick,
 				sizeof(avtimer_tick))) {
 					pr_err("copy_to_user failed\n");

--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_cfg80211.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_cfg80211.c
@@ -16404,6 +16404,12 @@ static int __wlan_hdd_cfg80211_testmode(struct wiphy *wiphy, void *data, int len
             buf = nla_data(tb[WLAN_HDD_TM_ATTR_DATA]);
             buf_len = nla_len(tb[WLAN_HDD_TM_ATTR_DATA]);
 
+            if (buf_len > sizeof(*hb_params)) {
+                hddLog(LOGE, FL("buf_len=%d exceeded hb_params size limit"),
+                       buf_len);
+                return -ERANGE;
+            }
+
             hb_params_temp =(tSirLPHBReq *)buf;
             if ((hb_params_temp->cmd == LPHB_SET_TCP_PARAMS_INDID) &&
                 (hb_params_temp->params.lphbTcpParamReq.timePeriodSec == 0))

--- a/sound/soc/msm/msm-cpe-lsm.c
+++ b/sound/soc/msm/msm-cpe-lsm.c
@@ -1888,6 +1888,13 @@ static int msm_cpe_lsm_reg_model(struct snd_pcm_substream *substream,
 
 	lsm_ops->lsm_get_snd_model_offset(cpe->core_handle,
 			session, &offset);
+	/* Check if 'p_info->param_size + offset' crosses U32_MAX. */
+	if (p_info->param_size > U32_MAX - offset) {
+		dev_err(rtd->dev,
+			"%s: Invalid param_size %d\n",
+			__func__, p_info->param_size);
+		return -EINVAL;
+	}
 	session->snd_model_size = p_info->param_size + offset;
 
 	session->snd_model_data = vzalloc(session->snd_model_size);

--- a/sound/soc/msm/qdsp6v2/msm-dolby-dap-config.c
+++ b/sound/soc/msm/qdsp6v2/msm-dolby-dap-config.c
@@ -677,7 +677,7 @@ int msm_dolby_dap_param_to_set_control_put(struct snd_kcontrol *kcontrol,
 					   struct snd_ctl_elem_value *ucontrol)
 {
 	int rc = 0, port_id, copp_idx;
-	uint32_t idx, j;
+	uint32_t idx, j, current_offset;
 	uint32_t device = ucontrol->value.integer.value[0];
 	uint32_t param_id = ucontrol->value.integer.value[1];
 	uint32_t offset = ucontrol->value.integer.value[2];
@@ -754,6 +754,19 @@ int msm_dolby_dap_param_to_set_control_put(struct snd_kcontrol *kcontrol,
 		default: {
 			/* cache the parameters */
 			dolby_dap_params_modified[idx] += 1;
+			current_offset = dolby_dap_params_offset[idx] + offset;
+			if (current_offset >= TOTAL_LENGTH_DOLBY_PARAM) {
+				pr_err("%s: invalid offset %d at idx %d\n",
+				__func__, offset, idx);
+				return -EINVAL;
+			}
+			if ((0 == length) || (current_offset + length - 1
+				< current_offset) || (current_offset + length
+				> TOTAL_LENGTH_DOLBY_PARAM)) {
+				pr_err("%s: invalid length %d at idx %d\n",
+				__func__, length, idx);
+				return -EINVAL;
+			}
 			dolby_dap_params_length[idx] = length;
 			pr_debug("%s: param recvd deviceId=0x%x paramId=0x%x offset=%d length=%d\n",
 				__func__, device, param_id, offset, length);

--- a/sound/soc/msm/qdsp6v2/msm-dolby-dap-config.c
+++ b/sound/soc/msm/qdsp6v2/msm-dolby-dap-config.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013-2014, 2016, The Linux Foundation. All rights reserved.
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License version 2 and
 * only version 2 as published by the Free Software Foundation.
@@ -17,6 +17,10 @@
 #include <sound/q6core.h>
 
 #include "msm-dolby-dap-config.h"
+
+#ifndef DOLBY_PARAM_VCNB_MAX_LENGTH
+#define DOLBY_PARAM_VCNB_MAX_LENGTH 40
+#endif
 
 /* dolby endp based parameters */
 struct dolby_dap_endp_params_s {
@@ -909,6 +913,11 @@ int msm_dolby_dap_param_visualizer_control_get(struct snd_kcontrol *kcontrol,
 	uint32_t param_payload_len =
 		DOLBY_PARAM_PAYLOAD_SIZE * sizeof(uint32_t);
 	int port_id, copp_idx, idx;
+	if (length > DOLBY_PARAM_VCNB_MAX_LENGTH || length <= 0) {
+		pr_err("%s Incorrect VCNB length", __func__);
+		ucontrol->value.integer.value[0] = 0;
+		return -EINVAL;
+	}
 	for (idx = 0; idx < AFE_MAX_PORTS; idx++) {
 		port_id = dolby_dap_params_states.port_id[idx];
 		copp_idx = dolby_dap_params_states.copp_idx[idx];

--- a/sound/soc/msm/qdsp6v2/msm-ds2-dap-config.c
+++ b/sound/soc/msm/qdsp6v2/msm-ds2-dap-config.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013-2017, The Linux Foundation. All rights reserved.
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License version 2 and
 * only version 2 as published by the Free Software Foundation.
@@ -1641,6 +1641,7 @@ static int msm_ds2_dap_param_visualizer_control_get(u32 cmd, void *arg)
 		ret = 0;
 		dolby_data->length = 0;
 		pr_err("%s Incorrect VCNB length", __func__);
+		return -EINVAL;
 	}
 
 	params_length = (2*length + DOLBY_VIS_PARAM_HEADER_SIZE) *

--- a/sound/soc/msm/qdsp6v2/msm-qti-pp-config.c
+++ b/sound/soc/msm/qdsp6v2/msm-qti-pp-config.c
@@ -484,7 +484,7 @@ static int msm_qti_pp_set_auxpcm_lb_vol_mixer(struct snd_kcontrol *kcontrol,
 static int msm_qti_pp_get_channel_map_mixer(struct snd_kcontrol *kcontrol,
 					    struct snd_ctl_elem_value *ucontrol)
 {
-	char channel_map[PCM_FORMAT_MAX_NUM_CHANNEL];
+	char channel_map[PCM_FORMAT_MAX_NUM_CHANNEL] = {0};
 	int i;
 
 	adm_get_multi_ch_map(channel_map, ADM_PATH_PLAYBACK);


### PR DESCRIPTION
It includes the patches for the following issues:

- Potential Information Leak in avtimer when Processing IOCTL_GET_AVTIMER_TICK (CVE-2016-5346) - https://www.codeaurora.org/potential-information-leak-avtimer-when-processing-ioctlgetavtimertick-cve-2016-5346
- Possible Integer Overflow to Buffer Overflow in msm_cpe_lsm_reg_model (CVE-2016-5860) - https://www.codeaurora.org/possible-integer-overflow-buffer-overflow-msmcpelsmregmodel-cve-2016-5860
- Detection of error condition without proper action in msm_ds2_dap_param_visualizer_control_get() (CVE-2016-5853) - https://www.codeaurora.org/detection-error-condition-without-proper-action-msmds2dapparamvisualizercontrolget-cve-2016-5853
- Heap overflow vulnerability in rndis_ipa driver when using multiple writes to loop-back debugfs file (CVE-2016-5868) - https://www.codeaurora.org/heap-overflow-vulnerability-rndisipa-driver-when-using-multiple-writes-loop-back-debugfs-file-cve
- Race Condition Can Lead to Buffer Overwrite in qdsp6v2 Driver (CVE-2017-0454) - https://www.codeaurora.org/race-condition-can-lead-buffer-overwrite-qdsp6v2-driver-cve-2017-0454
- Insufficient Initialization of kgsl_context Structure in kgsl_context_init() (CVE-2016-8479) - https://www.codeaurora.org/insufficient-initialization-kgslcontext-structure-kgslcontextinit-cve-2016-8479
- Information Leak and Buffer Overflow while Post Processing the Frame in msm_cpp Driver (CVE-2016-8413) - https://www.codeaurora.org/information-leak-and-buffer-overflow-while-post-processing-frame-msmcpp-driver-cve-2016-8413
- Possible Kernel Buffer Overflow in MSM Sound Driver (qdsp6v2) at Function msm_dolby_dap_param_to_set_control_put (CVE-2016-5867) - https://www.codeaurora.org/possible-kernel-buffer-overflow-msm-sound-driver-qdsp6v2-function-msmdolbydapparamtosetcontrolput
- Possible Integer Overflow to Buffer Overflow in msm_dolby_dap_param_visualizer_control_get (CVE-2016-5859) - https://www.codeaurora.org/possible-integer-overflow-buffer-overflow-msmdolbydapparamvisualizercontrolget-cve-2016-5859
- Uninitialized Channel Map Array Can Leak Data to User Space in qdsp6v2 Driver (CVE-2016-5347) - https://www.codeaurora.org/uninitialized-channel-map-array-can-leak-data-user-space-qdsp6v2-driver-cve-2016-5347
- Possible Stack Overflow in WiFi Driver Function __wlan_hdd_cfg80211_testmode (CVE-2017-0453) - https://www.codeaurora.org/possible-stack-overflow-wifi-driver-function-wlanhddcfg80211testmode-cve-2017-0453


Compile and run tested in tulip.

