### PR TITLE
[57r1] power: reset: msm-poweroff: Force hard reset for SoMC XBOOT

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -288,6 +288,7 @@ static void msm_restart_prepare(const char *cmd)
 				(cmd != NULL && cmd[0] != '\0'));
 	}
 
+#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
 	/* Force warm reset and allow device to
 	 * preserve memory on restart 
 	 * only for bootloader and recovery commands */
@@ -295,9 +296,18 @@ static void msm_restart_prepare(const char *cmd)
 		if ((!strncmp(cmd, "bootloader", 10)) ||
 				(!strncmp(cmd, "recovery", 8)))
 			need_warm_reset = true;
+		else
+			need_warm_reset = false;
 	}
+#else
+	/* Force hard reset for SoMC XBOOT */
+	need_warm_reset = false;
+#endif
 
-	qpnp_pon_system_pwr_off(PON_POWER_OFF_WARM_RESET);
+	if (need_warm_reset)
+		qpnp_pon_system_pwr_off(PON_POWER_OFF_WARM_RESET);
+	else
+		qpnp_pon_system_pwr_off(PON_POWER_OFF_HARD_RESET);
 
 	if (cmd != NULL) {
 		if (!strncmp(cmd, "bootloader", 10)) {


### PR DESCRIPTION
At least Yoshino platform uses XBOOT: this bootloader will
reboot to system even if we write the recovery restart
reason to the PMIC, unless we do hard reset.

Compatibility with the previous S1BOOT is retained through
setting the need_warm_reset variable in ifdef block.