### PR TITLE
drivers:gpu:msm: adjust drawobj timeout and memstore size for less performant platforms

### DIFF
--- a/drivers/gpu/msm/adreno_dispatch.c
+++ b/drivers/gpu/msm/adreno_dispatch.c
@@ -73,7 +73,11 @@ static unsigned int _dispatcher_q_inflight_hi = 15;
 static unsigned int _dispatcher_q_inflight_lo = 4;
 
 /* Command batch timeout (in milliseconds) */
+#if defined (CONFIG_ARCH_MSM8916) || defined (CONFIG_ARCH_SDM630) || defined (CONFIG_ARCH_SDM660)
+unsigned int adreno_drawobj_timeout = 4000;
+#else
 unsigned int adreno_drawobj_timeout = 2000;
+#endif
 
 /* Interval for reading and comparing fault detection registers */
 static unsigned int _fault_timer_interval = 200;

--- a/drivers/gpu/msm/kgsl.h
+++ b/drivers/gpu/msm/kgsl.h
@@ -51,7 +51,11 @@
 /* The number of memstore arrays limits the number of contexts allowed.
  * If more contexts are needed, update multiple for MEMSTORE_SIZE
  */
+#if defined (CONFIG_ARCH_MSM8916) || defined (CONFIG_ARCH_SDM630) || defined (CONFIG_ARCH_SDM660)
+#define KGSL_MEMSTORE_SIZE	((int)(PAGE_SIZE * 8))
+#else
 #define KGSL_MEMSTORE_SIZE	((int)(PAGE_SIZE * 2))
+#endif
 #define KGSL_MEMSTORE_GLOBAL	(0)
 #define KGSL_PRIORITY_MAX_RB_LEVELS 4
 #define KGSL_MEMSTORE_MAX	(KGSL_MEMSTORE_SIZE / \


### PR DESCRIPTION

platforms such as msm8956, sdm630 and sdm660 need more relaxed values to avoid gpu hangs and possibly other general instabilities.
Taken from kernel-copyleft 50.1.A.3.xxx:
https://github.com/sonyxperiadev/kernel-copyleft/blame/50.1.A.3.xxx/drivers/gpu/msm

Change-Id: I6516fa6b0a972690e600341e7c89cdfa9588cbe1