### PR TITLE
[LA.UM.5.7.r1] drivers: bcmdhd: Update nl80211 API at 4.4

### DIFF
--- a/drivers/net/wireless/bcmdhd/wl_cfg80211.c
+++ b/drivers/net/wireless/bcmdhd/wl_cfg80211.c
@@ -9239,6 +9239,9 @@ static s32 wl_setup_wiphy(struct wireless_dev *wdev, struct device *sdiofunc_dev
 		brcm_wowlan_config->patterns = NULL;
 		brcm_wowlan_config->n_patterns = 0;
 		brcm_wowlan_config->tcp = NULL;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+		brcm_wowlan_config->nd_config = NULL;
+#endif
 	} else {
 		WL_ERR(("Can not allocate memory for brcm_wowlan_config,"
 					" So wiphy->wowlan_config is set to NULL\n"));


### PR DESCRIPTION
Net Detect (nd_config) was implemented at 3.19 kernel version then
the bcmdhd driver should be updated to the same API level.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I0ab97838624fabeb93ff892df7a3011fa20a343b