### PR TITLE
Revert "arm64: DT: tone: Enable wakeup gesture"

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -249,8 +249,8 @@
 			preset_x_max = <1079>;
 			preset_y_max = <1919>;
 			preset_n_fingers = <10>;
-			wakeup_gesture_supported = <1>;
-			wakeup_gesture_lpm_disabled = <1>;
+			wakeup_gesture_supported = <0>;
+			wakeup_gesture_lpm_disabled = <0>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {
 				double_tap {


### PR DESCRIPTION
wakeup gesture bug is in kernespace.
Userspace patch was reverted already, so revert it here too.