### PR TITLE
[57r1] clk: msm: gcc-8976: Remove 400MHz clock step from VFE1

### DIFF
--- a/drivers/clk/msm/clock-gcc-8976.c
+++ b/drivers/clk/msm/clock-gcc-8976.c
@@ -960,7 +960,7 @@ static struct clk_freq_tbl ftbl_vfe1_clk_src[] = {
 	F( 266666667,          gpll0,    3,    0,     0),
 	F( 300000000,      gpll4_out,    4,    0,     0),
 	F( 320000000,          gpll0,  2.5,    0,     0),
-	F( 400000000,          gpll0,    2,    0,     0),
+	/*F( 400000000,          gpll0,    2,    0,     0),*/
 	F( 466000000,      gpll2_aux,    2,    0,     0),
 	F_END
 };
@@ -975,7 +975,7 @@ static struct rcg_clk vfe1_clk_src = {
 		.dbg_name = "vfe1_clk_src",
 		.ops = &clk_ops_rcg,
 		VDD_DIG_FMAX_MAP5(LOWER, 160000000, LOW, 300000000,
-		NOMINAL, 320000000, NOM_PLUS, 400000000,
+		NOMINAL, 320000000, NOM_PLUS, 466000000,
 		HIGH, 466000000),
 		CLK_INIT(vfe1_clk_src.c),
 	},


### PR DESCRIPTION
Cameras may request a wrong clock in camcorder mode on k4.4.
The removal of this clock step makes sure that the camera
framework will set a good, higher clock, that will make the
camera not to freeze.

This commit may be temporary.

---------------------------------------------------
Solves unability to use camcorder on SoMC Suzu.
https://github.com/sonyxperiadev/bug_tracker/issues/23