### PR TITLE
[57r1] SDIO fixes for main topic BCMDHD

### DIFF
--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1168,9 +1168,11 @@ out:
 static int mmc_sdio_runtime_suspend(struct mmc_host *host)
 {
 	/* No references to the card, cut the power to it. */
-	mmc_claim_host(host);
-	mmc_power_off(host);
-	mmc_release_host(host);
+	if (!mmc_card_keep_power(host)) {
+		mmc_claim_host(host);
+		mmc_power_off(host);
+		mmc_release_host(host);
+	}
 
 	return 0;
 }
@@ -1181,7 +1183,8 @@ static int mmc_sdio_runtime_resume(struct mmc_host *host)
 
 	/* Restore power and re-initialize. */
 	mmc_claim_host(host);
-	mmc_power_up(host, host->card->ocr);
+	if (!mmc_card_keep_power(host))
+		mmc_power_up(host, host->card->ocr);
 	ret = mmc_sdio_power_restore(host);
 	mmc_release_host(host);
 

--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1332,6 +1332,9 @@ int mmc_attach_sdio(struct mmc_host *host)
 			goto remove_added;
 	}
 
+	if (host->caps2 & MMC_CAP2_NONSTANDARD_NONREMOVABLE)
+		host->caps |= MMC_CAP_NONREMOVABLE;
+
 	mmc_claim_host(host);
 	return 0;
 

--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -4635,12 +4635,18 @@ static int sdhci_msm_probe(struct platform_device *pdev)
 	msm_host->pdata->sdiowakeup_irq = platform_get_irq_byname(pdev,
 							  "sdiowakeup_irq");
 	if (sdhci_is_valid_gpio_wakeup_int(msm_host)) {
+		unsigned long sdio_irq_flags = IRQF_SHARED;
+#ifdef CONFIG_BCMDHD_SDIO
+		sdio_irq_flags |= IRQF_TRIGGER_LOW;
+#else
+		sdio_irq_flags |= IRQF_TRIGGER_HIGH;
+#endif
 		dev_info(&pdev->dev, "%s: sdiowakeup_irq = %d\n", __func__,
 				msm_host->pdata->sdiowakeup_irq);
 		msm_host->is_sdiowakeup_enabled = true;
 		ret = request_irq(msm_host->pdata->sdiowakeup_irq,
 				  sdhci_msm_sdiowakeup_irq,
-				  IRQF_SHARED | IRQF_TRIGGER_HIGH,
+				  sdio_irq_flags,
 				  "sdhci-msm sdiowakeup", host);
 		if (ret) {
 			dev_err(&pdev->dev, "%s: request sdiowakeup IRQ %d: failed: %d\n",

--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -4680,6 +4680,7 @@ static int sdhci_msm_probe(struct platform_device *pdev)
 	if (msm_host->pdata->use_for_wifi) {
 		msm_host->mmc->caps &= ~MMC_CAP_NEEDS_POLL;
 		msm_host->mmc->caps2 |= MMC_CAP2_NONSTANDARD_OCR;
+		msm_host->mmc->caps2 |= MMC_CAP2_NONSTANDARD_NONREMOVABLE;
 		somc_wifi_mmc_host_register(msm_host->mmc);
 	}
 #endif

--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -456,6 +456,8 @@ struct mmc_host {
 #define MMC_CAP2_MAX_DISCARD_SIZE	(1 << 29)
 /* Non standard OCR for some SDIO cards */
 #define MMC_CAP2_NONSTANDARD_OCR	(1 << 30)
+/* The card cannot be removed once plugged in */
+#define MMC_CAP2_NONSTANDARD_NONREMOVABLE (1 << 31)
 
 	mmc_pm_flag_t		pm_caps;	/* supported pm features */
 


### PR DESCRIPTION
There are some SDIO cards that don't support plug in/out in
a standard way: once they are plugged in, it will not be
possible to plug them out and retain functionality through
suspend and resume.
This patch flags the card as NONREMOVABLE only after it has
been detected (otherwise, the detection handler will not
work).

In the example case of a BCM4356 SDIO card, the system may
start with no/unpowered card. We powerup the card and the
kernel recognizes it, then the specific driver for the chip
loads a firmware into its RAM: starting from this moment,
if we power down the card, we will not be able to power it
up again, since it will lose the firmware stored in RAM
and will never boot up anymore.

To make things worst, the whole BCM chip may be powered
down when the SDIO card gets a power cut, producing a
functionality breakage: the chip will be disconnected from
the WiFi network and the connection loss will be permanent,
as no sdiowakeup interrupt will fire: the chip is down.

Such cards do _not_ support any change in voltage once the
card setup is done, otherwise Bad Things Happen (TM), hence
the only way to get them working properly is to suspend the
host controller while keeping the card completely alive and
relying on its wireless driver to set it to low power mode.

Please note that, about power consumption, mileage may vary:
some wireless chips support a very very low power mode with
connection keepalive, some others do not, but this case is
not covered in this patch and will never be in this place,
as this is intended to only address problems coming from
the Linux MMC API, and whatever else happens out of it must
be managed out of it.