### PR TITLE
[64r1] arm: DT: msm8956-regulator: Typo fix

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-regulator.dtsi
@@ -705,7 +705,7 @@
 		compatible = "regulator-fixed";
 		regulator-name = "adv_vreg";
 		startup-delay-us = <400>;
-		enable-avtive-high;
+		enable-active-high;
 		gpio = <&pm8004_mpps 4 0>;
 	};
 


### PR DESCRIPTION
It is not used by Loire platform but this does not give us the right to leave typos here