### PR TITLE
[6.4.r1] arm: DT: Kugo: Fix typo in secondary camera node name

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo_camera.dtsi
@@ -81,7 +81,7 @@
 		qcom,clock-rates = <24000000 0>;
 	};
 
-	qcom,camera1@1{
+	qcom,camera@1{
 		cell-index = <1>;
 		compatible = "qcom,camera";
 		reg = <0x1>;


### PR DESCRIPTION
The correct node name is qcom,camera.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>