### PR TITLE
ext4 encryption: drop feature check

### DIFF
--- a/fs/ext4/ioctl.c
+++ b/fs/ext4/ioctl.c
@@ -626,9 +626,6 @@ resizefs_out:
 		struct ext4_encryption_policy policy;
 		int err = 0;
 
-		if (!ext4_has_feature_encrypt(sb))
-			return -EOPNOTSUPP;
-
 		if (copy_from_user(&policy,
 				   (struct ext4_encryption_policy __user *)arg,
 				   sizeof(policy))) {


### PR DESCRIPTION
Follow the taimen kernel and drop this check so that it is not
necessary to explicitly enable ext4 encryption in the superblock
(i.e. the default is now that ext4 encryption is enabled).