### PR TITLE
[LA.UM.5.7.r1] Build BCMDHD only for Loire and Tone devices

### DIFF
--- a/drivers/net/wireless/Makefile
+++ b/drivers/net/wireless/Makefile
@@ -55,6 +55,7 @@ obj-$(CONFIG_WL_TI)	+= ti/
 
 obj-$(CONFIG_MWIFIEX)	+= mwifiex/
 
+obj-$(CONFIG_BCMDHD)	+= bcmdhd/
 obj-$(CONFIG_BRCMFMAC)	+= brcm80211/
 obj-$(CONFIG_BRCMSMAC)	+= brcm80211/
 
@@ -68,4 +69,3 @@ obj-$(CONFIG_WCNSS_MEM_PRE_ALLOC) += cnss_prealloc/
 obj-$(CONFIG_CNSS_CRYPTO)	+= cnss_crypto/
 
 obj-y                           += controlfnc/
-obj-y				+= bcmdhd/


### PR DESCRIPTION
We don't use Broadcom hardware on our Maple and Tulip devices
so we don't need to build it for these devices. Just Loire and Tone
platform devices use it and they are already have CONFIG_BCMDHD=y
in their defconfigs.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>