### PR TITLE
[6.4.r1] [Loire] arm: DT: MSM8956: Add back ICE capability for eMMC

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956.dtsi
@@ -1273,7 +1273,6 @@
 	};
 
 	sdcc1_ice: sdcc1ice@7803000 {
-		status = "disabled";
 		compatible = "qcom,ice";
 		reg = <0x7803000 0x8000>;
 		interrupt-names = "sdcc_ice_nonsec_level_irq", "sdcc_ice_sec_level_irq";
@@ -1301,7 +1300,7 @@
 		reg = <0x7824900 0x500>, <0x7824000 0x800>, <0x7824e00 0x200>;
 		reg-names = "hc_mem", "core_mem", "cmdq_mem";
 
-		//sdhc-msm-crypto = <&sdcc1_ice>;
+		sdhc-msm-crypto = <&sdcc1_ice>;
 		interrupts = <0 123 0>, <0 138 0>;
 		interrupt-names = "hc_irq", "pwr_irq";
 


### PR DESCRIPTION
With the new mainline style clocks, ICE is not conflicting anymore
with the SDHCI clocks.