### PR TITLE
power: qpnp-smbcharger: release HVDCP wakelock upon usb removal

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -4924,6 +4924,7 @@ static void handle_usb_removal(struct smbchg_chip *chip)
 #ifdef CONFIG_QPNP_SMBCHARGER_EXTENSION
 	chip->somc_params.chg_det.settled_not_hvdcp = false;
 	chip->somc_params.chg_det.sub_type = POWER_SUPPLY_SUB_TYPE_UNKNOWN;
+	smbchg_relax(chip, PM_DETECT_HVDCP);
 	cancel_delayed_work_sync(&chip->hvdcp_det_work); // CHECKME
 #endif
 	smbchg_change_usb_supply_type(chip, POWER_SUPPLY_TYPE_UNKNOWN);


### PR DESCRIPTION
When usb is disconnected, HVDCP detection work is canceled, but the wakelock is not released.
Release it to let the device sleep again.