### PR TITLE
[URGENT] [DORA SMB FIX] Remove wrong typec psy changed notification

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -4641,9 +4641,6 @@ static int smbchg_change_usb_supply_type(struct smbchg_chip *chip,
 
 		power_supply_set_property(chip->usb_psy,
 				POWER_SUPPLY_PROP_SUB_TYPE, &val);
-
-		/* kholk 16/05/2017: TODO: Should we notify usb or typec psy?*/
-		power_supply_changed(chip->typec_psy);
 	}
 #endif
 


### PR DESCRIPTION
We don't need to notify anything else to the typec driver because
we are already setting power supply type and subtype.
Moreover, this call should have been null checked because it would
make non-typec (so, micro) devices to get a really-not-nice KP
because of the NULL psy.