### PR TITLE
[64r1] Enhance Yoshino camera user experience

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -566,6 +566,11 @@
 			qcom,soc-low-threshold = <5>;
 		};
 	};
+
+	qcom,cpp@ca04000 {
+		qcom,src-clock-rates = <200000000 384000000
+					576000000 600000000>;
+	};
 };
 
 &qusb_phy0 {

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
@@ -60,6 +60,10 @@
 			sony,tof-avdd-supply = <1>;
 		};
 	};
+
+	qcom,cpp@ca04000 {
+		qcom,min-clock-rate = <384000000>;
+	};
 };
 
 &pm8998_gpios {


### PR DESCRIPTION
We have a nice frequency of 384MHz that we can use for certain
resolutions and refresh rates on our cameras.
This frequency ensures we are not wasting battery unnecessarily,
reducing heat and that we have enough performance for a snappy
user experience.

Also, solve an user experience issue on Lilac front camera.