### PR TITLE
[5.7.r1] Restructuration and cleanup of somc_panel 

### DIFF
--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -4609,6 +4609,10 @@ int dsi_panel_device_register(struct platform_device *ctrl_pdev,
 	ctrl_pdata->panel_data.detect = spec_pdata->detect;
 	ctrl_pdata->panel_data.update_panel = spec_pdata->update_panel;
 	ctrl_pdata->panel_data.panel_pdev = ctrl_pdev;
+
+ #ifdef CONFIG_SOMC_PANEL_LABIBB
+	ctrl_pdata->spec_pdata->regulator_mgr->vreg_init(ctrl_pdata);
+ #endif
 #endif
 
 	if (ctrl_pdata->status_mode == ESD_REG ||

--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -3355,15 +3355,12 @@ static int mdss_dsi_ctrl_probe(struct platform_device *pdev)
 	atomic_set(&ctrl_pdata->te_irq_ready, 0);
 
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	ctrl_pdata->spec_pdata = devm_kzalloc(&pdev->dev,
-		sizeof(struct mdss_panel_specific_pdata),
-		GFP_KERNEL);
-	if (!ctrl_pdata->spec_pdata) {
-		pr_err("%s: FAILED: cannot allocate spec_pdata\n",
+	rc = somc_panel_allocate(pdev, ctrl_pdata);
+	if (unlikely(rc != 0)) {
+		pr_err("%s: FAILED: cannot allocate somc_panel structures\n",
 			__func__);
-		devm_kfree(&pdev->dev, ctrl_pdata->spec_pdata);
-		return -ENOMEM;
-	};
+		return rc;
+	}
 #endif
 
 	ctrl_name = of_get_property(pdev->dev.of_node, "label", NULL);

--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -3479,10 +3479,12 @@ static int mdss_dsi_ctrl_probe(struct platform_device *pdev)
 
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
 	if (ctrl_pdata->panel_data.panel_info.cont_splash_enabled &&
-		ctrl_pdata->spec_pdata->pcc_data.pcc_sts & PCC_STS_UD) {
-		rc = ctrl_pdata->spec_pdata->pcc_setup(&ctrl_pdata->panel_data);
+	    ctrl_pdata->spec_pdata->color_mgr->pcc_data.pcc_sts & PCC_STS_UD) {
+		rc = ctrl_pdata->spec_pdata->color_mgr->pcc_setup(
+			&ctrl_pdata->panel_data);
 		if (rc == 0)
-			ctrl_pdata->spec_pdata->pcc_data.pcc_sts &= ~PCC_STS_UD;
+			ctrl_pdata->spec_pdata->color_mgr->pcc_data.pcc_sts &=
+								 ~PCC_STS_UD;
 	}
 #endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
 

--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -3474,17 +3474,6 @@ static int mdss_dsi_ctrl_probe(struct platform_device *pdev)
 		goto error_shadow_clk_deinit;
 	}
 
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	if (ctrl_pdata->panel_data.panel_info.cont_splash_enabled &&
-	    ctrl_pdata->spec_pdata->color_mgr->pcc_data.pcc_sts & PCC_STS_UD) {
-		rc = ctrl_pdata->spec_pdata->color_mgr->pcc_setup(
-			&ctrl_pdata->panel_data);
-		if (rc == 0)
-			ctrl_pdata->spec_pdata->color_mgr->pcc_data.pcc_sts &=
-								 ~PCC_STS_UD;
-	}
-#endif /* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
-
 	pr_info("%s: Dsi Ctrl->%d initialized, DSI rev:0x%x, PHY rev:0x%x\n",
 		__func__, index, ctrl_pdata->shared_data->hw_rev,
 		ctrl_pdata->shared_data->phy_rev);

--- a/drivers/video/fbdev/msm/mdss_fb.c
+++ b/drivers/video/fbdev/msm/mdss_fb.c
@@ -4058,7 +4058,7 @@ static int __mdss_fb_perform_commit(struct msm_fb_data_type *mfd)
 			pr_warn("no kickoff function setup for fb%d\n",
 					mfd->index);
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-		mdss_dsi_panel_fps_data_update(mfd);
+		somc_panel_fpsd_data_update(mfd);
 #endif
 	} else if (fb_backup->atomic_commit) {
 		if (mfd->mdp.kickoff_fnc)
@@ -4068,7 +4068,7 @@ static int __mdss_fb_perform_commit(struct msm_fb_data_type *mfd)
 			pr_warn("no kickoff function setup for fb%d\n",
 				mfd->index);
 #ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-		mdss_dsi_panel_fps_data_update(mfd);
+		somc_panel_fpsd_data_update(mfd);
 #endif
 		fb_backup->atomic_commit = false;
 	} else {

--- a/drivers/video/fbdev/msm/mdss_panel.h
+++ b/drivers/video/fbdev/msm/mdss_panel.h
@@ -939,8 +939,6 @@ struct mdss_panel_info {
 	int disp_on_in_hs;
 	int wait_time_before_on_cmd;
 
-	u32 rev_u[2], rev_v[2]; /* ROI */
-
 	/* physical size in mm */
 	__u32 width;
 	__u32 height;

--- a/drivers/video/fbdev/msm/mdss_panel.h
+++ b/drivers/video/fbdev/msm/mdss_panel.h
@@ -314,36 +314,6 @@ enum mdss_intf_events {
 	MDSS_EVENT_MAX,
 };
 
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-struct change_fps_rtn_pos {
-	int num;
-	int *pos;
-};
-
-struct change_fps {
-	bool enable;
-	u64 disp_clk;
-	u32 dric_vbp;
-	u32 dric_vfp;
-	bool rtn_adj;
-	struct change_fps_rtn_pos rtn_pos;
-	bool te_c_update;
-	u32 threshold;
-	u32 te_c_60fps[2];
-	u32 te_c_45fps[2];
-	u32 te_c_pos[2];
-
-	u32 wait_on_60fps;
-	u32 wait_on_45fps;
-	u32 wait_off_60fps;
-	u32 wait_off_45fps;
-	u32 wait_on_cmds_num;
-	u32 wait_off_cmds_num;
-
-	bool susres_mode;
-};
-#endif	/* CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL */
-
 /**
  * mdss_panel_intf_event_to_string() - converts interface event enum to string
  * @event: interface event to be converted to string representation
@@ -439,9 +409,6 @@ struct lcd_panel_info {
 	/* Pad height */
 	u32 yres_pad;
 	u32 frame_rate;
-#ifdef CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL
-	struct change_fps chg_fps;
-#endif
 };
 
 

--- a/drivers/video/fbdev/msm/somc_panel/Makefile
+++ b/drivers/video/fbdev/msm/somc_panel/Makefile
@@ -6,6 +6,7 @@ obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= common.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_detect.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_polling.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_fps_manager.o
+obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_color_manager.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_driver.o
 obj-$(CONFIG_SOMC_PANEL_LABIBB)			+= panel_regulators.o
 obj-$(CONFIG_SOMC_PANEL_LEGACY)			+= panel_legacy.o

--- a/drivers/video/fbdev/msm/somc_panel/Makefile
+++ b/drivers/video/fbdev/msm/somc_panel/Makefile
@@ -5,6 +5,7 @@
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= common.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_detect.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_polling.o
+obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_fps_manager.o
 obj-$(CONFIG_FB_MSM_MDSS_SPECIFIC_PANEL)	+= panel_driver.o
 obj-$(CONFIG_SOMC_PANEL_LABIBB)			+= panel_regulators.o
 obj-$(CONFIG_SOMC_PANEL_LEGACY)			+= panel_legacy.o

--- a/drivers/video/fbdev/msm/somc_panel/common.c
+++ b/drivers/video/fbdev/msm/somc_panel/common.c
@@ -131,4 +131,40 @@ int somc_panel_vreg_ctrl(
 }
 
 
+int somc_panel_allocate(struct platform_device *pdev,
+		struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	ctrl->spec_pdata = devm_kzalloc(&pdev->dev,
+		sizeof(struct mdss_panel_specific_pdata),
+		GFP_KERNEL);
+	if (!ctrl->spec_pdata) {
+		pr_err("%s: FAILED: cannot allocate spec_pdata\n", __func__);
+		goto fail_specific;
+	};
 
+	ctrl->spec_pdata->color_mgr = devm_kzalloc(&pdev->dev,
+		sizeof(struct somc_panel_color_mgr), GFP_KERNEL);
+	if (!ctrl->spec_pdata->color_mgr) {
+		pr_err("%s: FAILED: Cannot allocate color_mgr\n", __func__);
+		goto fail_color_mgr;
+	};
+
+	ctrl->spec_pdata->regulator_mgr = devm_kzalloc(&pdev->dev,
+		sizeof (struct somc_panel_regulator_mgr), GFP_KERNEL);
+	if (!ctrl->spec_pdata->regulator_mgr) {
+		pr_err("%s: FAILED: Cannot allocate regulator_mgr\n",
+			__func__);
+		goto fail_regulator_mgr;
+	};
+
+	return 0;
+
+fail_regulator_mgr:
+	devm_kfree(&pdev->dev, ctrl->spec_pdata->regulator_mgr);
+fail_color_mgr:
+	devm_kfree(&pdev->dev, ctrl->spec_pdata->color_mgr);
+fail_specific:
+	devm_kfree(&pdev->dev, ctrl->spec_pdata);
+
+	return -ENOMEM;
+}

--- a/drivers/video/fbdev/msm/somc_panel/common.c
+++ b/drivers/video/fbdev/msm/somc_panel/common.c
@@ -130,25 +130,5 @@ int somc_panel_vreg_ctrl(
 	return ret;
 }
 
-void somc_panel_chg_fps_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
-{
-	struct mdss_panel_specific_pdata *spec_pdata = NULL;
-	struct mdss_panel_info *pinfo = NULL;
-	u32 fps_cmds, fps_payload;
-	char rtn;
 
-	pinfo = &ctrl_pdata->panel_data.panel_info;
-	spec_pdata = ctrl_pdata->spec_pdata;
 
-	if (ctrl_pdata->panel_data.panel_info.mipi.mode == DSI_CMD_MODE) {
-		if (spec_pdata->fps_cmds.cmd_cnt) {
-			fps_cmds = pinfo->lcdc.chg_fps.rtn_pos.pos[0];
-			fps_payload = pinfo->lcdc.chg_fps.rtn_pos.pos[1];
-			rtn = CHANGE_PAYLOAD(fps_cmds, fps_payload);
-			pr_debug("%s: change fps sequence --- rtn = 0x%x\n",
-				__func__, rtn);
-			mdss_dsi_panel_cmds_send(ctrl_pdata,
-						&spec_pdata->fps_cmds);
-		}
-	}
-}

--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -453,6 +453,9 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 	struct mdp_pa_v2_cfg_data picadj;
 	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
 	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	struct mdp_pp_feature_version pa_version = {
+		.pp_feature = PA,
+	};
 	u32 copyback = 0;
 	int ret;
 
@@ -477,6 +480,14 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 			__func__);
 		return -ENOMEM;
 	}
+
+	ret = mdss_mdp_pa_get_version(&pa_version);
+	if (ret) {
+		pr_err("%s: Cannot get PA HW version. Bailing out.\n",
+			__func__);
+		return -EINVAL;
+	};
+	picadj.version = pa_version.version_info;
 
 	padata->global_sat_adj = compat->sat_adj;
 	padata->global_hue_adj = compat->hue_adj;

--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -485,7 +485,7 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 	padata->flags = MDP_PP_OPS_ENABLE;
 
 	/* Check if values are in permitted range, otherwise read defaults */
-	if ( ((padata->global_sat_adj  < 224|| padata->global_sat_adj  > 12000)
+	if ( ((padata->global_sat_adj  < 0  || padata->global_sat_adj  > 12000)
 					    && padata->global_sat_adj != 128)||
 	      (padata->global_hue_adj  < 0  || padata->global_hue_adj  > 1536) ||
 	     ((padata->global_val_adj  < 0  || padata->global_val_adj  > 383)

--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -1,0 +1,595 @@
+/*
+ * Restructured unified display panel driver for Xperia Open Devices
+ *                    *** Color Management ***
+ *
+ * This driver is based on various SoMC implementations found in
+ * copyleft archives for various devices.
+ *
+ * Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) Sony Mobile Communications Inc. All rights reserved.
+ * Copyright (C) 2014-2017, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/module.h>
+#include <linux/interrupt.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+
+#include "../mdss_mdp.h"
+#include "../mdss_dsi.h"
+#include "somc_panels.h"
+
+#define PA_V2_BASIC_FEAT_ENB (MDP_PP_PA_HUE_ENABLE | MDP_PP_PA_SAT_ENABLE | \
+			      MDP_PP_PA_VAL_ENABLE | MDP_PP_PA_CONT_ENABLE)
+#define PA_V2_BASIC_MASK_ENB (MDP_PP_PA_HUE_MASK | MDP_PP_PA_SAT_MASK | \
+			      MDP_PP_PA_VAL_MASK | MDP_PP_PA_CONT_MASK)
+
+int somc_panel_parse_dt_colormgr_config(struct device_node *np,
+			struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	struct somc_panel_color_mgr *color_mgr = ctrl->spec_pdata->color_mgr;
+	u32 tmp;
+	int rc;
+
+	if (!of_find_property(np, "somc,mdss-dsi-pcc-table", NULL))
+		goto picadj_params;
+
+	/* PCC Parameters */
+	color_mgr->pcc_data.color_tbl =
+		kzalloc(color_mgr->pcc_data.tbl_size *
+			sizeof(struct mdss_pcc_color_tbl),
+			GFP_KERNEL);
+	if (!color_mgr->pcc_data.color_tbl) {
+		pr_err("no mem assigned: kzalloc fail\n");
+		return -ENOMEM;
+	}
+	rc = of_property_read_u32_array(np,
+		"somc,mdss-dsi-pcc-table",
+		(u32 *)color_mgr->pcc_data.color_tbl,
+		color_mgr->pcc_data.tbl_size *
+		sizeof(struct mdss_pcc_color_tbl) /
+		sizeof(u32));
+	if (rc) {
+		color_mgr->pcc_data.tbl_size = 0;
+		kzfree(color_mgr->pcc_data.color_tbl);
+		color_mgr->pcc_data.color_tbl = NULL;
+		pr_err("%s:%d, Unable to read pcc table",
+			__func__, __LINE__);
+		goto picadj_params;
+	}
+	color_mgr->pcc_data.pcc_sts |= PCC_STS_UD;
+
+	somc_panel_parse_dcs_cmds(np, &color_mgr->pre_uv_read_cmds,
+		"somc,mdss-dsi-pre-uv-command", NULL);
+
+	somc_panel_parse_dcs_cmds(np, &color_mgr->uv_read_cmds,
+		"somc,mdss-dsi-uv-command", NULL);
+
+	rc = of_property_read_u32(np,
+		"somc,mdss-dsi-uv-param-type", &tmp);
+	color_mgr->pcc_data.param_type =
+		(!rc ? tmp : CLR_DATA_UV_PARAM_TYPE_NONE);
+
+	rc = of_property_read_u32(np,
+		"somc,mdss-dsi-pcc-table-size", &tmp);
+	color_mgr->pcc_data.tbl_size =
+		(!rc ? tmp : 0);
+
+	color_mgr->mdss_force_pcc = of_property_read_bool(np,
+					"somc,mdss-dsi-pcc-force-cal");
+
+picadj_params:
+	/* Picture Adjustment (PicAdj) Parameters */
+	if (!of_find_property(np, "somc,mdss-dsi-use-picadj", NULL))
+		goto end;
+
+	rc = of_property_read_u32(np, "somc,mdss-dsi-use-picadj", &tmp);
+	color_mgr->picadj_data.flags = !rc ? MDP_PP_OPS_ENABLE : 0;
+
+	rc = of_property_read_u32(np, "somc,mdss-dsi-picadj-sat", &tmp);
+	color_mgr->picadj_data.sat_adj = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,mdss-dsi-picadj-hue", &tmp);
+	color_mgr->picadj_data.hue_adj = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,mdss-dsi-picadj-val", &tmp);
+	color_mgr->picadj_data.val_adj = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,mdss-dsi-picadj-cont", &tmp);
+	color_mgr->picadj_data.cont_adj = !rc ? tmp : -1;
+
+end:
+	return rc;
+}
+
+static void conv_uv_data(char *data, int param_type, int *u_data, int *v_data)
+{
+	switch (param_type) {
+	case CLR_DATA_UV_PARAM_TYPE_RENE_DEFAULT:
+		*u_data = ((data[0] & 0x0F) << 2) |
+			/* 4bit of data[0] higher data. */
+			((data[1] >> 6) & 0x03);
+			/* 2bit of data[1] lower data. */
+		*v_data = (data[1] & 0x3F);
+			/* Remainder 6bit of data[1] is effective as v_data. */
+		break;
+	case CLR_DATA_UV_PARAM_TYPE_NOVA_DEFAULT:
+	case CLR_DATA_UV_PARAM_TYPE_RENE_SR:
+		/* 6bit is effective as u_data */
+		*u_data = data[0] & 0x3F;
+		/* 6bit is effective as v_data */
+		*v_data = data[1] & 0x3F;
+		break;
+	case CLR_DATA_UV_PARAM_TYPE_NOVA_AUO:
+		/* 6bit is effective as u_data */
+		*u_data = data[0] & 0x3F;
+		/* 6bit is effective as v_data */
+		*v_data = data[2] & 0x3F;
+		break;
+	default:
+		pr_err("%s: Failed to conv type:%d\n", __func__, param_type);
+		break;
+	}
+}
+
+static int get_uv_param_len(int param_type, bool *short_response)
+{
+	int ret = 0;
+
+	*short_response = false;
+	switch (param_type) {
+	case CLR_DATA_UV_PARAM_TYPE_RENE_DEFAULT:
+		ret = CLR_DATA_REG_LEN_RENE_DEFAULT;
+		break;
+	case CLR_DATA_UV_PARAM_TYPE_NOVA_DEFAULT:
+		ret = CLR_DATA_REG_LEN_NOVA_DEFAULT;
+		break;
+	case CLR_DATA_UV_PARAM_TYPE_NOVA_AUO:
+		ret = CLR_DATA_REG_LEN_NOVA_AUO;
+		break;
+	case CLR_DATA_UV_PARAM_TYPE_RENE_SR:
+		ret = CLR_DATA_REG_LEN_RENE_SR;
+		*short_response = true;
+		break;
+	default:
+		pr_err("%s: Failed to get param len\n", __func__);
+		break;
+	}
+
+	return ret;
+}
+
+static void get_uv_data(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
+		int *u_data, int *v_data)
+{
+	struct somc_panel_color_mgr *color_mgr =
+			ctrl_pdata->spec_pdata->color_mgr;
+	struct dsi_cmd_desc *cmds = color_mgr->uv_read_cmds.cmds;
+	void *clk_handle;
+	int param_type = color_mgr->pcc_data.param_type;
+	char buf[MDSS_DSI_LEN];
+	char *pos = buf;
+	int len;
+	int i;
+	bool short_response;
+
+	len = get_uv_param_len(param_type, &short_response);
+
+	mdss_dsi_cmd_mdp_busy(ctrl_pdata);
+	mdss_bus_bandwidth_ctrl(1);
+
+	if (ctrl_pdata->panel_data.panel_info.type == MIPI_CMD_PANEL)
+		clk_handle = ctrl_pdata->mdp_clk_handle;
+	else
+		clk_handle = ctrl_pdata->dsi_clk_handle;
+
+	mdss_dsi_clk_ctrl(ctrl_pdata, clk_handle,
+				MDSS_DSI_ALL_CLKS, MDSS_DSI_CLK_ON);
+	for (i = 0; i < color_mgr->uv_read_cmds.cmd_cnt; i++) {
+		if (short_response)
+			mdss_dsi_cmds_rx(ctrl_pdata, cmds, 0, 0);
+		else
+			mdss_dsi_cmds_rx(ctrl_pdata, cmds, len, 0);
+		memcpy(pos, ctrl_pdata->rx_buf.data, len);
+		pos += len;
+		cmds++;
+	}
+	mdss_dsi_clk_ctrl(ctrl_pdata, clk_handle,
+				MDSS_DSI_ALL_CLKS, MDSS_DSI_CLK_OFF);
+	mdss_bus_bandwidth_ctrl(0);
+	conv_uv_data(buf, param_type, u_data, v_data);
+}
+
+static int find_color_area(struct mdp_pcc_cfg_data *pcc_config,
+	struct mdss_pcc_data *pcc_data)
+{
+	int i;
+	int ret = 0;
+
+	for (i = 0; i < pcc_data->tbl_size; i++) {
+		if (pcc_data->u_data < pcc_data->color_tbl[i].u_min)
+			continue;
+		if (pcc_data->u_data > pcc_data->color_tbl[i].u_max)
+			continue;
+		if (pcc_data->v_data < pcc_data->color_tbl[i].v_min)
+			continue;
+		if (pcc_data->v_data > pcc_data->color_tbl[i].v_max)
+			continue;
+		break;
+	}
+	pcc_data->tbl_idx = i;
+	if (i >= pcc_data->tbl_size) {
+		ret = -EINVAL;
+		goto exit;
+	}
+
+	pcc_config->r.r = pcc_data->color_tbl[i].r_data;
+	pcc_config->g.g = pcc_data->color_tbl[i].g_data;
+	pcc_config->b.b = pcc_data->color_tbl[i].b_data;
+exit:
+	return ret;
+}
+
+static int somc_panel_pcc_setup(struct mdss_panel_data *pdata)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
+	struct mdss_pcc_data *pcc_data = NULL;
+	struct mdss_panel_info *pinfo = NULL;
+	struct somc_panel_color_mgr *color_mgr = NULL;
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	int ret;
+	u32 copyback;
+	struct mdp_pcc_cfg_data pcc_config;
+	struct mdp_pcc_data_v1_7 pcc_payload;
+	struct mdp_pp_feature_version pcc_version = {
+		.pp_feature = PCC,
+	};
+
+	if (pdata == NULL) {
+		pr_err("%s: Invalid input data\n", __func__);
+		return -EINVAL;
+	}
+
+	ctrl_pdata = container_of(pdata, struct mdss_dsi_ctrl_pdata,
+				panel_data);
+
+	color_mgr = ctrl_pdata->spec_pdata->color_mgr;
+	if (!color_mgr) {
+		pr_err("%s: Color Manager is not initialized!!!\n", __func__);
+		goto exit;
+	}
+
+	pcc_data = &color_mgr->pcc_data;
+	if (!pcc_data->color_tbl) {
+		pr_err("%s: color_tbl not available: no pcc.\n", __func__);
+		goto exit;
+	}
+
+	mdss_dsi_op_mode_config(DSI_CMD_MODE, pdata);
+	if (color_mgr->pre_uv_read_cmds.cmds)
+		mdss_dsi_panel_cmds_send(
+			ctrl_pdata, &color_mgr->pre_uv_read_cmds);
+	if (color_mgr->uv_read_cmds.cmds) {
+		get_uv_data(ctrl_pdata, &pcc_data->u_data, &pcc_data->v_data);
+		pcc_data->u_data = CENTER_U_DATA;
+		pcc_data->v_data = CENTER_V_DATA;
+	}
+	if (pcc_data->u_data == 0 && pcc_data->v_data == 0) {
+		pr_err("%s: U/V Data is invalid.\n", __func__);
+		if (!color_mgr->mdss_force_pcc)
+			goto exit;
+
+		pr_info("%s: PCC force flag found. Forcing calibration.\n",
+								 __func__);
+	}
+
+	pinfo = &ctrl_pdata->panel_data.panel_info;
+	if (pinfo->rev_u[1] != 0) {
+		if (pinfo->rev_u[0] == 0)
+			pcc_data->u_data = pcc_data->u_data + pinfo->rev_u[1];
+		else if (pcc_data->u_data < pinfo->rev_u[1])
+			pcc_data->u_data = 0;
+		else
+			pcc_data->u_data = pcc_data->u_data - pinfo->rev_u[1];
+	}
+	if (pinfo->rev_v[1] != 0) {
+		if (pinfo->rev_v[0] == 0)
+			pcc_data->v_data = pcc_data->v_data + pinfo->rev_v[1];
+		else if (pcc_data->v_data < pinfo->rev_v[1])
+			pcc_data->v_data = 0;
+		else
+			pcc_data->v_data = pcc_data->v_data - pinfo->rev_v[1];
+	}
+
+	memset(&pcc_config, 0, sizeof(struct mdp_pcc_cfg_data));
+	ret = find_color_area(&pcc_config, pcc_data);
+	if (ret) {
+		pr_err("%s: Can't find color area!!!!\n", __func__);
+		goto exit;
+	}
+
+	if (pcc_data->color_tbl[pcc_data->tbl_idx].color_type != UNUSED) {
+		ret = mdss_mdp_pp_get_version(&pcc_version);
+		if (ret) {
+			pr_err("%s: FAIL: Cannot get PP version.\n", __func__);
+			goto exit;
+		}
+		memset(&pcc_payload, 0, sizeof(struct mdp_pcc_data_v1_7));
+		pcc_config.cfg_payload = &pcc_payload;
+		pcc_config.version = pcc_version.version_info;
+		pcc_config.block = MDP_LOGICAL_BLOCK_DISP_0;
+		pcc_config.ops = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE;
+
+		pcc_payload.r.r = pcc_config.r.r;
+		pcc_payload.g.g = pcc_config.g.g;
+		pcc_payload.b.b = pcc_config.b.b;
+
+		ret = mdss_mdp_pcc_config(mfd, &pcc_config, &copyback);
+		if (ret != 0)
+			pr_err("%s: Failed setting PCC data\n", __func__);
+	}
+
+	if (pinfo->rev_u[1] != 0 && pinfo->rev_v[1] != 0)
+		pr_info("%s: (%d):(ru[0], ru[1])=(%d, %d), (rv[0], rv[1])=(%d, %d)",
+			__func__, __LINE__,
+			pinfo->rev_u[0], pinfo->rev_u[1],
+			pinfo->rev_v[0], pinfo->rev_v[1]);
+
+	pr_info("%s: (%d):ct=%d area=%d ud=%d vd=%d r=0x%08X g=0x%08X b=0x%08X",
+		__func__, __LINE__,
+		pcc_data->color_tbl[pcc_data->tbl_idx].color_type,
+		pcc_data->color_tbl[pcc_data->tbl_idx].area_num,
+		pcc_data->u_data, pcc_data->v_data,
+		pcc_data->color_tbl[pcc_data->tbl_idx].r_data,
+		pcc_data->color_tbl[pcc_data->tbl_idx].g_data,
+		pcc_data->color_tbl[pcc_data->tbl_idx].b_data);
+
+exit:
+	return ret;
+}
+
+static int somc_panel_pa_setup(struct mdss_panel_data *pdata)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
+	struct somc_panel_color_mgr *color_mgr = NULL;
+	struct mdp_pa_cfg *padata = NULL;
+	struct mdp_pa_cfg_data picadj;
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	u32 copyback = 0;
+
+	ctrl_pdata = container_of(pdata, struct mdss_dsi_ctrl_pdata,
+				panel_data);
+
+	color_mgr = ctrl_pdata->spec_pdata->color_mgr;
+	if (!color_mgr) {
+		pr_err("%s: Color Manager is not initialized!!!\n", __func__);
+		return -EINVAL;
+	}
+
+	padata = &color_mgr->picadj_data;
+	if (!padata)
+		return -EINVAL;
+
+	memset(&picadj, 0, sizeof(struct mdp_pa_cfg_data));
+
+	/* Check if values are in permitted range, otherwise read defaults */
+	if ( ((padata->sat_adj  < 224 || padata->sat_adj  > 12000)
+						&& padata->sat_adj != 128)||
+	      (padata->hue_adj  < 0   || padata->hue_adj  > 1536) ||
+	     ((padata->val_adj  < 0   || padata->val_adj  > 383)
+						&& padata->val_adj  != 0) ||
+	     ((padata->cont_adj < 0   || padata->cont_adj > 383)
+						&& padata->cont_adj != 0) )
+	{
+		picadj.block = MDP_LOGICAL_BLOCK_DISP_0;
+		picadj.pa_data.flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_READ;
+
+		mdss_mdp_pa_config(mfd, &picadj, &copyback);
+		pr_err("%s: ERROR: Values not specified or invalid. \
+			Setting defaults.\n", __func__);
+		pr_err("%s (%d): defaults: sat=%d hue=%d val=%d cont=%d",
+			__func__, __LINE__,
+			picadj.pa_data.sat_adj, picadj.pa_data.hue_adj,
+			picadj.pa_data.val_adj, picadj.pa_data.cont_adj);
+
+		padata = &picadj.pa_data;
+	}
+
+	picadj.block = MDP_LOGICAL_BLOCK_DISP_0;
+	padata->flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE;
+	picadj.pa_data = *padata;
+
+	mdss_mdp_pa_config(mfd, &picadj, &copyback);
+
+	pr_info("%s (%d):sat=%d hue=%d val=%d cont=%d",
+		__func__, __LINE__, padata->sat_adj,
+		padata->hue_adj, padata->val_adj, padata->cont_adj);
+
+	return 0;
+}
+
+static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
+	struct somc_panel_color_mgr *color_mgr = NULL;
+	struct mdp_pa_cfg *compat = NULL;
+	struct mdp_pa_v2_data *padata = NULL;
+	struct mdp_pa_v2_cfg_data picadj;
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	u32 copyback = 0;
+	int ret;
+
+	ctrl_pdata = container_of(pdata, struct mdss_dsi_ctrl_pdata,
+				panel_data);
+
+	color_mgr = ctrl_pdata->spec_pdata->color_mgr;
+	if (!color_mgr) {
+		pr_err("%s: Color Manager is not initialized!!!\n", __func__);
+		return -EINVAL;
+	}
+
+	compat = &color_mgr->picadj_data;
+	if (!compat)
+		return -EINVAL;
+
+	memset(&picadj, 0, sizeof(struct mdp_pa_v2_cfg_data));
+
+	padata = kzalloc(sizeof(*padata), GFP_KERNEL);
+	if (padata == NULL) {
+		pr_err("%s: CRITICAL: Allocation failure. Bailing out.\n",
+			__func__);
+		return -ENOMEM;
+	}
+
+	padata->global_sat_adj = compat->sat_adj;
+	padata->global_hue_adj = compat->hue_adj;
+	padata->global_val_adj = compat->val_adj;
+	padata->global_cont_adj = compat->cont_adj;
+	padata->flags = MDP_PP_OPS_ENABLE;
+
+	/* Check if values are in permitted range, otherwise read defaults */
+	if ( ((padata->global_sat_adj  < 224|| padata->global_sat_adj  > 12000)
+					    && padata->global_sat_adj != 128)||
+	      (padata->global_hue_adj  < 0  || padata->global_hue_adj  > 1536) ||
+	     ((padata->global_val_adj  < 0  || padata->global_val_adj  > 383)
+					    && padata->global_val_adj  != 0) ||
+	     ((padata->global_cont_adj < 0  || padata->global_cont_adj > 383)
+					    && padata->global_cont_adj != 0) )
+	{
+		picadj.block = MDP_LOGICAL_BLOCK_DISP_0;
+		picadj.pa_v2_data.flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_READ |
+					  PA_V2_BASIC_FEAT_ENB |
+					  PA_V2_BASIC_MASK_ENB;
+
+		ret = mdss_mdp_pa_v2_config(mfd, &picadj, &copyback);
+		pr_err("%s: ERROR: Values not specified or invalid. \
+			Setting defaults.\n", __func__);
+		pr_err("%s (%d): defaults: sat=%d hue=%d val=%d cont=%d",
+			__func__, __LINE__,
+			picadj.pa_v2_data.global_sat_adj,
+			picadj.pa_v2_data.global_hue_adj,
+			picadj.pa_v2_data.global_val_adj,
+			picadj.pa_v2_data.global_cont_adj);
+
+		padata = &picadj.pa_v2_data;
+	}
+
+	picadj.block = MDP_LOGICAL_BLOCK_DISP_0;
+	padata->flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE |
+			PA_V2_BASIC_FEAT_ENB | PA_V2_BASIC_MASK_ENB;
+	picadj.pa_v2_data = *padata;
+
+	ret = mdss_mdp_pa_v2_config(mfd, &picadj, &copyback);
+	if (ret)
+		pr_err("%s: Cannot configure picadj: %d\n",
+			__func__, ret);
+
+	pr_info("%s (%d):sat=%d hue=%d val=%d cont=%d",
+		__func__, __LINE__, padata->global_sat_adj,
+		padata->global_hue_adj, padata->global_val_adj,
+		padata->global_cont_adj);
+
+	return ret;
+}
+
+static int somc_panel_picadj_setup(struct mdss_panel_data *pdata)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
+
+	ctrl_pdata = container_of(pdata, struct mdss_dsi_ctrl_pdata,
+				panel_data);
+
+	/*
+	 * Note: MDSS_DSI_HW_REV_101_1 is 8974Pro, which has MDP
+	 * revision 1.2.1 (102_1).
+	 * New picadj is required starting from MDP rev. 1.3.0 (103)
+	 * which has any DSI version >= 1.2.0 (102).
+	 */
+	if (ctrl_pdata->shared_data->hw_rev > MDSS_DSI_HW_REV_101_1)
+		return somc_panel_pa_v2_setup(pdata);
+	else
+		return somc_panel_pa_setup(pdata);
+}
+
+static ssize_t mdss_dsi_panel_pcc_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
+	struct mdss_pcc_data *pcc_data =
+		&ctrl_pdata->spec_pdata->color_mgr->pcc_data;
+	u32 r, g, b;
+
+	r = g = b = 0;
+	if (!pcc_data->color_tbl)
+		goto exit;
+	if (pcc_data->u_data == 0 && pcc_data->v_data == 0)
+		goto exit;
+	if (pcc_data->tbl_idx >= pcc_data->tbl_size)
+		goto exit;
+	if (pcc_data->color_tbl[pcc_data->tbl_idx].color_type == UNUSED)
+		goto exit;
+	r = pcc_data->color_tbl[pcc_data->tbl_idx].r_data;
+	g = pcc_data->color_tbl[pcc_data->tbl_idx].g_data;
+	b = pcc_data->color_tbl[pcc_data->tbl_idx].b_data;
+exit:
+	return scnprintf(buf, PAGE_SIZE, "0x%x 0x%x 0x%x ", r, g, b);
+}
+
+static struct device_attribute colormgr_attributes[] = {
+	__ATTR(cc, S_IRUGO, mdss_dsi_panel_pcc_show, NULL),
+};
+
+int somc_panel_colormgr_register_attr(struct device *dev)
+{
+	int i;
+	for (i = 0; i < ARRAY_SIZE(colormgr_attributes); i++)
+		if (device_create_file(dev, colormgr_attributes + i))
+			goto error;
+	return 0;
+error:
+	dev_err(dev, "%s: Cannot create Color Manager attributes\n", __func__);
+	for (--i; i >= 0 ; i--)
+		device_remove_file(dev, colormgr_attributes + i);
+	return -ENODEV;
+}
+
+static int somc_panel_colormgr_unblank_handler(struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	struct somc_panel_color_mgr *color_mgr = ctrl->spec_pdata->color_mgr;
+
+	if (color_mgr->pcc_data.pcc_sts & PCC_STS_UD) {
+		color_mgr->pcc_setup(&ctrl->panel_data);
+		color_mgr->pcc_data.pcc_sts &= ~PCC_STS_UD;
+	}
+
+	return 0;
+}
+
+int somc_panel_color_manager_init(struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	struct somc_panel_color_mgr *color_mgr = NULL;
+
+	color_mgr = ctrl->spec_pdata->color_mgr;
+	if (!color_mgr) {
+		pr_err("%s: Color Manager is NULL!!!\n", __func__);
+		return -EINVAL;
+	}
+
+	color_mgr->pcc_setup = somc_panel_pcc_setup;
+	color_mgr->picadj_setup = somc_panel_picadj_setup;
+	color_mgr->unblank_hndl = somc_panel_colormgr_unblank_handler;
+
+	return 0;
+}

--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -481,9 +481,9 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 		return -ENOMEM;
 	}
 
-	ret = mdss_mdp_pa_get_version(&pa_version);
+	ret = mdss_mdp_pp_get_version(&pa_version);
 	if (ret) {
-		pr_err("%s: Cannot get PA HW version. Bailing out.\n",
+		pr_err("%s: Cannot get PP HW version. Bailing out.\n",
 			__func__);
 		return -EINVAL;
 	};
@@ -523,9 +523,10 @@ static int somc_panel_pa_v2_setup(struct mdss_panel_data *pdata)
 	}
 
 	picadj.block = MDP_LOGICAL_BLOCK_DISP_0;
-	padata->flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE |
+	picadj.flags = MDP_PP_OPS_ENABLE | MDP_PP_OPS_WRITE |
 			PA_V2_BASIC_FEAT_ENB | PA_V2_BASIC_MASK_ENB;
-	picadj.pa_v2_data = *padata;
+	padata->flags = picadj.flags;
+	picadj.cfg_payload = padata;
 
 	ret = mdss_mdp_pa_v2_config(mfd, &picadj, &copyback);
 	if (ret)

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -57,12 +57,8 @@ bool alt_panelid_cmd;
 static bool mdss_panel_flip_ud = false;
 static bool mdss_force_pcc = false;
 
-static struct fps_data vpsd, fpsd;
-struct mdss_mdp_vsync_handler vs_handle;
-
 static int mdss_dsi_panel_pcc_setup(struct mdss_panel_data *pdata);
 static int mdss_dsi_panel_picadj_setup(struct mdss_panel_data *pdata);
-static void vsync_handler(struct mdss_mdp_ctl *ctl, ktime_t t);
 
 static int __init continous_splash_setup(char *str)
 {
@@ -854,151 +850,6 @@ static void mdss_dsi_panel_bl_ctrl(struct mdss_panel_data *pdata,
 	}
 }
 
-static void mdss_dsi_panel_fps_array_clear(struct fps_data *fps)
-{
-	memset(fps->fa, 0, sizeof(fps->fa));
-	fps->fps_array_cnt = 0;
-}
-
-static ssize_t mdss_dsi_panel_frame_counter(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.frame_counter);
-}
-
-static ssize_t mdss_dsi_panel_frames_per_ksecs(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.fpks);
-}
-
-static ssize_t mdss_dsi_panel_vsyncs_per_ksecs_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	if (vpsd.vps_en)
-		return scnprintf(buf, PAGE_SIZE, "%i\n", vpsd.fpks);
-	else
-		return scnprintf(buf, PAGE_SIZE,
-			"This function is invalid now.\n"
-			"Please read again after writing ON.\n");
-}
-
-static ssize_t mdss_dsi_panel_vsyncs_per_ksecs_store(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
-{
-	int ret = count;
-	long vps_en;
-	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
-	struct mdss_mdp_ctl *ctl = mdata->ctl_off;
-
-	if (kstrtol(buf, 10, &vps_en)) {
-		dev_err(dev, "%s: Error, buf = %s\n", __func__, buf);
-		ret = -EINVAL;
-		goto exit;
-	}
-
-	vs_handle.vsync_handler = (mdp_vsync_handler_t)vsync_handler;
-	vs_handle.cmd_post_flush = false;
-
-	if (vps_en) {
-		vs_handle.enabled = false;
-		if (!vpsd.vps_en && (ctl->ops.add_vsync_handler)) {
-			ctl->ops.add_vsync_handler(ctl, &vs_handle);
-			vpsd.vps_en = true;
-			pr_info("%s: vsyncs_per_ksecs is valid\n", __func__);
-		}
-	} else {
-		vs_handle.enabled = true;
-		if (vpsd.vps_en && (ctl->ops.remove_vsync_handler)) {
-			ctl->ops.remove_vsync_handler(ctl, &vs_handle);
-			vpsd.vps_en = false;
-			fpsd.fpks = 0;
-			pr_info("%s: vsyncs_per_ksecs is invalid\n", __func__);
-		}
-	}
-exit:
-	return ret;
-}
-
-static ssize_t mdss_dsi_panel_interval_ms_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.interval_ms);
-}
-
-static ssize_t mdss_dsi_panel_log_interval_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.log_interval);
-}
-
-static ssize_t mdss_dsi_panel_log_interval_store(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
-{
-	int ret = count;
-
-	if (sscanf(buf, "%4i", &fpsd.log_interval) != 1) {
-		pr_err("%s: Error, buf = %s\n", __func__, buf);
-		ret = -EINVAL;
-	}
-	return ret;
-}
-
-#define DEBUG_INTERVAL_ARRAY
-static ssize_t mdss_dsi_panel_interval_array_ms(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	u16 i, len, rc = 0;
-	char *tmp = buf;
-
-	mutex_lock(&fpsd.fps_lock);
-	len = fpsd.fa_last_array_pos;
-	/* Get the first frames from the buffer */
-	for (i = len + 1; i < DEF_FPS_ARRAY_SIZE; i++) {
-		if (fpsd.fa[i].time_delta) {
-#ifdef DEBUG_INTERVAL_ARRAY
-			/* FrameNumber, buf idx and delta time */
-			rc += scnprintf(tmp + rc, PAGE_SIZE - rc ,
-						"%03i[%03i]: %i,\n",
-						fpsd.fa[i].frame_nbr, i,
-						fpsd.fa[i].time_delta);
-#else
-			rc += scnprintf(tmp + rc, PAGE_SIZE - rc ,
-						"%i, ", fpsd.fa[i].time_delta);
-#endif
-		}
-	}
-	/* Get the rest frames from the buffer */
-	if (len) {
-		for (i = 0; i <= len; i++) {
-			if (fpsd.fa[i].time_delta) {
-#ifdef DEBUG_INTERVAL_ARRAY
-				/* FrameNumber, buf idx and delta time */
-				rc += scnprintf(tmp + rc, PAGE_SIZE - rc ,
-						"%03i[%03i]: %i,\n",
-						fpsd.fa[i].frame_nbr, i,
-						fpsd.fa[i].time_delta);
-#else
-				rc += scnprintf(tmp + rc, PAGE_SIZE - rc ,
-						"%i, ", fpsd.fa[i].time_delta);
-#endif
-			}
-		}
-	}
-	rc += scnprintf(tmp + rc, PAGE_SIZE - rc , "\n");
-
-	/* Clear the buffer once it is read */
-	mdss_dsi_panel_fps_array_clear(&fpsd);
-	mutex_unlock(&fpsd.fps_lock);
-
-	mutex_lock(&vpsd.fps_lock);
-	/* Clear the buffer once it is read */
-	mdss_dsi_panel_fps_array_clear(&vpsd);
-	mutex_unlock(&vpsd.fps_lock);
-
-	return rc;
-}
-
 static int mdss_dsi_panel_read_cabc(struct device *dev)
 {
 	struct platform_device *pdev = NULL;
@@ -1092,337 +943,23 @@ exit:
 	return scnprintf(buf, PAGE_SIZE, "0x%x 0x%x 0x%x ", r, g, b);
 }
 
-static int mdss_dsi_panel_chg_fps_calc
-		(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int dfpks) {
-	int dfps;
-	int dfpks_rev;
-	int rc = 0;
-	u32 vt, v_total, cur_vfp;
-	u32 vfp, vbp, yres;
-	u32 cmds, payload, val[2];
-	u64 clk;
-	static int line_us;
-	struct mdss_panel_specific_pdata *spec_pdata = NULL;
-	struct mdss_panel_info *pinfo = &ctrl_pdata->panel_data.panel_info;
-	struct dcs_cmd_req cmdreq;
-	char rtn, adj;
-	int i;
-
-	dfps = dfpks / 1000;
-
-	spec_pdata = ctrl_pdata->spec_pdata;
-	if (!spec_pdata) {
-		pr_err("%s: Invalid input data\n", __func__);
-		return -EINVAL;
-	}
-
-	if (pinfo->mipi.mode == DSI_CMD_MODE) {
-		clk = pinfo->lcdc.chg_fps.disp_clk;
-		vbp = pinfo->lcdc.chg_fps.dric_vbp;
-		vfp = pinfo->lcdc.chg_fps.dric_vfp;
-		yres = pinfo->yres;
-		adj = pinfo->lcdc.chg_fps.rtn_adj ? 1 : 0;
-
-		rtn = (char)div_u64(clk, (dfpks * (yres + vbp + vfp) / 1000));
-		dfpks_rev = (int)div_u64(clk, (rtn * (yres + vbp + vfp) / 1000));
-		dfps = dfpks_rev / 1000;
-
-		pr_debug("%s: clk=%llu vbp=%d vfp=%d yres=%d rtn=0x%x adj=%d\n",
-			__func__, clk, vbp, vfp, yres, rtn, adj);
-
-		for (i = 0; i < (pinfo->lcdc.chg_fps.rtn_pos.num / 2); i++) {
-			cmds = pinfo->lcdc.chg_fps.rtn_pos.pos[(i * 2)];
-			payload = pinfo->lcdc.chg_fps.rtn_pos.pos[(i * 2) + 1];
-			CHANGE_PAYLOAD(cmds, payload) = (rtn - adj);
-		}
-
-		pinfo->mipi.frame_rate = dfps;
-
-		if (pinfo->lcdc.chg_fps.te_c_update) {
-			cmds = pinfo->lcdc.chg_fps.te_c_pos[0];
-			payload = pinfo->lcdc.chg_fps.te_c_pos[1];
-
-			if (dfpks > pinfo->lcdc.chg_fps.threshold) {
-				val[0] = pinfo->lcdc.chg_fps.te_c_60fps[0];
-				val[1] = pinfo->lcdc.chg_fps.te_c_60fps[1];
-			} else {
-				val[0] = pinfo->lcdc.chg_fps.te_c_45fps[0];
-				val[1] = pinfo->lcdc.chg_fps.te_c_45fps[1];
-			}
-
-			CHANGE_PAYLOAD(cmds, payload) = val[0];
-			CHANGE_PAYLOAD(cmds, (payload + 1)) = val[1];
-		}
-
-		if (!pinfo->lcdc.chg_fps.susres_mode) {
-			pr_debug("%s: fps change sequence\n", __func__);
-
-			memset(&cmdreq, 0, sizeof(cmdreq));
-			cmdreq.cmds = spec_pdata->fps_cmds.cmds;
-			cmdreq.cmds_cnt = spec_pdata->fps_cmds.cmd_cnt;
-			cmdreq.rlen = 0;
-			cmdreq.cb = NULL;
-			mdss_dsi_cmdlist_put(ctrl_pdata, &cmdreq);
-		}
-
-		pr_info("%s: change fpks=%d\n", __func__, dfpks);
-	} else {
-		if (!line_us) {
-			vt = mdss_panel_get_vtotal(&ctrl_pdata
-						    ->panel_data.panel_info);
-			line_us = (NSEC_PER_SEC / 60) / vt;
-		}
-		v_total = (NSEC_PER_SEC / dfps) / line_us;
-		vfp = v_total
-			- (pinfo->lcdc.v_back_porch
-			+  pinfo->lcdc.v_pulse_width
-			+  pinfo->yres);
-
-		spec_pdata->new_vfp = vfp;
-		cur_vfp = pinfo->lcdc.v_front_porch;
-		pinfo->lcdc.v_front_porch = vfp;
-
-		rc = mdss_dsi_clk_div_config(pinfo, dfps);
-		ctrl_pdata->pclk_rate = pinfo->mipi.dsi_pclk_rate;
-		ctrl_pdata->byte_clk_rate = pinfo->clk_rate / 8;
-		pinfo->lcdc.v_front_porch = cur_vfp;
-		pr_info("%s: change fps=%d vfp=%d\n", __func__, dfps,
-				spec_pdata->new_vfp);
-	}
-	pinfo->new_fps         = dfps;
-	pinfo->mipi.input_fpks = dfpks;
-
-	return 0;
-}
-
-static int mdss_dsi_panel_chg_fps_check_state
-		(struct mdss_dsi_ctrl_pdata *ctrl, int dfpks) {
-	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
-	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
-	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
-	struct mdss_panel_info *pinfo = &ctrl->panel_data.panel_info;
-	struct mdss_dsi_ctrl_pdata *sctrl = NULL;
-	struct mdss_panel_specific_pdata *spec_pdata = NULL;
-	int rc = 0;
-
-	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
-		goto error;
-
-	if (dfpks == pinfo->mipi.input_fpks) {
-		pr_info("%s: fpks is already %d\n", __func__, dfpks);
-		goto end;
-	}
-
-	spec_pdata = ctrl->spec_pdata;
-
-	if ((pinfo->mipi.mode == DSI_CMD_MODE) &&
-	    (!spec_pdata->fps_cmds.cmd_cnt))
-		goto cmd_cnt_err;
-
-	if (!spec_pdata->disp_onoff_state)
-		goto disp_onoff_state_err;
-
-	if (mdss_dsi_sync_wait_enable(ctrl)) {
-		sctrl = mdss_dsi_get_other_ctrl(ctrl);
-		if (sctrl) {
-			if ((pinfo->mipi.mode == DSI_CMD_MODE)
-			&& (!sctrl->spec_pdata->fps_cmds.cmd_cnt))
-				goto cmd_cnt_err;
-
-			if (!spec_pdata->disp_onoff_state)
-				goto disp_onoff_state_err;
-
-			if (mdss_dsi_sync_wait_trigger(ctrl)) {
-				rc = mdss_dsi_panel_chg_fps_calc(sctrl, dfpks);
-				if (rc < 0)
-					goto end;
-				rc = mdss_dsi_panel_chg_fps_calc(ctrl, dfpks);
-			} else {
-				rc = mdss_dsi_panel_chg_fps_calc(ctrl, dfpks);
-				if (rc < 0)
-					goto end;
-				rc = mdss_dsi_panel_chg_fps_calc(sctrl, dfpks);
-			}
-		} else {
-			rc = mdss_dsi_panel_chg_fps_calc(ctrl, dfpks);
-		}
-	} else {
-		rc = mdss_dsi_panel_chg_fps_calc(ctrl, dfpks);
-	}
-end:
-	return rc;
-cmd_cnt_err:
-	pr_err("%s: change fps isn't supported\n", __func__);
-	return -EINVAL;
-disp_onoff_state_err:
-	pr_err("%s: Disp-On is not yet completed. Please retry\n", __func__);
-	return -EINVAL;
-error:
-	return -EINVAL;
-}
-
-static ssize_t mdss_dsi_panel_change_fpks_store(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
-{
-	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
-	int dfpks, rc;
-
-	rc = kstrtoint(buf, 10, &dfpks);
-	if (rc < 0) {
-		pr_err("%s: Error, buf = %s\n", __func__, buf);
-		return rc;
-	}
-
-	if (dfpks < 1000 * CHANGE_FPS_MIN
-			|| dfpks > 1000 * CHANGE_FPS_MAX) {
-		pr_err("%s: invalid value for change_fpks buf = %s\n",
-				 __func__, buf);
-		return -EINVAL;
-	}
-
-	rc = mdss_dsi_panel_chg_fps_check_state(ctrl_pdata, dfpks);
-	if (rc) {
-		pr_err("%s: Error, rc = %d\n", __func__, rc);
-		return rc;
-	}
-	return count;
-}
-
-static ssize_t mdss_dsi_panel_change_fpks_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
-	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
-	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
-	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
-
-	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
-		return 0;
-
-	return scnprintf(buf, PAGE_SIZE, "%d\n",
-		ctrl_pdata->panel_data.panel_info.mipi.input_fpks);
-}
-
-static ssize_t mdss_dsi_panel_change_fps_store(struct device *dev,
-		struct device_attribute *attr, const char *buf, size_t count)
-{
-	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
-	int dfps, dfpks, rc;
-
-	rc = kstrtoint(buf, 10, &dfps);
-	if (rc < 0) {
-		pr_err("%s: Error, buf = %s\n", __func__, buf);
-		return rc;
-	}
-
-	if (dfps >= 1000 * CHANGE_FPS_MIN
-			&& dfps <= 1000 * CHANGE_FPS_MAX) {
-		dfpks = dfps;
-	} else if (dfps >= CHANGE_FPS_MIN && dfps <= CHANGE_FPS_MAX) {
-		dfpks = dfps * 1000;
-	} else {
-		pr_err("%s: invalid value for change_fps buf = %s\n",
-				__func__, buf);
-		return -EINVAL;
-	}
-
-	rc = mdss_dsi_panel_chg_fps_check_state(ctrl_pdata, dfpks);
-	if (rc) {
-		pr_err("%s: Error, rc = %d\n", __func__, rc);
-		return rc;
-	}
-
-	return count;
-}
-
-static ssize_t mdss_dsi_panel_change_fps_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
-	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
-	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
-	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
-
-	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
-		return 0;
-
-	return scnprintf(buf, PAGE_SIZE, "%d\n",
-		ctrl_pdata->panel_data.panel_info.mipi.input_fpks / 1000);
-}
-
-static void mdss_dsi_panel_wait_change(
-		struct mdss_dsi_ctrl_pdata *ctrl_pdata, bool onoff)
-{
-	struct mdss_panel_info *pinfo = &ctrl_pdata->panel_data.panel_info;
-	struct dsi_cmd_desc *cmds_cmds = NULL;
-	char *wait = NULL;
-	char wait_60fps, wait_45fps;
-	u32 fpks = pinfo->mipi.input_fpks;
-	u32 cmds_num;
-
-	if (onoff) {
-		cmds_num = pinfo->lcdc.chg_fps.wait_on_cmds_num;
-		cmds_cmds = &ctrl_pdata->on_cmds.cmds[cmds_num];
-		if (cmds_cmds)
-			wait = &ctrl_pdata->on_cmds.cmds[cmds_num].dchdr.wait;
-		else
-			goto exit;
-
-		wait_60fps = (char)pinfo->lcdc.chg_fps.wait_on_60fps;
-		wait_45fps = (char)pinfo->lcdc.chg_fps.wait_on_45fps;
-	} else {
-		cmds_num = pinfo->lcdc.chg_fps.wait_off_cmds_num;
-		cmds_cmds = &ctrl_pdata->off_cmds.cmds[cmds_num];
-		if (cmds_cmds)
-			wait = &ctrl_pdata->off_cmds.cmds[cmds_num].dchdr.wait;
-		else
-			goto exit;
-
-		wait_60fps = (char)pinfo->lcdc.chg_fps.wait_off_60fps;
-		wait_45fps = (char)pinfo->lcdc.chg_fps.wait_off_45fps;
-	}
-
-	if (fpks > pinfo->lcdc.chg_fps.threshold)
-		*wait = wait_60fps;
-	else
-		*wait = wait_45fps;
-	pr_debug("%s: onoff[%d] wait = %d\n", __func__, onoff, *wait);
-exit:
-	return;
-}
-
 static struct device_attribute panel_attributes[] = {
-	__ATTR(frame_counter, S_IRUGO, mdss_dsi_panel_frame_counter, NULL),
-	__ATTR(frames_per_ksecs, S_IRUGO,
-				mdss_dsi_panel_frames_per_ksecs, NULL),
-	__ATTR(vsyncs_per_ksecs, S_IRUSR|S_IRGRP|S_IWUSR|S_IWGRP,
-				mdss_dsi_panel_vsyncs_per_ksecs_show,
-				mdss_dsi_panel_vsyncs_per_ksecs_store),
-	__ATTR(interval_ms, S_IRUGO, mdss_dsi_panel_interval_ms_show, NULL),
-	__ATTR(log_interval, S_IRUGO|S_IWUSR|S_IWGRP,
-					mdss_dsi_panel_log_interval_show,
-					mdss_dsi_panel_log_interval_store),
-	__ATTR(interval_array, S_IRUGO,
-				mdss_dsi_panel_interval_array_ms, NULL),
 	__ATTR(cabc, S_IRUGO|S_IWUSR|S_IWGRP, mdss_dsi_panel_cabc_show,
 						mdss_dsi_panel_cabc_store),
 	__ATTR(panel_id, S_IRUSR, mdss_dsi_panel_id_show, NULL),
 	__ATTR(cc, S_IRUGO, mdss_dsi_panel_pcc_show, NULL),
-	__ATTR(change_fps, S_IRUGO|S_IWUSR|S_IWGRP,
-					mdss_dsi_panel_change_fps_show,
-					mdss_dsi_panel_change_fps_store),
-	__ATTR(change_fpks, S_IRUGO|S_IWUSR|S_IWGRP,
-					mdss_dsi_panel_change_fpks_show,
-					mdss_dsi_panel_change_fpks_store),
 };
 
 static int register_attributes(struct device *dev)
 {
-	int i;
+	int i, rc = 0;
 	for (i = 0; i < ARRAY_SIZE(panel_attributes); i++)
 		if (device_create_file(dev, panel_attributes + i))
 			goto error;
-	return 0;
+
+	rc = somc_panel_fps_register_attr(dev);
+
+	return rc;
 error:
 	dev_err(dev, "%s: Unable to create interface\n", __func__);
 	for (--i; i >= 0 ; i--)
@@ -1505,7 +1042,6 @@ static int mdss_dsi_panel_on(struct mdss_panel_data *pdata)
 	}
 
 	if (ctrl_pdata->on_cmds.cmd_cnt && !pinfo->disp_on_in_hs) {
-		mdss_dsi_panel_wait_change(ctrl_pdata, true);
 		pr_debug("%s: panel on sequence (in low speed)\n", __func__);
 		mdss_dsi_panel_cmds_send(ctrl_pdata, &ctrl_pdata->on_cmds);
 		spec_pdata->disp_onoff_state = true;
@@ -1584,19 +1120,8 @@ static int mdss_dsi_post_panel_on(struct mdss_panel_data *pdata)
 			return rc;
 	}
 
-	if (pdata->panel_info.pdest == DISPLAY_1) {
-		int ifpks = ctrl->panel_data.panel_info.mipi.input_fpks;
-
-		if (pinfo->lcdc.chg_fps.enable) {
-			if (pinfo->lcdc.chg_fps.susres_mode)
-				mdss_dsi_panel_chg_fps_calc(ctrl, ifpks);
-	
-			somc_panel_chg_fps_cmds_send(ctrl);
-		} else {
-			pr_notice("%s: change fps is not supported.\n",
-							__func__);
-		}
-	}
+	if (pdata->panel_info.pdest == DISPLAY_1)
+		somc_panel_fpsman_panel_post_on(ctrl);
 
 end:
 	pr_debug("%s:-\n", __func__);
@@ -1608,8 +1133,6 @@ static int mdss_dsi_panel_off(struct mdss_panel_data *pdata)
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
 	struct mdss_panel_info *pinfo = NULL;
-	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
-	struct mdss_mdp_ctl *ctl = mdata->ctl_off;
 
 	if (pdata == NULL) {
 		pr_err("%s: Invalid input data\n", __func__);
@@ -1648,7 +1171,6 @@ static int mdss_dsi_panel_off(struct mdss_panel_data *pdata)
 		goto skip_off_cmds;
 
 	if (ctrl_pdata->off_cmds.cmd_cnt) {
-		mdss_dsi_panel_wait_change(ctrl_pdata, false);
 		mdss_dsi_panel_cmds_send(ctrl_pdata,
 					&ctrl_pdata->off_cmds);
 	}
@@ -1671,16 +1193,7 @@ static int mdss_dsi_panel_off(struct mdss_panel_data *pdata)
 		ctrl_pdata->panel_data.panel_info.lcdc.v_front_porch =
 			spec_pdata->new_vfp;
 
-	vs_handle.vsync_handler = (mdp_vsync_handler_t)vsync_handler;
-	vs_handle.cmd_post_flush = false;
-	vs_handle.enabled = true;
-
-	if (vpsd.vps_en && (ctl->ops.remove_vsync_handler)) {
-		ctl->ops.remove_vsync_handler(ctl, &vs_handle);
-		vpsd.vps_en = false;
-		fpsd.fpks = 0;
-		pr_info("%s: vsyncs_per_ksecs is invalid\n", __func__);
-	}
+	somc_panel_fpsman_panel_off();
 
 #ifndef CONFIG_SOMC_PANEL_INCELL
 	mdss_dsi_panel_reset(pdata, 0);
@@ -1768,7 +1281,6 @@ static int mdss_dsi_panel_disp_on(struct mdss_panel_data *pdata)
 
 	if (ctrl_pdata->on_cmds.cmd_cnt && pinfo->disp_on_in_hs) {
 		pr_debug("%s: panel on sequence (in high speed)\n", __func__);
-		mdss_dsi_panel_wait_change(ctrl_pdata, true);
 		mdss_dsi_set_tx_power_mode(0, pdata);
 		mdss_dsi_panel_cmds_send(ctrl_pdata, &ctrl_pdata->on_cmds);
 		spec_pdata->disp_onoff_state = true;
@@ -1868,92 +1380,6 @@ static int mdss_dsi_panel_power_ctrl_ex(struct mdss_panel_data *pdata, int enabl
 		pinfo->panel_power_state = enable;
 
 	return ret;
-}
-
-static u32 ts_diff_ms(struct timespec lhs, struct timespec rhs)
-{
-	struct timespec tdiff;
-	s64 nsec;
-	u32 msec;
-
-	tdiff = timespec_sub(lhs, rhs);
-	nsec = timespec_to_ns(&tdiff);
-	msec = (u32)nsec;
-	do_div(msec, NSEC_PER_MSEC);
-
-	return msec;
-}
-
-static void update_fps_data(struct fps_data *fps)
-{
-	if (mutex_trylock(&fps->fps_lock)) {
-		u32 fpks = 0;
-		u32 ms_since_last = 0;
-		u32 num_frames;
-		struct timespec tlast = fps->timestamp_last;
-		struct timespec tnow;
-		u32 msec;
-
-		getrawmonotonic(&tnow);
-		msec = ts_diff_ms(tnow, tlast);
-		fps->timestamp_last = tnow;
-
-		fps->interval_ms = msec;
-		fps->frame_counter++;
-		num_frames = fps->frame_counter - fps->frame_counter_last;
-
-		fps->fa[fps->fps_array_cnt].frame_nbr = fps->frame_counter;
-		fps->fa[fps->fps_array_cnt].time_delta = msec;
-		fps->fa_last_array_pos = fps->fps_array_cnt;
-		(fps->fps_array_cnt)++;
-		if (fps->fps_array_cnt >= DEF_FPS_ARRAY_SIZE)
-			fps->fps_array_cnt = 0;
-
-		ms_since_last = ts_diff_ms(tnow, fps->fpks_ts_last);
-
-		if (num_frames > 1 && ms_since_last >= fps->log_interval) {
-			fpks = (num_frames * 1000000) / ms_since_last;
-			fps->fpks_ts_last = tnow;
-			fps->frame_counter_last = fps->frame_counter;
-			fps->fpks = fpks;
-		}
-		mutex_unlock(&fps->fps_lock);
-	}
-}
-
-static void mdss_dsi_panel_fps_data_init(struct fps_data *fps)
-{
-	fps->frame_counter = 0;
-	fps->frame_counter_last = 0;
-	fps->log_interval = DEF_FPS_LOG_INTERVAL;
-	fps->fpks = 0;
-	fps->fa_last_array_pos = 0;
-	fps->vps_en = false;
-	getrawmonotonic(&fps->timestamp_last);
-	mutex_init(&fps->fps_lock);
-}
-
-int mdss_dsi_panel_fps_data_update(struct msm_fb_data_type *mfd)
-{
-	/* Only count fps on primary display */
-	if (mfd->index == 0)
-		update_fps_data(&fpsd);
-
-	return 0;
-}
-
-static void mdss_dsi_panel_vps_data_update(struct msm_fb_data_type *mfd)
-{
-	/* Only count vpks(hw vsyncs per ksecs) on primary display */
-	if (mfd->index == 0)
-		update_fps_data(&vpsd);
-}
-
-static void vsync_handler(struct mdss_mdp_ctl *ctl, ktime_t t)
-{
-	struct msm_fb_data_type *mfd = ctl->mfd;
-
-	mdss_dsi_panel_vps_data_update(mfd);
 }
 
 static void conv_uv_data(char *data, int param_type, int *u_data, int *v_data)
@@ -2412,7 +1838,6 @@ static void mdss_dsi_parse_trigger(struct device_node *np, char *trigger,
 	}
 }
 
-
 static int mdss_dsi_parse_dcs_cmds(struct device_node *np,
 		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key)
 {
@@ -2501,6 +1926,11 @@ exit_free:
 	return -ENOMEM;
 }
 
+int somc_panel_parse_dcs_cmds(struct device_node *np,
+		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key)
+{
+	return mdss_dsi_parse_dcs_cmds(np, pcmds, cmd_key, link_key);
+}
 
 int mdss_dsi_property_read_u32_var(struct device_node *np,
 		char *name, u32 **out_data, int *num)
@@ -3594,80 +3024,6 @@ static void mdss_dsi_parse_dfps_config(struct device_node *pan_node,
 	return;
 }
 
-static void mdss_dsi_parse_chgfps_config(struct device_node *pan_node,
-			struct mdss_dsi_ctrl_pdata *ctrl_pdata)
-{
-	int rc;
-	u32 res[2], tmp;
-	u64 tmp64;
-	struct mdss_panel_info *pinfo = &(ctrl_pdata->panel_data.panel_info);
-
-	mdss_dsi_parse_dcs_cmds(pan_node, &ctrl_pdata->spec_pdata->fps_cmds,
-					"somc,change-fps-command", NULL);
-
-	rc = of_property_read_u64(pan_node, "somc,display-clock", &tmp64);
-	pinfo->lcdc.chg_fps.disp_clk = tmp;
-
-	rc = of_property_read_u32(pan_node,
-		"somc,driver-ic-vbp", &tmp);
-	pinfo->lcdc.chg_fps.dric_vbp = tmp;
-
-	rc = of_property_read_u32(pan_node,
-		"somc,driver-ic-vfp", &tmp);
-	pinfo->lcdc.chg_fps.dric_vfp = tmp;
-
-	pinfo->lcdc.chg_fps.rtn_adj = of_property_read_bool(pan_node,
-		"somc,change-fps-rtn-adj");
-
-	(void)mdss_dsi_property_read_u32_var(pan_node,
-		"somc,change-fps-rtn-pos",
-		(u32 **)&pinfo->lcdc.chg_fps.rtn_pos.pos,
-		&pinfo->lcdc.chg_fps.rtn_pos.num);
-
-	pinfo->lcdc.chg_fps.susres_mode = of_property_read_bool(pan_node,
-		"somc,change-fps-suspend-resume-mode");
-
-	if (of_find_property(pan_node, "somc,fps-threshold", &tmp)) {
-		pinfo->lcdc.chg_fps.te_c_update = true;
-
-		rc = of_property_read_u32(pan_node,
-			"somc,fps-threshold", &tmp);
-		pinfo->lcdc.chg_fps.threshold = !rc ? tmp : 47400;
-
-		rc = of_property_read_u32_array(pan_node,
-			"somc,te-c-mode-60fps", res, 2);
-		pinfo->lcdc.chg_fps.te_c_60fps[0] = !rc ? res[0] : 0x03;
-		pinfo->lcdc.chg_fps.te_c_60fps[1] = !rc ? res[1] : 0x00;
-
-		rc = of_property_read_u32_array(pan_node,
-			"somc,te-c-mode-45fps", res, 2);
-		pinfo->lcdc.chg_fps.te_c_45fps[0] = !rc ? res[0] : 0x04;
-		pinfo->lcdc.chg_fps.te_c_45fps[1] = !rc ? res[1] : 0xFF;
-
-		rc = of_property_read_u32_array(pan_node,
-			"somc,te-c-mode-pos", res, 2);
-		pinfo->lcdc.chg_fps.te_c_pos[0] = !rc ? res[0] : 3;
-		pinfo->lcdc.chg_fps.te_c_pos[1] = !rc ? res[1] : 1;
-
-		/* Note: Remove feature? */
-		rc = of_property_read_u32_array(pan_node,
-			"somc,change-wait-on", res, 2);
-		pinfo->lcdc.chg_fps.wait_on_60fps = !rc ? res[0] : 0;
-		pinfo->lcdc.chg_fps.wait_on_45fps = !rc ? res[1] : 0;
-
-		rc = of_property_read_u32_array(pan_node,
-			"somc,change-wait-off", res, 2);
-		pinfo->lcdc.chg_fps.wait_off_60fps = !rc ? res[0] : 0;
-		pinfo->lcdc.chg_fps.wait_off_45fps = !rc ? res[1] : 0;
-
-		rc = of_property_read_u32_array(pan_node,
-			"somc,change-wait-cmds-num", res, 2);
-		pinfo->lcdc.chg_fps.wait_on_cmds_num = !rc ? res[0] : 0;
-		pinfo->lcdc.chg_fps.wait_off_cmds_num = !rc ? res[1] : 0;
-		/* Note: End */
-	}
-}
-
 static int mdss_dsi_parse_polling_config(struct device_node *pan_node,
 			struct mdss_dsi_ctrl_pdata *ctrl)
 {
@@ -4580,10 +3936,7 @@ int mdss_panel_parse_dt(struct device_node *np,
 			MSM_DBA_CHIP_NAME_MAX_LEN);
 	}
 
-	pinfo->lcdc.chg_fps.enable = of_property_read_bool(np,
-					"somc,change-fps-enable");
-	if (pinfo->lcdc.chg_fps.enable)
-		mdss_dsi_parse_chgfps_config(np, ctrl_pdata);
+	somc_panel_parse_dt_chgfps_config(np, ctrl_pdata);
 
 	rc = mdss_dsi_parse_polling_config(np, ctrl_pdata);
 	if (rc)
@@ -4857,7 +4210,6 @@ int mdss_dsi_panel_init(struct device_node *node,
 	spec_pdata->panel_power_ctrl = mdss_dsi_panel_power_ctrl_ex;
 	spec_pdata->reset = mdss_dsi_panel_reset_seq;
 	spec_pdata->disp_on = mdss_dsi_panel_disp_on;
-	spec_pdata->update_fps = mdss_dsi_panel_fps_data_update;
 	spec_pdata->unblank = mdss_dsi_panel_unblank;
 
 	ctrl_pdata->on = mdss_dsi_panel_on;
@@ -4870,10 +4222,7 @@ int mdss_dsi_panel_init(struct device_node *node,
 	ctrl_pdata->switch_mode = mdss_dsi_panel_switch_mode;
 
 
-	mdss_dsi_panel_fps_data_init(&fpsd);
-	mdss_dsi_panel_fps_data_init(&vpsd);
-
-	vs_handle.vsync_handler = NULL;
+	somc_panel_fps_manager_init();
 
 	return 0;
 error:

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -3294,25 +3294,6 @@ int mdss_panel_parse_dt(struct device_node *np,
 	if (rc)
 		pr_err("%s: Failed to parse lab/ibb vregs DT!!\n", __func__);
 
-	rc = of_property_read_u32_array(np,
-		"somc,mdss-dsi-u-rev", res, 2);
-	if (rc) {
-		pinfo->rev_u[0] = 0;
-		pinfo->rev_u[1] = 0;
-	} else {
-		pinfo->rev_u[0] = res[0];
-		pinfo->rev_u[1] = res[1];
-	}
-	rc = of_property_read_u32_array(np,
-		"somc,mdss-dsi-v-rev", res, 2);
-	if (rc) {
-		pinfo->rev_v[0] = 0;
-		pinfo->rev_v[1] = 0;
-	} else {
-		pinfo->rev_v[0] = res[0];
-		pinfo->rev_v[1] = res[1];
-	}
-
 	spec_pdata->pwron_reset = of_property_read_bool(np,
 					"somc,panel-pwron-reset");
 

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -3325,6 +3325,7 @@ int mdss_panel_parse_dt(struct device_node *np,
 			MSM_DBA_CHIP_NAME_MAX_LEN);
 	}
 
+	if (pinfo->pdest == pinfo->dsi_master)
 	somc_panel_parse_dt_colormgr_config(np, ctrl_pdata);
 	if (rc)
 		pr_err("%s: Failed to parse Color Manager configuration\n",

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -3344,6 +3344,10 @@ int mdss_panel_parse_dt(struct device_node *np,
 			MSM_DBA_CHIP_NAME_MAX_LEN);
 	}
 
+	somc_panel_parse_dt_colormgr_config(np, ctrl_pdata);
+	if (rc)
+		pr_err("%s: Failed to parse Color Manager configuration\n",
+			__func__);
 	somc_panel_parse_dt_chgfps_config(np, ctrl_pdata);
 
 	rc = mdss_dsi_parse_polling_config(np, ctrl_pdata);

--- a/drivers/video/fbdev/msm/somc_panel/panel_fps_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_fps_manager.c
@@ -1,0 +1,936 @@
+/*
+ * Restructured unified display panel driver for Xperia Open Devices
+ *                     *** FPS Management ***
+ *
+ * This driver is based on various SoMC implementations found in
+ * copyleft archives for various devices.
+ *
+ * Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) Sony Mobile Communications Inc. All rights reserved.
+ * Copyright (C) 2014-2017, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/module.h>
+#include <linux/interrupt.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+
+#include "../mdss_mdp.h"
+#include "../mdss_dsi.h"
+#include "somc_panels.h"
+
+#define PSEC ((u64)1000000000000)
+#define KSEC ((u64)1000)
+
+static struct fps_data fpsd, vpsd;
+static struct mdss_mdp_vsync_handler vs_handle;
+
+int somc_panel_parse_dt_chgfps_config(struct device_node *np,
+			struct mdss_dsi_ctrl_pdata *ctrl_pdata)
+{
+	struct mdss_panel_info *pinfo = &(ctrl_pdata->panel_data.panel_info);
+	struct change_fps *chg_fps = &ctrl_pdata->spec_pdata->chg_fps;
+	static const char *fps_mode;
+	static const char *fps_type;
+	int rc;
+	u32 tmp;
+
+	chg_fps->enable = of_property_read_bool(np,
+					"somc,change-fps-enable");
+	if (!chg_fps->enable)
+		return 0;
+
+	chg_fps->input_fpks = pinfo->mipi.frame_rate * 1000;
+	somc_panel_parse_dcs_cmds(np, &ctrl_pdata->spec_pdata->fps_cmds,
+				"somc,change-fps-command", NULL);
+
+	rc = of_property_read_u32(np,
+				"somc,driver-ic-vdisp", &tmp);
+	if (rc) {
+		pr_err("%s: Display vdisp not specified\n", __func__);
+		goto error;
+	}
+	chg_fps->dric_vdisp = tmp;
+
+	fps_type = of_get_property(np,
+				"somc,change-fps-panel-type", NULL);
+	if (!fps_type) {
+		pr_err("%s:%d, Panel type not specified\n",
+						__func__, __LINE__);
+		goto error;
+	}
+
+	if (!strncmp(fps_type, "uhd_4k_type", 11)) {
+		chg_fps->type = FPS_TYPE_UHD_4K;
+	} else if (!strncmp(fps_type, "hybrid_incell_type", 18)) {
+		chg_fps->type = FPS_TYPE_HYBRID_INCELL;
+	} else if (!strncmp(fps_type, "full_incell_type", 16)) {
+		chg_fps->type = FPS_TYPE_FULL_INCELL;
+	} else {
+		pr_err("%s: Unable to read fps panel type\n", __func__);
+		goto error;
+	}
+
+	fps_mode = of_get_property(np,
+				"somc,change-fps-panel-mode", NULL);
+	if (!fps_mode) {
+		pr_err("%s:%d, Panel mode not specified\n",
+						__func__, __LINE__);
+		goto error;
+	}
+
+	if (!strncmp(fps_mode, "susres_mode", 11)) {
+		chg_fps->mode = FPS_MODE_SUSRES;
+	} else if (!strncmp(fps_mode, "dynamic_mode", 12)) {
+		chg_fps->mode = FPS_MODE_DYNAMIC;
+	} else {
+		pr_err("%s: Unable to read fps panel mode\n", __func__);
+		goto error;
+	}
+
+	switch (chg_fps->type) {
+	case FPS_TYPE_UHD_4K:
+		(void)mdss_dsi_property_read_u32_var(np,
+			"somc,change-fps-rtn-pos",
+			(u32 **)&chg_fps->send_pos.pos,
+			&chg_fps->send_pos.num);
+
+			rc = of_property_read_u32(np,
+				"somc,driver-ic-total-porch", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC total_porch not specified\n",
+							__func__);
+			goto error;
+		}
+		chg_fps->dric_total_porch = tmp;
+
+		rc = of_property_read_u32(np,
+					"somc,driver-ic-rclk", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC rclk not specified\n",
+							__func__);
+			goto error;
+		}
+		chg_fps->dric_rclk = tmp;
+
+		chg_fps->rtn_adj = of_property_read_bool(np,
+				"somc,change-fps-rtn-adj");
+		break;
+	case FPS_TYPE_HYBRID_INCELL:
+		(void)mdss_dsi_property_read_u32_var(np,
+			"somc,change-fps-send-pos",
+			(u32 **)&chg_fps->send_pos.pos,
+			&chg_fps->send_pos.num);
+
+		rc = of_property_read_u32(np,
+				"somc,driver-ic-rtn",  &tmp);
+		if (rc) {
+			pr_err("%s: DrIC rtn not specified\n",
+							__func__);
+			goto error;
+		}
+		chg_fps->dric_rtn = tmp;
+
+		(void)mdss_dsi_property_read_u32_var(np,
+			"somc,change-fps-send-pos",
+			(u32 **)&chg_fps->send_pos.pos,
+			&chg_fps->send_pos.num);
+
+		rc = of_property_read_u32(np,
+					"somc,driver-ic-mclk", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC mclk not specified\n",
+				__func__);
+			goto error;
+		}
+		chg_fps->dric_mclk = tmp;
+
+		rc = of_property_read_u32(np,
+					"somc,driver-ic-vtouch", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC vtouch not specified\n",
+				__func__);
+			goto error;
+		}
+		chg_fps->dric_vtouch = tmp;
+
+		rc = of_property_read_u32(np,
+				"somc,change-fps-send-byte", &tmp);
+		if (rc) {
+			pr_err("%s: fps bytes send not specified\n",
+							__func__);
+			goto error;
+		}
+		chg_fps->send_byte = tmp;
+
+		rc = of_property_read_u32(np,
+			"somc,change-fps-porch-mask-pos", &tmp);
+		if (rc) {
+			pr_warn("%s: fps mask position not specified\n",
+							__func__);
+			chg_fps->mask_pos = 0;
+		} else {
+			chg_fps->mask_pos = tmp;
+			rc = of_property_read_u32(np,
+				"somc,change-fps-porch-mask", &tmp);
+			if (rc) {
+				pr_warn("%s: fps mask not specified\n",
+							__func__);
+				chg_fps->mask = 0x0;
+			} else {
+				chg_fps->mask = tmp;
+			}
+		}
+		break;
+	case FPS_TYPE_FULL_INCELL:
+		(void)mdss_dsi_property_read_u32_var(np,
+			"somc,change-fps-rtn-pos",
+			(u32 **)&chg_fps->send_pos.pos,
+			&chg_fps->send_pos.num);
+
+		rc = of_property_read_u32(np,
+				"somc,driver-ic-total-porch", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC total_porch not specified\n",
+							__func__);
+			goto error;
+		}
+		chg_fps->dric_total_porch = tmp;
+
+		rc = of_property_read_u32(np,
+					"somc,driver-ic-rclk", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC rclk not specified\n",
+				__func__);
+			goto error;
+		}
+		chg_fps->dric_rclk = tmp;
+
+		rc = of_property_read_u32(np,
+					"somc,driver-ic-vtp", &tmp);
+		if (rc) {
+			pr_err("%s: DrIC vtp not specified\n",
+				__func__);
+			goto error;
+		}
+		chg_fps->dric_tp = tmp;
+		break;
+	default:
+		pr_err("%s: Read panel mode failed.\n", __func__);
+		goto error;
+	}
+error:
+	return rc;
+}
+
+static u32 ts_diff_ms(struct timespec lhs, struct timespec rhs)
+{
+	struct timespec tdiff;
+	s64 nsec;
+	u32 msec;
+
+	tdiff = timespec_sub(lhs, rhs);
+	nsec = timespec_to_ns(&tdiff);
+	msec = (u32)nsec;
+	do_div(msec, NSEC_PER_MSEC);
+
+	return msec;
+}
+
+static struct fps_data *somc_panel_get_fps_address(fps_type type)
+{
+	switch (type) {
+	case FPSD:
+		return &fpsd;
+	case VPSD:
+		return &vpsd;
+	default:
+		pr_err("%s: select Failed!\n", __func__);
+		return NULL;
+	}
+}
+
+static void update_fps_data(struct fps_data *fps)
+{
+	if (mutex_trylock(&fps->fps_lock)) {
+		u32 fpks = 0;
+		u32 ms_since_last = 0;
+		u32 num_frames;
+		struct timespec tlast = fps->timestamp_last;
+		struct timespec tnow;
+		u32 msec;
+
+		getrawmonotonic(&tnow);
+		msec = ts_diff_ms(tnow, tlast);
+		fps->timestamp_last = tnow;
+
+		fps->interval_ms = msec;
+		fps->frame_counter++;
+		num_frames = fps->frame_counter - fps->frame_counter_last;
+
+		fps->fa[fps->fps_array_cnt].frame_nbr = fps->frame_counter;
+		fps->fa[fps->fps_array_cnt].time_delta = msec;
+		fps->fa_last_array_pos = fps->fps_array_cnt;
+		(fps->fps_array_cnt)++;
+		if (fps->fps_array_cnt >= DEF_FPS_ARRAY_SIZE)
+			fps->fps_array_cnt = 0;
+
+		ms_since_last = ts_diff_ms(tnow, fps->fpks_ts_last);
+
+		if (num_frames > 1 && ms_since_last >= fps->log_interval) {
+			fpks = (num_frames * 1000000) / ms_since_last;
+			fps->fpks_ts_last = tnow;
+			fps->frame_counter_last = fps->frame_counter;
+			fps->fpks = fpks;
+		}
+		mutex_unlock(&fps->fps_lock);
+	}
+}
+
+static void somc_panel_fps_data_init(fps_type type)
+{
+	struct fps_data *fps = somc_panel_get_fps_address(type);
+
+	if (!fps) {
+		pr_err("%s: select Failed!\n", __func__);
+		return;
+	}
+
+	fps->frame_counter = 0;
+	fps->frame_counter_last = 0;
+	fps->log_interval = DEF_FPS_LOG_INTERVAL;
+	fps->fpks = 0;
+	fps->fa_last_array_pos = 0;
+	fps->vps_en = false;
+	getrawmonotonic(&fps->timestamp_last);
+	mutex_init(&fps->fps_lock);
+}
+
+static void somc_panel_fps_data_update(
+		struct msm_fb_data_type *mfd, fps_type type)
+{
+	struct fps_data *fps = somc_panel_get_fps_address(type);
+
+	if (!fps) {
+		pr_err("%s: select Failed!\n", __func__);
+		return;
+	}
+
+	if (mfd->index == 0)
+		update_fps_data(fps);
+}
+
+void somc_panel_fpsd_data_update(struct msm_fb_data_type *mfd)
+{
+	somc_panel_fps_data_update(mfd, FPSD);
+}
+
+struct fps_data somc_panel_get_fps_data(void)
+{
+	return fpsd;
+}
+
+struct fps_data somc_panel_get_vps_data(void)
+{
+	return vpsd;
+}
+
+static void vsync_handler(struct mdss_mdp_ctl *ctl, ktime_t t)
+{
+	struct msm_fb_data_type *mfd = ctl->mfd;
+
+	somc_panel_fps_data_update(mfd, VPSD);
+}
+
+static void somc_panel_fps_cmd_send(
+		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
+		u32 dfpks_rev, int dfpks) {
+	char dfps = (char)(dfpks_rev / KSEC);
+	struct mdss_panel_specific_pdata *spec_pdata = ctrl_pdata->spec_pdata;
+	struct mdss_panel_info *pinfo = &ctrl_pdata->panel_data.panel_info;
+
+	pinfo->mipi.frame_rate = dfps;
+
+	if (spec_pdata->chg_fps.mode != FPS_MODE_SUSRES) {
+		pr_debug("%s: fps change sequence\n", __func__);
+		mdss_dsi_panel_cmds_send(ctrl_pdata,
+				&ctrl_pdata->spec_pdata->fps_cmds);
+	}
+	pr_notice("%s: change fpks=%d\n", __func__, dfpks);
+
+	pinfo->new_fps		= dfps;
+	spec_pdata->chg_fps.input_fpks	= dfpks;
+}
+
+static int somc_panel_fps_calc_rtn(
+		struct mdss_dsi_ctrl_pdata *ctrl_pdata, int dfpks) {
+	u32 dfpks_rev;
+	u32 vtotal_porch, vdisp;
+	u32 vrclk, vtp;
+	u32 cmds, payload;
+	struct mdss_panel_specific_pdata *spec_pdata = ctrl_pdata->spec_pdata;
+	u16 rtn;
+	int i, j, byte_cnt;
+	char send_rtn[sizeof(u16)] = {0};
+
+	vtotal_porch = spec_pdata->chg_fps.dric_total_porch;
+	vdisp = spec_pdata->chg_fps.dric_vdisp;
+
+	vrclk = spec_pdata->chg_fps.dric_rclk;
+	vtp = spec_pdata->chg_fps.dric_tp;
+
+	if (!dfpks || !(vdisp + vtotal_porch + vtp)) {
+		pr_err("%s: Invalid param dfpks=%d vdisp=%d porch=%d vtp=%d\n",
+				__func__, dfpks, vdisp, vtotal_porch, vtp);
+		return -EINVAL;
+	}
+
+	rtn = (u16)(
+		(vrclk * KSEC) /
+		(dfpks * (vdisp + vtotal_porch + vtp))
+		);
+
+	if (!rtn || !(vdisp + vtotal_porch + vtp)) {
+		pr_err("%s: Invalid param rtn=%d vdisp=%d porch=%d vtp=%d\n",
+				__func__, dfpks, vdisp, vtotal_porch, vtp);
+		return -EINVAL;
+	}
+
+	dfpks_rev = (u32)(
+		(vrclk * KSEC) /
+		(rtn * (vdisp + vtotal_porch + vtp))
+		);
+
+	pr_debug("%s: porch=%d vdisp=%d vtp=%d vrclk=%d rtn=0x%x\n",
+		__func__, vtotal_porch, vdisp, vtp, vrclk, rtn);
+
+	for (i = 0; i < sizeof(send_rtn) ; i++) {
+		send_rtn[i] = (char)(rtn & 0x00FF);
+		pr_debug("%s: send_rtn[%d]=0x%x\n",
+				__func__, i, send_rtn[i]);
+		if (rtn > 0xFF) {
+			rtn = (rtn >> 8);
+		} else {
+			byte_cnt = i;
+			break;
+		}
+	}
+
+	for (i = 0; i < (spec_pdata->chg_fps.send_pos.num / 2); i++) {
+		cmds = spec_pdata->chg_fps.send_pos.pos[(i * 2)];
+		payload = spec_pdata->chg_fps.send_pos.pos[(i * 2) + 1];
+		for (j = 0; j <= byte_cnt ; j++)
+			CHANGE_PAYLOAD(cmds, payload + j) =
+				send_rtn[byte_cnt - j];
+	}
+
+	somc_panel_fps_cmd_send(ctrl_pdata, dfpks_rev, dfpks);
+
+	return 0;
+}
+
+static int somc_panel_fps_calc_porch
+		(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int dfpks) {
+	u64 vmclk;
+	u64 vtouch;
+	u32 dfpks_rev;
+	u32 vdisp;
+	u32 cmds, payload;
+	int i, j;
+	u16 porch_calc = 0;
+	u16 send_byte;
+	u16 rtn;
+	u8 mask_pos;
+	char mask;
+	char porch[CHANGE_FPS_PORCH] = {0};
+	char send[CHANGE_FPS_SEND] = {0};
+	struct mdss_panel_specific_pdata *spec_pdata = ctrl_pdata->spec_pdata;
+	struct dsi_panel_cmds *fps_cmds = &(spec_pdata->fps_cmds);
+
+	rtn = spec_pdata->chg_fps.dric_rtn;
+	vdisp = spec_pdata->chg_fps.dric_vdisp;
+	vtouch = spec_pdata->chg_fps.dric_vtouch;
+	vmclk = (u64)spec_pdata->chg_fps.dric_mclk;
+	send_byte = spec_pdata->chg_fps.send_byte;
+	mask_pos = spec_pdata->chg_fps.mask_pos;
+	mask = spec_pdata->chg_fps.mask;
+
+	if (!dfpks || !vmclk || !rtn) {
+		pr_err("%s: Invalid param dfpks=%d vmclk=%llu rtn%d\n",
+				__func__, dfpks, vmclk, rtn);
+		return -EINVAL;
+	}
+
+	porch_calc = (u16)((
+			(((PSEC * KSEC) - (KSEC * vtouch * (u64)dfpks)) /
+			((u64)dfpks * vmclk * (u64)rtn)) - (u64)vdisp) / 2);
+
+	if (!(vmclk * rtn * (vdisp + porch_calc) + vtouch)) {
+		pr_err("%s: Invalid param \
+			vmclk=%llu rtn=%d vdisp=%d porch=%d vtouch=%llu\n",
+			__func__, vmclk, rtn, vdisp, porch_calc, vtouch);
+		return -EINVAL;
+	}
+
+	dfpks_rev = (u32)(
+		(PSEC * KSEC) /
+		(vmclk * rtn * (vdisp + porch_calc) + vtouch));
+
+	pr_debug("%s: porch=%d vdisp=%d vtouch=%llu vmclk=%llu rtn=0x%x\n",
+		__func__, porch_calc, vdisp, vtouch, vmclk, rtn);
+
+	for (i = 0; i < CHANGE_FPS_PORCH ; i++) {
+		porch[i] = (char)(porch_calc & 0x00FF);
+		pr_debug("%s: porch[%d]=0x%x\n", __func__, i, porch[i]);
+		porch_calc = (porch_calc >> 8);
+	}
+
+	for (i = 0; i < send_byte; i = i + 2) {
+		memcpy(send + i, porch, sizeof(char));
+		memcpy(send + i + 1, porch + 1, sizeof(char));
+	}
+
+	for (i = 0; i < (spec_pdata->chg_fps.send_pos.num / 2); i++) {
+		cmds = spec_pdata->chg_fps.send_pos.pos[(i * 2)];
+		payload = spec_pdata->chg_fps.send_pos.pos[(i * 2) + 1];
+		for (j = 0; j < send_byte ; j++) {
+			if (j == mask_pos)
+				send[j] = (mask | send[j]);
+			CHANGE_PAYLOAD(cmds, payload + j) = send[j];
+			pr_debug("%s: fps_cmds.cmds[%d].payload[%d]) = 0x%x\n",
+				__func__,
+				cmds, payload + j,
+				fps_cmds->cmds[cmds].payload[payload + j]);
+		}
+	}
+
+	somc_panel_fps_cmd_send(ctrl_pdata, dfpks_rev, dfpks);
+
+	return 0;
+}
+
+static int somc_panel_fps_calc_adj
+		(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int dfpks) {
+	u32 dfpks_rev;
+	u32 vtotal_porch, vdisp, vrclk;
+	u32 cmds, payload;
+	struct mdss_panel_specific_pdata *spec_pdata = ctrl_pdata->spec_pdata;
+	u16 rtn;
+	int i, j, byte_cnt;
+	char send_rtn[sizeof(u16)] = {0}, adj;
+
+	if (!spec_pdata) {
+		pr_err("%s: Invalid input data\n", __func__);
+		return -EINVAL;
+	}
+
+	vtotal_porch = spec_pdata->chg_fps.dric_total_porch;
+	vdisp = spec_pdata->chg_fps.dric_vdisp;
+	vrclk = spec_pdata->chg_fps.dric_rclk;
+	adj = spec_pdata->chg_fps.rtn_adj ? 1 : 0;
+
+	if (!dfpks || !(vdisp + vtotal_porch)) {
+		pr_err("%s: Invalid param dfpks=%d vdisp=%d porch=%d\n",
+				__func__, dfpks, vdisp, vtotal_porch);
+		return -EINVAL;
+	}
+
+	rtn = (u16)(vrclk / (dfpks * (vdisp + vtotal_porch) / 1000)) - adj;
+
+	if (!rtn || !(vdisp + vtotal_porch)) {
+		pr_err("%s: Invalid param rtn=%d vdisp=%d　porch=%d\n",
+				__func__, rtn, vdisp, vtotal_porch);
+		return -EINVAL;
+	}
+
+	dfpks_rev = (u32)(vrclk / (rtn * (vdisp + vtotal_porch) / 1000));
+
+	pr_debug("%s: porch=%d vdisp=%d vrclk=%d rtn=0x%x adj=%d\n",
+		__func__, vtotal_porch, vdisp, vrclk, rtn + adj, adj);
+
+	for (i = 0; i < sizeof(send_rtn) ; i++) {
+		send_rtn[i] = (char)(rtn & 0x00FF);
+		pr_debug("%s: send_rtn[%d]=0x%x\n",
+				__func__, i, send_rtn[i]);
+		if (rtn > 0xFF) {
+			rtn = (rtn >> 8);
+		} else {
+			byte_cnt = i;
+			break;
+		}
+	}
+
+	for (i = 0; i < (spec_pdata->chg_fps.send_pos.num / 2); i++) {
+		cmds = spec_pdata->chg_fps.send_pos.pos[(i * 2)];
+		payload = spec_pdata->chg_fps.send_pos.pos[(i * 2) + 1];
+		for (j = 0; j <= byte_cnt ; j++)
+			CHANGE_PAYLOAD(cmds, payload + j) =
+				send_rtn[byte_cnt - j];
+	}
+
+	somc_panel_fps_cmd_send(ctrl_pdata, dfpks_rev, dfpks);
+
+	return 0;
+}
+
+static int somc_panel_chg_fps_calc
+		(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int dfpks) {
+	int ret = -EINVAL;
+	struct mdss_panel_specific_pdata *spec_pdata = NULL;
+
+	spec_pdata = ctrl_pdata->spec_pdata;
+	if (!spec_pdata) {
+		pr_err("%s: Invalid input data\n", __func__);
+		return ret;
+	}
+
+	switch (spec_pdata->chg_fps.type) {
+	case FPS_TYPE_UHD_4K:
+		ret = somc_panel_fps_calc_adj(ctrl_pdata, dfpks);
+		break;
+	case FPS_TYPE_HYBRID_INCELL:
+		ret = somc_panel_fps_calc_porch(ctrl_pdata, dfpks);
+		break;
+	case FPS_TYPE_FULL_INCELL:
+		ret = somc_panel_fps_calc_rtn(ctrl_pdata, dfpks);
+		break;
+	default:
+		pr_err("%s: Invalid type data\n", __func__);
+		break;
+	}
+
+	return ret;
+}
+
+static int mdss_dsi_panel_chg_fps_check_state
+		(struct mdss_dsi_ctrl_pdata *ctrl, int dfpks) {
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
+	struct mdss_panel_info *pinfo = &ctrl->panel_data.panel_info;
+	struct mdss_dsi_ctrl_pdata *sctrl = NULL;
+	struct mdss_panel_specific_pdata *specific = NULL;
+	int rc = 0;
+
+	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
+		goto error;
+
+	if ((pinfo->mipi.mode == DSI_CMD_MODE) &&
+			(!ctrl->spec_pdata->fps_cmds.cmd_cnt))
+		goto cmd_cnt_err;
+
+	specific = ctrl->spec_pdata;
+
+	if (!specific->disp_onoff_state)
+		goto disp_onoff_state_err;
+
+	if (mdss_dsi_sync_wait_enable(ctrl)) {
+		sctrl = mdss_dsi_get_other_ctrl(ctrl);
+		if (sctrl) {
+			if (mdss_dsi_sync_wait_trigger(ctrl)) {
+				rc = somc_panel_chg_fps_calc(sctrl, dfpks);
+				if (rc < 0)
+					goto end;
+				rc = somc_panel_chg_fps_calc(ctrl, dfpks);
+			} else {
+				rc = somc_panel_chg_fps_calc(ctrl, dfpks);
+				if (rc < 0)
+					goto end;
+				rc = somc_panel_chg_fps_calc(sctrl, dfpks);
+			}
+		} else {
+			rc = somc_panel_chg_fps_calc(ctrl, dfpks);
+		}
+	} else {
+		rc = somc_panel_chg_fps_calc(ctrl, dfpks);
+	}
+end:
+	return rc;
+cmd_cnt_err:
+	pr_err("%s: change fps isn't supported\n", __func__);
+	return -EINVAL;
+disp_onoff_state_err:
+	pr_err("%s: Disp-On is not yet completed. Please retry\n", __func__);
+	return -EINVAL;
+error:
+	return -EINVAL;
+}
+
+ssize_t somc_panel_change_fpks_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
+	int dfpks, rc;
+
+	if (!ctrl_pdata || !ctrl_pdata->spec_pdata) {
+		pr_err("%s: Invalid input data\n", __func__);
+		return -EINVAL;
+	}
+
+	if (!ctrl_pdata->spec_pdata->chg_fps.enable) {
+		pr_err("%s: change fps not enabled\n", __func__);
+		return -EINVAL;
+	}
+
+	rc = kstrtoint(buf, 10, &dfpks);
+	if (rc < 0) {
+		pr_err("%s: Error, buf = %s\n", __func__, buf);
+		return rc;
+	}
+
+	if (dfpks < 1000 * CHANGE_FPS_MIN
+			|| dfpks > 1000 * CHANGE_FPS_MAX) {
+		pr_err("%s: invalid value for change_fpks buf = %s\n",
+				 __func__, buf);
+		return -EINVAL;
+	}
+
+	if (dfpks == ctrl_pdata->spec_pdata->chg_fps.input_fpks) {
+		pr_notice("%s: fpks is already %d\n", __func__, dfpks);
+		return count;
+	}
+
+	rc = mdss_dsi_panel_chg_fps_check_state(ctrl_pdata, dfpks);
+	if (rc) {
+		pr_err("%s: Error, rc = %d\n", __func__, rc);
+		return rc;
+	}
+	return count;
+}
+
+ssize_t somc_panel_change_fpks_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
+
+	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
+		return 0;
+
+	return scnprintf(buf, PAGE_SIZE, "%d\n",
+		ctrl_pdata->spec_pdata->chg_fps.input_fpks);
+}
+
+ssize_t somc_panel_change_fps_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
+	int dfps, dfpks, rc;
+
+	if (!ctrl_pdata || !ctrl_pdata->spec_pdata) {
+		pr_err("%s: Invalid input data\n", __func__);
+		return -EINVAL;
+	}
+
+	if (!ctrl_pdata->spec_pdata->chg_fps.enable) {
+		pr_err("%s: change fps not enabled\n", __func__);
+		return -EINVAL;
+	}
+
+	rc = kstrtoint(buf, 10, &dfps);
+	if (rc < 0) {
+		pr_err("%s: Error, buf = %s\n", __func__, buf);
+		return rc;
+	}
+
+	if (dfps >= 1000 * CHANGE_FPS_MIN
+			&& dfps <= 1000 * CHANGE_FPS_MAX) {
+		dfpks = dfps;
+	} else if (dfps >= CHANGE_FPS_MIN && dfps <= CHANGE_FPS_MAX) {
+		dfpks = dfps * 1000;
+	} else {
+		pr_err("%s: invalid value for change_fps buf = %s\n",
+				__func__, buf);
+		return -EINVAL;
+	}
+
+	if (dfpks == ctrl_pdata->spec_pdata->chg_fps.input_fpks) {
+		pr_notice("%s: fpks is already %d\n", __func__, dfpks);
+		return count;
+	}
+
+	rc = mdss_dsi_panel_chg_fps_check_state(ctrl_pdata, dfpks);
+	if (rc) {
+		pr_err("%s: Error, rc = %d\n", __func__, rc);
+		return rc;
+	}
+	return count;
+}
+
+ssize_t somc_panel_change_fps_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata = dev_get_drvdata(dev);
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct msm_fb_data_type *mfd = mdata->ctl_off->mfd;
+	struct mdss_overlay_private *mdp5_data = mfd_to_mdp5_data(mfd);
+
+	if (!mdp5_data->ctl || !mdp5_data->ctl->power_state)
+		return 0;
+
+	return scnprintf(buf, PAGE_SIZE, "%d\n",
+		ctrl_pdata->spec_pdata->chg_fps.input_fpks / 1000);
+}
+
+void somc_panel_chg_fps_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl_pdata)
+{
+	struct mdss_panel_specific_pdata *spec_pdata = NULL;
+	u32 fps_cmds, fps_payload;
+	char rtn;
+
+	spec_pdata = ctrl_pdata->spec_pdata;
+
+	if (ctrl_pdata->panel_data.panel_info.mipi.mode == DSI_CMD_MODE) {
+		if (spec_pdata->fps_cmds.cmd_cnt) {
+			fps_cmds = spec_pdata->chg_fps.send_pos.pos[0];
+			fps_payload = spec_pdata->chg_fps.send_pos.pos[1];
+			rtn = CHANGE_PAYLOAD(fps_cmds, fps_payload);
+			pr_debug("%s: change fps sequence --- rtn = 0x%x\n",
+				__func__, rtn);
+			mdss_dsi_panel_cmds_send(ctrl_pdata,
+				&ctrl_pdata->spec_pdata->fps_cmds);
+		}
+	}
+}
+
+static ssize_t somc_panel_vsyncs_per_ksecs_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int ret = count;
+	long vps_en;
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct mdss_mdp_ctl *ctl = mdata->ctl_off;
+
+	if (kstrtol(buf, 10, &vps_en)) {
+		dev_err(dev, "%s: Error, buf = %s\n", __func__, buf);
+		ret = -EINVAL;
+		goto exit;
+	}
+
+	vs_handle.vsync_handler = (mdp_vsync_handler_t)vsync_handler;
+	vs_handle.cmd_post_flush = false;
+
+	if (vps_en) {
+		vs_handle.enabled = false;
+		if (!vpsd.vps_en && (ctl->ops.add_vsync_handler)) {
+			ctl->ops.add_vsync_handler(ctl, &vs_handle);
+			vpsd.vps_en = true;
+			pr_notice("%s: vsyncs_per_ksecs is valid\n", __func__);
+		}
+	} else {
+		vs_handle.enabled = true;
+		if (vpsd.vps_en && (ctl->ops.remove_vsync_handler)) {
+			ctl->ops.remove_vsync_handler(ctl, &vs_handle);
+			vpsd.vps_en = false;
+			fpsd.fpks = 0;
+			pr_notice("%s: vsyncs_per_ksecs is invalid\n", __func__);
+		}
+	}
+exit:
+	return ret;
+}
+
+static ssize_t somc_panel_vsyncs_per_ksecs_show(struct device *dev,
+			struct device_attribute *attr, char *buf)
+{
+	if (vpsd.vps_en)
+		return scnprintf(buf, PAGE_SIZE, "%i\n", vpsd.fpks);
+	else
+		return scnprintf(buf, PAGE_SIZE,
+		"This function is invalid now.\n"
+		"Please read again after writing ON.\n");
+}
+
+static ssize_t somc_panel_frame_counter(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.frame_counter);
+}
+
+static ssize_t somc_panel_frames_per_ksecs(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%i\n", fpsd.fpks);
+}
+
+static struct device_attribute panel_fps_attributes[] = {
+	__ATTR(frame_counter, S_IRUGO, somc_panel_frame_counter, NULL),
+	__ATTR(frames_per_ksecs, S_IRUGO,
+				somc_panel_frames_per_ksecs, NULL),
+	__ATTR(vsyncs_per_ksecs, S_IRUSR|S_IRGRP|S_IWUSR|S_IWGRP,
+				somc_panel_vsyncs_per_ksecs_show,
+				somc_panel_vsyncs_per_ksecs_store),
+	__ATTR(change_fps, S_IRUGO|S_IWUSR|S_IWGRP,
+					somc_panel_change_fps_show,
+					somc_panel_change_fps_store),
+	__ATTR(change_fpks, S_IRUGO|S_IWUSR|S_IWGRP,
+					somc_panel_change_fpks_show,
+					somc_panel_change_fpks_store),
+};
+
+int somc_panel_fps_register_attr(struct device *dev)
+{
+	int i;
+	for (i = 0; i < ARRAY_SIZE(panel_fps_attributes); i++)
+		if (device_create_file(dev, panel_fps_attributes + i))
+			goto error;
+	return 0;
+error:
+	dev_err(dev, "%s: Cannot create FPS Manager attributes\n", __func__);
+	for (--i; i >= 0 ; i--)
+		device_remove_file(dev, panel_fps_attributes + i);
+	return -ENODEV;
+}
+
+void somc_panel_fpsman_panel_off(void)
+{
+	struct mdss_data_type *mdata = mdss_mdp_get_mdata();
+	struct mdss_mdp_ctl *ctl = mdata->ctl_off;
+
+	vs_handle.vsync_handler = (mdp_vsync_handler_t)vsync_handler;
+	vs_handle.cmd_post_flush = false;
+	vs_handle.enabled = true;
+	if (vpsd.vps_en && (ctl->ops.remove_vsync_handler)) {
+		ctl->ops.remove_vsync_handler(ctl, &vs_handle);
+		vpsd.vps_en = false;
+		fpsd.fpks = 0;
+		pr_notice("%s: vsyncs_per_ksecs is invalid\n", __func__);
+	}
+}
+
+void somc_panel_fpsman_panel_post_on(struct mdss_dsi_ctrl_pdata *ctrl)
+{
+	struct change_fps *chg_fps = &ctrl->spec_pdata->chg_fps;
+
+	if (chg_fps->enable) {
+		if (chg_fps->mode == FPS_MODE_SUSRES)
+			somc_panel_chg_fps_calc(ctrl, chg_fps->input_fpks);
+
+		somc_panel_chg_fps_cmds_send(ctrl);
+	} else {
+		pr_notice("%s: change fps not supported.\n", __func__);
+	}
+
+	return;
+}
+
+int somc_panel_fps_manager_init(void)
+{
+	somc_panel_fps_data_init(FPSD);
+	somc_panel_fps_data_init(VPSD);
+
+	vs_handle.vsync_handler = NULL;
+
+	return 0;
+}

--- a/drivers/video/fbdev/msm/somc_panel/panel_legacy.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_legacy.c
@@ -283,6 +283,7 @@ static int legacy_panel_power_on_ex(struct mdss_panel_data *pdata)
 {
 	struct mdss_dsi_ctrl_pdata *ctrl_pdata = NULL;
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
+	struct somc_panel_regulator_mgr *regulator_mgr = NULL;
 	int ret;
 
 	ctrl_pdata = container_of(pdata, struct mdss_dsi_ctrl_pdata,
@@ -305,8 +306,10 @@ static int legacy_panel_power_on_ex(struct mdss_panel_data *pdata)
 	if (pdata->panel_info.pdest != DISPLAY_1)
 		return 0;
 
-	if (spec_pdata->vreg_init)
-		spec_pdata->vreg_init(ctrl_pdata);
+	regulator_mgr = spec_pdata->regulator_mgr;
+
+	if (regulator_mgr->vreg_init)
+		regulator_mgr->vreg_init(ctrl_pdata);
 
 	somc_panel_down_period_quirk(spec_pdata);
 

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -169,6 +169,29 @@ struct somc_panel_color_mgr {
 	struct mdp_pa_cfg picadj_data;
 };
 
+struct somc_panel_regulator_mgr {
+	int (*vreg_init) (struct mdss_dsi_ctrl_pdata *ctrl);
+	int (*vreg_ctrl) (struct mdss_dsi_ctrl_pdata *ctrl, int enable);
+
+	u32 lab_output_voltage;
+	u32 ibb_output_voltage;
+	u32 lab_current_max;
+	u32 ibb_current_max;
+	u32 lab_fast_precharge_time;
+	u32 lab_soft_start;
+	u32 ibb_soft_start;
+	bool lab_pd_full;
+	bool ibb_pd_full;
+
+	bool lab_current_max_enable;
+	bool ibb_current_max_enable;
+	bool fast_prechg_enb;
+	bool lab_soft_enb;
+	bool ibb_soft_enb;
+	bool lab_pd_enb;
+	bool ibb_pd_enb;
+};
+
 struct mdss_panel_specific_pdata {
 	int (*disp_on) (struct mdss_panel_data *pdata);
 	int (*detect) (struct mdss_panel_data *pdata);
@@ -187,6 +210,7 @@ struct mdss_panel_specific_pdata {
 				 struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 
 	struct somc_panel_color_mgr *color_mgr;
+	struct somc_panel_regulator_mgr *regulator_mgr;
 
 	bool disp_on_in_boot;
 	bool disp_onoff_state;
@@ -227,27 +251,6 @@ struct mdss_panel_specific_pdata {
 	u32 current_period;
 	u32 down_period;
 	u32 new_vfp;
-
-	/* LAB/IBB SoMC regulator params */
-	u32 lab_output_voltage;
-	u32 ibb_output_voltage;
-	u32 lab_current_max;
-	u32 ibb_current_max;
-	u32 lab_fast_precharge_time;
-	u32 lab_soft_start;
-	u32 ibb_soft_start;
-	bool lab_pd_full;
-	bool ibb_pd_full;
-
-	bool lab_current_max_enable;
-	bool ibb_current_max_enable;
-	bool fast_prechg_enb;
-	bool lab_soft_enb;
-	bool ibb_soft_enb;
-	bool lab_pd_enb;
-	bool ibb_pd_enb;
-	int (*vreg_init) (struct mdss_dsi_ctrl_pdata *ctrl);
-	int (*vreg_ctrl) (struct mdss_dsi_ctrl_pdata *ctrl, int enable);
 
 	struct change_fps chg_fps;
 	struct poll_ctrl polling;

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -260,6 +260,8 @@ void somc_panel_fpsd_data_update(struct msm_fb_data_type *mfd);
 int mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable);
 int mdss_dsi_pinctrl_set_state(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 					bool active);
+int somc_panel_allocate(struct platform_device *pdev,
+		struct mdss_dsi_ctrl_pdata *ctrl);
 
 static inline struct mdss_dsi_ctrl_pdata *mdss_dsi_get_master_ctrl(
 					struct mdss_panel_data *pdata)
@@ -273,5 +275,4 @@ static inline struct mdss_dsi_ctrl_pdata *mdss_dsi_get_master_ctrl(
 
 	return mdss_dsi_get_ctrl_by_index(dsi_master);
 }
-
 #endif

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -61,6 +61,7 @@ struct mdss_pcc_data {
 	u8 pcc_sts;
 	u32 u_data;
 	u32 v_data;
+	u32 rev_u[2], rev_v[2]; /* ROI */
 	int param_type;
 };
 

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -182,8 +182,6 @@ struct mdss_panel_specific_pdata {
 	int32_t adc_uv;
 	int panel_detect;
 	int init_from_begin;
-	int cabc_enabled;
-	int cabc_active;
 	int lcm_bl_gpio;
 	int disp_dcdc_en_gpio;
 	int disp_p5;
@@ -203,11 +201,6 @@ struct mdss_panel_specific_pdata {
 	struct mdss_panel_power_seq ewu_seq;
 #endif
 
-	struct dsi_panel_cmds cabc_early_on_cmds;
-	struct dsi_panel_cmds cabc_on_cmds;
-
-	struct dsi_panel_cmds cabc_off_cmds;
-	struct dsi_panel_cmds cabc_late_off_cmds;
 	struct dsi_panel_cmds fps_cmds;
 
 	struct dsi_panel_cmds einit_cmds;

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -155,8 +155,21 @@ struct change_fps {
 	u32 dric_tp;
 };
 
-struct mdss_panel_specific_pdata {
+struct somc_panel_color_mgr {
 	int (*pcc_setup)(struct mdss_panel_data *pdata);
+	int (*picadj_setup)(struct mdss_panel_data *pdata);
+	int (*unblank_hndl)(struct mdss_dsi_ctrl_pdata *ctrl);
+
+	bool mdss_force_pcc;
+
+	struct dsi_panel_cmds pre_uv_read_cmds;
+	struct dsi_panel_cmds uv_read_cmds;
+
+	struct mdss_pcc_data pcc_data;
+	struct mdp_pa_cfg picadj_data;
+};
+
+struct mdss_panel_specific_pdata {
 	int (*disp_on) (struct mdss_panel_data *pdata);
 	int (*detect) (struct mdss_panel_data *pdata);
 	int (*update_panel) (struct mdss_panel_data *pdata);
@@ -172,6 +185,8 @@ struct mdss_panel_specific_pdata {
 	int (*dsi_request_gpios)(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 	int (*parse_specific_dt)(struct device_node *np,
 				 struct mdss_dsi_ctrl_pdata *ctrl_pdata);
+
+	struct somc_panel_color_mgr *color_mgr;
 
 	bool disp_on_in_boot;
 	bool disp_onoff_state;
@@ -206,12 +221,6 @@ struct mdss_panel_specific_pdata {
 	struct dsi_panel_cmds einit_cmds;
 	struct dsi_panel_cmds init_cmds;
 	struct dsi_panel_cmds id_read_cmds;
-
-	bool pcc_enable;
-	struct dsi_panel_cmds pre_uv_read_cmds;
-	struct dsi_panel_cmds uv_read_cmds;
-	struct mdss_pcc_data pcc_data;
-	struct mdp_pa_cfg picadj_data;
 
 	struct mdss_panel_power_seq on_seq;
 	struct mdss_panel_power_seq off_seq;

--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -106,6 +106,55 @@ struct poll_ctrl {
 	void (*cancel_work) (struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 };
 
+typedef enum FPS_TYPE {
+	FPSD,
+	VPSD
+} fps_type;
+
+typedef enum FPS_PANEL_TYPE {
+	FPS_TYPE_UHD_4K,
+	FPS_TYPE_HYBRID_INCELL,
+	FPS_TYPE_FULL_INCELL,
+} fps_panel_type;
+
+typedef enum FPS_PANEL_MODE {
+	FPS_MODE_SUSRES,
+	FPS_MODE_DYNAMIC,
+} fps_panel_mode;
+
+struct change_fps_send_pos {
+	int num;
+	int *pos;
+};
+
+struct change_fps {
+	/* common */
+	bool enable;
+	fps_panel_type type;
+	fps_panel_mode mode;
+	u32 dric_vdisp;
+	struct change_fps_send_pos send_pos;
+	u32 dric_rclk;
+	u32 dric_total_porch;
+	u8 chg_fps_type;
+	u8 chg_fps_mode;
+	int input_fpks;
+
+	/* uhd_4k */
+	bool rtn_adj;
+
+	/* hybrid */
+	u32 dric_mclk;
+	u32 dric_vtouch;
+	u16 dric_rtn;
+	u16 send_byte;
+	u16 mask_pos;
+	char mask;
+
+	/* full */
+	u32 dric_tp;
+};
+
 struct mdss_panel_specific_pdata {
 	int (*pcc_setup)(struct mdss_panel_data *pdata);
 	int (*disp_on) (struct mdss_panel_data *pdata);
@@ -198,11 +247,12 @@ struct mdss_panel_specific_pdata {
 	int (*vreg_init) (struct mdss_dsi_ctrl_pdata *ctrl);
 	int (*vreg_ctrl) (struct mdss_dsi_ctrl_pdata *ctrl, int enable);
 
+	struct change_fps chg_fps;
 	struct poll_ctrl polling;
 };
 
+void somc_panel_fpsd_data_update(struct msm_fb_data_type *mfd);
 int mdss_dsi_panel_power_detect(struct platform_device *pdev, int enable);
-int mdss_dsi_panel_fps_data_update(struct msm_fb_data_type *mfd);
 int mdss_dsi_pinctrl_set_state(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 					bool active);
 

--- a/drivers/video/fbdev/msm/somc_panel/somc_panels.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panels.h
@@ -25,8 +25,11 @@
 #define ADC_RNG_MAX			1
 #define ADC_PNUM			2
 
-#define CHANGE_FPS_MIN 			36
-#define CHANGE_FPS_MAX 			63
+#define CHANGE_FPS_MIN 			22
+#define CHANGE_FPS_MAX 			60
+
+#define CHANGE_FPS_PORCH		2
+#define CHANGE_FPS_SEND			10
 
 #define DEF_FPS_LOG_INTERVAL		100
 #define DEF_FPS_ARRAY_SIZE		120
@@ -93,8 +96,6 @@ int  somc_panel_vreg_ctrl(
 		struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		char *vreg, bool enable);
 
-void somc_panel_chg_fps_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
-
 /* Main */
 void somc_panel_down_period_quirk(
 			struct mdss_panel_specific_pdata *spec_pdata);
@@ -110,6 +111,9 @@ int  mdss_dsi_request_gpios(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 int  mdss_dsi_property_read_u32_var(struct device_node *np,
 		char *name, u32 **out_data, int *num);
 
+int  somc_panel_parse_dcs_cmds(struct device_node *np,
+		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key);
+
 /* Detection */
 int  do_panel_detect(struct device_node **node,
 		struct platform_device *pdev,
@@ -120,6 +124,15 @@ int  do_panel_detect(struct device_node **node,
 void poll_worker_schedule(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 void poll_worker_cancel(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 int  panel_polling_init(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
+
+/* FPS Manager */
+int  somc_panel_parse_dt_chgfps_config(struct device_node *pan_node,
+			struct mdss_dsi_ctrl_pdata *ctrl_pdata);
+void somc_panel_chg_fps_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
+void somc_panel_fpsman_panel_post_on(struct mdss_dsi_ctrl_pdata *ctrl);
+void somc_panel_fpsman_panel_off(void);
+int  somc_panel_fps_register_attr(struct device *dev);
+int  somc_panel_fps_manager_init(void);
 
 /* Regulators */
 #ifdef CONFIG_SOMC_PANEL_LABIBB

--- a/drivers/video/fbdev/msm/somc_panel/somc_panels.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panels.h
@@ -134,6 +134,10 @@ void somc_panel_fpsman_panel_off(void);
 int  somc_panel_fps_register_attr(struct device *dev);
 int  somc_panel_fps_manager_init(void);
 
+/* Color Manager */
+int  somc_panel_color_manager_init(struct mdss_dsi_ctrl_pdata *ctrl);
+int  somc_panel_colormgr_register_attr(struct device *dev);
+
 /* Regulators */
 #ifdef CONFIG_SOMC_PANEL_LABIBB
 int somc_panel_vregs_dt(struct device_node *np,

--- a/drivers/video/fbdev/msm/somc_panel/somc_panels.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panels.h
@@ -135,6 +135,8 @@ int  somc_panel_fps_register_attr(struct device *dev);
 int  somc_panel_fps_manager_init(void);
 
 /* Color Manager */
+int somc_panel_parse_dt_colormgr_config(struct device_node *np,
+			struct mdss_dsi_ctrl_pdata *ctrl);
 int  somc_panel_color_manager_init(struct mdss_dsi_ctrl_pdata *ctrl);
 int  somc_panel_colormgr_register_attr(struct device *dev);
 


### PR DESCRIPTION
This is a huge restructuration of my somc_panel driver.
Includes separation of color correction and dynamic fps from the main panel driver, where only the essential panel management code should reside in.
Also, while at it, fix the LAB/IBB implementation for the new 4.4 kernel.

This patchset also includes a nice cleanup of the variables placement: now we use specific structures for the moved and new code, making GCC to be able to optimize and eventually auto-pack and align them for both performance and runtime memory savings.
Should also sensibly decrease the boot times, but that's on the order of a few milliseconds.


Please note that, even if this is portable to older kernels using somc_panel driver, this is deprecating SoMC Yukon, Rhine, Shinano and Kitakami support, due to the new code involved.
Those platforms may work on backports, but DT changes (and small code fixes) will be strictly required, especially for the Dynamic FPS functionality.