### PR TITLE
[LA.UM.5.7] tty: msm_serial_hs: Do not reset client counter to 0 when ldisc is enabled

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2746,8 +2746,10 @@ static int msm_hs_startup(struct uart_port *uport)
 
 
 	spin_lock_irqsave(&uport->lock, flags);
+#ifndef CONFIG_LINE_DISCIPLINE_DRIVER
 	atomic_set(&msm_uport->client_count, 0);
 	atomic_set(&msm_uport->client_req_state, 0);
+#endif
 	LOG_USR_MSG(msm_uport->ipc_msm_hs_pwr_ctxt,
 			"%s: Client_Count 0\n", __func__);
 	msm_hs_start_rx_locked(uport);


### PR DESCRIPTION
This change was introduced here: 0f7b40556b2577458a4fdf3b592e840fc5ecc22f
And it was wrongly modified here: f9fb880b09f1efb5f816c638f3522582ca97fa58

So this change resets the client counter to 0 (zero) only
if the ldisc driver is not used since it is invoked twice
when stating the ldisc, resulting in a mismatching counter.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I27beeda3a22c788b8d6a452a5c381caf07949e8c