### PR TITLE
[6.4.r1] Fix USB SDP mode charging issues (charging from PC)

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -6152,6 +6152,7 @@ static int smbchg_usb_get_property(struct power_supply *psy,
 	struct smbchg_chip *chip = power_supply_get_drvdata(psy);
 
 	switch (psp) {
+	case POWER_SUPPLY_PROP_SDP_CURRENT_MAX:
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
 		val->intval = chip->usb_current_max;
 		break;
@@ -6180,6 +6181,7 @@ static int smbchg_usb_set_property(struct power_supply *psy,
 	struct smbchg_chip *chip = power_supply_get_drvdata(psy);
 
 	switch (psp) {
+	case POWER_SUPPLY_PROP_SDP_CURRENT_MAX:
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
 		chip->usb_current_max = val->intval;
 		break;
@@ -6198,6 +6200,7 @@ static int
 smbchg_usb_is_writeable(struct power_supply *psy, enum power_supply_property psp)
 {
 	switch (psp) {
+	case POWER_SUPPLY_PROP_SDP_CURRENT_MAX:
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
 		return 1;
 	default:
@@ -6216,6 +6219,7 @@ static char *smbchg_usb_supplicants[] = {
 static enum power_supply_property smbchg_usb_properties[] = {
 	POWER_SUPPLY_PROP_PRESENT,
 	POWER_SUPPLY_PROP_ONLINE,
+	POWER_SUPPLY_PROP_SDP_CURRENT_MAX,
 	POWER_SUPPLY_PROP_CURRENT_MAX,
 	POWER_SUPPLY_PROP_TYPE,
 	POWER_SUPPLY_PROP_HEALTH,

--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -3882,19 +3882,19 @@ static void smbchg_external_power_changed(struct power_supply *psy)
 		vote(chip->usb_suspend_votable, POWER_SUPPLY_EN_VOTER,
 				!prop.intval, 0);
 
+#ifdef CONFIG_USB_MSM_OTG
+	rc = power_supply_get_property(chip->usb_psy,
+				POWER_SUPPLY_PROP_CURRENT_MAX, &prop);
+	if (rc == 0)
+		chip->usb_current_max = prop.intval;
+#endif
+
 	current_limit = chip->usb_current_max / 1000;
 
 	/* Override if type-c charger used */
 	if (chip->typec_current_ma > 500 &&
 			current_limit < chip->typec_current_ma)
 		current_limit = chip->typec_current_ma;
-
-#ifdef CONFIG_USB_MSM_OTG
-	rc = power_supply_get_property(chip->usb_psy,
-				POWER_SUPPLY_PROP_CURRENT_MAX, &prop);
-	if (rc == 0)
-		current_limit = prop.intval / 1000;
-#endif
 
 	read_usb_type(chip, &usb_type_name, &usb_supply_type);
 #ifdef CONFIG_QPNP_SMBCHARGER_EXTENSION

--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -6162,6 +6162,7 @@ static int smbchg_usb_get_property(struct power_supply *psy,
 	case POWER_SUPPLY_PROP_ONLINE:
 		val->intval = chip->usb_online;
 		break;
+	case POWER_SUPPLY_PROP_REAL_TYPE:
 	case POWER_SUPPLY_PROP_TYPE:
 		val->intval = chip->usb_supply_type;
 		break;
@@ -6221,6 +6222,7 @@ static enum power_supply_property smbchg_usb_properties[] = {
 	POWER_SUPPLY_PROP_ONLINE,
 	POWER_SUPPLY_PROP_SDP_CURRENT_MAX,
 	POWER_SUPPLY_PROP_CURRENT_MAX,
+	POWER_SUPPLY_PROP_REAL_TYPE,
 	POWER_SUPPLY_PROP_TYPE,
 	POWER_SUPPLY_PROP_HEALTH,
 };


### PR DESCRIPTION
[  138.097972] healthd: battery l=39 v=3849 t=27.0 h=2 st=2 c=-379 fc=2623000 cc=0 chg=u
[  183.739272] healthd: battery l=39 v=3856 t=26.5 h=2 st=2 c=-394 fc=2623000 cc=0 chg=u
[  198.100608] healthd: battery l=39 v=3859 t=26.5 h=2 st=2 c=-393 fc=2623000 cc=0 chg=u
[  219.414375] healthd: battery l=40 v=3859 t=26.5 h=2 st=2 c=-393 fc=2623000 cc=0 chg=u
[  219.479717] healthd: battery l=40 v=3859 t=26.5 h=2 st=2 c=-393 fc=2623000 cc=0 chg=u
[  258.098392] healthd: battery l=40 v=3862 t=26.0 h=2 st=2 c=-384 fc=2623000 cc=0 chg=u
[  318.100493] healthd: battery l=40 v=3860 t=25.7 h=2 st=2 c=-329 fc=2623000 cc=0 chg=u
[  347.700263] healthd: battery l=40 v=3867 t=25.7 h=2 st=2 c=-384 fc=2623000 cc=0 chg=u
[  347.762255] healthd: battery l=40 v=3867 t=25.7 h=2 st=2 c=-384 fc=2623000 cc=0 chg=u
[  349.198457] healthd: battery l=40 v=3867 t=25.7 h=2 st=2 c=-384 fc=2623000 cc=0 chg=u
[  378.100420] healthd: battery l=40 v=3868 t=25.2 h=2 st=2 c=-387 fc=2623000 cc=0 chg=u
[  438.098594] healthd: battery l=40 v=3872 t=25.2 h=2 st=2 c=-395 fc=2623000 cc=0 chg=u
[  470.111313] healthd: battery l=40 v=3873 t=25.2 h=2 st=2 c=-397 fc=2623000 cc=0 chg=u
[  470.143391] healthd: battery l=40 v=3873 t=25.2 h=2 st=2 c=-397 fc=2623000 cc=0 chg=u
[  498.100404] healthd: battery l=40 v=3872 t=25.0 h=2 st=2 c=-376 fc=2623000 cc=0 chg=u
[  514.597004] healthd: battery l=40 v=3872 t=25.0 h=2 st=2 c=-376 fc=2623000 cc=0 chg=u
[  558.100576] healthd: battery l=40 v=3874 t=25.0 h=2 st=2 c=-373 fc=2623000 cc=0 chg=u
[  588.147341] healthd: battery l=41 v=3877 t=25.0 h=2 st=2 c=-397 fc=2623000 cc=0 chg=u
[  588.224172] healthd: battery l=41 v=3877 t=25.0 h=2 st=2 c=-397 fc=2623000 cc=0 chg=u
[  618.098118] healthd: battery l=41 v=3872 t=24.5 h=2 st=2 c=-338 fc=2623000 cc=0 chg=u
[  677.038475] healthd: battery l=41 v=3816 t=24.5 h=2 st=2 c=114 fc=2623000 cc=0 chg=u
[  677.052538] healthd: battery l=41 v=3816 t=24.5 h=2 st=2 c=114 fc=2623000 cc=0 chg=u
[  678.098528] healthd: battery l=41 v=3816 t=24.5 h=2 st=2 c=114 fc=2623000 cc=0 chg=u
[  679.979360] healthd: battery l=41 v=3816 t=24.5 h=2 st=2 c=114 fc=2623000 cc=0 chg=u


Tested on SoMC Dora.
@oshmoun tested on SoMC Kugo.
