### PR TITLE
drivers: clk: msm: make sure old_safe_freq is initialized

### DIFF
--- a/drivers/clk/msm/clock-generic.c
+++ b/drivers/clk/msm/clock-generic.c
@@ -786,7 +786,7 @@ static int mux_div_clk_set_rate(struct clk *c, unsigned long rate)
 	struct mux_div_clk *md = to_mux_div_clk(c);
 	unsigned long flags, rrate;
 	unsigned long new_prate, new_parent_orig_rate;
-	unsigned long old_safe_freq, max_safe_freq = 0;
+	unsigned long old_safe_freq = 0, max_safe_freq = 0;
 	struct clk *old_parent, *new_parent;
 	u32 new_div, old_div;
 	int rc, i;


### PR DESCRIPTION
having old_safe_freq uninitialised leads to having random values.
The now random value is set as a safe_freq near the end of mux_div_clk_set_rate().
This newly set safe_freq is then used for comparisons against new rates that are to be set, and that
obviously fails, because the safe_freq value was random in the first place!
Intialise old_safe_freq to 0 to avoid such cases.
This was the major issue causing sony tone devices (msm8996) to have severely degraded 3d
performance!