### PR TITLE
[57r1] IOMMUv1: Fix possible memory leak, switch to LPAE scattergather mapping

### DIFF
--- a/drivers/iommu/qcom/msm_iommu-v1.c
+++ b/drivers/iommu/qcom/msm_iommu-v1.c
@@ -644,9 +644,11 @@ static int msm_iommu_dynamic_attach(struct iommu_domain *domain, struct device *
 
 	ret = idr_alloc_cyclic(&iommu_drvdata->asid_idr, priv,
 			iommu_drvdata->ncb + 2, MAX_ASID + 1, GFP_KERNEL);
-
-	if (ret < 0)
+	if (ret < 0) {
+		pr_err("Failed to allocate idr for dynamic domain.\n");
+		free_io_pgtable_ops(pgtbl_ops);
 		return -ENOSPC;
+	}
 
 	priv->asid = ret;
 	priv->base = ctx_drvdata->attached_domain;


### PR DESCRIPTION
The memory leak fix works in an unlikely to happen situation, but it's obviously worth it to fix.

The switch to LPAE sg mapping improves performance.