### PR TITLE
arm: DT: msm8956-gpu: replace 550mhz frequency with 540mhz

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-gpu.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-gpu.dtsi
@@ -151,7 +151,7 @@
 			/* TURBO */
 			qcom,gpu-pwrlevel@1 {
 				reg = <1>;
-				qcom,gpu-freq = <550000000>;
+				qcom,gpu-freq = <540000000>;
 				qcom,bus-freq = <9>;
 				qcom,bus-min = <9>;
 				qcom,bus-max = <10>;


### PR DESCRIPTION
the 550mhz frequency did not work properly due to issues with PLL3.
To fix that, PLL6 was used, but that caused a small deviation in the resulting rate (550mhz -> 540mhz).
Reflect the change here to keep the frequency tables synced up.

Change-Id: I67e091428c3fb83f5269a0409df3b26bed4dbd91