### PR TITLE
Aries dsi panel: Fix screen flickering on Chinese cmd Panels

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-somc-aries.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-somc-aries.dtsi
@@ -44,7 +44,7 @@
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,panel-supply-entries = <&shinano_panel_power_supply>;
 		qcom,mdss-dsi-panel-destination = "display_1";
-		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-width = <720>;
 		qcom,mdss-dsi-panel-height = <1280>;
 		qcom,mdss-dsi-bpp = <24>;


### PR DESCRIPTION
the Chinese screen mounted on my phone is recognized as default_panel_1
[    0.512955] panel_detect_setup: DriverIC GPIO: 1
[    0.512966] do_panel_detect: Starting ADC Panel Detection...
[    0.512975] adc_panel_detect: Found panel ADC: 900522
[    0.513036] mdss_panel_parse_dt: Panel Name = default
[    0.513082] mdss_dsi_panel_timing_from_dt: found new timing "somc,default_panel_1" (f3da18f4)
[    0.513130] mdss_dsi_panel_timing_switch: ndx=0 switching to panel timing "somc,default_panel_1"

but there there was a significant flickering of the screen, so I investigated and i found that Chinese panels work in dsi_cmd_mode.
Also on original 3.4 kernel the default_panel_1 configuration is setted to dsi_cmd_mode.
This fixes the problem on my phone so i hope it will fix the problem to other users too!