### PR TITLE
[57r1] arm: DT: msm8956: Add proxy consumer to gdsc_mdss

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -3253,6 +3253,8 @@
 	clock-names = "core_clk", "bus_clk";
 	clocks = <&clock_gcc clk_gcc_mdss_mdp_clk>,
 		 <&clock_gcc clk_gcc_mdss_axi_clk>;
+	proxy-supply = <&gdsc_mdss>;
+	qcom,proxy-consumer-enable;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add proxy consumer of itself to gdsc_mdss to keep it in line with
MSM8996 and MSM8998 configuration.