### PR TITLE
[57r1] arm: DT: Loire-camera: Add EEPROM support nodes on Suzu and Kugo

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo_camera.dtsi
@@ -45,6 +45,37 @@
 		qcom,cam-vreg-op-mode = <300000>;
 	};
 
+	eeprom0: qcom,eeprom@0 {
+		cell-index = <0>;
+		compatible = "qcom,eeprom";
+		reg = <0x0>;
+		cam_vdig-supply = <&pm8950_l3>;
+		cam_vio-supply = <&camera_rgbcir_vreg>;
+		cam_vana-supply = <&pm8950_l9>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1100000 0 2200000 2700000>;
+		qcom,cam-vreg-max-voltage = <1100000 0 2200000 2700000>;
+		qcom,cam-vreg-op-mode = <85000 0 103000 300000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_default &msm_gpio_35_def>;
+		pinctrl-1 = <&cam_sensor_mclk0_sleep &msm_gpio_35_def>;
+		gpios = <&msm_gpio 26 0>, <&msm_gpio 35 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-req-tbl-num = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0";
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk0_clk_src>,
+			 <&clock_gcc clk_gcc_camss_mclk0_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+		qcom,clock-rates = <24000000 0>;
+	};
+
 	qcom,camera@0 {
 		cell-index = <0>;
 		compatible = "qcom,camera";
@@ -52,6 +83,7 @@
 		qcom,csiphy-sd-index = <0>;
 		qcom,csid-sd-index = <0>;
 		qcom,mount-angle = <90>;
+		qcom,eeprom-src = <&eeprom0>;
 		qcom,actuator-src = <&actuator0>;
 		qcom,led-flash-src = <&led_flash0>;
 		cam_vdig-supply = <&pm8950_l3>;

--- a/arch/arm/boot/dts/qcom/msm8956-loire-suzu_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-suzu_camera.dtsi
@@ -57,6 +57,68 @@
 		qcom,cam-vreg-op-mode = <300000>;
 	};
 
+	eeprom0: qcom,eeprom@0 {
+		cell-index = <0>;
+		compatible = "qcom,eeprom";
+		reg = <0x0>;
+		cam_vdig-supply = <&pm8950_l3>;
+		cam_vio-supply = <&camera_rgbcir_vreg>;
+		cam_vana-supply = <&pm8950_l9>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1100000 0 2200000 2700000>;
+		qcom,cam-vreg-max-voltage = <1100000 0 2200000 2700000>;
+		qcom,cam-vreg-op-mode = <85000 0 103000 300000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_default &msm_gpio_35_def>;
+		pinctrl-1 = <&cam_sensor_mclk0_sleep &msm_gpio_35_def>;
+		gpios = <&msm_gpio 26 0>, <&msm_gpio 35 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-req-tbl-num = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0";
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk0_clk_src>,
+			 <&clock_gcc clk_gcc_camss_mclk0_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+		qcom,clock-rates = <24000000 0>;
+	};
+
+	eeprom1: qcom,eeprom@1 {
+		cell-index = <1>;
+		compatible = "qcom,eeprom";
+		reg = <0x1>;
+		cam_vdig-supply = <&pm8950_l1>;
+		cam_vana-supply = <&pm8950_l10>;
+		cam_vio-supply = <&camera_rgbcir_vreg>;
+		cam_vaf-supply = <&pm8950_l17>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana", "cam_vaf";
+		qcom,cam-vreg-min-voltage = <1000000 0 2700000 2700000>;
+		qcom,cam-vreg-max-voltage = <1000000 0 2700000 2700000>;
+		qcom,cam-vreg-op-mode = <333000 0 46000 300000>;
+		qcom,gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_default &msm_gpio_38_def>;
+		pinctrl-1 = <&cam_sensor_mclk2_sleep &msm_gpio_38_def>;
+		gpios = <&msm_gpio 28 0>, <&msm_gpio 38 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-req-tbl-num = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1";
+		qcom,sensor-position = <1>;
+		qcom,sensor-mode = <1>;
+		qcom,cci-master = <1>;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk2_clk_src>,
+			 <&clock_gcc clk_gcc_camss_mclk2_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+		qcom,clock-rates = <24000000 0>;
+	};
+
 	qcom,camera@0 {
 		cell-index = <0>;
 		compatible = "qcom,camera";
@@ -64,6 +126,7 @@
 		qcom,csiphy-sd-index = <0>;
 		qcom,csid-sd-index = <0>;
 		qcom,mount-angle = <90>;
+		qcom,eeprom-src = <&eeprom0>;
 		qcom,actuator-src = <&actuator0>;
 		qcom,led-flash-src = <&led_flash0>;
 		cam_vdig-supply = <&pm8950_l3>;
@@ -100,6 +163,7 @@
 		qcom,csiphy-sd-index = <1>;
 		qcom,csid-sd-index = <1>;
 		qcom,mount-angle = <90>;
+		qcom,eeprom-src = <&eeprom1>;
 		qcom,actuator-src = <&actuator1>;
 		cam_vdig-supply = <&pm8950_l1>;
 		cam_vana-supply = <&pm8950_l10>;


### PR DESCRIPTION
Where present, add the EEPROM support.
Currently added to IMX300, IMX214.