### PR TITLE
[5.7.r1] fbdev: msm: somc_panel: Avoid continuous re-setup of PicAdj

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -611,9 +611,10 @@ static int somc_panel_colormgr_unblank_handler(struct mdss_dsi_ctrl_pdata *ctrl)
 		color_mgr->pcc_data.pcc_sts &= ~PCC_STS_UD;
 	}
 
-	if (color_mgr->picadj_data.flags & MDP_PP_OPS_ENABLE)
+	if (color_mgr->picadj_data.flags & MDP_PP_OPS_ENABLE) {
 		color_mgr->picadj_setup(&ctrl->panel_data);
-
+		color_mgr->picadj_data.flags &= ~MDP_PP_OPS_ENABLE;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
On unblank, we were continuously re-setting up the picadj
parameters: there's no need to, and also leads to errors on
kernel 4.4 because of actually good locking.

Remove the enable flag once parameters are sent to the
hardware for the first time.