### PR TITLE
[57r1] Update msm_audio_ion for QCOM IOMMU v1

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2830,6 +2830,7 @@
 		compatible = "qcom,msm-audio-ion";
 		qcom,smmu-version = <2>;
 		qcom,smmu-enabled;
+		qcom,smmu-force-sid = <0x0 0x1>; /* u64 */
 		iommus = <&apps_smmu 14>;
 	};
 

--- a/drivers/soc/qcom/qdsp6v2/msm_audio_ion.c
+++ b/drivers/soc/qcom/qdsp6v2/msm_audio_ion.c
@@ -854,6 +854,9 @@ static int msm_audio_ion_probe(struct platform_device *pdev)
 		msm_audio_ion_data.smmu_sid_bits =
 			smmu_sid << MSM_AUDIO_SMMU_SID_OFFSET;
 
+		/* Give a chance to DMA APIs to register an IOMMU master */
+		of_dma_configure(dev, dev->of_node);
+
 		if (msm_audio_ion_data.smmu_version == 0x1) {
 			rc = msm_audio_smmu_init_legacy(dev);
 		} else if (msm_audio_ion_data.smmu_version == 0x2) {


### PR DESCRIPTION
When IOMMU assisted allocations are enabled, we need to get a
handle to an IOMMU master (specified in DT): this is being
actually done by calling arm_iommu_attach_device and that's ok.

The driver is not accounting for clean IOMMU drivers: it does
expect the IOMMU driver to auto-register its masters at probe
time which is not a common practice, infact the only driver
doing this is arm-smmu.
We need to use the msm_audio_ion driver with a new, clean and
Linux API adhering IOMMU driver (msm_iommu-v1) that is adding
the masters through the of_xlate IOMMU API callback: this
requires setting up the DMA-API mappings properly, which will
also configure the IOMMU through the appropriate standard API
calls.