### PR TITLE
[57r1] arm: DT: MSM8956-camera: Add reset controller support to CPP node

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-camera.dtsi
@@ -387,6 +387,10 @@
 		clock-names = "camss_top_ahb_clk", "cpp_core_clk",
 			"camss_vfe_cpp_ahb_clk", "camss_vfe_cpp_axi_clk",
 			"camss_vfe_cpp_clk","micro_iface_clk", "camss_ahb_clk";
+
+		resets = <&clock_mmss RST_CAMSS_MICRO_BCR>;
+		reset-names = "micro_iface_reset";
+
 		qcom,clock-rates = <0 240000000 0 0 240000000 0 0>;
 		qcom,min-clock-rate = <160000000>;
 		qcom,bus-master = <1>;


### PR DESCRIPTION
The CPP node requires reset controller support and I already
added the required code to the GCC clock source.
Specify the reset in CPP node.