### PR TITLE
[57r1] power: reset: Fix reboot to FOTAKernel recovery on some Sony devices

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -307,7 +307,11 @@ static void msm_restart_prepare(const char *cmd)
 		} else if (!strncmp(cmd, "recovery", 8)) {
 			qpnp_pon_set_restart_reason(
 				PON_RESTART_REASON_RECOVERY);
+#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
+			__raw_writel(0x6f656d46, restart_reason); //oem-46
+#else
 			__raw_writel(0x77665502, restart_reason);
+#endif
 		} else if (!strcmp(cmd, "rtc")) {
 			qpnp_pon_set_restart_reason(
 				PON_RESTART_REASON_RTC);


### PR DESCRIPTION
Sony uses non-standard way to enter recovery on devices with S1 bootloader (all?)
Make kernel do the same thing for "reboot recovery" as it does for "reboot oem-46". At least for loire and tone.