### PR TITLE
[5.7.r1] Globally use Q6ASMv3 parameters for legacy SoC

### DIFF
--- a/sound/soc/msm/qdsp6v2/msm-pcm-q6-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-pcm-q6-v2.c
@@ -347,13 +347,9 @@ static int msm_pcm_playback_prepare(struct snd_pcm_substream *substream)
 			return -ENOMEM;
 		}
 	} else {
-#ifdef CONFIG_ARCH_MSM8998
 		ret = q6asm_open_write_v4(prtd->audio_client,
 			fmt_type, bits_per_sample);
-#else
-		ret = q6asm_open_write_v3(prtd->audio_client,
-			fmt_type, bits_per_sample);
-#endif
+
 		if (ret < 0) {
 			pr_err("%s: q6asm_open_write_v4 failed (%d)\n",
 			__func__, ret);

--- a/sound/soc/msm/qdsp6v2/q6asm.c
+++ b/sound/soc/msm/qdsp6v2/q6asm.c
@@ -2507,9 +2507,15 @@ EXPORT_SYMBOL(q6asm_open_read_v3);
 int q6asm_open_read_v4(struct audio_client *ac, uint32_t format,
 			uint16_t bits_per_sample, bool ts_mode)
 {
+#if !defined(CONFIG_ARCH_MSM8916) && !defined(CONFIG_ARCH_MSM8996)
 	return __q6asm_open_read(ac, format, bits_per_sample,
 				 PCM_MEDIA_FORMAT_V4 /*media fmt block ver*/,
 				 ts_mode);
+#else
+	return __q6asm_open_read(ac, format, bits_per_sample,
+				 PCM_MEDIA_FORMAT_V3/*media fmt block ver*/,
+				 false/*ts_mode*/);
+#endif
 }
 EXPORT_SYMBOL(q6asm_open_read_v4);
 
@@ -2808,9 +2814,15 @@ EXPORT_SYMBOL(q6asm_open_write_v3);
 int q6asm_open_write_v4(struct audio_client *ac, uint32_t format,
 			uint16_t bits_per_sample)
 {
+#if !defined(CONFIG_ARCH_MSM8916) && !defined(CONFIG_ARCH_MSM8996)
 	return __q6asm_open_write(ac, format, bits_per_sample,
 				  ac->stream_id, false /*gapless*/,
 				  PCM_MEDIA_FORMAT_V4 /*pcm_format_block_ver*/);
+#else
+	return __q6asm_open_write(ac, format, bits_per_sample,
+				  ac->stream_id, false /*gapless*/,
+				  PCM_MEDIA_FORMAT_V3 /*pcm_format_block_ver*/);
+#endif
 }
 EXPORT_SYMBOL(q6asm_open_write_v4);
 


### PR DESCRIPTION
The previous fix was actually fixing only part of the q6asm problems.
This one is ugly, but ... effective.


Also, I'm truly sorry for us all, but there's no less ugly alternative.