### PR TITLE
[6.4.r1] Fix Nile Discovery camera

### DIFF
--- a/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
@@ -251,12 +251,39 @@
 		clock-names = "cam_src_clk", "cam_clk";
 		qcom,clock-rates = <24000000 0>;
 	};
+
+	qcom,i2c_standard_mode {
+		qcom,hw-scl-stretch-en = <1>;
+	};
+
+	qcom,i2c_fast_mode {
+		qcom,hw-thigh = <43>;
+		qcom,hw-tlow = <64>;
+		qcom,hw-tsu-sto = <41>;
+		qcom,hw-tsu-sta = <41>;
+		qcom,hw-thd-dat = <25>;
+		qcom,hw-thd-sta = <35>;
+		qcom,hw-tbuf = <64>;
+		qcom,hw-scl-stretch-en = <1>;
+		qcom,hw-trdhld = <6>;
+		qcom,hw-tsp = <3>;
+		qcom,cci-clk-src = <37500000>;
+		status = "ok";
+	};
+
+	qcom,i2c_fast_plus_mode {
+		qcom,hw-thigh = <16>;
+		qcom,hw-tlow = <22>;
+		qcom,hw-tsu-sto = <17>;
+		qcom,hw-tsu-sta = <18>;
+		qcom,hw-thd-dat = <16>;
+		qcom,hw-thd-sta = <15>;
+		qcom,hw-tbuf = <19>;
+		qcom,hw-scl-stretch-en = <1>;
+		qcom,hw-trdhld = <3>;
+		qcom,hw-tsp = <3>;
+		qcom,cci-clk-src = <37500000>;
+		status = "ok";
+	};
 };
 
-&i2c_freq_100Khz {
-	qcom,hw-scl-stretch-en = <1>;
-};
-
-&i2c_freq_400Khz {
-	qcom,hw-scl-stretch-en = <1>;
-};

--- a/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
@@ -14,7 +14,7 @@
  * VREGs mapping
  *
  * VDIG VIO VANA ACT OIS SENSOR
- * 52   13  50   L18 N   IMX300 (BACK)
+ * 52   13  50   L3  N   IMX300 (BACK)
  * 12   13  51   L3  L3  IMX234 (FRONT)
  * 52   13  51   N   N   IMX219 (FRONT)
  */
@@ -110,7 +110,7 @@
 		reg = <0x0>;
 		compatible = "qcom,actuator";
 		qcom,cci-master = <0>;
-		cam_vaf-supply = <&pm660l_l8>;
+		cam_vaf-supply = <&pm660l_l3>;
 		qcom,cam-vreg-name = "cam_vaf";
 		qcom,cam-vreg-min-voltage = <2800000>;
 		qcom,cam-vreg-max-voltage = <2800000>;
@@ -151,7 +151,7 @@
 		qcom,mount-angle = <0>;
 		qcom,led-flash-src = <&led_flash0>;
 		qcom,actuator-src = <&actuator0>;
-		cam_vaf-supply = <&pm660l_l8>;
+		cam_vaf-supply = <&pm660l_l3>;
 		cam_vdig-supply = <&cam_vdig_imx300_219_vreg>;
 		cam_vio-supply = <&cam_vio_vreg>;
 		cam_vana-supply = <&cam_vana_rear_vreg>;


### PR DESCRIPTION
The vreg rail was wrong. Also, configure custom i2c parameters, as the other devices with the same camera/actuator are, with the difference of (necessarily) enabled scl stretched timings.

TEST: Camera is working on SoMC Nile Discovery.