### PR TITLE
[57r1] Add configuration for the QC FastRPC on MSM8956

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -3139,6 +3139,17 @@
 		qcom,apr-dest-type = "ADSP";
 	};
 
+	qcom,msm_fastrpc {
+		compatible = "qcom,msm-fastrpc-adsp";
+		qcom,fastrpc-smd;
+
+		qcom,msm_fastrpc_compute_cb1 {
+			compatible = "qcom,msm-fastrpc-compute-cb";
+			label = "adsprpc-smd";
+			iommus = <&apps_smmu 16>;
+		};
+	};
+
 	qcom,avtimer@c0a300c {
 		compatible = "qcom,avtimer";
 		reg = <0x0c0a300c 0x4>,


### PR DESCRIPTION
arm: DT: MSM8956: Add FastRPC configuration and context banks

On k3.10 we got it automatically with an hardcoded context bank
name being searched in the hacked iommu domains driver.........

On k4.4 the FastRPC is finally a platform device: add it to DT
along with the compute context bank IOMMU association.