### PR TITLE
[57r1 LOIRE] media: msm: camera_v2: isp47: Preset num_norm_clk to VFE clk count

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
@@ -2526,6 +2526,8 @@ int msm_vfe47_get_clks(struct vfe_device *vfe_dev)
 	if (rc)
 		return rc;
 
+	vfe_dev->num_norm_clk = vfe_dev->num_clk;
+
 	for (i = 0; i < vfe_dev->num_clk; i++) {
 		if (strcmp(vfe_dev->vfe_clk_info[i].clk_name,
 				"camss_vfe_stream_clk") == 0) {


### PR DESCRIPTION
The num_norm_clk variable is getting fed to the camera SOC-API
when cycling to (de)initialize ISP clocks.
In case we have a HVX clock (vfe stream clock) it is getting set
to a specific value but, otherwise, it was left to the previously
initialized one (which is zero!), hence clocks will not get up.

This fixes clock init for all the SoCs that don't have any HVX
clock, such as the ones using the older VFE40.