### PR TITLE
[UM.5.5.r1] Decrease BT/FM TX timeouts to improve deep sleep ratio.

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -120,8 +120,8 @@ DECLARE_DELAYED_WORK(sleep_workqueue, bluesleep_sleep_work);
 #define bluesleep_rx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
 #define bluesleep_tx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
 
-/* 5 second timeout */
-#define TX_TIMER_INTERVAL  5
+/* 1 second timeout */
+#define TX_TIMER_INTERVAL 1
 
 /* state variable names and bit positions */
 #define BT_PROTO	0x01

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci_uart.h
@@ -75,7 +75,7 @@
  */
 #define LDISC_TIME             1500
 #define CMD_RESP_TIME          800
-#define CMD_WR_TIME            5000
+#define CMD_WR_TIME            1000
 #define POR_RETRY_COUNT        5
 
 

--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_sh_ldisc.c
@@ -1999,7 +1999,8 @@ long brcm_sh_ldisc_write(struct sk_buff *skb)
                 brcm_hci_write(hu, skb->data, skb->len);
 #endif
             brcm_hci_uart_tx_wakeup(hu);
-            if (!wait_for_completion_timeout(&hu->cmd_rcvd, msecs_to_jiffies(5000))) {
+            if (!wait_for_completion_timeout(&hu->cmd_rcvd,
+                    msecs_to_jiffies(CMD_WR_TIME))) {
                 pr_err(" waiting for command response - timed out");
                 return 0;
             }

--- a/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
+++ b/drivers/bluetooth/broadcom/v4l2_fm_driver/fmdrv.h
@@ -50,7 +50,7 @@
 /* Flag info */
 #define FM_CORE_READY                 3
 
-#define FM_DRV_TX_TIMEOUT       (5*HZ)  /* 5 sec */
+#define FM_DRV_TX_TIMEOUT       (1*HZ)  /* 1 sec */
 #define FM_DRV_RX_SEEK_TIMEOUT       (20*HZ)  /* 20 sec */
 
 #define NO_OF_ENTRIES_IN_ARRAY(array) (sizeof(array) / sizeof(array[0]))


### PR DESCRIPTION
Decrease the tx timeouts in the bluesleep driver and the
broadcom BT/FM driver to 1 second such that the device enters
deep sleep earlier. This can improve the deep sleep ratio of
devices with a connected BT device due to the many keep alive
packets sent around. For each of thes packets the bluesleep
driver would block suspend for 5-10s otherwise (where keep
alive packets are typically sent every 12s).

Change-Id: I5661f25643acbeaf1c326af45ff20bb9f1a2bd2f
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>