### PR TITLE
[loire] fix mp3 playback on internal speakers

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -2652,8 +2652,12 @@
 		compatible = "qcom,msm-pcm-lpa";
 	};
 
-	compress: qcom,msm-compr-dsp {
+	compr: qcom,msm-compr-dsp {
 		compatible = "qcom,msm-compr-dsp";
+	};
+
+	compress: qcom,msm-compress-dsp {
+		compatible = "qcom,msm-compress-dsp";
 	};
 
 	voip: qcom,msm-voip-dsp {

--- a/sound/soc/msm/msm-dai-fe.c
+++ b/sound/soc/msm/msm-dai-fe.c
@@ -2512,6 +2512,7 @@ static struct snd_soc_dai_driver msm_fe_dais[] = {
 			.rate_min =	8000,
 			.rate_max = 384000,
 		},
+#ifndef CONFIG_ARCH_SONY_LOIRE
 		.capture = {
 			.stream_name = "MultiMedia16 Capture",
 			.aif_name = "MM_UL16",
@@ -2526,7 +2527,11 @@ static struct snd_soc_dai_driver msm_fe_dais[] = {
 			.rate_min =     8000,
 			.rate_max =     48000,
 		},
+#endif
 		.ops = &msm_fe_Multimedia_dai_ops,
+#ifdef CONFIG_ARCH_SONY_LOIRE
+		.compress_new = snd_soc_new_compress,
+#endif
 		.name = "MultiMedia16",
 		.probe = fe_dai_probe,
 	},


### PR DESCRIPTION
This PR fixes a couple issues on loire devices that break audio playback using offload on internal speakers.
1. The commit https://github.com/sonyxperiadev/kernel/commit/da60e6ac20006f2e5e350b0a75066ed5c2a461a4 removed a dt node required to register some ctls. This node is re-added.
2. The commit https://github.com/sonyxperiadev/kernel/commit/7357058c09a8a923f6698cf045e9ab5c677bb32b reserved MultiMedia16 for NOIRQ, which isn't supported on loire. An ifdef for loire is added there to use the older configuration.