### PR TITLE
ASoC: wsa881x: Fix wsa881x speaker damage

### DIFF
--- a/sound/soc/codecs/wsa881x.c
+++ b/sound/soc/codecs/wsa881x.c
@@ -968,6 +968,8 @@ static void wsa881x_init(struct snd_soc_codec *codec)
 
 	wsa881x->version = snd_soc_read(codec, WSA881X_CHIP_ID1);
 	wsa881x_regmap_defaults(wsa881x->regmap, wsa881x->version);
+	/* Enable software reset output from soundwire slave */
+	snd_soc_update_bits(codec, WSA881X_SWR_RESET_EN, 0x07, 0x07);
 	/* Bring out of analog reset */
 	snd_soc_update_bits(codec, WSA881X_CDC_RST_CTL, 0x02, 0x02);
 	/* Bring out of digital reset */


### PR DESCRIPTION
wsa881x speaker damage has been reported due to DC at
wsa output. Add a register setting which will reset
the soundwire when there are any
DC or synchronization issues.

CRs-Fixed: 2086505
Change-Id: I929d2eb7d096005e5089f3bfabded6901d81439e
Signed-off-by: Vatsal Bucha <vbucha@codeaurora.org>