### PR TITLE
[DONOTMERGE]input: misc: fpc1145: remove all wake logic

### DIFF
--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -47,7 +47,6 @@
 #include <linux/of.h>
 #include <linux/of_gpio.h>
 #include <linux/uaccess.h>
-#include <linux/wakelock.h>
 #include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
 
@@ -121,7 +120,6 @@ struct fpc1145_data {
 	bool irq_fired;
 	wait_queue_head_t irq_evt;
 
-	struct wake_lock wakelock;
 	struct mutex lock;
 	bool prepared;
 };
@@ -303,15 +301,11 @@ exit:
 
 static int fpc1145_device_open(struct inode *inode, struct file *fp)
 {
-	wake_lock_timeout(&fpc1145_drvdata->wakelock,
-				usecs_to_jiffies(250));
 	return 0;
 }
 
 static int fpc1145_device_release(struct inode *inode, struct file *fp)
 {
-	if (wake_lock_active(&fpc1145_drvdata->wakelock))
-		wake_unlock(&fpc1145_drvdata->wakelock);
 	return 0;
 }
 
@@ -367,9 +361,6 @@ static long fpc1145_device_ioctl(struct file *fp,
 			return rc;
 
 		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
-		if (val)
-			wake_lock_timeout(&fpc1145_drvdata->wakelock,
-					msecs_to_jiffies(400));
 
 		rc = put_user(val, (int*) usr);
 		break;
@@ -432,7 +423,6 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 
 	fpc1145->irq_fired = true;
 
-	wake_lock_timeout(&fpc1145->wakelock, msecs_to_jiffies(20));
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 
@@ -565,7 +555,6 @@ static int fpc1145_probe(struct platform_device *pdev)
 	irqf = IRQF_TRIGGER_HIGH | IRQF_ONESHOT;
 	mutex_init(&fpc1145->lock);
 
-	wake_lock_init(&fpc1145->wakelock, WAKE_LOCK_SUSPEND, "fpc_wake");
 	init_waitqueue_head(&fpc1145->irq_evt);
 	fpc1145->irq_fired = false;
 
@@ -599,7 +588,6 @@ static int fpc1145_remove(struct platform_device *pdev)
 {
 	struct fpc1145_data *fpc1145 = platform_get_drvdata(pdev);
 
-	wake_lock_destroy(&fpc1145->wakelock);
 	mutex_destroy(&fpc1145->lock);
 #ifdef CONFIG_ARCH_SONY_LOIRE
 	(void)vreg_setup(fpc1145, VCC_SPI, false);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -568,7 +568,6 @@ static int fpc1145_probe(struct platform_device *pdev)
 		goto exit;
 	}
 	dev_dbg(dev, "requested irq %d\n", gpio_to_irq(fpc1145->irq_gpio));
-	enable_irq_wake(fpc1145->irq);
 
 	if (of_property_read_bool(dev->of_node, "fpc,enable-on-boot")) {
 		dev_info(dev, "Enabling hardware\n");


### PR DESCRIPTION
The wakelock is not needed anymore with the new hidl hal implementation.
Tested additionally with fingerprint gestures enabled, which is known to cause device crashes without the wakelock, and there were no crashes observed.

Change-Id: Ibacff4b4afb7d167191da5aef9b0b219d3a87e18