### PR TITLE
mmc: core: sdio: Add bcmdhd specific quirk for OCR on LV selection

### DIFF
--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1090,6 +1090,7 @@ static int mmc_sdio_resume(struct mmc_host *host)
 static u32 mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 {
 	int bit;
+	u32 ocr_orig = ocr;
 
 	pr_debug("%s \n",__func__);
 
@@ -1100,11 +1101,18 @@ static u32 mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 		ocr &= 3 << bit;
 		ocr = ocr >> 1;
 
+ #ifdef CONFIG_BCMDHD
+		/* If standard OCR, send it as it is. BCMDHD only. */
+		pr_debug("%s: ocr = 0x%x", __func__, ocr);
+		if (ocr_orig > 0x30ffff00)
+			ocr = ocr_orig;
+ #endif
+
 		/* Power cycle card to select lowest possible voltage */
 		mmc_power_cycle(host, ocr);
 	}
 
-	return ocr;
+	return ocr_orig;
 }
 #endif
 


### PR DESCRIPTION
Fixes SDIO reinitialization after firmware loading in certain cases and with certain firmwares.