### PR TITLE
[LA.UM.5.7] drivers: tty: serial: Fix bluetooth serial communication

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -67,10 +67,6 @@
 #include <linux/platform_data/msm_serial_hs.h>
 #include <linux/msm-bus.h>
 
-#ifdef CONFIG_BT_MSM_SLEEP
-#include <net/bluetooth/bluesleep.h>
-#endif
-
 #include "msm_serial_hs_hwreg.h"
 #define UART_SPS_CONS_PERIPHERAL 0
 #define UART_SPS_PROD_PERIPHERAL 1
@@ -312,16 +308,10 @@ static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 	switch (cmd) {
 	case MSM_ENABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_on(&msm_uport->uport);
-#ifdef CONFIG_BT_MSM_SLEEP
-		bluesleep_outgoing_data();
-#endif
 		break;
 	}
 	case MSM_DISABLE_UART_CLOCK: {
 		ret = msm_hs_request_clock_off(&msm_uport->uport);
-#ifdef CONFIG_BT_MSM_SLEEP
-		bluesleep_tx_allow_sleep();
-#endif
 		break;
 	}
 	case MSM_GET_UART_CLOCK_STATUS: {
@@ -1453,11 +1443,6 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	/* Queue transfer request to SPS */
 	ret = sps_transfer_one(sps_pipe_handle, src_addr, tx_count,
 				msm_uport, flags);
-
-	/* Notify the bluesleep driver of outgoing data, if available. */
-#if defined(CONFIG_BT_MSM_SLEEP) && !defined(CONFIG_LINE_DISCIPLINE_DRIVER)
-	bluesleep_outgoing_data();
-#endif
 
 	MSM_HS_DBG("%s:Enqueue Tx Cmd, ret %d\n", __func__, ret);
 }


### PR DESCRIPTION
It is not required anymore.

This patch fixes serial communication for Broadcom BT targets.

Change-Id: I4707b5d514a500a005b212487ca2a163b5153bb6
Signed-off-by: Humberto Borba <humberos@gmail.com>