### PR TITLE
[6.4.r1] tty: serial: Correct IPC_LOGGING ifdef

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -3634,9 +3634,9 @@ static int msm_hs_probe(struct platform_device *pdev)
 	memset(name, 0, sizeof(name));
 	scnprintf(name, sizeof(name), "%s%s", dev_name(msm_uport->uport.dev),
 									"_rx");
+#ifdef CONFIG_IPC_LOGGING
 	msm_uport->rx.ipc_rx_ctxt = ipc_log_context_create(
 					IPC_MSM_HS_LOG_DATA_PAGES, name, 0);
-#ifdef CONFIG_IPC_LOGGING
 	if (!msm_uport->rx.ipc_rx_ctxt)
 		dev_err(&pdev->dev, "%s: error creating rx logging context",
 								__func__);


### PR DESCRIPTION
ipc_log_context_create() is function used to create a ipc log context.
All code that uses this function must be placed under IPC_LOGGING ifdef.
In our case this function is placed before ifdef. Hence, fix this.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>