### PR TITLE
dts: msm8956: add disabled-pin pinctrl attribute

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -49,6 +49,10 @@
 };
 
 &soc {
+	pinctrl@1000000 {
+		disabled-pins = <0 1 2 3>;
+	};
+
 	fpc1145 {
 		status = "ok";
 		compatible = "fpc,fpc1020", "fpc1145";


### PR DESCRIPTION
This prevents an access to these when reading gpio status from debugfs,
otherwise it hangs the device.

Signed-off-by: Oleksiy Avramchenko <oleksiy.avramchenko@sony.com>