### PR TITLE
[5.7.r1] usb: phy: phy-msm-usb: Assign usb_psy to phy globally used psy

### DIFF
--- a/drivers/usb/phy/phy-msm-usb.c
+++ b/drivers/usb/phy/phy-msm-usb.c
@@ -3978,6 +3978,7 @@ static int msm_otg_probe(struct platform_device *pdev)
 		pr_err("%s: Cannot get USB power_supply\n", __func__);
 		return -EPROBE_DEFER;
 	} else {
+		psy = motg->usb_psy;
 		power_supply_get_property(motg->usb_psy,
 			POWER_SUPPLY_PROP_PRESENT, &pval);
 	}


### PR DESCRIPTION
The phy needs to know which power supply to use.