### PR TITLE
[57r1] net: wireless: bcmdhd: Add MMC_PM_WAKE_SDIO_IRQ quirk for QCOM sdhci

### DIFF
--- a/drivers/net/wireless/bcmdhd/bcmsdh_sdmmc_linux.c
+++ b/drivers/net/wireless/bcmdhd/bcmsdh_sdmmc_linux.c
@@ -247,6 +247,18 @@ static int bcmsdh_sdmmc_suspend(struct device *pdev)
 		dhd_mmc_suspend = FALSE;
 		return err;
 	}
+
+#ifdef CONFIG_ARCH_QCOM
+	/* For QCOM sdhci-msm enable wakeup sdio irq when suspending */
+	err = sdio_set_host_pm_flags(func, MMC_PM_WAKE_SDIO_IRQ);
+	if (err) {
+		sd_err(("%s: error while setting up sdiowakeup interrupt\n",
+				__func__));
+		dhd_mmc_suspend = FALSE;
+		return err;
+	}
+#endif
+
 #if defined(OOB_INTR_ONLY)
 	bcmsdh_oob_intr_set(sdioh->bcmsdh, FALSE);
 #endif 


### PR DESCRIPTION
The qcom sdhci controller (sdhci-msm) needs this flag to enable
the sdiowakeup interrupt on suspend.
This will allow the sdhci to wakeup the SDIO card whenever the
BCM chip wants to do any operation while the system is sleeping
(keepalive etc).