### PR TITLE
[57r1] ASoC: msm: msm8952-slimbus: Get codec through snd_soc API for EAR

### DIFF
--- a/sound/soc/msm/msm8952-slimbus.c
+++ b/sound/soc/msm/msm8952-slimbus.c
@@ -1137,7 +1137,7 @@ static int msm_ear_enable_put(struct snd_kcontrol *kcontrol,
 	struct snd_ctl_elem_value *ucontrol)
 {
 	int ret;
-	struct snd_soc_codec *codec = snd_kcontrol_chip(kcontrol);
+	struct snd_soc_codec *codec = snd_soc_kcontrol_codec(kcontrol);
 	struct snd_soc_card *card = codec->component.card;
 	struct msm8952_asoc_mach_data *pdata = snd_soc_card_get_drvdata(card);
 


### PR DESCRIPTION
The msm_ear_enable_put was getting snd_soc_codec structure
incorrectly.
Use the ASoC sound API correctly.