### PR TITLE
[57r1] soc: qcom: qdsp6v2: Fix using uninitialized variables

### DIFF
--- a/drivers/soc/qcom/qdsp6v2/apr_tal_glink.c
+++ b/drivers/soc/qcom/qdsp6v2/apr_tal_glink.c
@@ -115,7 +115,7 @@ int apr_tal_write(struct apr_svc_ch_dev *apr_ch, void *data,
 {
 	int rc = 0, retries = 0;
 	void *pkt_data = NULL;
-	struct apr_tx_buf *tx_buf;
+	struct apr_tx_buf *tx_buf = NULL;
 	struct apr_pkt_priv *pkt_priv_ptr = pkt_priv;
 
 	if (!apr_ch->handle || !pkt_priv)


### PR DESCRIPTION
Sanify the code and initialize all of the uninited vars.