### PR TITLE
input: clearpad_incell: Update multi-touch protocol

### DIFF
--- a/drivers/input/touchscreen/clearpad_core.c
+++ b/drivers/input/touchscreen/clearpad_core.c
@@ -2779,6 +2779,8 @@ static void clearpad_funcarea_initialize(struct clearpad_t *this)
 				pointer_area.y1 -= pointer_data->offset_y;
 				pointer_area.y2 -= pointer_data->offset_y;
 			}
+			input_mt_init_slots(this->input,
+						this->extents.n_fingers, 0);
 			input_set_abs_params(this->input, ABS_MT_TRACKING_ID,
 					0, this->extents.n_fingers, 0, 0);
 			input_set_abs_params(this->input, ABS_MT_POSITION_X,
@@ -2918,8 +2920,8 @@ static void clearpad_funcarea_down(struct clearpad_t *this,
 			break;
 		touch_major = max(cur->wx, cur->wy) + 1;
 		touch_minor = min(cur->wx, cur->wy) + 1;
-		input_report_abs(idev, ABS_MT_TRACKING_ID, cur->id);
-		input_report_abs(idev, ABS_MT_TOOL_TYPE, cur->tool);
+		input_mt_slot(idev, cur->id);
+		input_mt_report_slot_state(idev, cur->tool, true);
 		input_report_abs(idev, ABS_MT_POSITION_X, cur->x);
 		input_report_abs(idev, ABS_MT_POSITION_Y, cur->y);
 		if (this->touch_pressure_enabled)
@@ -2931,7 +2933,6 @@ static void clearpad_funcarea_down(struct clearpad_t *this,
 		if (this->touch_orientation_enabled)
 			input_report_abs(idev, ABS_MT_ORIENTATION,
 				 (cur->wx > cur->wy));
-		input_mt_sync(idev);
 		break;
 	case SYN_FUNCAREA_BUTTON:
 		LOG_EVENT(this, "button\n");
@@ -2961,7 +2962,8 @@ static void clearpad_funcarea_up(struct clearpad_t *this,
 		LOG_EVENT(this, "%s up\n", valid ? "pt" : "unused pt");
 		if (!valid)
 			break;
-		input_mt_sync(idev);
+		input_mt_slot(idev, pointer->cur.id);
+		input_mt_report_slot_state(idev, pointer->cur.tool, false);
 		break;
 	case SYN_FUNCAREA_BUTTON:
 		LOG_EVENT(this, "button up\n");

--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -17,6 +17,7 @@
 
 #include <linux/platform_device.h>
 #include <linux/input.h>
+#include <linux/input/mt.h>
 #include <linux/module.h>
 #include <linux/interrupt.h>
 #include <linux/delay.h>
@@ -3885,6 +3886,8 @@ static void clearpad_funcarea_initialize(struct clearpad_t *this)
 				pointer_area.y1 -= pointer_data->offset_y;
 				pointer_area.y2 -= pointer_data->offset_y;
 			}
+			input_mt_init_slots(this->input,
+						this->extents.n_fingers, 0);
 			input_set_abs_params(this->input, ABS_MT_TRACKING_ID,
 					0, this->extents.n_fingers, 0, 0);
 			input_set_abs_params(this->input, ABS_MT_POSITION_X,
@@ -4023,8 +4026,8 @@ static void clearpad_funcarea_down(struct clearpad_t *this,
 			break;
 		touch_major = max(cur->wx, cur->wy) + 1;
 		touch_minor = min(cur->wx, cur->wy) + 1;
-		input_report_abs(idev, ABS_MT_TRACKING_ID, cur->id);
-		input_report_abs(idev, ABS_MT_TOOL_TYPE, cur->tool);
+		input_mt_slot(idev, cur->id);
+		input_mt_report_slot_state(idev, cur->tool, true);
 		input_report_abs(idev, ABS_MT_POSITION_X, cur->x);
 		input_report_abs(idev, ABS_MT_POSITION_Y, cur->y);
 		if (this->touch_pressure_enabled)
@@ -4036,7 +4039,6 @@ static void clearpad_funcarea_down(struct clearpad_t *this,
 		if (this->touch_orientation_enabled)
 			input_report_abs(idev, ABS_MT_ORIENTATION,
 				 (cur->wx > cur->wy));
-		input_mt_sync(idev);
 		break;
 	case SYN_FUNCAREA_BUTTON:
 		LOG_EVENT(this, "button\n");
@@ -4066,7 +4068,8 @@ static void clearpad_funcarea_up(struct clearpad_t *this,
 		LOG_EVENT(this, "%s up\n", valid ? "pt" : "unused pt");
 		if (!valid)
 			break;
-		input_mt_sync(idev);
+		input_mt_slot(idev, pointer->cur.id);
+		input_mt_report_slot_state(idev, pointer->cur.tool, false);
 		break;
 	case SYN_FUNCAREA_BUTTON:
 		LOG_EVENT(this, "button up\n");


### PR DESCRIPTION
Use protocol type B.
Report multi-touch events with input_mt_slot().

This is needed in order to fix touch issues in some utilities that
depends on an implementation of "Protocol Example B" from kernel's
Documentation/input/multi-touch-protocol.txt (i.e. MultiROM).

Change-Id: Ib406829f1306d87a0b19e119e5a91d5448a4c02b

input: clearpad_incell: Adapt to the input_mt usage

Adapt for the flags of input_mt_init_slots
Change-Id: Ife23ff4dad2a422f4807d3c41ab5dfcd37e9f01b
Signed-off-by: Adrian DC radian.dc@gmail.com