### PR TITLE
[6.4.r1] rqbalance: Fix CPU resources lockdown (and some lagging)

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -607,7 +607,7 @@ static int balanced_cpufreq_transition(struct notifier_block *nb,
 {
 	struct cpufreq_freqs *freqs = data;
 	unsigned long cpu_freq;
-	int n;
+	int n = 0;
 
 	/*
 	 * If we have at least one BIG CPU online, then take

--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -75,9 +75,6 @@ typedef enum {
 	UP,
 } RQBALANCE_STATE;
 
-#define USERSPACE_RUNNING	0
-#define USERSPACE_LOW_POWER	1
-
 #define CLUSTER_LITTLE		0
 #define CLUSTER_BIG		1
 #define MAX_CLUSTERS		2
@@ -106,7 +103,6 @@ static unsigned long up_delay;
 static unsigned long down_delay;
 static unsigned long last_change_time;
 static unsigned int  load_sample_rate = 20; /* msec */
-static unsigned int  userspace_suspend_state = 0;
 static struct workqueue_struct *rqbalance_wq;
 static struct delayed_work rqbalance_work;
 static RQBALANCE_STATE rqbalance_state;
@@ -535,20 +531,6 @@ static void rqbalance_work_func(struct work_struct *work)
 
 	CPU_SPEED_BALANCE balance;
 
-	switch (userspace_suspend_state) {
-		case USERSPACE_RUNNING:
-			break;
-		case USERSPACE_LOW_POWER:
-		{
-			int i;
-			if (num_online_cpus() == 1)
-				return;
-			for (i = 1; i < nr_cpu_ids; i++)
-				cpu_down(cpu);
-			return;
-		}
-	}
-
 	switch (rqbalance_state) {
 	case IDLE:
 		break;
@@ -755,7 +737,6 @@ static ssize_t show_uint_array(struct cpuquiet_attribute *cattr,
 
 CPQ_SIMPLE_ATTRIBUTE(balance_level, 0644, uint);
 CPQ_SIMPLE_ATTRIBUTE(load_sample_rate, 0644, uint);
-CPQ_SIMPLE_ATTRIBUTE(userspace_suspend_state, 0644, uint);
 CPQ_CUSTOM_ATTRIBUTE(up_delay, 0644,
 			show_ulong_delay, store_ulong_delay);
 CPQ_CUSTOM_ATTRIBUTE(down_delay, 0644,
@@ -772,7 +753,6 @@ CPQ_CUSTOM_ATTRIBUTE(nr_run_thresholds, 0644,
 static struct attribute *rqbalance_attrs[] = {
 	&balance_level_attr.attr,
 	&load_sample_rate_attr.attr,
-	&userspace_suspend_state_attr.attr,
 	&up_delay_attr.attr,
 	&down_delay_attr.attr,
 	&idle_bottom_freq_attr.attr,


### PR DESCRIPTION
This patchset aims to address some lagging issues in some rather rare conditions on some devices, less rare on some others. Also, some cleanup has been done.

When the decider sets the RQBalance state to downcore, we may
still have a very CPU intensive process that is locking CPUFreq
to maximum frequency: this will make our frequency-based
algorithm kickstarter to just do nothing, while the userspace
may be spawning lots of other processes, resulting in a complete
hog of the current CPU available resources without being unable
to unlock more.

Of course, directly running a full evaluation right after that
will just waste CPU cycles and resources, so also introduce a
new worker delay variable "recheck_delay" that wants to be "an
high amount of time", preset to 2*down_delay: this will make us
able to wait enough time so that, if we have a single thread
that is very CPU intensive, we give it time to finish its job
without putting even more load on our system.

So:
If we want to forcefully downcore, and
- We haven't onlined all cores
- Our CPU is intensively used (perhaps by just one thread);
Then, run the worker again after recheck_delay millseconds
and prefer doing an upcore full evaluation to eventually
unlock more resources.


This PR appears to be similar to #1454, but:
1. Fixes the performance regressions introduced by that one
2. Fixes the power regressions
3. Decides based to the real current system load, instead of blindly temporarily disabling the downcore decision