### PR TITLE
[6.4.r1] somc_panel: Set picadj parameters only on DSI master

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -581,6 +581,14 @@ static int somc_panel_picadj_setup(struct mdss_panel_data *pdata)
 				panel_data);
 
 	/*
+	 * In case of a split-dsi panel configuration, do not set
+	 * any picadj parameter for the second half, as that would
+	 * be useless and may reset the whole block.
+	 */
+	if (pdata->panel_info.pdest != pdata->panel_info.dsi_master)
+		return 0;
+
+	/*
 	 * Note: MDSS_DSI_HW_REV_101_1 is 8974Pro, which has MDP
 	 * revision 1.2.1 (102_1).
 	 * New picadj is required starting from MDP rev. 1.3.0 (103)


### PR DESCRIPTION
In case of a split-dsi panel configuration, do not set any
picadj parameter for the second half, as that would be uselessly
re-setting the same parameters, or it may create issues such as
multiplied (or added) values or reset the whole block and just
discard any applied calibration.


Tested on split-dsi SoMC Maple.
Calibrations applied OK