### PR TITLE
[5.7.r1] Fix loire lpm and kanuti cpufreq

### DIFF
--- a/drivers/cpuidle/lpm-levels.c
+++ b/drivers/cpuidle/lpm-levels.c
@@ -1587,6 +1587,8 @@ static int lpm_cpuidle_enter(struct cpuidle_device *dev,
 		if (idx > 0)
 			update_debug_pc_event(CPU_EXIT, idx, success,
 							0xdeaffeed, true);
+	} else {
+		success = psci_enter_sleep(cluster, idx, true);
 	}
 #else
 	BUG_ON(!use_psci);
@@ -1839,6 +1841,8 @@ static int lpm_suspend_enter(suspend_state_t state)
 #if defined(CONFIG_MSM_PM) && defined(CONFIG_ARCH_MSM8916)
 	if (!use_psci)
 		msm_cpu_pm_enter_sleep(cluster->cpu->levels[idx].mode, false);
+	else
+		psci_enter_sleep(cluster, idx, true);
 #else
 	BUG_ON(!use_psci);
 	psci_enter_sleep(cluster, idx, true);

--- a/drivers/regulator/onsemi-ncp6335d.c
+++ b/drivers/regulator/onsemi-ncp6335d.c
@@ -764,7 +764,7 @@ int __init ncp6335d_regulator_init(void)
 	return i2c_add_driver(&ncp6335d_regulator_driver);
 }
 EXPORT_SYMBOL(ncp6335d_regulator_init);
-subsys_initcall(ncp6335d_regulator_init);
+arch_initcall(ncp6335d_regulator_init);
 
 static void __exit ncp6335d_regulator_exit(void)
 {


### PR DESCRIPTION
After the previous PR, Loire platform got a regression that was successfully fixed in this PR, other platforms was not affected. Also there is onsemi regulator patch for early initialization, this is necessary for the correct cpufreq initialization.
This PR was tested on Suzu device, Loire platform.