### PR TITLE
[1.3.3] Kanuti deepsleep fix + cleanup

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -81,19 +81,6 @@
 						0x31 0 255 0 0
 						/* ABS_MT_ORIENTATION, -128, 127, 0, 0 */
 						0x34 0xfffffed7 127 0 0>;
-
-					cy,vkeys_x = <720>;
-					cy,vkeys_y = <1280>;
-
-					cy,virtual_keys = /* KeyCode CenterX CenterY Width Height */
-						/* KEY_BACK */
-						<158 1360 90 160 180
-						/* KEY_MENU */
-						139 1360 270 160 180
-						/* KEY_HOME */
-						102 1360 450 160 180
-						/* KEY SEARCH */
-						217 1360 630 160 180>;
 				};
 			};
 		};
@@ -163,34 +150,6 @@
 						0x37 0 1 0 0
 						/* ABS_DISTANCE, 0, 255, 0, 0 */
 						0x19 0 255 0 0>;
-
-					cy,vkeys_x = <720>;
-					cy,vkeys_y = <1280>;
-
-					cy,virtual_keys = /* KeyCode CenterX CenterY Width Height */
-						/* KEY_BACK */
-						<158 1360 90 160 180
-						/* KEY_MENU */
-						139 1360 270 160 180
-						/* KEY_HOMEPAGE */
-						172 1360 450 160 180
-						/* KEY SEARCH */
-						217 1360 630 160 180>;
-				};
-
-				cy,btn {
-					cy,name = "cyttsp5_btn";
-
-					cy,inp_dev_name = "cyttsp5_btn";
-				};
-
-				cy,proximity {
-					cy,name = "cyttsp5_proximity";
-
-					cy,inp_dev_name = "cyttsp5_proximity";
-					cy,abs =
-						/* ABS_DISTANCE, CY_PROXIMITY_MIN_VAL, CY_PROXIMITY_MAX_VAL, 0, 0 */
-						<0x19 0 1 0 0>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -13,6 +13,7 @@
 / {
         aliases {
                 /delete-property/ spi0;
+                /delete-property/ spi5;
         };
 };
 
@@ -343,6 +344,13 @@
 	status = "disabled";
 };
 
+&spi_5 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	/delete-property/ pinctrl-1;
+	status = "disabled";
+};
+
 &i2c_0 {
 	qcom,clk-freq-out = <400000>;
 };
@@ -468,6 +476,10 @@
 	/delete-node/ spi0_suspend;
 	/delete-node/ spi0_cs0_active;
 	/delete-node/ spi0_cs0_suspend;
+	/delete-node/ spi5_active;
+	/delete-node/ spi5_suspend;
+	/delete-node/ spi5_cs0_active;
+	/delete-node/ spi5_cs0_suspend;
 
 	tlmm_gpio_key {
 		qcom,pins = <&gp 108>, <&gp 109>, <&gp 51>, <&gp 11>;

--- a/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8939-kanuti_tulip.dtsi
@@ -460,18 +460,6 @@
 
 /* Pinctrl */
 &tlmm_pinmux {
-	hwid_pins {
-		qcom,pins = <&gp 0>, <&gp 1>, <&gp 2>, <&gp 3>,
-			    <&gp 8>, <&gp 9>, <&gp 107>, <&gp 35>;
-		qcom,num-grp-pins = <8>;
-		qcom,pin-func = <0>;
-		label = "fih_hwid_pin";
-		hwid_init: init {
-			drive-strength = <2>;
-			bias-disable;
-		};
-	};
-
 	/delete-node/ spi0_active;
 	/delete-node/ spi0_suspend;
 	/delete-node/ spi0_cs0_active;

--- a/drivers/input/touchscreen/cyttsp4/cyttsp4_devtree.c
+++ b/drivers/input/touchscreen/cyttsp4/cyttsp4_devtree.c
@@ -45,7 +45,9 @@
 #include "cyttsp4_regs.h"
 #include "cyttsp4_devtree.h"
 
+#ifndef CONFIG_MACH_SONY_TULIP
 #define ENABLE_VIRTUAL_KEYS
+#endif
 
 #define MAX_NAME_LENGTH		64
 

--- a/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
+++ b/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
@@ -383,7 +383,6 @@ static void __exit cyttsp4_i2c_exit(void)
 }
 module_exit(cyttsp4_i2c_exit);
 
-MODULE_ALIAS(CYTTSP4_I2C_NAME);
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Cypress TrueTouch(R) Standard Product (TTSP) I2C driver");
 MODULE_AUTHOR("Cypress");

--- a/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
+++ b/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
@@ -254,6 +254,12 @@ static int cyttsp4_i2c_probe(struct i2c_client *client,
 	dev_dbg(dev, "%s: add adap='%s' (CYTTSP4_I2C_NAME=%s)\n", __func__,
 		ts_i2c->id, CYTTSP4_I2C_NAME);
 
+	rc = cyttsp4_ping_hw(ts_i2c);
+	if (rc) {
+		dev_err(dev, "%s: No HW detected\n", __func__);
+		goto add_adapter_err;
+	}
+
 	vdd = regulator_get(&client->dev, "vdd");
 	if (IS_ERR(vdd)) {
 		printk("%s: Failed to get vdd regulator\n", __func__);
@@ -302,12 +308,6 @@ static int cyttsp4_i2c_probe(struct i2c_client *client,
 	}
 
 	pm_runtime_enable(&client->dev);
-
-	rc = cyttsp4_ping_hw(ts_i2c);
-	if (rc) {
-		dev_err(dev, "%s: No HW detected\n", __func__);
-		goto add_adapter_err;
-	}
 
 	rc = cyttsp4_add_adapter(ts_i2c->id, &ops, dev);
 	if (rc) {

--- a/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
+++ b/drivers/input/touchscreen/cyttsp4/cyttsp4_i2c.c
@@ -366,22 +366,7 @@ static struct i2c_driver cyttsp4_i2c_driver = {
 	.id_table = cyttsp4_i2c_id,
 };
 
-static int __init cyttsp4_i2c_init(void)
-{
-	int rc = i2c_add_driver(&cyttsp4_i2c_driver);
-
-	pr_info("%s: Cypress TTSP I2C Touchscreen Driver (Built %s) rc=%d\n",
-		 __func__, CY_DRIVER_DATE, rc);
-	return rc;
-}
-module_init(cyttsp4_i2c_init);
-
-static void __exit cyttsp4_i2c_exit(void)
-{
-	i2c_del_driver(&cyttsp4_i2c_driver);
-	pr_info("%s: module exit\n", __func__);
-}
-module_exit(cyttsp4_i2c_exit);
+module_i2c_driver(cyttsp4_i2c_driver);
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Cypress TrueTouch(R) Standard Product (TTSP) I2C driver");

--- a/drivers/input/touchscreen/cyttsp5/cyttsp5_devtree.c
+++ b/drivers/input/touchscreen/cyttsp5/cyttsp5_devtree.c
@@ -31,7 +31,9 @@
 #include <linux/cyttsp5_platform.h>
 #include <linux/of_gpio.h>
 
+#ifndef CONFIG_MACH_SONY_TULIP
 #define ENABLE_VIRTUAL_KEYS
+#endif
 
 #define MAX_NAME_LENGTH		64
 

--- a/drivers/input/touchscreen/cyttsp5/cyttsp5_i2c.c
+++ b/drivers/input/touchscreen/cyttsp5/cyttsp5_i2c.c
@@ -281,25 +281,7 @@ static struct i2c_driver cyttsp5_i2c_driver = {
 	.id_table = cyttsp5_i2c_id,
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0))
 module_i2c_driver(cyttsp5_i2c_driver);
-#else
-static int __init cyttsp5_i2c_init(void)
-{
-	int rc = i2c_add_driver(&cyttsp5_i2c_driver);
-
-	pr_info("%s: Cypress TTSP v5 I2C Driver (Built %s) rc=%d\n",
-		 __func__, CY_DRIVER_DATE, rc);
-	return rc;
-}
-module_init(cyttsp5_i2c_init);
-
-static void __exit cyttsp5_i2c_exit(void)
-{
-	i2c_del_driver(&cyttsp5_i2c_driver);
-}
-module_exit(cyttsp5_i2c_exit);
-#endif
 
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("Cypress TrueTouch(R) Standard Product I2C driver");

--- a/drivers/input/touchscreen/cyttsp5/cyttsp5_i2c.c
+++ b/drivers/input/touchscreen/cyttsp5/cyttsp5_i2c.c
@@ -155,8 +155,10 @@ static int cyttsp5_i2c_probe(struct i2c_client *client,
 
 #ifdef CONFIG_MACH_SONY_TULIP
 	/* cyttsp detection */
-	if (cyttsp_i2c_driver)
-		return 0;
+	if (cyttsp_i2c_driver) {
+		dev_err(dev, "%s: CYTTSP4 detected. Stop probing.\n", __func__);
+		return -ENODEV;
+	}
 #endif
 
 	dev_info(dev, "%s: Starting %s probe...\n", __func__, CYTTSP5_I2C_NAME);


### PR DESCRIPTION
Welcome deepsleep on Tulip device.

This patchset prevents kernel panic when device with cyttsp4 panels going to deep sleep.
This fix is critical for Tulip, otherwise you will get a kernel panic every time when you try to go into deep sleep.
Also cleanup Kanuti DT, especially disable SPI_5, remove cyttsp4/5 virtual keys, cyttsp5 proximity and fih hwid_pins.
