### PR TITLE
[1.3.3] Kanuti audio

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -365,14 +365,7 @@
 	sound {
 		qcom,msm-mclk-freq = <9600000>;
 		qcom,msm-mbhc-hphl-swh = <1>;
-		/delete-property/ cdc_lines_quat_ext_act;
-		/delete-property/ cdc_lines_quat_ext_sus;
-
-		qcom,cdc-vdd-spkr-pd-gpios = <&msm_gpio 116 0>;
-		qcom,cdc-vdd-rcv-pd-gpios = <&msm_gpio 49 0>;
 		qcom,cdc-vdd-spkr-gpios = <&msm_gpio 49 0>;
-		qcom,cdc-vdd-hac-gpios = <&msm_gpio 116 0>;
-
 		/delete-node/ qcom,cdc-us-euro-gpios;
 	};
 };

--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -515,11 +515,6 @@
 		qcom,num-grp-pins = <4>;
 	};
 
-	ext-cdc-tlmm-lines { /* Verify me. CAF or FIH? */
-		qcom,pins = <&gp 112>, <&gp 117>, <&gp 118>, <&gp 119>;
-		qcom,num-grp-pins = <4>;
-	};
-
 	bma2x2_int_pin {
 		qcom,pins = <&gp 69>;
 		qcom,pin-func = <0>;

--- a/sound/soc/codecs/msm8x16-wcd.c
+++ b/sound/soc/codecs/msm8x16-wcd.c
@@ -3072,6 +3072,13 @@ static int msm8x16_wcd_codec_enable_spk_pa(struct snd_soc_dapm_widget *w,
 	dev_dbg(w->codec->dev, "%s %d %s\n", __func__, event, w->name);
 	switch (event) {
 	case SND_SOC_DAPM_PRE_PMU:
+#ifdef CONFIG_MACH_SONY_TULIP
+		if (vdd_spkr_gpio >= 0) {
+			gpio_direction_output(vdd_spkr_gpio, 1);
+			pr_debug("%s: Enabled 5V external supply for speaker\n",
+					__func__);
+		}
+#endif
 		snd_soc_update_bits(codec,
 			MSM8X16_WCD_A_DIGITAL_CDC_ANA_CLK_CTL, 0x10, 0x10);
 		snd_soc_update_bits(codec,
@@ -3170,6 +3177,13 @@ static int msm8x16_wcd_codec_enable_spk_pa(struct snd_soc_dapm_widget *w,
 		}
 		break;
 	case SND_SOC_DAPM_POST_PMD:
+#ifdef CONFIG_MACH_SONY_TULIP
+		if (vdd_spkr_gpio >= 0) {
+			gpio_direction_output(vdd_spkr_gpio, 0);
+			pr_debug("%s: Disabled 5V external supply for speaker\n",
+					__func__);
+		}
+#endif
 		snd_soc_update_bits(codec,
 			MSM8X16_WCD_A_ANALOG_SPKR_PWRSTG_CTL, 0xE0, 0x00);
 		usleep_range(CODEC_DELAY_1_MS, CODEC_DELAY_1_1_MS);

--- a/sound/soc/codecs/msm8x16-wcd.h
+++ b/sound/soc/codecs/msm8x16-wcd.h
@@ -61,6 +61,10 @@ extern const u8 msm8x16_wcd_reg_readonly[MSM8X16_WCD_CACHE_SIZE];
 extern const u8 msm8x16_wcd_reset_reg_defaults[MSM8X16_WCD_CACHE_SIZE];
 extern const u8 cajon_digital_reg[MSM8X16_WCD_CACHE_SIZE];
 
+#ifdef CONFIG_MACH_SONY_TULIP
+extern int vdd_spkr_gpio;
+#endif
+
 enum codec_versions {
 	TOMBAK_1_0,
 	TOMBAK_2_0,

--- a/sound/soc/msm/msm8x16.c
+++ b/sound/soc/msm/msm8x16.c
@@ -2640,10 +2640,11 @@ static int msm8x16_asoc_machine_probe(struct platform_device *pdev)
 		dev_dbg(&pdev->dev,
 			"%s: missing %s in dt node\n", __func__, vdd_spkr);
 	} else {
-		if (!gpio_is_valid(vdd_spkr_gpio)) {
-			pr_err("%s: Invalid vdd speaker gpio: %d",
+		ret = gpio_request(vdd_spkr_gpio, "vdd_spkr_gpio");
+		if (ret) {
+			/* GPIO to enable vdd spkr exists, but failed request */
+			pr_err("%s: Failed to request vdd spkr gpio %d\n",
 				__func__, vdd_spkr_gpio);
-			return -EINVAL;
 		}
 	}
 #endif

--- a/sound/soc/msm/msm8x16.c
+++ b/sound/soc/msm/msm8x16.c
@@ -65,6 +65,10 @@ static int msm_btsco_ch = 1;
 static int msm_ter_mi2s_tx_ch = 1;
 static int msm_pri_mi2s_rx_ch = 1;
 
+#ifdef CONFIG_MACH_SONY_TULIP
+int vdd_spkr_gpio = -1;
+#endif
+
 static int msm_proxy_rx_ch = 2;
 static int msm8909_auxpcm_rate = 8000;
 
@@ -2551,6 +2555,9 @@ static int msm8x16_asoc_machine_probe(struct platform_device *pdev)
 	const char *ext_pa = "qcom,msm-ext-pa";
 	const char *mclk = "qcom,msm-mclk-freq";
 	const char *spk_ext_pa = "qcom,msm-spk-ext-pa";
+#ifdef CONFIG_MACH_SONY_TULIP
+	const char *vdd_spkr = "qcom,cdc-vdd-spkr-gpios";
+#endif
 	const char *ptr = NULL;
 	const char *type = NULL;
 	const char *ext_pa_str = NULL;
@@ -2625,6 +2632,21 @@ static int msm8x16_asoc_machine_probe(struct platform_device *pdev)
 			return -EINVAL;
 		}
 	}
+
+#ifdef CONFIG_MACH_SONY_TULIP
+	vdd_spkr_gpio = of_get_named_gpio(pdev->dev.of_node,
+				vdd_spkr, 0);
+	if (vdd_spkr_gpio < 0) {
+		dev_dbg(&pdev->dev,
+			"%s: missing %s in dt node\n", __func__, vdd_spkr);
+	} else {
+		if (!gpio_is_valid(vdd_spkr_gpio)) {
+			pr_err("%s: Invalid vdd speaker gpio: %d",
+				__func__, vdd_spkr_gpio);
+			return -EINVAL;
+		}
+	}
+#endif
 
 	ret = of_property_read_string(pdev->dev.of_node, codec_type, &ptr);
 	if (ret) {
@@ -2782,6 +2804,9 @@ static int msm8x16_asoc_machine_remove(struct platform_device *pdev)
 		iounmap(pdata->vaddr_gpio_mux_pcm_ctl);
 	snd_soc_unregister_card(card);
 	mutex_destroy(&pdata->cdc_mclk_mutex);
+#ifdef CONFIG_MACH_SONY_TULIP
+	gpio_free(vdd_spkr_gpio);
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
Welcome fully working audio on Tulip device!:)
This patchset introduces support for external power for the speaker. Also, remove accidentally ported or obsolete parameters of audio nodes.
Also this patchset does not affect other platforms.

Note No.1: Patchset requires an updated mixer_paths. (PR: https://github.com/sonyxperiadev/device-sony-tulip/pull/52)
Note No.2: To get a fully working audio, requires an Audio HAL patch with msm8939-snd-card-mtp support.
