### PR TITLE
[5.7.r1] Fix ALL Tone and Loire devices after somc_panel restructuration

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
@@ -110,6 +110,10 @@
 		somc,ewu-wait-after-touch-reset = <0>;
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <4326>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "full_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
@@ -111,14 +111,16 @@
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01
 				 29 01 00 00 00 00 02 C6 51];
-		somc,driver-ic-vbp = <31>;
+		somc,driver-ic-total-porch = <31>;
 		somc,driver-ic-vdisp = <1920>;
-		somc,display-clock = /bits/ 64 <14000000000>;
-		somc,driver-ic-vfp = <936>;
+		somc,driver-ic-rclk = <14000000>;
+		somc,driver-ic-vtp = <936>;
 		somc,change-fps-rtn-pos = <2 1>;
 		somc,mdss-dsi-pcc-enable;
 		somc,mdss-dsi-uv-command = [06 01 00 00 00 00 01 DA

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-720p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-720p-cmd.dtsi
@@ -110,6 +110,8 @@
 		somc,ewu-rst-seq = <0 2>, <1 5>;
 		somc,ewu-wait-after-touch-reset = <0>;
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-720p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-720p-cmd.dtsi
@@ -109,6 +109,10 @@
 		somc,pw-down-period = <100>;
 		somc,ewu-rst-seq = <0 2>, <1 5>;
 		somc,ewu-wait-after-touch-reset = <0>;
+
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <6592>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "full_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
@@ -123,6 +123,10 @@
 		somc,ewu-wait-after-touch-reset = <40>;
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <4326>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "hybrid_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
@@ -124,6 +124,8 @@
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "hybrid_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01
@@ -132,7 +134,7 @@
 		somc,driver-ic-vdisp = <1920>;
 		somc,driver-ic-vtouch = <6818000>;
 		somc,driver-ic-mclk = <61539>;
-		somc,change-fps-rtn-pos = <2 4>;
+		somc,change-fps-send-pos = <2 4>;
 		somc,change-fps-send-byte = <4>;
 		somc,change-fps-porch-mask-pos = <3>;
 		somc,change-fps-porch-mask = <0xF0>;

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-720p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-720p-cmd.dtsi
@@ -117,6 +117,8 @@
 		somc,pw-down-period = <100>;
 		somc,ewu-wait-after-touch-reset = <40>;
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "hybrid_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-720p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-720p-cmd.dtsi
@@ -116,6 +116,10 @@
 		somc,pw-wait-after-off-touch-int-n = <0>;
 		somc,pw-down-period = <100>;
 		somc,ewu-wait-after-touch-reset = <40>;
+
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <6592>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "hybrid_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
@@ -106,6 +106,10 @@
 		somc,ewu-wait-after-touch-reset = <0>;
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <4326>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "full_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
@@ -107,14 +107,16 @@
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01
 				 29 01 00 00 00 00 02 C6 59];
-		somc,driver-ic-vbp = <7>;
+		somc,driver-ic-total-porch = <7>;
 		somc,driver-ic-vdisp = <1920>;
-		somc,display-clock = /bits/ 64 <14000000000>;
-		somc,driver-ic-vfp = <682>;
+		somc,driver-ic-rclk = <14000000>;
+		somc,driver-ic-vtp = <682>;
 		somc,change-fps-rtn-pos = <2 1>;
 		somc,mdss-dsi-pcc-enable;
 		somc,mdss-dsi-uv-command = [06 01 00 00 00 00 01 DA

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
@@ -118,6 +118,9 @@
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <4326>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "full_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
@@ -119,14 +119,16 @@
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01
 				 29 01 00 00 00 00 02 C6 59];
-		somc,driver-ic-vbp = <11>;
+		somc,driver-ic-total-porch = <11>;
 		somc,driver-ic-vdisp = <1920>;
-		somc,display-clock = /bits/ 64 <14000000000>;
-		somc,driver-ic-vfp = <682>;
+		somc,driver-ic-rclk = <14000000>;
+		somc,driver-ic-vtp = <682>;
 		somc,change-fps-rtn-pos = <2 1>;
 
 		somc,mdss-dsi-pcc-enable;

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
@@ -120,14 +120,16 @@
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 
 		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
 		somc,change-fps-command =
 				[29 01 00 00 00 00 02 B0 04
 				 29 01 00 00 00 00 02 D6 01
 				 29 01 00 00 00 00 02 C6 59];
-		somc,driver-ic-vbp = <11>;
+		somc,driver-ic-total-porch = <11>;
 		somc,driver-ic-vdisp = <1920>;
-		somc,display-clock = /bits/ 64 <14000000000>;
-		somc,driver-ic-vfp = <682>;
+		somc,driver-ic-rclk = <14000000>;
+		somc,driver-ic-vtp = <682>;
 		somc,change-fps-rtn-pos = <2 1>;
 
 		somc,mdss-dsi-pcc-enable;

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
@@ -119,6 +119,9 @@
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
 
+		/* (vback porch + vfront porch + vpulse width + yres) * 2 */
+		qcom,mdss-tear-check-sync-cfg-height = <4326>;
+
 		somc,change-fps-enable;
 		somc,change-fps-panel-type = "full_incell_type";
 		somc,change-fps-panel-mode = "dynamic_mode";

--- a/drivers/usb/phy/phy-msm-qusb-v2.c
+++ b/drivers/usb/phy/phy-msm-qusb-v2.c
@@ -445,7 +445,7 @@ static u32 qusb_phy_get_tune1_param(struct qusb_phy *qphy)
 	return reg;
 }
 #else
-static void usb_phy_get_tune1_param(struct qusb_phy *qphy)
+static void qusb_phy_get_tune1_param(struct qusb_phy *qphy)
 {
 	u8 reg;
 	u32 bit_mask = 1;


### PR DESCRIPTION
Recent somc_panel restructuration introduced the somc_panel FPS Manager, which uses a new implementation way from SoMC's Yoshino code, which is slightly better than the one we used... which was based on heavily modified Shinano code.
The new FPS Manager is made exclusively for INCELL panels (but...it can actually work fine on legacy) and brings different configuration entry names, so, updating ALL our panels was necessary.

About the TE commit, it is a "proper hack": we need this after the removal of the bad hacks we had in the mdss_mdp_intf_cmd.c source, which was just doing the calculations for us. The reason of this "proper hack" is that with it we can _safely_ use FPS Manager's Dynamic Mode (fps parameters calculation and change on-the-fly instead of on-off) so... even if it's a sort of hack... it's.. not... really... because when we want to use this feature, the MDSS driver is unable to auto-calculate the TE height correctly, so we need to feed it by hand.
Though, this happens only on Tone and Loire (and legacy) devices, so Yoshino panel was not updated.