### PR TITLE
[5.5.r1] Fix Keyaki USB

### DIFF
--- a/drivers/usb/misc/fusb301.c
+++ b/drivers/usb/misc/fusb301.c
@@ -1850,7 +1850,7 @@ static int fusb301_parse_dt(struct fusb301_chip *chip)
 
 	data->cbl_sns_gpio = of_get_named_gpio(dev_node,
 						"fusb301,cbl_sns-gpio", 0);
-	if (data->cbl_sns_gpio < 0) {
+	if (data->cbl_sns_enabled && data->cbl_sns_gpio < 0) {
 		dev_err(cdev, "cbl_sns_gpio is not available\n");
 		rc = data->cbl_sns_gpio;
 		goto out;


### PR DESCRIPTION
If CBL sensing is not enabled, we have no CBL sensing gpio, hence
we shall not fail here.