### PR TITLE
[DORA DRS FIX] arm: DT: dsi-panel-somc: lgd: Specify panel clockrate to fix DRS

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p-cmd.dtsi
@@ -359,6 +359,8 @@
 				qcom,mdss-tear-check-sync-init-val = <1920>;
 				qcom,mdss-tear-check-start-pos = <1920>;
 				qcom,mdss-tear-check-rd-ptr-trigger-intr = <1921>;
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
 			};
 
 			1080p120 {
@@ -387,6 +389,8 @@
 				qcom,mdss-tear-check-sync-init-val = <1920>;
 				qcom,mdss-tear-check-start-pos = <1920>;
 				qcom,mdss-tear-check-rd-ptr-trigger-intr = <1921>;
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
 			};
 		};
 	};


### PR DESCRIPTION
Specifying clockrate is mandatory to fix DRS, otherwise bad
rate calculation happens.