### PR TITLE
[5.7.r1] arm: DT: Maple: Use two flash supplies for camera-flash

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
@@ -25,8 +25,8 @@
 	led_flash0: qcom,camera-flash@0 {
 		cell-index = <0>;
 		compatible = "qcom,camera-flash";
-		qcom,flash-source = <&pmi8998_flash0>;
-		qcom,torch-source = <&pmi8998_torch0>;
+		qcom,flash-source = <&pmi8998_flash0 &pmi8998_flash1>;
+		qcom,torch-source = <&pmi8998_torch0 &pmi8998_torch1>;
 		qcom,switch-source = <&pmi8998_switch0>;
 		status = "ok";
 	};


### PR DESCRIPTION
Using both supplies we are configuring both rails. For some
reason, if we don't do that, the fault handler will kick in
and the flash will not work.