### PR TITLE
[57r1] arm: DT: msm8956: Advertise slave side cp on vidc

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2298,6 +2298,7 @@
 		qcom,allowed-clock-rates = <466000000 400000000 360000000
 					    228570000 133330000 100000000
 					    80000000 72727200>;
+		qcom,slave-side-cp;
 		qcom,sw-power-collapse;
 		qcom,reset-clock-control;
 		qcom,regulator-scaling;


### PR DESCRIPTION
MSM8956's content protection mode is slave side.