### PR TITLE
[5.7.r1] [REOPENING] ASoC: msm8998: Add SoMC Yoshino sound quirks

### DIFF
--- a/sound/soc/msm/msm8998.c
+++ b/sound/soc/msm/msm8998.c
@@ -177,6 +177,9 @@ struct msm_pinctrl_info {
 struct msm_asoc_mach_data {
 	u32 mclk_freq;
 	int us_euro_gpio; /* used by gpio driver API */
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	int ear_en_gpio;
+#endif
 	struct device_node *us_euro_gpio_p; /* used by pinctrl API */
 	struct device_node *hph_en1_gpio_p; /* used by pinctrl API */
 	struct device_node *hph_en0_gpio_p; /* used by pinctrl API */
@@ -499,6 +502,12 @@ static SOC_ENUM_SINGLE_EXT_DECL(mi2s_rx_format, bit_format_text);
 static SOC_ENUM_SINGLE_EXT_DECL(mi2s_tx_format, bit_format_text);
 static SOC_ENUM_SINGLE_EXT_DECL(hifi_function, hifi_text);
 
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+static int ear_enable_states;
+static const char *const ear_enable_states_text[] = {"Disable", "Enable"};
+static SOC_ENUM_SINGLE_EXT_DECL(ear_enable_state, ear_enable_states_text);
+#endif
+
 static struct platform_device *spdev;
 static int msm_hifi_control;
 
@@ -535,8 +544,13 @@ static struct wcd_mbhc_config wcd_mbhc_cfg = {
 	.key_code[7] = 0,
 	.linein_th = 5000,
 	.moisture_en = true,
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	.anc_micbias = MIC_BIAS_3,
+	.enable_anc_mic_detect = true,
+#else
 	.anc_micbias = MIC_BIAS_2,
 	.enable_anc_mic_detect = false,
+#endif
 };
 
 static struct snd_soc_dapm_route wcd_audio_paths_tasha[] = {
@@ -1391,6 +1405,63 @@ static int usb_audio_tx_format_put(struct snd_kcontrol *kcontrol,
 
 	return rc;
 }
+
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+static int ear_enable_get(struct snd_kcontrol *kcontrol,
+	struct snd_ctl_elem_value *ucontrol)
+{
+	int gpio_state = 0;
+
+	switch (ear_enable_states) {
+	case 1:
+		gpio_state = 1;
+		break;
+	case 0:
+	default:
+		gpio_state = 0;
+		break;
+	}
+
+	ucontrol->value.integer.value[0] = gpio_state;
+	pr_debug("%s: ear_enable_states = %d\n", __func__,
+			ear_enable_states);
+
+	return 0;
+}
+
+static int ear_enable_put(struct snd_kcontrol *kcontrol,
+	struct snd_ctl_elem_value *ucontrol)
+{
+	int ret;
+	struct snd_soc_card *card = platform_get_drvdata(spdev);
+	struct msm_asoc_mach_data *pdata = snd_soc_card_get_drvdata(card);
+
+	pr_debug("%s: ucontrol value = %ld\n", __func__,
+			ucontrol->value.integer.value[0]);
+
+	if (pdata->ear_en_gpio >= 0) {
+		ret = gpio_request(pdata->ear_en_gpio, "ear_en_gpio");
+		if (ret) {
+			pr_err("%s: request ear_en_gpio failed, ret:%d\n",
+				__func__, ret);
+			return ret;
+		}
+		switch (ucontrol->value.integer.value[0]) {
+		case 1:
+			gpio_set_value(pdata->ear_en_gpio, 1);
+			break;
+		case 0:
+		default:
+			gpio_set_value(pdata->ear_en_gpio, 0);
+			break;
+		}
+		gpio_free(pdata->ear_en_gpio);
+		ear_enable_states = ucontrol->value.integer.value[0];
+	}
+
+	return 0;
+}
+#endif
 
 static int ext_disp_get_port_idx(struct snd_kcontrol *kcontrol)
 {
@@ -2757,6 +2828,11 @@ static const struct snd_kcontrol_new msm_snd_controls[] = {
 			msm_mi2s_tx_format_get, msm_mi2s_tx_format_put),
 	SOC_ENUM_EXT("HiFi Function", hifi_function, msm_hifi_get,
 			msm_hifi_put),
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	SOC_ENUM_EXT("Ear_Enable_States", ear_enable_state,
+		ear_enable_get,
+		ear_enable_put),
+#endif
 };
 
 static int msm_snd_enable_codec_ext_clk(struct snd_soc_codec *codec,
@@ -3702,8 +3778,13 @@ static void *def_tasha_mbhc_cal(void)
 	if (!tasha_wcd_cal)
 		return NULL;
 
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+#define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(tasha_wcd_cal)->X) = (Y))
+	S(v_hs_max, 1700);
+#else
 #define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(tasha_wcd_cal)->X) = (Y))
 	S(v_hs_max, 1600);
+#endif
 #undef S
 #define S(X, Y) ((WCD_MBHC_CAL_BTN_DET_PTR(tasha_wcd_cal)->X) = (Y))
 	S(num_btn, WCD_MBHC_DEF_BUTTONS);
@@ -3721,6 +3802,10 @@ static void *def_tasha_mbhc_cal(void)
 	btn_high[5] = 500;
 	btn_high[6] = 500;
 	btn_high[7] = 500;
+
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	btn_high[1] = 137;
+#endif
 
 	return tasha_wcd_cal;
 }
@@ -7185,7 +7270,9 @@ static int msm_asoc_machine_probe(struct platform_device *pdev)
 {
 	struct snd_soc_card *card;
 	struct msm_asoc_mach_data *pdata;
+#ifndef CONFIG_ARCH_SONY_YOSHINO
 	const char *mbhc_audio_jack_type = NULL;
+#endif
 	char *mclk_freq_prop_name;
 	const struct of_device_id *match;
 	int ret;
@@ -7298,6 +7385,7 @@ static int msm_asoc_machine_probe(struct platform_device *pdev)
 		}
 	}
 
+#ifndef CONFIG_ARCH_SONY_YOSHINO
 	ret = of_property_read_string(pdev->dev.of_node,
 		"qcom,mbhc-audio-jack-type", &mbhc_audio_jack_type);
 	if (ret) {
@@ -7320,6 +7408,7 @@ static int msm_asoc_machine_probe(struct platform_device *pdev)
 			dev_dbg(&pdev->dev, "Unknown value, set to default");
 		}
 	}
+#endif
 	/*
 	 * Parse US-Euro gpio info from DT. Report no error if us-euro
 	 * entry is not found in DT file as some targets do not support
@@ -7355,6 +7444,19 @@ static int msm_asoc_machine_probe(struct platform_device *pdev)
 		ret = 0;
 	}
 
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	/* Parse EAR_EN info for NX5L2750C */
+	pdata->ear_en_gpio = of_get_named_gpio(pdev->dev.of_node,
+				"qcom,ear-en-gpios", 0);
+	if (pdata->ear_en_gpio < 0) {
+		dev_err(&pdev->dev, "property %s not detected in node %s",
+			"qcom,ear-en-gpios",
+			pdev->dev.of_node->full_name);
+		ret = -ENODEV;
+		goto err;
+	}
+#endif
+
 	i2s_auxpcm_init(pdev);
 
 	is_initial_boot = true;
@@ -7372,6 +7474,13 @@ err:
 		gpio_free(pdata->us_euro_gpio);
 		pdata->us_euro_gpio = 0;
 	}
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	if (pdata->ear_en_gpio > 0) {
+		dev_dbg(&pdev->dev, "%s initialize ear_en gpio %d\n",
+			__func__, pdata->ear_en_gpio);
+		pdata->ear_en_gpio = 0;
+	}
+#endif
 	msm_release_pinctrl(pdev);
 	devm_kfree(&pdev->dev, pdata);
 	return ret;


### PR DESCRIPTION
These are quirks for SoMC Yoshino platform.
Taken from copyleft release 45.0.A.5.1.


FIXES IN CALL AUDIO FROM HANDSET