### PR TITLE
[5.7.r1] mmc: core: sdio: Interpret non-standard IO_OP_COND for BCM SDIO

### DIFF
--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1089,16 +1089,22 @@ static int mmc_sdio_resume(struct mmc_host *host)
 #ifdef CONFIG_MMC_SOMC_LOW_VOLTAGE
 static u32 mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 {
-	pr_info("%s \n",__func__);
+	int bit;
+
+	pr_debug("%s \n",__func__);
 
 	if ((host->ocr_avail == MMC_VDD_165_195) && mmc_host_uhs(host) &&
 		((ocr & host->ocr_avail) == 0)) {
-		/* lowest voltage can be selected in mmc_power_cycle */
+		/* Interpret non-standard IO_OP_COND */
+		bit = ffs(ocr) - 1;
+		ocr &= 3 << bit;
+		ocr = ocr >> 1;
+
+		/* Power cycle card to select lowest possible voltage */
 		mmc_power_cycle(host, ocr);
-		host->card->ocr = 0;
 	}
 
-	return host->card->ocr;
+	return ocr;
 }
 #endif
 


### PR DESCRIPTION
Broadcom SDIO cards do give a reply that is non-standard, as per
the SDIO 3.0 specification.
These cards will give the OCR with CMD5 which, by spec, can reply
with a minimum voltage range of 2.0-2.1V and with lower bits
being reserved.

Interpret the voltage request by applying some bit shifting to
the right (being minimum bit8) so that we fake adhering to
spec while getting the right voltage range of 1.65-1.95V (1.8V)
and without modifying the whole thing in the MMC APIs to manage
the single case which is anyway also deprecated.