### PR TITLE
[57r1] [URGENT] fbdev: msm: somc_panel: Fix coding mistake in color manager

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -619,7 +619,7 @@ static ssize_t somc_panel_colormgr_pcc_select_show(struct device *dev,
 	struct mdss_dsi_ctrl_pdata *ctrl = dev_get_drvdata(dev);
 	struct somc_panel_color_mgr *color_mgr = ctrl->spec_pdata->color_mgr;
 
-	return scnprintf(buf, PAGE_SIZE, "%hu\n", color_mgr->pcc_profile_avail);
+	return scnprintf(buf, PAGE_SIZE, "%hu\n", color_mgr->pcc_profile);
 }
 
 static ssize_t somc_panel_colormgr_pcc_select_store(struct device *dev,
@@ -653,7 +653,7 @@ static ssize_t somc_panel_colormgr_pcc_profile_avail_show(struct device *dev,
 	struct mdss_dsi_ctrl_pdata *ctrl = dev_get_drvdata(dev);
 	struct somc_panel_color_mgr *color_mgr = ctrl->spec_pdata->color_mgr;
 
-	return scnprintf(buf, PAGE_SIZE, "%hu\n", color_mgr->pcc_profile);
+	return scnprintf(buf, PAGE_SIZE, "%hu\n", color_mgr->pcc_profile_avail);
 }
 
 static struct device_attribute colormgr_attributes[] = {


### PR DESCRIPTION
In commit 0b898659b I have introduced a coding mistake that
was making sysfs to return the PCC Profile Available variable
on the PCC Profile Selection show sysfs method and vice versa.

Correct this behavior and remember to not code when tired.