### PR TITLE
[LA.BR.1.3.3_rb2.14] prima (ported from qcacld-2.0): Fix array out-of-bounds & integer underflow in _iw_set_genie

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -2379,6 +2379,13 @@ static int __iw_set_genie(struct net_device *dev,
         hddLog(VOS_TRACE_LEVEL_INFO, "%s: IE[0x%X], LEN[%d]",
             __func__, elementId, eLen);
 
+        if (remLen < eLen) {
+            hddLog(LOGE, "Remaining len: %u less than ie len: %u",
+                   remLen, eLen);
+            ret = -EINVAL;
+            goto exit;
+        }
+
         switch ( elementId )
          {
             case IE_EID_VENDOR:
@@ -2461,8 +2468,11 @@ static int __iw_set_genie(struct net_device *dev,
                 hddLog (LOGE, "%s Set UNKNOWN IE %X",__func__, elementId);
                 goto exit;
     }
-        genie += eLen;
         remLen -= eLen;
+
+        /* Move genie only if next element is present */
+        if (remLen >= 2)
+            genie += eLen;
     }
 
 exit:


### PR DESCRIPTION
'wrqu->data.length' holds the total number of IE data buffer.
Add a check to make sure the number of remaining data to be read is
greater than or equal to IE length.

Also, advance the buffer pointer to point to the next element only
if next element is present.

Change-Id: Ic60f3e0650f365955dab4099eb8740e9789e00cc
CRs-Fixed: 1100132