### PR TITLE
ASoC: msm: qdsp6v2: Fix format parsing

### DIFF
--- a/sound/soc/msm/qdsp6v2/msm-pcm-q6-noirq.c
+++ b/sound/soc/msm/qdsp6v2/msm-pcm-q6-noirq.c
@@ -310,7 +310,7 @@ static int msm_pcm_hw_params(struct snd_pcm_substream *substream,
 	if (prtd->enabled)
 		return 0;
 
-	switch (runtime->format) {
+	switch (params_format(params)) {
 	case SNDRV_PCM_FORMAT_S24_LE:
 		bits_per_sample = 24;
 		sample_word_size = 32;


### PR DESCRIPTION
Use pcm params to query for format instead
of reading from the runtime struct

Bug: 62918461
Change-Id: I0c938f80d81a0bc8c9160a21e971e8a533844336
Signed-off-by: Haynes Mathew George <hgeorge@codeaurora.org>