### PR TITLE
[57r1] clk: msm: cpu-8976: Specify CCI safe frequency correctly

### DIFF
--- a/drivers/clk/msm/clock-cpu-8976.c
+++ b/drivers/clk/msm/clock-cpu-8976.c
@@ -301,7 +301,7 @@ static struct mux_div_clk a53ssmux = {
 
 static struct mux_div_clk ccissmux = {
 	.ops = &rcg_mux_div_ops,
-	.safe_freq = 200000000,
+	SRC_SAFE_FREQ(200000000, 200000000),
 	.data = {
 		.max_div = 32,
 		.min_div = 2,


### PR DESCRIPTION
The API changed unexpectedly. Now we must use a macro....