### PR TITLE
mmc: host: sdhci-msm: keep clocks enabled if suspend fails

### DIFF
--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -5055,6 +5055,10 @@ static int sdhci_msm_suspend_noirq(struct device *dev)
 	if (atomic_read(&msm_host->clks_on)) {
 		pr_warn("%s: %s: clock ON after suspend, aborting suspend\n",
 			mmc_hostname(host->mmc), __func__);
+		ret = sdhci_msm_enable_controller_clock(host);
+		if (ret)
+			pr_warn("%s: %s: failed to enable clock to avoid unclocked access!",
+				mmc_hostname(host->mmc), __func__);
 		ret = -EAGAIN;
 	}
 


### PR DESCRIPTION
If clocks are found to be enable whiled suspending, then the suspend is aborted.
However, it is possible for the clocks to be disabled by whatever caused them to be enabled at the time of suspend.
This leads to a race condition just before the suspend retry is triggered, where the clocks are disabled just as another task is trying to access the controller.

When this happens, the device crashes with the error:
[18096.907961] Unhandled fault: synchronous external abort (0x96000010) at 0xffffff800a93e928

To avoid this, make sure the clocks remain enabled when suspend fails by calling sdhci_msm_enable_controller_clock(host).

Change-Id: I554027c6c7f04d91cd773510c94dbc45f4eaa5f3