### PR TITLE
[6.4.r1] Use PRODUCT_PLATFORM_SOD as build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@
 # Android makefile to build kernel as a part of Android Build
 
 ifeq ($(BUILD_KERNEL),true)
-ifeq ($(filter-out loire tone yoshino,$(PRODUCT_PLATFORM)),)
+ifeq ($(PRODUCT_PLATFORM_SOD),true)
 
 KERNEL_SRC := $(call my-dir)
 


### PR DESCRIPTION
From now on there is no need to manually add a new platform
to each of the project dependencyes.

Reference to: https://github.com/sonyxperiadev/device-sony-common/commit/9c362746e5aac2ae52b49cafa0349a14b98655ef

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>