### PR TITLE
mmc: sdio: force a specific OCR for BCMDHD cards

### DIFF
--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -1091,6 +1091,9 @@ static u32 mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 {
 	int bit;
 	u32 ocr_orig = ocr;
+#ifdef CONFIG_BCMDHD
+	u32 ocr_fake = 0x180;
+#endif
 
 	pr_debug("%s \n",__func__);
 
@@ -1102,10 +1105,10 @@ static u32 mmc_select_low_voltage(struct mmc_host *host, u32 ocr)
 		ocr = ocr >> 1;
 
  #ifdef CONFIG_BCMDHD
-		/* If standard OCR, send it as it is. BCMDHD only. */
-		pr_debug("%s: ocr = 0x%x", __func__, ocr);
-		if (ocr_orig > 0x30ffff00)
-			ocr = ocr_orig;
+		/* Always force a specific OCR. BCMDHD only. */
+		pr_debug("%s: forcing ocr to 0x%x instead of 0x%x",
+			 mmc_hostname(host), ocr_fake, ocr);
+		ocr = ocr_fake;
  #endif
 
 		/* Power cycle card to select lowest possible voltage */


### PR DESCRIPTION
This replaces the previous solution of trying to get a "good" OCR value from the one received from the card.
The previous solution, while mainly working, couldn't handle specific ocr values, and rendered bcmdhd nonfunctional.
After some tries into getting the code to properly recognize those unusual ocr values, it proved to be very difficult because of the lack of documentation.
Hence, another route was taken, which is to force the ocr value that's know to be the correct one needed by the card.
This is an ugly, but currently necessary, hack to guarantee more wifi stability on loire devices.

Change-Id: I539774b060ce877c3fd8af31de34a3dc5a6d6a87