### PR TITLE
[6.4.r1] Fix Tone GPU lag issues on Android >=8.0

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-v3.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-v3.dtsi
@@ -135,7 +135,7 @@
 
 			qcom,speed-bin = <0>;
 
-			qcom,initial-pwrlevel = <6>;
+			qcom,initial-pwrlevel = <5>;
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;
@@ -208,7 +208,7 @@
 
 			qcom,speed-bin = <1>;
 
-			qcom,initial-pwrlevel = <4>;
+			qcom,initial-pwrlevel = <3>;
 
 			qcom,gpu-pwrlevel@0 {
 				reg = <0>;


### PR DESCRIPTION
Android >= 8.0 has strange requirements on GPU clocks.