### PR TITLE
power: reset: exclude keyaki device from special recovery handling

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -307,7 +307,7 @@ static void msm_restart_prepare(const char *cmd)
 		} else if (!strncmp(cmd, "recovery", 8)) {
 			qpnp_pon_set_restart_reason(
 				PON_RESTART_REASON_RECOVERY);
-#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
+#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_MACH_SONY_DORA) || defined(CONFIG_MACH_SONY_KAGURA) 
 			__raw_writel(0x6f656d46, restart_reason); //oem-46
 #else
 			__raw_writel(0x77665502, restart_reason);


### PR DESCRIPTION
keyaki misbehaves when trying to enter recovery using oem-46.
The device enters a weird mode, that can only be exited by using fastboot or flash mode.
Even trying to force shutdown the device does not work.
This has been tested and confirmed occuring on older and the latest bootloader.
Therefore, disable reboot to recovery on keyaki using the oem code.

Change-Id: I0f8e8bd013dbc96538590c0dd8e3fd19db3d8428