### PR TITLE
[6.4.r1] Fix display and let Tone and Yoshino platform boot

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -3144,6 +3144,14 @@
 	status = "disabled";
 };
 
+&mdss_fb0 {
+	/delete-node/ qcom,cont-splash-memory;
+};
+
+&mdss_fb2 {
+	/delete-node/ qcom,cont-splash-memory;
+};
+
 &labibb {
 	qcom,lab@de00 {
 		qcom,qpnp-lab-init-voltage = <5700000>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -43,6 +43,9 @@
 	reg = <0x0 0x9d400000 0x0 0x02400000>;
 };
 
+&mdss_fb0 {
+	/delete-node/ qcom,cont-splash-memory;
+};
 
 &soc {
 	pinctrl@03400000 {


### PR DESCRIPTION
Remove the cont-splash-memory from the framebuffer nodes to
avoid IOMMU related crashes at display open from userspace.
This is    necessary after    a sane QC fix on mdss_mdp_splash_logo
appeared, as commit hash 245031160bff81703cf109e473329c3f01d77304:
previously, the    PA to VA mapping was completely    broken but now,
being it sane, we need the related IOMMU domain    to be set as   
UNSECURE and correctly released    by the bootloader.

This is a HACK and will have the side effect of displaying  
corruption for one second prior the Android bootanimation to
kick in.