### PR TITLE
Recheck if CPU is balanced if cpufreq stays constant

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -563,8 +563,8 @@ static void rqbalance_work_func(struct work_struct *work)
 		else if(num_online_cpus() == nr_cpu_ids)
 			stop_load_timer();
 
-			queue_delayed_work(rqbalance_wq,
-						 &rqbalance_work, up_delay);
+		queue_delayed_work(
+			rqbalance_wq, &rqbalance_work, up_delay);
 		break;
 	case UP:
 		balance = balanced_speed_balance();

--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -555,8 +555,11 @@ static void rqbalance_work_func(struct work_struct *work)
 		break;
 	case DOWN:
 		cpu = get_slowest_cpu_n();
-		if (cpu < nr_cpu_ids)
+		if (cpu < nr_cpu_ids) {
 			up = false;
+			// Next time recheck if CPU is balanced
+			rqbalance_state = UP;
+		}
 		else
 			stop_load_timer();
 

--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -560,7 +560,7 @@ static void rqbalance_work_func(struct work_struct *work)
 			// Next time recheck if CPU is balanced
 			rqbalance_state = UP;
 		}
-		else
+		else if(num_online_cpus() == nr_cpu_ids)
 			stop_load_timer();
 
 			queue_delayed_work(rqbalance_wq,


### PR DESCRIPTION
This fixes an edge case where no re-evaluation of CPU balance
is performed. This could happen with the following situation:

3 cores online, core_0 and core_1 at around 100 load and max cpufreq.
 * core_3 clocks down below idle_bottom_freq
 * rqbalance_work_func will result in shutdown of core_3
 * repeat: rqbalance_work_func stays in rqbalance_state == DOWN
         => No re-evaluation of CPU load balance until load
            is reduced and therefore cpufreq changes