### PR TITLE
[57r1] arm: DT: msm8956: Fix typoed buffer types for vidc secure iommu

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2528,7 +2528,7 @@
 			compatible = "qcom,msm-vidc,context-bank";
 			label = "venus_sec_non_pixel";
 			iommus = <&apps_smmu 5>;
-			buffer-types = <0x380>;
+			buffer-types = <0x480>;
 			virtual-addr-pool = <0x1000000 0x24800000>;
 			qcom,secure-context-bank;
 		};


### PR DESCRIPTION
Venus secure non-pixel context allows buffer types 0x480.
