### PR TITLE
[57r1] fbdev: msm: somc_panel: Add PCC custom profiling

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
+++ b/drivers/video/fbdev/msm/somc_panel/somc_panel_exts.h
@@ -42,6 +42,14 @@ enum {
 	PANEL_DRIVER_IC_NONE,
 };
 
+enum {
+	PANEL_CALIB_6000K,
+	PANEL_CALIB_F6,
+	PANEL_CALIB_D50,
+	PANEL_CALIB_D65,
+	PANEL_CALIB_END,
+};
+
 struct mdss_pcc_color_tbl {
 	u32 color_type;
 	u32 area_num;
@@ -161,6 +169,7 @@ struct somc_panel_color_mgr {
 	int (*picadj_setup)(struct mdss_panel_data *pdata);
 	int (*unblank_hndl)(struct mdss_dsi_ctrl_pdata *ctrl);
 
+	unsigned short pcc_profile;
 	bool mdss_force_pcc;
 
 	struct dsi_panel_cmds pre_uv_read_cmds;


### PR DESCRIPTION
This implements user selectable custom PCC profiles by completely
reusing	the current PCC	code and introduces the	concept of user
selectable display whitepoint calibration.
To switch between profiles, a new "pcc_profile" rw sysfs entry
was added.

The user, or the userspace application, will be able to read the
current profile by querying and to switch between profiles by
writing to the sysfs.
The current concept will apply the new calibration whenever at
least one frame will be sent to the display.

Note: this is limited to 4 color profiles, but can be extended.