### PR TITLE
[57r1] msm-poweroff: Fix for kernel panic and reboot reasons

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -198,6 +198,9 @@ static int dload_set(const char *val, struct kernel_param *kp)
 #else
 static void set_dload_mode(int on)
 {
+	if (tcsr_boot_misc_detect)
+		scm_io_write(tcsr_boot_misc_detect, 0);
+
 	return;
 }
 
@@ -275,6 +278,8 @@ static void msm_restart_prepare(const char *cmd)
 
 	set_dload_mode(download_mode &&
 			(in_panic || restart_mode == RESTART_DLOAD));
+#else
+	set_dload_mode(0);
 #endif
 
 	if (qpnp_pon_check_hard_reset_stored()) {

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -47,6 +47,13 @@
 #define SCM_EDLOAD_MODE			0X01
 #define SCM_DLOAD_CMD			0x10
 
+#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
+ #define TARGET_SOMC_S1BOOT
+#endif
+#if defined(CONFIG_ARCH_SONY_YOSHINO)
+ #define TARGET_SOMC_XBOOT
+#endif
+
 
 static int restart_mode;
 static void *restart_reason;
@@ -62,6 +69,19 @@ static void scm_disable_sdi(void);
  * So the SDI cannot be re-enabled when it already by-passed.
 */
 
+static int in_panic;
+static int panic_prep_restart(struct notifier_block *this,
+			      unsigned long event, void *ptr)
+{
+	in_panic = 1;
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block panic_blk = {
+	.notifier_call	= panic_prep_restart,
+};
+
+
 #ifdef CONFIG_QCOM_DLOAD_MODE
 #define EDL_MODE_PROP "qcom,msm-imem-emergency_download_mode"
 #define DL_MODE_PROP "qcom,msm-imem-download_mode"
@@ -69,7 +89,6 @@ static void scm_disable_sdi(void);
 #define KASLR_OFFSET_PROP "qcom,msm-imem-kaslr_offset"
 #endif
 
-static int in_panic;
 static int download_mode;
 static struct kobject dload_kobj;
 static void *dload_mode_addr, *dload_type_addr;
@@ -97,17 +116,6 @@ struct reset_attribute {
 
 module_param_call(download_mode, dload_set, param_get_int,
 			&download_mode, 0644);
-
-static int panic_prep_restart(struct notifier_block *this,
-			      unsigned long event, void *ptr)
-{
-	in_panic = 1;
-	return NOTIFY_DONE;
-}
-
-static struct notifier_block panic_blk = {
-	.notifier_call	= panic_prep_restart,
-};
 
 int scm_set_dload_mode(int arg1, int arg2)
 {
@@ -293,20 +301,18 @@ static void msm_restart_prepare(const char *cmd)
 				(cmd != NULL && cmd[0] != '\0'));
 	}
 
-#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
+#if defined(TARGET_SOMC_S1BOOT) || defined(TARGET_SOMC_XBOOT)
 	/* Force warm reset and allow device to
-	 * preserve memory on restart 
-	 * only for bootloader and recovery commands */
+	 * preserve memory on restart for kernel
+	 * panic or for bootloader and recovery
+	 * commands */
 	if (cmd != NULL) {
 		if ((!strncmp(cmd, "bootloader", 10)) ||
-				(!strncmp(cmd, "recovery", 8)))
+		    (!strncmp(cmd, "recovery", 8)) || in_panic)
 			need_warm_reset = true;
 		else
 			need_warm_reset = false;
 	}
-#else
-	/* Force hard reset for SoMC XBOOT */
-	need_warm_reset = false;
 #endif
 
 	if (need_warm_reset)
@@ -320,11 +326,13 @@ static void msm_restart_prepare(const char *cmd)
 				PON_RESTART_REASON_BOOTLOADER);
 			__raw_writel(0x77665500, restart_reason);
 		} else if (!strncmp(cmd, "recovery", 8)) {
+#ifdef TARGET_SOMC_XBOOT
+			qpnp_pon_set_restart_reason(
+				PON_RESTART_REASON_OEM_F);
+			__raw_writel(0x6f656d46, restart_reason); //oem-F
+#else
 			qpnp_pon_set_restart_reason(
 				PON_RESTART_REASON_RECOVERY);
-#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
-			__raw_writel(0x6f656d46, restart_reason); //oem-46
-#else
 			__raw_writel(0x77665502, restart_reason);
 #endif
 		} else if (!strcmp(cmd, "rtc")) {
@@ -356,7 +364,7 @@ static void msm_restart_prepare(const char *cmd)
 			enable_emergency_dload_mode();
 		} else {
 			pr_notice("%s : cmd is %s, set to reboot mode\n", __func__, cmd);
-#ifdef CONFIG_ARCH_SONY_YOSHINO
+#ifdef TARGET_SOMC_XBOOT
 			qpnp_pon_set_restart_reason(PON_RESTART_REASON_UNKNOWN);
 #else
 			qpnp_pon_set_restart_reason(PON_RESTART_REASON_REBOOT);
@@ -365,7 +373,7 @@ static void msm_restart_prepare(const char *cmd)
 		}
 	} else {
 		pr_notice("%s : cmd is NULL, set to reboot mode\n", __func__);
-#ifdef CONFIG_ARCH_SONY_YOSHINO
+#ifdef TARGET_SOMC_XBOOT
 		qpnp_pon_set_restart_reason(PON_RESTART_REASON_UNKNOWN);
 		__raw_writel(0x77665501, restart_reason);
 #else
@@ -436,7 +444,9 @@ static void do_msm_poweroff(void)
 	set_dload_mode(0);
 	scm_disable_sdi();
 	qpnp_pon_system_pwr_off(PON_POWER_OFF_SHUTDOWN);
+#ifdef TARGET_SOMC_XBOOT
 	qpnp_pon_set_restart_reason(PON_RESTART_REASON_NONE);
+#endif
 
 	halt_spmi_pmic_arbiter();
 	deassert_ps_hold();
@@ -546,11 +556,12 @@ static int msm_restart_probe(struct platform_device *pdev)
 	struct device_node *np;
 	int ret = 0;
 
+	atomic_notifier_chain_register(&panic_notifier_list, &panic_blk);
+
 #ifdef CONFIG_QCOM_DLOAD_MODE
 	if (scm_is_call_available(SCM_SVC_BOOT, SCM_DLOAD_CMD) > 0)
 		scm_dload_supported = true;
 
-	atomic_notifier_chain_register(&panic_notifier_list, &panic_blk);
 	np = of_find_compatible_node(NULL, NULL, DL_MODE_PROP);
 	if (!np) {
 		pr_err("unable to find DT imem DLOAD mode node\n");
@@ -660,8 +671,10 @@ skip_sysfs_create:
 		scm_disable_sdi();
 #endif
 
+#ifdef TARGET_SOMC_XBOOT
 	__raw_writel(0xC0DEDEAD, restart_reason);
 	qpnp_pon_set_restart_reason(PON_RESTART_REASON_KERNEL_PANIC);
+#endif
 
 	return 0;
 

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -653,6 +653,10 @@ skip_sysfs_create:
 	if (!download_mode)
 		scm_disable_sdi();
 #endif
+
+	__raw_writel(0xC0DEDEAD, restart_reason);
+	qpnp_pon_set_restart_reason(PON_RESTART_REASON_KERNEL_PANIC);
+
 	return 0;
 
 err_restart_reason:

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -431,6 +431,7 @@ static void do_msm_poweroff(void)
 	set_dload_mode(0);
 	scm_disable_sdi();
 	qpnp_pon_system_pwr_off(PON_POWER_OFF_SHUTDOWN);
+	qpnp_pon_set_restart_reason(PON_RESTART_REASON_NONE);
 
 	halt_spmi_pmic_arbiter();
 	deassert_ps_hold();


### PR DESCRIPTION
This PR refactors the handling of reboot reasons for SoMC devices.
Now the code is divided by bootloader (S1BOOT or XBOOT) and not by platform anymore.

Now the reboot reasons are okay and we inform the bootloader correctly: the device can cleanly reboot to fastboot, recovery and back to system.
Moreover, the pstore functionality is restored, as now we are correctly detecting kernel panic conditions and choosing to warm reboot the board, so that RAM contents are preserved.