### PR TITLE
[57r1] [PR 1/2] msm-poweroff cleanup to restore pstore functionality

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -198,6 +198,9 @@ static int dload_set(const char *val, struct kernel_param *kp)
 #else
 static void set_dload_mode(int on)
 {
+	if (tcsr_boot_misc_detect)
+		scm_io_write(tcsr_boot_misc_detect, 0);
+
 	return;
 }
 
@@ -275,6 +278,8 @@ static void msm_restart_prepare(const char *cmd)
 
 	set_dload_mode(download_mode &&
 			(in_panic || restart_mode == RESTART_DLOAD));
+#else
+	set_dload_mode(0);
 #endif
 
 	if (qpnp_pon_check_hard_reset_stored()) {

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -653,6 +653,10 @@ skip_sysfs_create:
 	if (!download_mode)
 		scm_disable_sdi();
 #endif
+
+	__raw_writel(0xC0DEDEAD, restart_reason);
+	qpnp_pon_set_restart_reason(PON_RESTART_REASON_KERNEL_PANIC);
+
 	return 0;
 
 err_restart_reason:

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -431,6 +431,7 @@ static void do_msm_poweroff(void)
 	set_dload_mode(0);
 	scm_disable_sdi();
 	qpnp_pon_system_pwr_off(PON_POWER_OFF_SHUTDOWN);
+	qpnp_pon_set_restart_reason(PON_RESTART_REASON_NONE);
 
 	halt_spmi_pmic_arbiter();
 	deassert_ps_hold();


### PR DESCRIPTION
This is the first of a two-parts PR, because the second part is not ready yet.

This first part starts a necessary cleanup of the PMIC reboot reasons, so that the pstore functionality is restored and the reboot is finally completely clean.


The second part will fix the reboot reasons for all platforms to be able to normally reboot to recovery by correctly informing the bootloader about which boot partition to choose in the warm reboot.