### PR TITLE
sound: msm8952-slimbus: use correct enum for MSM_Ear_Enable_States

### DIFF
--- a/sound/soc/msm/msm8952-slimbus.c
+++ b/sound/soc/msm/msm8952-slimbus.c
@@ -1286,7 +1286,7 @@ static const struct snd_kcontrol_new msm_snd_controls[] = {
 		     msm_auxpcm_rate_get, msm_auxpcm_rate_put),
 	SOC_ENUM_EXT("PROXY_RX Channels", msm_snd_enum[9],
 			msm_proxy_rx_ch_get, msm_proxy_rx_ch_put),
-	SOC_ENUM_EXT("MSM_Ear_Enable_States", msm_snd_enum[10],
+	SOC_ENUM_EXT("MSM_Ear_Enable_States", msm_snd_enum[13],
 			msm_ear_enable_get, msm_ear_enable_put),
 #ifdef CONFIG_ARCH_SONY_LOIRE
 	SOC_ENUM_EXT("AUX PCM SampleRate", msm8952_auxpcm_enum[0],


### PR DESCRIPTION
when porting the change from 3.10, the new values in msm_snd_devices were not considered.
Therefore, the control was still using the enum from index 10, which now corresponds to slim6_rx_sample_rate_text.
Set the correct index number to allow the control to use the correct values.