### PR TITLE
[57r1] net: wireless: bcmdhd: Fix spin locking for BCMSDIO case

### DIFF
--- a/drivers/net/wireless/bcmdhd/dhd_linux.c
+++ b/drivers/net/wireless/bcmdhd/dhd_linux.c
@@ -9989,7 +9989,7 @@ dhd_os_tcpackunlock(dhd_pub_t *pub, unsigned long flags)
 
 	if (dhd) {
 #ifdef BCMSDIO
-		spin_lock_bh(&dhd->tcpack_lock);
+		spin_unlock_bh(&dhd->tcpack_lock);
 #else
 		spin_unlock_irqrestore(&dhd->tcpack_lock, flags);
 #endif /* BCMSDIO */


### PR DESCRIPTION
In dhd_os_tcpackunlock there was bad handling of spin locking.
The intended thing was to spin unlock, not to spin lock.