### PR TITLE
1.3.3 cpuquiet

### DIFF
--- a/drivers/cpuquiet/cpuquiet.c
+++ b/drivers/cpuquiet/cpuquiet.c
@@ -1,7 +1,7 @@
 /*
  * drivers/cpuquiet/cpuquiet.c - Core cpuquiet functionality
  *
- * Copyright (c) 2012-2013 NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2012-2016 NVIDIA CORPORATION.  All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -178,6 +178,7 @@ static void __cpuinit cpuquiet_work_func(struct work_struct *work)
 	/* always keep CPU0 online */
 	cpumask_set_cpu(0, &online);
 	cpu_online = *cpu_online_mask;
+	cpumask_clear_cpu(0, &offline);
 
 	if (max_cpus < min_cpus)
 		max_cpus = min_cpus;

--- a/drivers/cpuquiet/governor.c
+++ b/drivers/cpuquiet/governor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2012-2014 NVIDIA CORPORATION.  All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,6 +49,10 @@ struct cpuquiet_governor *cpuquiet_find_governor(const char *str)
 int cpuquiet_switch_governor(struct cpuquiet_governor *gov)
 {
 	int err = 0;
+
+	/* Governor is already set, bail early */
+	if (cpuquiet_curr_governor == gov)
+		return err;
 
 	if (cpuquiet_curr_governor) {
 		if (cpuquiet_curr_governor->stop)


### PR DESCRIPTION
Don't start/stop the governor unnecessarily when switching to the same governor and do not allow CPU0 offline.