### PR TITLE
[TESTINGNEEDED] fbdev: msm: somc_panel: Use B sequence as poweroff reset sequence

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -3266,6 +3266,9 @@ int mdss_panel_parse_dt(struct device_node *np,
 		"somc,pw-off-rst-b-seq",
 		(u32 **)&spec_pdata->off_seq.rst_b_seq,
 		&spec_pdata->off_seq.seq_b_num);
+	// if no poweroff reset sequence is declared, but B sequence is, use it
+	if(spec_pdata->off_seq.rst_b_seq && !spec_pdata->off_seq.rst_seq)
+		spec_pdata->off_seq.rst_seq = spec_pdata->off_seq.rst_b_seq;
 	rc = of_property_read_u32(np, "somc,pw-down-period", &tmp);
 	spec_pdata->down_period = !rc ? tmp : 0;
 


### PR DESCRIPTION
The stock panel driver uses the B sequence as a normal poweroff reset sequence, if found.
https://github.com/sonyxperiadev/kernel-copyleft/blob/41.2.A.0.xxx/drivers/video/msm/mdss/mdss_dsi_panel_driver.c#L1109-L1121
This is not the case in our driver, and leads to issues with dt2w on hybrid incell panels.
The reason for that is that the devicetree nodes of hybrid incell panels only declare the B sequences (somc,pw-off-rst-b-seq).
The missing normal poweroff reset sequence causes the driver to always report a fatal error upon turning off the panel:
[  967.464295] FATAL: poweroff reset sequence is NULL!!

The solution is to add a check to make sure that there's always a poweroff reset sequence set, by falling back to the B
sequence. This makes the driver behaviour similar to that on stock.

This needs testing on all devices that have hybrid incell panels!
If you want to report your tests, please include the panel id along with the device name!
Currently tested on:
kugo with panel id 8 (works fine)