### PR TITLE
epoll: Drop struct epoll_event definition

### DIFF
--- a/include/uapi/linux/eventpoll.h
+++ b/include/uapi/linux/eventpoll.h
@@ -56,6 +56,7 @@
 #define EPOLL_PACKED
 #endif
 
+#ifdef __KERNEL__
 struct epoll_event {
 	__u32 events;
 	__u64 data;
@@ -73,4 +74,5 @@ static inline void ep_take_care_of_epollwakeup(struct epoll_event *epev)
 	epev->events &= ~EPOLLWAKEUP;
 }
 #endif
+#endif /* __KERNEL__ */
 #endif /* _UAPI_LINUX_EVENTPOLL_H */


### PR DESCRIPTION
Add kernel header sanitizer check to drop struct epoll_event.
This struct epoll_event is not following the POSIX standard
and defining element in opaque data type.

Change-Id: I1eecef1b64eb1fb8f0dd6999263093a453e7b9fb
Signed-off-by: Prasad Sodagudi <psodagud@codeaurora.org>