### PR TITLE
drivers: bluesleep: Fix unbalanced IRQ for tone

### DIFF
--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -439,11 +439,12 @@ int bluesleep_start(bool is_clock_enabled)
 
 	// For ldisc-controlled BT, the clock is enabled by upper layers, so
 	// make bluesleep aware of this state.
-	if(is_clock_enabled) {
+	if (is_clock_enabled)
 		atomic_set(&uart_is_on, 1);
-	} else {
+#ifdef CONFIG_LINE_DISCIPLINE_DRIVER
+	else
 		hsuart_power(HS_UART_ON);
-	}
+#endif
 
 	enable_wakeup_irq(1);
 	set_bit(BT_PROTO, &flags);
@@ -652,7 +653,7 @@ static int bluesleep_probe(struct platform_device *pdev)
 		goto free_bt_ext_wake;
 	}
 
-	atomic_set(&bsi->wakeup_irq_disabled, 1);
+	enable_wakeup_irq(0);
 
 	return 0;
 


### PR DESCRIPTION
rfkill is starting/stoping bluetooth when BT driver is probe so it is not
necessary to handle it from BT start function.

[   21.537099] Call trace:
[   21.537103] Exception stack(0xffffffc096f2ba10 to 0xffffffc096f2bb40)
[   21.537106] ba00:                                   ffffffc072080000 0000008000000000
[   21.537110] ba20: ffffffc096f2bbe0 ffffff80080df9e4 ffffff80093b8990 0000000000025220
[   21.537113] ba40: 0000000000000006 0000000000000000 ffffff8009241508 0000000000000002
[   21.537116] ba60: ffffffc096f2bb00 ffffff80080dd1e4 ffffff80080dd1b0 000000000000012c
[   21.537119] ba80: ffffff800955d198 ffffff800955d000 0000000000000140 0000000000000001
[   21.537122] baa0: 0000000000000186 0000000000000004 000000000000001d 0000000000000001
[   21.537125] bac0: ffffffc096f28000 0000000000000000 0000000000000000 0000000000000000
[   21.537128] bae0: ffffff80093b8b04 636e616c61626e55 6c62616e65206465 0000000000000001
[   21.537131] bb00: 00000000df624388 00000000e0e2b26c 00000000cded6080 00000000e0dff308
[   21.537134] bb20: 00000000e6c97a43 0000000000000000 ffffff800816bc0c 0000000000000000
[   21.537139] [<ffffff80080df9e4>] __enable_irq+0x34/0x74
[   21.537142] [<ffffff80080dfa80>] enable_irq+0x5c/0x6c
[   21.537149] [<ffffff8008813e1c>] enable_wakeup_irq+0x34/0x90
[   21.537153] [<ffffff8008814d24>] bluesleep_start+0x118/0x148
[   21.537156] [<ffffff8008813ae8>] bcm43xx_bt_rfkill_set_power+0x50/0x90
[   21.537162] [<ffffff8008c2a5a4>] rfkill_set_block+0x90/0x11c
[   21.537166] [<ffffff8008c2a924>] state_store+0x84/0xa0
[   21.537172] [<ffffff80084dd018>] dev_attr_store+0x20/0x28
[   21.537178] [<ffffff80081ce0bc>] sysfs_kf_write+0x44/0x4c
[   21.537182] [<ffffff80081cd4dc>] kernfs_fop_write+0x108/0x160
[   21.537186] [<ffffff800816b8dc>] __vfs_write+0x28/0xd0
[   21.537190] [<ffffff800816baf0>] vfs_write+0xac/0x144
[   21.537193] [<ffffff800816bc54>] SyS_write+0x48/0x84
[   21.537198] [<ffffff8008083e30>] el0_svc_naked+0x24/0x28

To do: Check bluetooth on loire platform.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I934edb99b9b5bf2b416313065ff167a41d5e40ee