### PR TITLE
[57r1 VIDC] arm: DT: msm8956: Refactor Venus non_secure_cb and add documentation

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2439,15 +2439,25 @@
 
 
 		/* IOMMU Contexts: Non Secure */
-		/* Address pool from 1500MB to 3532MB && 3532MB to 3548MB */
+		/* venus_ns
+		 * Address pool from 1500MB to 3532MB && 3532MB to 3548MB
+		 *
+		 *			 Pool 1
+		 *    Start: 0x5dc00000		Length: 0x7f000000
+		 *    Allowed Types: 0x7ff	SMEM Partition: 0
+		 *
+		 *			 Pool 2
+		 *    Start: 0xdcc00000		Length: 0x1000000
+		 *    Allowed Types: 0x800	SMEM Partition: 1
+		 */
+
 		non_secure_cb {
 			compatible = "qcom,msm-vidc,context-bank";
 			label = "venus_ns";
 			iommus = <&apps_smmu 21>;
 			/* Buffer types relative to the two address pools */
-			buffer-types = <0x7ff>, <0x800>;
-			virtual-addr-pool = <0x5dc00000 0x7f000000
-					     0xdcc00000 0x1000000>;
+			buffer-types = <0xfff>;
+			virtual-addr-pool = <0x5dc00000 0x80000000>;
 		};
 
 		/* IOMMU Contexts: Secure */


### PR DESCRIPTION
The MSM8956 SoC has got a split non secure context bank for the
Venus HW with two SMEM partitions and here on k4.4 this
configuration is not supported anymore.

Modify the configuration to declare one large address pool,
corresponding to the sum of the two (luckily contiguous) SMEM
partitions and allow all buffer types.
While at it, document precisely the two SMEM partitions in case
of future problems.