### PR TITLE
[LA.UM.5.7.r1] arm: DT: msm8956: Fix Energy Aware sensor linking

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1240,35 +1240,35 @@
 		qcom,high-hyst-temp = <5>;
 
 		ea0: ea0 {
-			sensor = <&sensor_information1>;
+			sensor = <&sensor_information9>;
 		};
 
 		ea1: ea1 {
-			sensor = <&sensor_information1>;
+			sensor = <&sensor_information9>;
 		};
 
 		ea2: ea2 {
-			sensor = <&sensor_information1>;
+			sensor = <&sensor_information9>;
 		};
 
 		ea3: ea3 {
-			sensor = <&sensor_information1>;
+			sensor = <&sensor_information9>;
 		};
 
 		ea4: ea4 {
-			sensor = <&sensor_information3>;
-		};
-
-		ea5: ea5 {
 			sensor = <&sensor_information4>;
 		};
 
-		ea6: ea6 {
+		ea5: ea5 {
 			sensor = <&sensor_information5>;
 		};
 
-		ea7: ea7 {
+		ea6: ea6 {
 			sensor = <&sensor_information6>;
+		};
+
+		ea7: ea7 {
+			sensor = <&sensor_information7>;
 		};
 	};
 


### PR DESCRIPTION
The sensor map was updated based on information received
from mitigation profiles.

CPU0-3: mitigation_profile0: sensor_information9
CPU4:   mitigation_profile1: sensor_information4
CPU5:   mitigation_profile2: sensor_information5
CPU6:   mitigation_profile3: sensor_information6
CPU7:   mitigation_profile4: sensor_information7

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>