### PR TITLE
[LA.UM.5.7] headers: Do not export eventpoll.h on android build system

### DIFF
--- a/include/uapi/linux/Kbuild
+++ b/include/uapi/linux/Kbuild
@@ -121,7 +121,9 @@ header-y += errno.h
 header-y += errqueue.h
 header-y += esoc_ctrl.h
 header-y += ethtool.h
+ifeq ($(ANDROID_BUILD_TOP),)
 header-y += eventpoll.h
+endif
 header-y += fadvise.h
 header-y += falloc.h
 header-y += fanotify.h


### PR DESCRIPTION
ANDROID_BUILD_TOP is a global variable for android build system

https://android.googlesource.com/platform/build/+/master/envsetup.sh#297

It can be used to avoid conflicts with userspace headers.

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: Ib596fce6abfd0f23f21878c65ddd0ecf187d97f0