### PR TITLE
[64r1] [LOIRE] Fix MSM8956 battery drainage issue

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -522,21 +522,8 @@
 	clock_gcc_gfx: gfx3d-clock-controller@1800000 {
                 compatible = "qcom,gcc-gfx-8976";
                 reg = <0x1800000 0x80000>;
-               // reg-names = "cc_base";
 		vdd_dig_gfx-supply = <&pm8950_s2_level>;
 		vdd_gfx-supply = <&gfx_vreg_corner>;
-		gpu_handle = <&msm_gpu>;
-                qcom,gfxfreq-corner =
-			<         0   0 >,
-			< 133333333   1 >,  /* Min SVS   */
-			< 200000000   2 >,  /* Low SVS   */
-			< 266666667   3 >,  /* SVS Minus */
-			< 300000000   4 >,  /* SVS       */
-			< 366670000   5 >,  /* SVS Plus  */
-			< 432000000   6 >,  /* NOM       */
-			< 480000000   7 >,  /* Turbo     */
-			< 550000000   8 >,  /* Super Turbo */
-			< 600000000   9 >;  /* Super Turbo */
 		#clock-cells = <1>;
 		status = "ok";
 	};

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -523,6 +523,7 @@
                 compatible = "qcom,gcc-gfx-8976";
                 reg = <0x1800000 0x80000>;
                // reg-names = "cc_base";
+		vdd_dig_gfx-supply = <&pm8950_s2_level>;
 		vdd_gfx-supply = <&gfx_vreg_corner>;
 		gpu_handle = <&msm_gpu>;
                 qcom,gfxfreq-corner =

--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -514,7 +514,6 @@
 	clock_gcc_mdss: mdss-clock-controller@1800000 {
 		compatible = "qcom,gcc-mdss-8976";
 		reg = <0x1800000 0x80000>;
-                //reg-names = "cc_base";
 		#clock-cells = <1>;
 		status = "ok";
 	};
@@ -532,55 +531,7 @@
 		compatible = "qcom,cc-debug-8976";
 		#clock-cells = <1>;
 	};
-#if 0
-	clock_gcc: qcom,gcc@1800000 {
-		compatible = "qcom,gcc-8976";
-		reg = <0x1800000 0x80000>;
-		reg-names = "cc_base";
-		vdd_dig-supply = <&pm8950_s2_level>;
-		#reset-cells = <1>;
-	};
 
-	clock_debug: qcom,cc-debug@1874000 {
-		compatible = "qcom,cc-debug-8976";
-		clocks = <&clock_cpu clk_cpu_debug_pri_mux>;
-		clock-names = "debug_cpu_clk";
-		#clock-cells = <1>;
-	};
-
-	clock_gcc_gfx: qcom,gcc-gfx@1800000 {
-                compatible = "qcom,gcc-gfx-8976";
-                reg = <0x1800000 0x80000>;
-                reg-names = "cc_base";
-		vdd_gfx-supply = <&gfx_vreg_corner>;
-		gpu_handle = <&msm_gpu>;
-                qcom,gfxfreq-corner =
-			<         0   0 >,
-			< 133333333   1 >,  /* Min SVS   */
-			< 200000000   2 >,  /* Low SVS   */
-			< 266666667   3 >,  /* SVS Minus */
-			< 300000000   4 >,  /* SVS       */
-			< 366670000   5 >,  /* SVS Plus  */
-			< 432000000   6 >,  /* NOM       */
-			< 480000000   7 >,  /* Turbo     */
-			< 550000000   8 >,  /* Super Turbo */
-			< 600000000   9 >;  /* Super Turbo */
-		#clock-cells = <1>;
-	};
-
-	clock_gcc_mdss: qcom,gcc-mdss@1800000 {
-		compatible = "qcom,gcc-mdss-8976";
-		reg = <0x1800000 0x80000>;
-                reg-names = "cc_base";
-		clocks = <&mdss_dsi0_pll clk_dsi_pll0_pixel_clk_src>,
-			 <&mdss_dsi0_pll clk_dsi_pll0_byte_clk_src>,
-			 <&mdss_dsi1_pll clk_dsi_pll1_pixel_clk_src>,
-			 <&mdss_dsi1_pll clk_dsi_pll1_byte_clk_src>;
-		clock-names = "pclk0_src", "byte0_src", "pclk1_src",
-				 "byte1_src";
-		#clock-cells = <1>;
-	};
-#endif
 	clock_cpu: qcom,cpu-clock-8976@b016000 {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -693,14 +644,6 @@
 			<  614400000 6>;
 		#clock-cells = <1>;
 		ranges;
-		qcom,spm@0 {
-			compatible = "qcom,cpu-spm-8976";
-			reg = <0x0b111200 0x100>,
-			      <0x0b011200 0x100>,
-			      <0x0b1d4000 0x100>;
-			reg-names = "spm_c0_base", "spm_c1_base",
-				     "spm_cci_base";
-		};
 	};
 
 	cci_cache: qcom,cci {

--- a/drivers/clk/qcom/gcc-msm8976.c
+++ b/drivers/clk/qcom/gcc-msm8976.c
@@ -432,6 +432,12 @@ static struct clk_regmap gpll2_out_main = {
 	},
 };
 
+#define F_GPLL(f, l, m, n) { (f), (l), (m), (n), 0 }
+
+static struct pll_freq_tbl gpll3_freq_tbl[] = {
+	F_GPLL(1100000000, 57, 7, 24),
+};
+
 static struct clk_pll gpll3 = {
 	.l_reg		= 0x22004,
 	.m_reg		= 0x22008,
@@ -440,6 +446,7 @@ static struct clk_pll gpll3 = {
 	.mode_reg	= 0x22000,
 	.status_reg	= 0x22024,
 	.status_bit	= 17,
+	.freq_tbl	= gpll3_freq_tbl,
 	.clkr.hw.init = &(struct clk_init_data) {
 		.name = "gpll3",
 		.parent_names = (const char*[]) { "xo" },
@@ -4269,6 +4276,8 @@ static int gcc_8976_probe(struct platform_device *pdev)
 
 	clk_pll_configure_sr_hpm_lp(&gpll3, regmap,
 					&gpll3_config, true);
+
+	clk_set_rate(gpll3.clkr.hw.clk, 1100000000);
 
 	/* Enable AUX2 clock for APSS */
 	regmap_update_bits(regmap, 0x60000, BIT(2), BIT(2));

--- a/drivers/clk/qcom/gcc-msm8976.c
+++ b/drivers/clk/qcom/gcc-msm8976.c
@@ -315,7 +315,6 @@ static const char * const gcc_parent_names_mdss_byte1[] = {
 static const struct parent_map gcc_parent_map_gfx3d[] = {
 	{ P_XO, 0 },
 	{ P_GPLL0_OUT_MAIN, 1 },
-	{ P_GPLL3_OUT_MAIN, 2 },
 	{ P_GPLL4_GFX3D, 5 },
 	{ P_GPLL6_GFX3D, 3 },
 };
@@ -323,7 +322,6 @@ static const struct parent_map gcc_parent_map_gfx3d[] = {
 static const char * const gcc_parent_names_gfx3d[] = {
 	"xo",
 	"gpll0_out_main",
-	"gpll3_out_main",
 	"gpll4_out_main",
 	"gpll6_out_main",
 };
@@ -1540,11 +1538,11 @@ static const struct freq_tbl ftbl_gfx3d_clk_src[] = {
 	F( 240000000,   P_GPLL6_GFX3D,  4.5,    0,     0),
 	F( 266666667,P_GPLL0_OUT_MAIN,    3,    0,     0),
 	F( 300000000,   P_GPLL4_GFX3D,    4,    0,     0),
-	F( 366670000,P_GPLL3_OUT_MAIN,    3,    0,     0),
+	F( 360000000,   P_GPLL6_GFX3D,    3,    0,     0),
 	F( 400000000,P_GPLL0_OUT_MAIN,    2,    0,     0),
 	F( 432000000,   P_GPLL6_GFX3D,  2.5,    0,     0),
 	F( 480000000,   P_GPLL4_GFX3D,  2.5,    0,     0),
-	F( 550000000,P_GPLL3_OUT_MAIN,    2,    0,     0),
+	F( 540000000,   P_GPLL6_GFX3D,    2,    0,     0),
 	F( 600000000,   P_GPLL4_GFX3D,    2,    0,     0),
 	{ }
 };
@@ -1560,10 +1558,10 @@ static struct clk_init_data gfx3d_clk_params = {
 			LOW_SVS,	200000000,
 			SVS_MINUS,	266666667,
 			SVS,		300000000,
-			SVS_PLUS,	366670000,
+			SVS_PLUS,	360000000,
 			NOMINAL,	432000000,
 			TURBO,		480000000,
-			TURBO_L1,	550000000,
+			TURBO_L1,	540000000,
 			SUPER_TURBO,	600000000),
 };
 
@@ -3263,7 +3261,7 @@ static struct clk_branch gcc_oxili_gfx3d_clk = {
 			},
 			.num_parents = 1,
 			.flags = CLK_SET_RATE_PARENT,
-			VDD_DIG_GFX_FMAX_MAP5(LOWER, 300000000, LOW, 366670000,
+			VDD_DIG_GFX_FMAX_MAP5(LOWER, 300000000, LOW, 360000000,
 				NOMINAL, 432000000, NOM_PLUS, 480000000,
 				HIGH, 600000000),
 			.ops = &clk_branch2_ops,

--- a/drivers/clk/qcom/gcc-msm8976.c
+++ b/drivers/clk/qcom/gcc-msm8976.c
@@ -1565,7 +1565,7 @@ static struct clk_rcg2 gfx3d_clk_src = {
 	.hid_width = 5,
 	.parent_map = gcc_parent_map_gfx3d,
 	.freq_tbl = ftbl_gfx3d_clk_src,
-//	.flags = FORCE_ENABLE_RCGR,
+	.flags = FORCE_ENABLE_RCGR,
 	.clkr.hw.init = &gfx3d_clk_params,
 };
 

--- a/drivers/clk/qcom/gcc-msm8976.c
+++ b/drivers/clk/qcom/gcc-msm8976.c
@@ -1545,7 +1545,7 @@ static struct clk_init_data gfx3d_clk_params = {
 	.name = "gfx3d_clk_src",
 	.parent_names = gcc_parent_names_gfx3d,
 	.num_parents = ARRAY_SIZE(gcc_parent_names_gfx3d),
-	.ops = &clk_gfx3d_src_ops,
+	.ops = &clk_rcg2_ops,
 	.vdd_class = &vdd_gfx,
 	//.flags = CLK_SET_RATE_PARENT,
 	VDD_GFX_FMAX_MAP9(MIN_SVS,	133333333,

--- a/drivers/clk/qcom/gcc-msm8976.c
+++ b/drivers/clk/qcom/gcc-msm8976.c
@@ -42,6 +42,7 @@
 /* Porting starts here */
 
 static DEFINE_VDD_REGULATORS(vdd_dig, VDD_DIG_NUM, 1, vdd_corner);
+static DEFINE_VDD_REGULATORS(vdd_dig_gfx, VDD_DIG_NUM, 1, vdd_corner);
 static DEFINE_VDD_REGULATORS(vdd_gfx, VDD_GFX_MAX, 1, vdd_gfx_corner);
 
 #define F(f, s, h, m, n) { (f), (s), (2 * (h) - 1), (m), (n) }
@@ -3255,7 +3256,7 @@ static struct clk_branch gcc_oxili_gfx3d_clk = {
 			},
 			.num_parents = 1,
 			.flags = CLK_SET_RATE_PARENT,
-			VDD_DIG_FMAX_MAP5(LOWER, 300000000, LOW, 366670000,
+			VDD_DIG_GFX_FMAX_MAP5(LOWER, 300000000, LOW, 366670000,
 				NOMINAL, 432000000, NOM_PLUS, 480000000,
 				HIGH, 600000000),
 			.ops = &clk_branch2_ops,
@@ -4856,6 +4857,13 @@ static int msm_gcc_8976_gfx_probe(struct platform_device *pdev)
 		if (PTR_ERR(vdd_gfx.regulator[0]) != -EPROBE_DEFER)
 			dev_err(&pdev->dev, "Unable to get vdd_gfx regulator!");
 		return PTR_ERR(vdd_gfx.regulator[0]);
+	}
+
+	vdd_dig_gfx.regulator[0] = devm_regulator_get(&pdev->dev, "vdd_dig_gfx");
+	if (IS_ERR(vdd_gfx.regulator[0])) {
+		if (PTR_ERR(vdd_dig_gfx.regulator[0]) != -EPROBE_DEFER)
+			dev_err(&pdev->dev, "Unable to get vdd_dig_gfx regulator!");
+		return PTR_ERR(vdd_dig_gfx.regulator[0]);
 	}
 
 	ret = qcom_cc_really_probe(pdev, &gcc_msm8976_gfx3d_desc, regmap);

--- a/drivers/clk/qcom/vdd-level-8976.h
+++ b/drivers/clk/qcom/vdd-level-8976.h
@@ -62,6 +62,22 @@
 	},                                      \
 	.num_rate_max = VDD_DIG_NUM
 
+#define VDD_GFX_FMAX_MAP9(l1, f1, l2, f2, l3, f3, l4, f4, l5, f5, l6, f6, \
+				l7, f7, l8, f8, l9, f9) \
+	.vdd_class = &vdd_gfx,			\
+	.rate_max = (unsigned long[VDD_GFX_MAX]) {	\
+		[VDD_GFX_##l1] = (f1),		\
+		[VDD_GFX_##l2] = (f2),		\
+		[VDD_GFX_##l3] = (f3),		\
+		[VDD_GFX_##l4] = (f4),		\
+		[VDD_GFX_##l5] = (f5),		\
+		[VDD_GFX_##l6] = (f6),		\
+		[VDD_GFX_##l7] = (f7),		\
+		[VDD_GFX_##l8] = (f8),		\
+		[VDD_GFX_##l9] = (f9),		\
+	},					\
+	.num_rate_max = VDD_GFX_MAX
+
 enum vdd_dig_levels {
 	VDD_DIG_NONE,
 	VDD_DIG_LOWER,		/* SVS2 */
@@ -72,6 +88,20 @@ enum vdd_dig_levels {
 	VDD_DIG_NUM
 };
 
+enum vdd_gfx_levels {
+	VDD_GFX_NONE,		/* OFF			*/
+	VDD_GFX_MIN_SVS,	/* MIN:  MinSVS		*/
+	VDD_GFX_LOW_SVS,	/* LOW:  LowSVS		*/
+	VDD_GFX_SVS_MINUS,	/* LOW:  SVS-		*/
+	VDD_GFX_SVS,		/* LOW:  SVS		*/
+	VDD_GFX_SVS_PLUS,	/* LOW:  SVS+		*/
+	VDD_GFX_NOMINAL,	/*       NOMINAL	*/
+	VDD_GFX_TURBO,		/* HIGH: TURBO		*/
+	VDD_GFX_TURBO_L1,	/* HIGH: TURBO_L1	*/
+	VDD_GFX_SUPER_TURBO,	/* HIGH: SUPER_TURBO	*/
+	VDD_GFX_MAX,		/*    FURNACE MODE!	*/
+};
+
 static int vdd_corner[] = {
 	RPM_REGULATOR_LEVEL_NONE,               /* VDD_DIG_NONE */
 	RPM_REGULATOR_LEVEL_SVS,		/* VDD_DIG_LOWER  */
@@ -79,6 +109,19 @@ static int vdd_corner[] = {
 	RPM_REGULATOR_LEVEL_NOM,		/* VDD_DIG_NOMINAL */
 	RPM_REGULATOR_LEVEL_NOM_PLUS,		/* VDD_DIG_NOM_PLUS */
 	RPM_REGULATOR_LEVEL_TURBO,		/* VDD_DIG_TURBO */
+};
+
+static int vdd_gfx_corner[] = {
+	VDD_GFX_NONE,		/* OFF			*/
+	VDD_GFX_MIN_SVS,	/* MIN:  MinSVS		*/
+	VDD_GFX_LOW_SVS,	/* LOW:  LowSVS		*/
+	VDD_GFX_SVS_MINUS,	/* LOW:  SVS-		*/
+	VDD_GFX_SVS,		/* LOW:  SVS		*/
+	VDD_GFX_SVS_PLUS,	/* LOW:  SVS+		*/
+	VDD_GFX_NOMINAL,	/*       NOMINAL	*/
+	VDD_GFX_TURBO,		/* HIGH: TURBO		*/
+	VDD_GFX_TURBO_L1,	/* HIGH: TURBO_L1	*/
+	VDD_GFX_SUPER_TURBO,	/* HIGH: SUPER_TURBO	*/
 };
 
 #endif

--- a/drivers/clk/qcom/vdd-level-8976.h
+++ b/drivers/clk/qcom/vdd-level-8976.h
@@ -62,6 +62,17 @@
 	},                                      \
 	.num_rate_max = VDD_DIG_NUM
 
+#define VDD_DIG_GFX_FMAX_MAP5(l1, f1, l2, f2, l3, f3, l4, f4, l5, f5) \
+	.vdd_class = &vdd_dig_gfx, \
+	.rate_max = (unsigned long[VDD_DIG_NUM]) {  \
+		[VDD_DIG_##l1] = (f1),          \
+		[VDD_DIG_##l2] = (f2),          \
+		[VDD_DIG_##l3] = (f3),          \
+		[VDD_DIG_##l4] = (f4),          \
+		[VDD_DIG_##l5] = (f5),          \
+	},                                      \
+	.num_rate_max = VDD_DIG_NUM
+
 #define VDD_GFX_FMAX_MAP9(l1, f1, l2, f2, l3, f3, l4, f4, l5, f5, l6, f6, \
 				l7, f7, l8, f8, l9, f9) \
 	.vdd_class = &vdd_gfx,			\


### PR DESCRIPTION
The GFX3D clock's power supply was getting stuck because of invalid refcounts: this was producing an anomalous battery consumption issue that was draining it fast.

Fix the issue by giving it the proper supplies and refactor the clock declarations to remove uselessly DT-declared clock tables and make them static.

Also, cleanup the DTs from missed leftovers.