### PR TITLE
[57r1] MSM8916-class tasha snd card clock fix, probe OK

### DIFF
--- a/sound/soc/codecs/audio-ext-clk.c
+++ b/sound/soc/codecs/audio-ext-clk.c
@@ -21,8 +21,26 @@
 #include <linux/platform_device.h>
 #include <linux/gpio.h>
 #include <linux/of_gpio.h>
-#include <dt-bindings/clock/audio-ext-clk.h>
 #include <sound/q6afe-v2.h>
+
+#ifndef CONFIG_ARCH_MSM8916
+#include <dt-bindings/clock/audio-ext-clk.h>
+#else
+ #ifdef clk_audio_ap_clk
+  #undef clk_audio_ap_clk
+ #endif
+
+ #ifdef clk_audio_pmi_clk
+  #undef clk_audio_pmi_clk
+ #endif
+
+#include <dt-bindings/clock/msm-clocks-8976.h>
+
+/* Hacky: those clocks are not present in 8916-class SoC!! */
+#define clk_audio_ap_clk2       0x454d1e91
+#define clk_audio_lpass_mclk    0xf0f2a284
+#define clk_audio_pmi_lnbb_clk   0x57312343
+#endif
 
 struct pinctrl_info {
 	struct pinctrl *pinctrl;


### PR DESCRIPTION
ASoC: codecs: audio-ext-clk: Fixup clocks for MSM8916-class SoC

This driver was made for new SoCs using new clock definitions
that are in line with each other.
The MSM8916-class SoCs though are using different HWIO, hence
we need to use the right clock definitions for this SoC class
also in audio-ext-clk to let it provide the right clocks.