### PR TITLE
[6.4.r1] Fix JPEG DMA nodes on MSM8998, MSM8996

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-camera.dtsi
@@ -569,7 +569,7 @@
 
 	qcom,jpeg@aa0000 {
 		cell-index = <3>;
-		compatible = "qcom,jpeg_dma";
+		compatible = "qcom,jpegdma";
 		reg = <0xaa0000 0x4000>,
 			<0xa60000 0x3000>;
 		reg-names = "jpeg_hw", "jpeg_vbif";

--- a/arch/arm/boot/dts/qcom/msm8998-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-camera.dtsi
@@ -806,7 +806,7 @@
 
 	qcom,jpeg@caa0000 {
 		cell-index = <3>;
-		compatible = "qcom,jpeg_dma";
+		compatible = "qcom,jpegdma";
 		reg = <0xcaa0000 0x4000>,
 			<0xca60000 0x3000>;
 		reg-names = "jpeg_hw", "jpeg_vbif";

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -505,6 +505,11 @@
 		startup-delay-us = <0>;
 		enable-active-high;
 		gpio = <&pmi8998_gpios 1 0>;
+
+		proxy-supply = <&pm8998_lvs1>;
+		qcom,proxy-consumer-enable;
+		qcom,proxy-consumer-current = <0>;
+		qcom,proxy-consumer-voltage = <0 0>;
 	};
 
 	cam_vdig_front_verg: cam_vdig_front_verg {
@@ -513,6 +518,11 @@
 		startup-delay-us = <0>;
 		enable-active-high;
 		gpio = <&tlmm 25 0>;
+
+		proxy-supply = <&pm8998_s3>;
+		qcom,proxy-consumer-enable;
+		qcom,proxy-consumer-current = <105000>;
+		qcom,proxy-consumer-voltage = <1352000 1352000>;
 	};
 
 	cam_vdig_rear_verg: cam_vdig_rear_verg {

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -2885,6 +2885,62 @@
 	};
 };
 
+&cam_sensor_rear_active {
+	mux {
+		pins = "gpio30";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio30";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cam_sensor_rear_suspend {
+	mux {
+		pins = "gpio30";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio30";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cam_sensor_front_active {
+	mux {
+		pins = "gpio28";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio28";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cam_sensor_front_suspend {
+	mux {
+		pins = "gpio28";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio28";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
 &mdss_hdmi_tx {
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_camera.dtsi
@@ -110,8 +110,8 @@
 		qcom,csiphy-sd-index = <2>;
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <0>;
-		cam_vdig-supply = <&pm8998_s3>;
-		cam_vio-supply = <&pm8998_lvs1>;
+		cam_vdig-supply = <&cam_vdig_front_verg>;
+		cam_vio-supply = <&cam_vio_verg>;
 		cam_vana-supply = <&vana_stub_vreg>;
 		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
 		qcom,cam-vreg-min-voltage = <1352000 0 2700000>;
@@ -121,15 +121,11 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_front_active>;
 		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_front_suspend>;
-		gpios = <&tlmm 14 0>, <&tlmm 28 0>,
-			<&pmi8998_gpios 1 0>, <&tlmm 25 0>;
+		gpios = <&tlmm 14 0>, <&tlmm 28 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-vio = <2>;
-		qcom,gpio-vdig = <3>;
-		qcom,gpio-req-tbl-num   = <0 1 2 3>;
-		qcom,gpio-req-tbl-flags = <1 0 0 0>;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1",
-					  "GPIO_VIO", "GPIO_VDIG";
+		qcom,gpio-req-tbl-num   = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1";
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_camera.dtsi
@@ -19,6 +19,7 @@
 
 &soc {
 	/delete-node/ qcom,camera-flash@0;
+	/delete-node/ qcom,camera-flash@1;
 	/delete-node/ qcom,gpio-regulator@0;
 
 	led_flash0: qcom,camera-flash@0 {
@@ -43,6 +44,7 @@
 &cci {
 	/delete-node/ qcom,actuator@0;
 	/delete-node/ qcom,actuator@1;
+	/delete-node/ qcom,laserled@0;
 	/delete-node/ qcom,ois@0;
 	/delete-node/ qcom,tof@0;
 	/delete-node/ qcom,eeprom@0;
@@ -51,6 +53,7 @@
 	/delete-node/ qcom,camera@0;
 	/delete-node/ qcom,camera@1;
 	/delete-node/ qcom,camera@2;
+	/delete-node/ qcom,camera@3;
 
 	actuator0: qcom,actuator@0 {
 		cell-index = <0>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
@@ -123,8 +123,8 @@
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <0>;
 		qcom,actuator-src = <&actuator1>;
-		cam_vdig-supply = <&pm8998_s3>;
-		cam_vio-supply = <&pm8998_lvs1>;
+		cam_vdig-supply = <&cam_vdig_front_verg>;
+		cam_vio-supply = <&cam_vio_verg>;
 		cam_vaf-supply = <&pm8998_l22>;
 		cam_vana-supply = <&vana_stub_vreg>;
 		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vaf", "cam_vana";
@@ -135,15 +135,11 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_front_active>;
 		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_front_suspend>;
-		gpios = <&tlmm 14 0>, <&tlmm 28 0>,
-			<&pmi8998_gpios 1 0>, <&tlmm 25 0>;
+		gpios = <&tlmm 14 0>, <&tlmm 28 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-vio = <2>;
-		qcom,gpio-vdig = <3>;
-		qcom,gpio-req-tbl-num   = <0 1 2 3>;
-		qcom,gpio-req-tbl-flags = <1 0 0 0>;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1",
-					  "GPIO_VIO", "GPIO_VDIG";
+		qcom,gpio-req-tbl-num   = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1";
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-maple-camera.dtsi
@@ -19,6 +19,7 @@
 
 &soc {
 	/delete-node/ qcom,camera-flash@0;
+	/delete-node/ qcom,camera-flash@1;
 	/delete-node/ qcom,gpio-regulator@0;
 
 	led_flash0: qcom,camera-flash@0 {
@@ -43,6 +44,7 @@
 &cci {
 	/delete-node/ qcom,actuator@0;
 	/delete-node/ qcom,actuator@1;
+	/delete-node/ qcom,laserled@0;
 	/delete-node/ qcom,ois@0;
 	/delete-node/ qcom,tof@0;
 	/delete-node/ qcom,eeprom@0;
@@ -51,6 +53,7 @@
 	/delete-node/ qcom,camera@0;
 	/delete-node/ qcom,camera@1;
 	/delete-node/ qcom,camera@2;
+	/delete-node/ qcom,camera@3;
 
 	actuator0: qcom,actuator@0 {
 		cell-index = <0>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-poplar_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-poplar_camera.dtsi
@@ -123,8 +123,8 @@
 		qcom,csid-sd-index = <2>;
 		qcom,mount-angle = <0>;
 		qcom,actuator-src = <&actuator1>;
-		cam_vdig-supply = <&pm8998_s3>;
-		cam_vio-supply = <&pm8998_lvs1>;
+		cam_vdig-supply = <&cam_vdig_front_verg>;
+		cam_vio-supply = <&cam_vio_verg>;
 		cam_vaf-supply = <&pm8998_l22>;
 		cam_vana-supply = <&vana_stub_vreg>;
 		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vaf", "cam_vana";
@@ -135,15 +135,11 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_front_active>;
 		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_front_suspend>;
-		gpios = <&tlmm 14 0>, <&tlmm 28 0>,
-			<&pmi8998_gpios 1 0>, <&tlmm 25 0>;
+		gpios = <&tlmm 14 0>, <&tlmm 28 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-vio = <2>;
-		qcom,gpio-vdig = <3>;
-		qcom,gpio-req-tbl-num   = <0 1 2 3>;
-		qcom,gpio-req-tbl-flags = <1 0 0 0>;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1",
-					  "GPIO_VIO", "GPIO_VDIG";
+		qcom,gpio-req-tbl-num   = <0 1>;
+		qcom,gpio-req-tbl-flags = <1 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK2", "CAM_RESET1";
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-poplar_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-poplar_camera.dtsi
@@ -19,6 +19,7 @@
 
 &soc {
 	/delete-node/ qcom,camera-flash@0;
+	/delete-node/ qcom,camera-flash@1;
 	/delete-node/ qcom,gpio-regulator@0;
 
 	led_flash0: qcom,camera-flash@0 {
@@ -43,6 +44,7 @@
 &cci {
 	/delete-node/ qcom,actuator@0;
 	/delete-node/ qcom,actuator@1;
+	/delete-node/ qcom,laserled@0;
 	/delete-node/ qcom,ois@0;
 	/delete-node/ qcom,tof@0;
 	/delete-node/ qcom,eeprom@0;
@@ -51,6 +53,7 @@
 	/delete-node/ qcom,camera@0;
 	/delete-node/ qcom,camera@1;
 	/delete-node/ qcom,camera@2;
+	/delete-node/ qcom,camera@3;
 
 	actuator0: qcom,actuator@0 {
 		cell-index = <0>;


### PR DESCRIPTION
On 6.4.r1, jpegdma has never worked because of ... bad compatible string.

Tested on SoMC Maple.
FRONT SNAPSHOT OK
BACK SNAPSHOT OK

Depends on #1555 