### PR TITLE
[DONOTMERGE 5.7] power: qcom: qpnp-fg-gen3: add missing break in switch statement

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -3453,6 +3453,7 @@ static int fg_psy_set_property(struct power_supply *psy,
 				pval->intval);
 			return -EINVAL;
 		}
+		break;
 	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_VOLTAGE:
 		rc = fg_set_constant_chg_voltage(chip, pval->intval);
 		break;


### PR DESCRIPTION
A break is missing in a switch statement. Add it.

Change-Id: Ib298194957ff2cc1aaba5bd4335afe9d0f9cf6f5
Signed-off-by: Nicholas Troast <ntroast@codeaurora.org>