### PR TITLE
pwm-qpnp: fix the uninitialized pwm mode issue

### DIFF
--- a/drivers/pwm/pwm-qpnp.c
+++ b/drivers/pwm/pwm-qpnp.c
@@ -1600,7 +1600,7 @@ static void qpnp_pwm_disable(struct pwm_chip *pwm_chip,
  */
 int pwm_change_mode(struct pwm_device *pwm, enum pm_pwm_mode mode)
 {
-	int rc;
+	int rc = 0;
 	unsigned long flags;
 	struct qpnp_pwm_chip *chip;
 
@@ -2221,8 +2221,10 @@ static int qpnp_parse_dt_config(struct platform_device *pdev,
 	}
 
 	rc = of_property_read_u32(of_node, "qcom,mode-select", &mode);
-	if (rc)
+	if (rc) {
+		chip->pwm_mode = -EINVAL;
 		goto read_opt_props;
+	}
 
 	if (mode > PM_PWM_MODE_LPG ||
 		(mode == PM_PWM_MODE_PWM && found_pwm_subnode == 0) ||


### PR DESCRIPTION
If the led request the PWM mode and the initial mode is PWM
when change the led pwm mode, it will fail to change pwm mode
for no mode change with a uninitialized return code and cause
the LED configuration failing

Change-Id: I29ba3823fb7b4f0d1b2a0d9f22c464c94fbe9717
Signed-off-by: yanyh2 <yanyh2@lenovo.com>
Reviewed-on: https://gerrit.mot.com/1072946
SME-Granted: SME Approvals Granted
SLTApproved: Slta Waiver
Tested-by: Jira Key
Reviewed-by: Yeqing Wang <wangyq13@motorola.com>
Reviewed-by: Coverity Analysis <coverity@motorola.com>
Reviewed-by: Kenneth Kessler <kennykessler@motorola.com>
Submit-Approved: Jira Key