### PR TITLE
[LA.UM.5.7.r1] Avoid loire logspam by skipping unsupported regulator op

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-mdss-pll.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-mdss-pll.dtsi
@@ -37,6 +37,7 @@
 				qcom,supply-max-voltage = <0>;
 				qcom,supply-enable-load = <0>;
 				qcom,supply-disable-load = <0>;
+				qcom,supply-drms-unsupported;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/qcom/msm8956-mdss.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-mdss.dtsi
@@ -249,6 +249,7 @@
 				qcom,supply-max-voltage = <0>;
 				qcom,supply-enable-load = <0>;
 				qcom,supply-disable-load = <0>;
+				qcom,supply-drms-unsupported;
 			};
 		};
 

--- a/drivers/clk/msm/mdss/mdss-pll-util.c
+++ b/drivers/clk/msm/mdss/mdss-pll-util.c
@@ -260,6 +260,9 @@ static int mdss_pll_util_parse_dt_supply(struct platform_device *pdev,
 
 		mp->vreg_config[i].post_off_sleep = (!rc ? tmp : 0);
 
+		mp->vreg_config[i].drms_unsupported = of_property_read_bool(supply_node,
+					"qcom,supply-drms-unsupported");
+
 		pr_debug("%s min=%d, max=%d, enable=%d, disable=%d, preonsleep=%d, postonsleep=%d, preoffsleep=%d, postoffsleep=%d\n",
 					mp->vreg_config[i].vreg_name,
 					mp->vreg_config[i].min_voltage,

--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -589,6 +589,9 @@ static int mdss_dsi_get_dt_vreg_data(struct device *dev,
 			mp->vreg_config[i].post_off_sleep = tmp;
 		}
 
+		mp->vreg_config[i].drms_unsupported = of_property_read_bool(supply_node,
+			"qcom,supply-drms-unsupported");
+
 		pr_debug("%s: %s min=%d, max=%d, enable=%d, disable=%d, preonsleep=%d, postonsleep=%d, preoffsleep=%d, postoffsleep=%d\n",
 			__func__,
 			mp->vreg_config[i].vreg_name,

--- a/drivers/video/fbdev/msm/mdss_io_util.c
+++ b/drivers/video/fbdev/msm/mdss_io_util.c
@@ -229,8 +229,9 @@ int msm_dss_enable_vreg(struct dss_vreg *in_vreg, int num_vreg, int enable)
 			if (in_vreg[i].pre_on_sleep && need_sleep)
 				usleep_range(in_vreg[i].pre_on_sleep * 1000,
 					in_vreg[i].pre_on_sleep * 1000);
-			rc = regulator_set_load(in_vreg[i].vreg,
-				in_vreg[i].enable_load);
+			if (!in_vreg[i].drms_unsupported)
+				rc = regulator_set_load(in_vreg[i].vreg,
+					in_vreg[i].enable_load);
 			if (rc < 0) {
 				DEV_ERR("%pS->%s: %s set opt m fail\n",
 					__builtin_return_address(0), __func__,
@@ -253,8 +254,9 @@ int msm_dss_enable_vreg(struct dss_vreg *in_vreg, int num_vreg, int enable)
 			if (in_vreg[i].pre_off_sleep)
 				usleep_range(in_vreg[i].pre_off_sleep * 1000,
 					in_vreg[i].pre_off_sleep * 1000);
-			regulator_set_load(in_vreg[i].vreg,
-				in_vreg[i].disable_load);
+			if (!in_vreg[i].drms_unsupported)
+				rc = regulator_set_load(in_vreg[i].vreg,
+					in_vreg[i].enable_load);
 			regulator_disable(in_vreg[i].vreg);
 			if (in_vreg[i].post_off_sleep)
 				usleep_range(in_vreg[i].post_off_sleep * 1000,

--- a/include/linux/mdss_io_util.h
+++ b/include/linux/mdss_io_util.h
@@ -58,6 +58,7 @@ struct dss_vreg {
 	int post_on_sleep;
 	int pre_off_sleep;
 	int post_off_sleep;
+	bool drms_unsupported;
 };
 
 struct dss_gpio {


### PR DESCRIPTION
on loire devices, gdsc does not support drms, but calls to regulator_set_load are still made.
This is especially problematic in mdss_io_util, where calls are frequent and cause logspam.
Fix it by avoiding the unsupported call if a property in dt is declared.