### PR TITLE
[5.7.r1] [TESTMEFIRST] Enable 1080p@120Hz on ALL Tone devices

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
@@ -42,6 +42,8 @@
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1b 08 09 05 03 04 a0];
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 	};
 
 	dsi_jdi_synaptics_cmd_6: somc,jdi_synaptics_cmd_6_panel {
@@ -84,6 +86,8 @@
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1b 08 09 05 03 04 a0];
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 	};
 
 	dsi_sharp_synaptics_cmd_3: somc,sharp_synaptics_cmd_3_panel {
@@ -105,6 +109,8 @@
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1b 08 09 05 03 04 a0];
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 	};
 
 	dsi_sharp_synaptics_cmd_9: somc,sharp_synaptics_cmd_9_panel {
@@ -126,6 +132,8 @@
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1b 08 09 05 03 04 a0];
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 	};
 
 	dsi_default_panel: somc,default_cmd_panel {

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-dora.dtsi
@@ -133,18 +133,9 @@
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -161,19 +152,6 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				39 01 00 00 00 00 02 36 00
-				39 01 00 00 00 00 02 3A 77
-				39 01 00 00 00 00 05 2A 00 00 04 37
-				39 01 00 00 00 00 05 2B 00 00 07 7F
-				39 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-post-panel-on-command = [
-				39 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				39 01 00 00 14 00 01 28
-				39 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -184,9 +162,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_hybrid_incell>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
@@ -236,5 +211,36 @@
 				24 1b 08 09 05 03 04 a0];
 
 		somc,ewu-wait-after-touch-reset = <40>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
@@ -46,6 +46,8 @@
 		somc,pw-wait-after-on-touch-reset-first = <90>;
 		somc,pw-wait-after-on-touch-int-n = <10>;
 
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 		qcom,mdss-dsi-display-timings {
 			1080p60 {
 				qcom,mdss-dsi-on-command = [
@@ -122,6 +124,8 @@
 		somc,pw-wait-after-on-touch-int-n = <10>;
 		somc,pw-wait-after-off-touch-reset = <6>;
 
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-susres";
 		qcom,mdss-dsi-display-timings {
 			1080p60 {
 				qcom,mdss-dsi-on-command = [

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-kagura.dtsi
@@ -42,29 +42,59 @@
 				24 1b 08 09 05 03 04 a0];
 		qcom,mdss-pan-physical-width-dimension = <64>;
 		qcom,mdss-pan-physical-height-dimension = <114>;
-		qcom,mdss-dsi-on-command = [
-				29 01 00 00 00 00 02 B0 00
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 03 C4 70 22
-				29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
-				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
-				29 01 00 00 00 00 02 B0 03
-				39 01 00 00 00 00 02 35 00
-				39 01 00 00 00 00 02 36 00
-				39 01 00 00 00 00 02 3A 77
-				39 01 00 00 00 00 05 2A 00 00 04 37
-				39 01 00 00 00 00 05 2B 00 00 07 7F
-				39 01 00 00 00 00 03 44 00 00
-				39 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-off-command = [
-				39 01 00 00 14 00 01 28
-				29 01 00 00 00 00 02 B0 00
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
-				29 01 00 00 00 00 02 B0 03
-				39 01 00 00 50 00 01 10];
+
 		somc,pw-wait-after-on-touch-reset-first = <90>;
 		somc,pw-wait-after-on-touch-int-n = <10>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 50 00 01 10];
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 50 00 01 10];
+			};
+		};
 	};
 
 	dsi_sharp_synaptics_cmd_9: somc,sharp_synaptics_cmd_9_panel {
@@ -88,13 +118,26 @@
 				24 1f 08 09 05 03 04 a0
 				24 1f 08 09 05 03 04 a0
 				24 1b 08 09 05 03 04 a0];
-		qcom,mdss-dsi-on-command = [
-				39 01 00 00 00 00 02 35 00
-				05 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-post-panel-on-command = [
-				05 01 00 00 78 00 01 11];
+
 		somc,pw-wait-after-on-touch-int-n = <10>;
 		somc,pw-wait-after-off-touch-reset = <6>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 35 00
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 78 00 01 11];
+			};
+			1080p120 {
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 35 00
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 78 00 01 11];
+			};
+		};
 	};
 
 	dsi_default_panel: somc,default_cmd_panel {
@@ -102,18 +145,9 @@
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <64>;
 		qcom,mdss-pan-physical-height-dimension = <114>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -130,31 +164,6 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				29 01 00 00 00 00 02 B0 00
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 03 C4 70 22
-				29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
-				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
-				29 01 00 00 00 00 02 B0 03
-				39 01 00 00 00 00 02 35 00
-				39 01 00 00 00 00 02 36 00
-				39 01 00 00 00 00 02 3A 77
-				39 01 00 00 00 00 05 2A 00 00 04 37
-				39 01 00 00 00 00 05 2B 00 00 07 7F
-				39 01 00 00 00 00 03 44 00 00
-				39 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-post-panel-on-command = [
-				39 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				39 01 00 00 14 00 01 28
-				29 01 00 00 00 00 02 B0 00
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
-				29 01 00 00 00 00 02 B0 03
-				39 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -165,9 +174,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_hybrid_incell>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
@@ -219,5 +225,90 @@
 
 		somc,mdss-dsi-disp-on-in-hs = <0>;
 		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-suzu.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-suzu.dtsi
@@ -104,18 +104,9 @@
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -132,19 +123,6 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				39 01 00 00 00 00 02 36 00
-				39 01 00 00 00 00 02 3A 77
-				39 01 00 00 00 00 05 2A 00 00 04 37
-				39 01 00 00 00 00 05 2B 00 00 07 7F
-				39 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-post-panel-on-command = [
-				39 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				39 01 00 00 14 00 01 28
-				39 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -155,9 +133,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_hybrid_incell>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
@@ -199,5 +174,64 @@
 		somc,lab-output-voltage = <5600000>;
 		somc,ibb-output-voltage = <5600000>;
 		somc,ewu-wait-after-touch-reset = <40>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p-cmd.dtsi
@@ -23,18 +23,9 @@
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -51,23 +42,7 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				29 01 00 00 00 00 02 B0 04
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 20 C1 84 00 00 FF 47 99 80 39 EB FF CF 9A 73 8D FD BF D6 31 2F 89 F1 3F 00 00 40 22 82 03 08 00 01
-				15 01 00 00 00 00 02 35 00
-				05 01 00 00 78 00 01 11
-				29 01 00 00 00 00 1F C7 0F 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 79 0B 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 73
-				29 01 00 00 00 00 14 C8 00 00 00 00 00 FC 00 00 00 00 00 FC 00 00 00 00 00 FC 00];
-		qcom,mdss-dsi-post-panel-on-command = [
-				05 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				05 01 00 00 28 00 01 28
-				29 01 00 00 00 00 1D D3 13 3B BB B3 A5 33 33 33 00 80 A1 AA 4F 4F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
-				29 01 00 00 28 00 04 D4 00 00 00
-				05 01 00 00 78 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -78,9 +53,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -358,5 +330,74 @@
 				0x00 0xE0 0x04 0x07 0x00 0x03 0x8000 0x8000 0x8000
 				0x00 0xE1 0x00 0x03 0x00 0x03 0x8000 0x8000 0x8000
 				0xFF 0x00 0x0E 0x38 0x0C 0x2F 0x8000 0x8000 0x8000>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 04
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 20 C1 84 00 00 FF 47 99 80 39 EB FF CF 9A 73 8D FD BF D6 31 2F 89 F1 3F 00 00 40 22 82 03 08 00 01
+						15 01 00 00 00 00 02 35 00
+						05 01 00 00 78 00 01 11
+						29 01 00 00 00 00 1F C7 0F 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 79 0B 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 73
+						29 01 00 00 00 00 14 C8 00 00 00 00 00 FC 00 00 00 00 00 FC 00 00 00 00 00 FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 28 00 01 28
+						29 01 00 00 00 00 1D D3 13 3B BB B3 A5 33 33 33 00 80 A1 AA 4F 4F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 28 00 04 D4 00 00 00
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 04
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 20 C1 84 00 00 FF 47 99 80 39 EB FF CF 9A 73 8D FD BF D6 31 2F 89 F1 3F 00 00 40 22 82 03 08 00 01
+						15 01 00 00 00 00 02 35 00
+						05 01 00 00 78 00 01 11
+						29 01 00 00 00 00 1F C7 0F 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 79 0B 1F 29 34 41 4D 55 61 42 49 54 60 67 6D 73
+						29 01 00 00 00 00 14 C8 00 00 00 00 00 FC 00 00 00 00 00 FC 00 00 00 00 00 FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 28 00 01 28
+						29 01 00 00 00 00 1D D3 13 3B BB B3 A5 33 33 33 00 80 A1 AA 4F 4F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 28 00 04 D4 00 00 00
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p-cmd.dtsi
@@ -23,18 +23,9 @@
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -51,28 +42,6 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				29 01 00 00 00 00 02 B0 00
-				29 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 03 C4 70 03
-				29 01 00 00 00 00 1B ED 27 31 2F 13 00 6A 99 03 17 91 F2 00 00 03 14 17 3F 14 12 26 23 00 20 00 00 57
-				29 01 00 00 00 00 1B EE 13 61 5F 09 00 6A 99 03 00 01 B2 00 00 03 00 00 33 14 12 00 21 00 20 00 00 57
-				29 01 00 00 00 00 1B EF 27 31 2F 13 00 00 00 00 00 00 00 00 00 03 14 17 0F 14 00 00 20 00 00 00 00 A6
-				29 01 00 00 00 00 1B F0 E3 07 73 DF 00 00 00 00 00 00 00 00 E0 E3 00 00 03 14 00 00 20 00 00 00 00 A7
-				39 01 00 00 00 00 02 35 00
-				39 01 00 00 00 00 02 36 00
-				39 01 00 00 00 00 02 3A 77
-				39 01 00 00 00 00 05 2A 00 00 04 37
-				39 01 00 00 00 00 05 2B 00 00 07 7F
-				39 01 00 00 00 00 03 44 00 00
-				39 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-post-panel-on-command = [
-				39 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				39 01 00 00 14 00 01 28
-				39 01 00 00 50 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -83,9 +52,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -376,5 +342,90 @@
 				0x00 0xE0 0x04 0x07 0x00 0x03 0x8000 0x8000 0x8000
 				0x00 0xE1 0x00 0x03 0x00 0x03 0x8000 0x8000 0x8000
 				0xFF 0x00 0x0E 0x38 0x0C 0x2F 0x8000 0x8000 0x8000>;
+
+		qcom,dynamic-mode-switch-enabled;
+		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-immediate";
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 03
+						29 01 00 00 00 00 1B ED 27 31 2F 13 00 6A 99 03 17 91 F2 00 00 03 14 17 3F 14 12 26 23 00 20 00 00 57
+						29 01 00 00 00 00 1B EE 13 61 5F 09 00 6A 99 03 00 01 B2 00 00 03 00 00 33 14 12 00 21 00 20 00 00 57
+						29 01 00 00 00 00 1B EF 27 31 2F 13 00 00 00 00 00 00 00 00 00 03 14 17 0F 14 00 00 20 00 00 00 00 A6
+						29 01 00 00 00 00 1B F0 E3 07 73 DF 00 00 00 00 00 00 00 00 E0 E3 00 00 03 14 00 00 20 00 00 00 00 A7
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 03 C4 70 03
+						29 01 00 00 00 00 1B ED 27 31 2F 13 00 6A 99 03 17 91 F2 00 00 03 14 17 3F 14 12 26 23 00 20 00 00 57
+						29 01 00 00 00 00 1B EE 13 61 5F 09 00 6A 99 03 00 01 B2 00 00 03 00 00 33 14 12 00 21 00 20 00 00 57
+						29 01 00 00 00 00 1B EF 27 31 2F 13 00 00 00 00 00 00 00 00 00 03 14 17 0F 14 00 00 20 00 00 00 00 A6
+						29 01 00 00 00 00 1B F0 E3 07 73 DF 00 00 00 00 00 00 00 00 E0 E3 00 00 03 14 00 00 20 00 00 00 00 A7
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						39 01 00 00 00 00 01 29];
+						39 01 00 00 50 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
@@ -23,18 +23,9 @@
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -51,19 +42,7 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				23 01 00 00 00 00 02 B0 04
-				23 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 20 C1 84 00 10 F0 47 F9 FF AF FF AF CF 9A 73 8D FD F5 7F FD FF 0F F1 1F 00 AA 40 02 C2 11 08 00 01
-				29 01 00 00 00 00 0a CB 8D F4 4B 2C 00 04 08 00 00
-				05 01 00 00 64 00 01 11];
-		qcom,mdss-dsi-post-panel-on-command = [
-				05 01 00 00 00 00 01 29];
-		qcom,mdss-dsi-off-command = [
-				05 01 00 00 14 00 01 28
-				05 01 00 00 64 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -74,9 +53,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -354,5 +330,66 @@
 				0x00 0xE0 0x04 0x07 0x00 0x03 0x8000 0x8000 0x8000
 				0x00 0xE1 0x00 0x03 0x00 0x03 0x8000 0x8000 0x8000
 				0xFF 0x00 0x0E 0x38 0x0C 0x2F 0x8000 0x8000 0x8000>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 20 C1 84 00 10 F0 47 F9 FF AF FF AF CF 9A 73 8D FD F5 7F FD FF 0F F1 1F 00 AA 40 02 C2 11 08 00 01
+						29 01 00 00 00 00 0a CB 8D F4 4B 2C 00 04 08 00 00
+						05 01 00 00 64 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 14 00 01 28
+						05 01 00 00 64 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 20 C1 84 00 10 F0 47 F9 FF AF FF AF CF 9A 73 8D FD F5 7F FD FF 0F F1 1F 00 AA 40 02 C2 11 08 00 01
+						29 01 00 00 00 00 0a CB 8D F4 4B 2C 00 04 08 00 00
+						05 01 00 00 64 00 01 11];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 14 00 01 28
+						05 01 00 00 64 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID3.dtsi
@@ -23,18 +23,9 @@
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -51,28 +42,7 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				39 01 00 00 00 00 02 51 FF
-				39 01 00 00 00 00 02 53 0C
-				39 01 00 00 00 00 02 55 00
-				39 01 00 00 00 00 02 35 00
-				23 01 00 00 00 00 02 B0 04
-				23 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
-				29 01 00 00 00 00 11 D0 19 01 91 0B 94 1A 09 00 00 00 19 99 00 00 00 00
-				29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
-				29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
-				29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
-				29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
-				29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
-		qcom,mdss-dsi-post-panel-on-command = [
-				05 01 00 00 00 00 01 29
-				05 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-off-command = [
-				05 01 00 00 00 00 01 28
-				05 01 00 00 78 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -83,9 +53,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -366,5 +333,83 @@
 				0x00 0xE0 0x04 0x07 0x00 0x03 0x8000 0x8000 0x8000
 				0x00 0xE1 0x00 0x03 0x00 0x03 0x8000 0x8000 0x8000
 				0xFF 0x00 0x0E 0x38 0x0C 0x2F 0x8000 0x8000 0x8000>;
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 51 FF
+						39 01 00 00 00 00 02 53 0C
+						39 01 00 00 00 00 02 55 00
+						39 01 00 00 00 00 02 35 00
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
+						29 01 00 00 00 00 11 D0 19 01 91 0B 94 1A 09 00 00 00 19 99 00 00 00 00
+						29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
+						29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
+						29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
+						29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29
+						05 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 00 00 01 28
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 51 FF
+						39 01 00 00 00 00 02 53 0C
+						39 01 00 00 00 00 02 55 00
+						39 01 00 00 00 00 02 35 00
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
+						29 01 00 00 00 00 11 D0 19 01 91 0B 94 1A 09 00 00 00 19 99 00 00 00 00
+						29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
+						29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
+						29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
+						29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29
+						05 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 00 00 01 28
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-1080p-cmd-ID9.dtsi
@@ -23,18 +23,9 @@
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-destination = "display_1";
-		qcom,mdss-dsi-panel-width = <1080>;
-		qcom,mdss-dsi-panel-height = <1920>;
 		qcom,mdss-dsi-bpp = <24>;
-		qcom,mdss-dsi-h-back-porch = <8>;
-		qcom,mdss-dsi-h-pulse-width = <8>;
-		qcom,mdss-dsi-h-front-porch = <56>;
-		qcom,mdss-dsi-v-back-porch = <8>;
-		qcom,mdss-dsi-v-pulse-width = <8>;
-		qcom,mdss-dsi-v-front-porch = <227>;
 		qcom,mdss-pan-physical-width-dimension = <61>;
 		qcom,mdss-pan-physical-height-dimension = <110>;
-		qcom,mdss-dsi-panel-framerate = <60>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-h-sync-skew = <0>;
@@ -51,29 +42,6 @@
 		qcom,mdss-dsi-dma-trigger = "trigger_sw";
 		qcom,mdss-dsi-mdp-trigger = "none";
 		qcom,mdss-dsi-tx-eot-append;
-		qcom,mdss-dsi-on-command = [
-				39 01 00 00 00 00 02 51 FF
-				39 01 00 00 00 00 02 53 0C
-				39 01 00 00 00 00 02 55 00
-				39 01 00 00 00 00 02 35 00
-				23 01 00 00 00 00 02 B0 04
-				23 01 00 00 00 00 02 D6 01
-				29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
-				29 01 00 00 00 00 0C D5 66 00 00 01 25 01 25 00 25 00 25
-				29 01 00 00 00 00 11 D0 19 01 91 0B 94 0F 0A 00 00 00 19 99 00 00 00 00
-				29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
-				29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
-				29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
-				29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
-				29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
-		qcom,mdss-dsi-post-panel-on-command = [
-				05 01 00 00 00 00 01 29
-				05 01 00 00 78 00 01 11];
-		qcom,mdss-dsi-off-command = [
-				05 01 00 00 00 00 01 28
-				05 01 00 00 78 00 01 10];
-		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
-		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-te-pin-select = <1>;
 		qcom,mdss-dsi-wr-mem-start = <0x2c>;
 		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
@@ -84,9 +52,6 @@
 		qcom,mdss-dsi-lane-1-state;
 		qcom,mdss-dsi-lane-2-state;
 		qcom,mdss-dsi-lane-3-state;
-		qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
-		qcom,mdss-dsi-t-clk-post = <0x1B>;
-		qcom,mdss-dsi-t-clk-pre = <0x2B>;
 		qcom,mdss-dsi-lp11-init;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <4095>;
@@ -367,5 +332,88 @@
 				0x00 0xE0 0x04 0x07 0x00 0x03 0x8000 0x8000 0x8000
 				0x00 0xE1 0x00 0x03 0x00 0x03 0x8000 0x8000 0x8000
 				0xFF 0x00 0x0E 0x38 0x0C 0x2F 0x8000 0x8000 0x8000>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 51 FF
+						39 01 00 00 00 00 02 53 0C
+						39 01 00 00 00 00 02 55 00
+						39 01 00 00 00 00 02 35 00
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
+						29 01 00 00 00 00 0C D5 66 00 00 01 25 01 25 00 25 00 25
+						29 01 00 00 00 00 11 D0 19 01 91 0B 94 0F 0A 00 00 00 19 99 00 00 00 00
+						29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
+						29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
+						29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
+						29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29
+						05 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 00 00 01 28
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-dsi-panel-framerate = <120>;
+				qcom,mdss-dsi-panel-timings = [E6 38 26 00 68 6E 2A 3C 2C 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x1B>;
+				qcom,mdss-dsi-t-clk-pre = <0x2B>;
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 51 FF
+						39 01 00 00 00 00 02 53 0C
+						39 01 00 00 00 00 02 55 00
+						39 01 00 00 00 00 02 35 00
+						23 01 00 00 00 00 02 B0 04
+						23 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 09 C9 1F 60 1F 60 90 90 C4 00
+						29 01 00 00 00 00 0C D5 66 00 00 01 25 01 25 00 25 00 25
+						29 01 00 00 00 00 11 D0 19 01 91 0B 94 0F 0A 00 00 00 19 99 00 00 00 00
+						29 01 00 00 00 00 1D D3 1B 3B BB BD B5 33 33 33 00 80 A6 A0 5F 5F 33 33 33 F7 F2 0F 7D 7C FF 0F 99 00 FF FF
+						29 01 00 00 00 00 21 D7 04 FF 23 55 47 1E FE 78 F0 19 A8 0F 38 3E 60 1C 0F 8F C7 E3 99 E1 20 00 00 00 00 F0 EB 39 18 07
+						29 01 00 00 00 00 20 C1 84 00 00 00 88 01 00 40 C0 35 E6 1A 63 CD B1 E6 C0 7A 00 C8 08 00 00 AA 40 02 82 01 08 00 01
+						29 01 00 00 00 00 1F C7 06 10 1A 23 35 44 4E 5D 42 4B 57 64 6B 71 79 04 0E 19 22 35 43 4E 5D 42 4A 55 63 6B 70 79
+						29 01 00 00 00 00 14 C8 01 00 FD 01 FF FC 00 00 FD 01 FF FC 00 00 FD 01 FF FC 00];
+				qcom,mdss-dsi-post-panel-on-command = [
+						05 01 00 00 00 00 01 29
+						05 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-off-command = [
+						05 01 00 00 00 00 01 28
+						05 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+				qcom,mdss-tear-check-sync-cfg-height = <4326>;
+			};
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-4k-cmd-ID6.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-sharp-4k-cmd-ID6.dtsi
@@ -1067,7 +1067,7 @@
 		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-immediate";
 		qcom,dcs-cmd-by-left;
 		qcom,mdss-dsi-display-timings {
-			1080p {
+			1080p60 {
 				qcom,mdss-dsi-timing-default;
 				qcom,mdss-dsi-panel-width = <540>;
 				qcom,mdss-dsi-panel-height = <1920>;
@@ -1078,6 +1078,64 @@
 				qcom,mdss-dsi-v-pulse-width = <2>;
 				qcom,mdss-dsi-v-front-porch = <12>;
 				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x07>;
+				qcom,mdss-dsi-t-clk-pre = <0x29>;
+				qcom,mdss-dsi-on-command = [
+							39 01 00 00 00 00 06 F0 55 AA 52 08 00
+							15 01 00 00 00 00 02 C9 01
+							15 01 00 00 00 00 02 90 00
+							15 01 00 00 00 00 02 58 01
+							39 01 00 00 00 00 06 F0 55 AA 52 08 07
+							15 01 00 00 00 00 02 EF 01
+							39 01 00 00 00 00 06 F0 55 AA 52 08 00
+							15 01 00 00 00 00 02 B4 01
+							39 01 00 00 00 00 10 BD 00 AC 0C 0C 00 01 56 09 09 01 01 0C 0C 00 D9
+							15 01 00 00 00 00 02 35 00
+							39 01 00 00 00 00 03 44 00 00
+							39 01 00 00 00 00 06 F0 55 AA 52 08 01
+							39 01 00 00 00 00 03 D4 88 88
+							39 01 00 00 00 00 05 FF AA 55 A5 80
+							15 01 00 00 00 00 02 6F 01
+							15 01 00 00 00 00 02 F3 10
+							39 01 00 00 00 00 05 FF AA 55 A5 00];
+				qcom,mdss-dsi-post-panel-on-command  = [
+							05 01 00 00 00 00 01 29
+							05 01 00 00 43 00 01 11];
+
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+
+				qcom,mdss-dsi-timing-switch-command = [
+							39 00 00 00 00 00 06 F0 55 AA 52 08 00
+							15 00 00 00 00 00 02 C9 01
+							15 00 00 00 00 00 02 90 00
+							15 00 00 00 00 00 02 58 01
+							15 00 00 00 00 00 02 03 00
+							39 00 00 00 00 00 06 F0 55 AA 52 08 04
+							15 01 00 00 00 00 02 C0 03
+							];
+				qcom,mdss-dsi-timing-switch-command-state =
+					"dsi_lp_mode";
+
+				qcom,mdss-tear-check-sync-init-val = <3840>;
+				qcom,mdss-tear-check-start-pos = <3840>;
+				qcom,mdss-tear-check-rd-ptr-trigger-intr = <3841>;
+
+				qcom,config-select = <&dsi_dual_default_cmd_config0>;
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <540>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <300>;
+				qcom,mdss-dsi-h-pulse-width = <40>;
+				qcom,mdss-dsi-h-front-porch = <400>;
+				qcom,mdss-dsi-v-back-porch = <10>;
+				qcom,mdss-dsi-v-pulse-width = <2>;
+				qcom,mdss-dsi-v-front-porch = <12>;
+				qcom,mdss-dsi-panel-framerate = <120>;
 				qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
 				qcom,mdss-dsi-t-clk-post = <0x07>;
 				qcom,mdss-dsi-t-clk-pre = <0x29>;
@@ -1254,7 +1312,7 @@
 		qcom,dynamic-mode-switch-type = "dynamic-resolution-switch-immediate";
 		qcom,dcs-cmd-by-left;
 		qcom,mdss-dsi-display-timings {
-			1080p {
+			1080p60 {
 				qcom,mdss-dsi-timing-default;
 				qcom,mdss-dsi-panel-width = <540>;
 				qcom,mdss-dsi-panel-height = <1920>;
@@ -1265,6 +1323,29 @@
 				qcom,mdss-dsi-v-pulse-width = <2>;
 				qcom,mdss-dsi-v-front-porch = <12>;
 				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+				qcom,mdss-dsi-t-clk-post = <0x07>;
+				qcom,mdss-dsi-t-clk-pre = <0x29>;
+
+				qcom,mdss-tear-check-sync-init-val = <3840>;
+				qcom,mdss-tear-check-start-pos = <3840>;
+				qcom,mdss-tear-check-rd-ptr-trigger-intr = <3841>;
+
+				qcom,config-select = <&dsi_dual_default_cmd_config0>;
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
+			};
+
+			1080p120 {
+				qcom,mdss-dsi-panel-width = <540>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <300>;
+				qcom,mdss-dsi-h-pulse-width = <40>;
+				qcom,mdss-dsi-h-front-porch = <400>;
+				qcom,mdss-dsi-v-back-porch = <10>;
+				qcom,mdss-dsi-v-pulse-width = <2>;
+				qcom,mdss-dsi-v-front-porch = <12>;
+				qcom,mdss-dsi-panel-framerate = <120>;
 				qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
 				qcom,mdss-dsi-t-clk-post = <0x07>;
 				qcom,mdss-dsi-t-clk-pre = <0x29>;

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -2077,7 +2077,10 @@ static void mdss_dsi_parse_dms_config(struct device_node *np,
 	/* default mode is suspend_resume */
 	pinfo->mipi.dms_mode = DYNAMIC_MODE_SWITCH_SUSPEND_RESUME;
 	data = of_get_property(np, "qcom,dynamic-mode-switch-type", NULL);
-	if (data && !strcmp(data, "dynamic-resolution-switch-immediate")) {
+	if (!data)
+		goto parse_videocmd;
+
+	if (!strcmp(data, "dynamic-resolution-switch-immediate")) {
 		if (!list_empty(&ctrl->panel_data.timings_list))
 			pinfo->mipi.dms_mode =
 				DYNAMIC_MODE_RESOLUTION_SWITCH_IMMEDIATE;
@@ -2087,7 +2090,12 @@ static void mdss_dsi_parse_dms_config(struct device_node *np,
 
 		goto exit;
 	}
+	if (!strcmp(data, "dynamic-resolution-switch-susres")) {
+		pinfo->mipi.dms_mode = DYNAMIC_MODE_SWITCH_SUSPEND_RESUME;
+		goto exit;
+	}
 
+parse_videocmd:
 	if (data && !strcmp(data, "dynamic-switch-immediate"))
 		pinfo->mipi.dms_mode = DYNAMIC_MODE_SWITCH_IMMEDIATE;
 	else

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -2656,6 +2656,9 @@ int mdss_dsi_panel_timing_switch(struct mdss_dsi_ctrl_pdata *ctrl,
 
 	/* Set color correction parameters again for the new mode */
 	somc_panel_colormgr_reset(ctrl);
+	
+	/* Refresh FPS immediately in case of refresh rate change */
+	somc_panel_fpsman_refresh(ctrl, true);
 
 	mdss_dsi_clk_refresh(&ctrl->panel_data, ctrl->update_phy_timing);
 

--- a/drivers/video/fbdev/msm/somc_panel/panel_fps_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_fps_manager.c
@@ -909,6 +909,23 @@ void somc_panel_fpsman_panel_off(void)
 	}
 }
 
+void somc_panel_fpsman_refresh(struct mdss_dsi_ctrl_pdata *ctrl,
+		bool immediate_refresh)
+{
+	struct change_fps *chg_fps = &ctrl->spec_pdata->chg_fps;
+	struct mdss_panel_info *pinfo = &ctrl->panel_data.panel_info;
+
+	if (!chg_fps->enable) {
+		pr_debug("%s: change fps not supported\n", __func__);
+		return;
+	}
+
+	chg_fps->input_fpks = pinfo->mipi.frame_rate * 1000;
+
+	if (immediate_refresh)
+		somc_panel_chg_fps_calc(ctrl, chg_fps->input_fpks);
+}
+
 void somc_panel_fpsman_panel_post_on(struct mdss_dsi_ctrl_pdata *ctrl)
 {
 	struct change_fps *chg_fps = &ctrl->spec_pdata->chg_fps;

--- a/drivers/video/fbdev/msm/somc_panel/somc_panels.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panels.h
@@ -26,7 +26,7 @@
 #define ADC_PNUM			2
 
 #define CHANGE_FPS_MIN 			22
-#define CHANGE_FPS_MAX 			60
+#define CHANGE_FPS_MAX 			120
 
 #define CHANGE_FPS_PORCH		2
 #define CHANGE_FPS_SEND			10

--- a/drivers/video/fbdev/msm/somc_panel/somc_panels.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panels.h
@@ -131,6 +131,8 @@ int  somc_panel_parse_dt_chgfps_config(struct device_node *pan_node,
 void somc_panel_chg_fps_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl_pdata);
 void somc_panel_fpsman_panel_post_on(struct mdss_dsi_ctrl_pdata *ctrl);
 void somc_panel_fpsman_panel_off(void);
+void somc_panel_fpsman_refresh(struct mdss_dsi_ctrl_pdata *ctrl,
+		bool immediate_refresh);
 int  somc_panel_fps_register_attr(struct device *dev);
 int  somc_panel_fps_manager_init(void);
 


### PR DESCRIPTION
This converts the DT panel configuration to the timings way. Moreover, it adds one more timing to the list, configuring the panel for 120Hz/120FPS.

Panel configuration will anyway assume that we are on 60Hz by default and the 120Hz configuration has to be activated from ExtendedSettings.