### PR TITLE
add a couple of loire dt charger patches to fix a crash when connecting to AC charger

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -908,6 +908,7 @@
 	qcom,charge-unknown-battery;
 	qcom,usb_dp-vadc = <&pmi8950_vadc>;
 	qcom,usb_dm-vadc = <&pmi8950_vadc>;
+	qcom,usbin-vadc = <&pmi8950_vadc>;
 	qcom,float-voltage-mv = <4300>;
 	qcom,precharging-timeout-mins = <24>;
 	qcom,charging-timeout-mins = <768>;

--- a/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-suzu-common.dtsi
@@ -64,6 +64,9 @@
 	somc,fastchg-cool-current-ma = <700>;
 	somc,thermal-engine-fastchg-current = <1850 1850 1850 1100 900 700 500 300 300 300 300 300 300 0 0>;
 	somc,thermal-mitigation-usb-9v = <1500 1400 1200 1000 1000 1000 1000 1000 1200 900 700 500 300 0 0>;
+	somc,thermal-mitigation-usb-8v = <1800 1800 1800 1500 1100 1100 1100 1100 1200 900 700 500 300 0 0>;
+	somc,thermal-mitigation-usb-7v = <2000 2000 2000 1500 1200 1200 1200 1200 1200 900 700 500 300 0 0>;
+	somc,thermal-mitigation-usb-6v = <2000 2000 2000 1500 1500 1500 1500 1500 1200 900 700 500 300 0 0>;
 	somc,thermal-mitigation-usb-5v = <1500 1500 1500 1500 1500 1500 1500 1500 1200 900 700 500 300 0 0>;
 	somc,limit-usb-5v-level = <8>;
 };


### PR DESCRIPTION
Currently suzu device crashes when you try to connect to AC charger [1], "arm/dt: [temp] add charge thermal parameter for avoid kernel crash" addresses that issue, adding "arm/dt: loire: charger: add vadc for charger" as well since it's related

[1]
[   29.340944] Unable to handle kernel NULL pointer dereference at virtual address 00000000
[   29.348229] pgd = ffffff8009555000
[   29.356153] [00000000] *pgd=00000000ddbfe003, *pud=00000000ddbfe003, *pmd=0000000000000000
[   29.367232] ------------[ cut here ]------------
[   29.367368] Kernel BUG at ffffff800877ae70 [verbose debug info unavailable]
[   29.371958] Internal error: Oops - BUG: 96000006 [#1] PREEMPT SMP
[   29.378571] CPU: 0 PID: 4 Comm: kworker/0:0 Not tainted 4.4.21-g08f587b-dirty #20
[   29.384902] Hardware name: SoMC Suzu-ROW (DT)
[   29.392268] Workqueue: events smbchg_hvdcp_det_work
[   29.401224] task: ffffffc08f192580 ti: ffffffc08f1b8000 task.ti: ffffffc08f1b8000
[   29.401506] PC is at somc_chg_therm_set_icl+0x19c/0x2d0
[   29.409002] LR is at somc_chg_therm_set_icl+0xd8/0x2d0
...
[   29.709737] [<ffffff800877ae70>] somc_chg_therm_set_icl+0x19c/0x2d0
[   29.717459] [<ffffff800877b6bc>] smbchg_hvdcp_det_work+0x144/0x170
[   29.723599] [<ffffff80080ad39c>] process_one_work+0x1b4/0x2bc
[   29.729777] [<ffffff80080ad7a4>] worker_thread+0x300/0x420
[   29.735654] [<ffffff80080b289c>] kthread+0xd8/0xe0
[   29.740964] [<ffffff8008083df0>] ret_from_fork+0x10/0x20