### PR TITLE
[57r1] input: misc: fpc1145: Implement miscdevice, IOCTLs, PM, wakelocks, redo regulators

### DIFF
--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -513,7 +513,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 	if (rc)
 		goto exit;
 
-	irqf = IRQF_TRIGGER_RISING | IRQF_ONESHOT;
+	irqf = IRQF_TRIGGER_HIGH | IRQF_ONESHOT;
 	mutex_init(&fpc1145->lock);
 
 	wake_lock_init(&fpc1145->wakelock, WAKE_LOCK_SUSPEND, "fpc_wake");

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -609,6 +609,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 		goto exit;
 	}
 	dev_dbg(dev, "requested irq %d\n", gpio_to_irq(fpc1145->irq_gpio));
+	enable_irq_wake(gpio_to_irq(fpc1145->irq_gpio));
 
 	rc = sysfs_create_group(&dev->kobj, &attribute_group);
 	if (rc) {

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -367,6 +367,10 @@ static long fpc1145_device_ioctl(struct file *fp,
 			return rc;
 
 		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
+		if (val)
+			wake_lock_timeout(&fpc1145_drvdata->wakelock,
+					msecs_to_jiffies(400));
+
 		rc = put_user(val, (int*) usr);
 		break;
 	default:
@@ -428,7 +432,7 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 
 	fpc1145->irq_fired = true;
 
-	wake_lock_timeout(&fpc1145->wakelock, usecs_to_jiffies(250));
+	wake_lock_timeout(&fpc1145->wakelock, msecs_to_jiffies(20));
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -29,15 +29,27 @@
  * modify it under the terms of the GNU General Public License Version 2
  * as published by the Free Software Foundation.
  */
+/*
+ * IOCTL implementation for FPC1145 driver
+ * Copyright (C) 2017 AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License Version 2
+ * as published by the Free Software Foundation.
+ */
 
 #include <linux/delay.h>
+#include <linux/fs.h>
 #include <linux/gpio.h>
 #include <linux/interrupt.h>
+#include <linux/ioctl.h>
 #include <linux/kernel.h>
+#include <linux/miscdevice.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/of.h>
 #include <linux/of_gpio.h>
+#include <linux/uaccess.h>
 #include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
 
@@ -49,6 +61,14 @@
 #define PWR_ON_STEP_RANGE2 900
 #define NUM_PARAMS_REG_ENABLE_SET 2
 #define FPC_SYMLINK "fpc1145_device"
+
+#define FPC_IOC_MAGIC	0x1145
+#define FPC_IOCWPREPARE	_IOW(FPC_IOC_MAGIC, 0x01, int)
+#define FPC_IOCWDEVWAKE	_IOW(FPC_IOC_MAGIC, 0x02, int)
+#define FPC_IOCWRESET	_IOW(FPC_IOC_MAGIC, 0x03, int)
+#define FPC_IOCRPREPARE	_IOR(FPC_IOC_MAGIC, 0x81, int)
+#define FPC_IOCRDEVWAKE	_IOR(FPC_IOC_MAGIC, 0x82, int)
+#define FPC_IOCRIRQ	_IOR(FPC_IOC_MAGIC, 0x83, int)
 
 static const char * const pctl_names[] = {
 	"fpc1145_reset_reset",
@@ -91,6 +111,8 @@ struct fpc1145_data {
 	struct mutex lock;
 	bool prepared;
 };
+
+static struct fpc1145_data *fpc1145_drvdata = NULL;
 
 static int vreg_setup(struct fpc1145_data *fpc1145, const char *name,
 	bool enable)
@@ -403,6 +425,74 @@ static const struct attribute_group attribute_group = {
 	.attrs = attributes,
 };
 
+static int fpc1145_device_open(struct inode *inode, struct file *fp)
+{
+	return 0;
+}
+
+static int fpc1145_device_release(struct inode *inode, struct file *fp)
+{
+	return 0;
+}
+
+static long fpc1145_device_ioctl(struct file *fp,
+		unsigned int cmd, unsigned long arg)
+{
+	int8_t val = 0;
+	int rc = -EINVAL;
+
+	if (unlikely(arg > 1))
+		return -EINVAL;
+
+	switch (cmd) {
+	case FPC_IOCWPREPARE:
+		dev_dbg(fpc1145_drvdata->dev, "%s device\n",
+			(arg == 0 ? "Unpreparing" : "Preparing"));
+		rc = device_prepare(fpc1145_drvdata, !!arg);
+		break;
+	case FPC_IOCWDEVWAKE:
+		dev_dbg(fpc1145_drvdata->dev, "Setting devwake %lu\n", arg);
+		dev_dbg(fpc1145_drvdata->dev, "WDEVWAKE Not implemented.\n");
+		break;
+	case FPC_IOCWRESET:
+		dev_dbg(fpc1145_drvdata->dev, "Resetting device\n");
+		rc = hw_reset(fpc1145_drvdata);
+		break;
+	case FPC_IOCRPREPARE:
+		rc = put_user((int8_t)fpc1145_drvdata->prepared,
+				(uint32_t*) arg);
+		break;
+	case FPC_IOCRDEVWAKE:
+		dev_dbg(fpc1145_drvdata->dev, "RDEVWAKE Not implemented.\n");
+		break;
+	case FPC_IOCRIRQ:
+		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
+		rc = put_user(val, (uint32_t*) arg);
+		break;
+	default:
+		rc = -ENOIOCTLCMD;
+		dev_err(fpc1145_drvdata->dev, "Unknown IOCTL 0x%x.\n", cmd);
+		break;
+	}
+
+	return rc;
+}
+
+static const struct file_operations fpc1145_device_fops = {
+	.owner = THIS_MODULE,
+	.llseek = no_llseek,
+	.open = fpc1145_device_open,
+	.release = fpc1145_device_release,
+	.unlocked_ioctl = fpc1145_device_ioctl,
+	.compat_ioctl = fpc1145_device_ioctl,
+};
+
+static struct miscdevice fpc1145_misc = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "fingerprint",
+	.fops = &fpc1145_device_fops,
+};
+
 static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 {
 	struct fpc1145_data *fpc1145 = handle;
@@ -452,6 +542,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 
 	fpc1145->dev = dev;
 	platform_set_drvdata(pdev, fpc1145);
+	fpc1145_drvdata = fpc1145;
 
 	if (!np) {
 		dev_err(dev, "no of node found\n");
@@ -535,6 +626,10 @@ static int fpc1145_probe(struct platform_device *pdev)
 		dev_info(dev, "Enabling hardware\n");
 		(void)device_prepare(fpc1145, true);
 	}
+
+	rc = misc_register(&fpc1145_misc);
+	if (!rc)
+		goto exit;
 
 	dev_info(dev, "%s: ok\n", __func__);
 exit:


### PR DESCRIPTION
This commit implements a miscdevice and IOCTLs to replace the
current ugly sysfs handling.
The sysfs implementation will be removed once the userspace
will be migrated to the new IOCTLs management.

-------------------------------------
TEST: Maple OK
All devices will have no reason to produce badnesses, since the old sysfs implementation is still there and fully functional.
The legacy implementation will be removed once the userspace will be fully converted to IOCTLs.