### PR TITLE
[LA.UM.5.7.r1] arm64: Ignore Image.lz4 and Image.lz4-dtb from git point of view

### DIFF
--- a/arch/arm64/boot/.gitignore
+++ b/arch/arm64/boot/.gitignore
@@ -2,3 +2,5 @@ Image
 Image-dtb
 Image.gz
 Image.gz-dtb
+Image.lz4
+Image.lz4-dtb


### PR DESCRIPTION
we will need this in the future