### PR TITLE
[LA.UM.5.7] drivers: tty: serial: Reset the client counter

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2746,7 +2746,7 @@ static int msm_hs_startup(struct uart_port *uport)
 
 
 	spin_lock_irqsave(&uport->lock, flags);
-#ifndef CONFIG_LINE_DISCIPLINE_DRIVER
+#ifndef CONFIG_BT_MSM_SLEEP
 	atomic_set(&msm_uport->client_count, 0);
 	atomic_set(&msm_uport->client_req_state, 0);
 #endif


### PR DESCRIPTION
Reset the client counter to 0 only if CONFIG_BT_MSM_SLEEP
is not used since it is invoked twice when starting the bluesleep driver,
resulting in a mismatching counter.

This patch will fix the deep sleep state.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I27200ed6b5b0826c9bb93abab16b6f0df63e4b8a