### PR TITLE
[5.7.r1] arm: DT: MSM8998-camera: Fix jpeg dma compatible name

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-camera.dtsi
@@ -806,7 +806,7 @@
 
 	qcom,jpeg@caa0000 {
 		cell-index = <3>;
-		compatible = "qcom,jpegdma";
+		compatible = "qcom,jpeg_dma";
 		reg = <0xcaa0000 0x4000>,
 			<0xca60000 0x3000>;
 		reg-names = "jpeg_hw", "jpeg_vbif";


### PR DESCRIPTION
QC typoed it. The right string is "qcom,jpeg_dma".