### PR TITLE
[5.7.r1] arm: DT: MSM8956: Fix IOMMU node for msm-audio-ion

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2772,7 +2772,7 @@
 		compatible = "qcom,msm-audio-ion";
 		qcom,smmu-version = <2>;
 		qcom,smmu-enabled;
-		iommus = <&apps_smmu 0x2c01>;
+		iommus = <&apps_smmu 14>;
 	};
 
 	qcom,adsprpc-mem {


### PR DESCRIPTION
Declare the right IOMMU for this node: the previous onewas a
leftover from a previous IOMMU driver development test.