### PR TITLE
[57r1] fbdev: msm: somc_panel: Skip MDSS op mode reconf for PCC on legacy

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -331,7 +331,10 @@ static int somc_panel_pcc_setup(struct mdss_panel_data *pdata)
 		goto exit;
 	}
 
-	mdss_dsi_op_mode_config(DSI_CMD_MODE, pdata);
+	if (!of_machine_is_compatible("qcom,msm8956") ||
+	    !of_machine_is_compatible("qcom,msm8939"))
+		mdss_dsi_op_mode_config(DSI_CMD_MODE, pdata);
+
 	if (color_mgr->pre_uv_read_cmds.cmds)
 		mdss_dsi_panel_cmds_send(
 			ctrl_pdata, &color_mgr->pre_uv_read_cmds);


### PR DESCRIPTION
Legacy SoCs do not need to reconfigure the mdss op mode to
command mode (especially when driving a panel in cmd mode)
and, if we try to, the interface may even crash, leading to
a kernel panic.
Between the ones that we support, these SoCs include MSM8956
and MSM8939.