### PR TITLE
[1.3.3] arm: DT: MSM8939-mdss: Disable MDSS1 intf by default

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -472,6 +472,7 @@
 &mdss_dsi1 {
 	vddio-supply = <&pm8916_l16>;
 	qcom,platform-regulator-settings = [02 09 03 00 20 00 01];
+	status = "disabled";
 };
 
 &pm8916_mpps {


### PR DESCRIPTION
MSM8916 MSM8936 MSM8939 devices usually have only one MDSS interface connected to a display.
Disable the other interface to get faster mdss probing, hence fast boot times, and less errors at boot time.