### PR TITLE
[LA.UM.5.7.r1] Tone/Yoshino: Remove not needed debug_region memory allocation

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -22,13 +22,6 @@
 	};
 
 	reserved-memory {
-		debug_region: debug_region@a7e00000 {
-			compatible = "removed-dma-pool", "qcom,debug_memory";
-			no-map;
-			reg = <0 0xa7e00000 0 0x100000>;
-			label = "debug_mem";
-		};
-
 		pstore_reserve_mem: pstore_reserve_mem_region_region@a7f00000 {
 			compatible = "removed-dma-pool";
 			no-map;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -24,13 +24,6 @@
 	};
 
 	reserved-memory {
-		debug_region: debug_region@ffb00000 {
-			compatible = "removed-dma-pool", "qcom,debug_memory";
-			no-map;
-			reg = <0 0xffb00000 0 0x100000>;
-			label = "debug_mem";
-		};
-
 		pstore_reserve_mem: pstore_reserve_mem_region_region@ffc00000 {
 			compatible = "removed-dma-pool";
 			no-map;


### PR DESCRIPTION
This will be removed on Loire platform in this commit: https://github.com/sonyxperiadev/kernel/pull/1494/commits/5a18d4485975ab08514e25479ee3430d5bb472be so let's follow it on all our platforms