### PR TITLE
Revert "PORT: msm: camera2_v2: Initialize buf_time to boottime"

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp_util.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp_util.c
@@ -218,8 +218,6 @@ void msm_isp_get_timestamp(struct msm_isp_timestamp *time_stamp,
 		get_monotonic_boottime(&ts);
 		time_stamp->buf_time.tv_sec    = ts.tv_sec;
 		time_stamp->buf_time.tv_usec   = ts.tv_nsec/1000;
-		/* Initialize buf_time to be boottime as well */
-		time_stamp->buf_time = time_stamp->event_time;
 	}
 }
 


### PR DESCRIPTION
This commit causes video recording to break after a certain period of
time, because the implementation is not complete.
Revert it for now, until the complete implementation is ready.

This reverts commit 6498522f9bfb58602f205030cd8f03371295e186.

Change-Id: Ic28be6d3203d1a42ddd7af6ffd1ee0190a7ca7b8