### PR TITLE
[6.4.r1] [CRITICAL] tty: msm_serial_hs: Fix autosuspend selection for new DT property

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -3428,7 +3428,7 @@ static void  msm_serial_hs_rt_init(struct uart_port *uport)
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	int delay = 100;
 
-	if (!msm_uport->no_autosuspend)
+	if (msm_uport->no_autosuspend)
 		delay = -1;
 
 	MSM_HS_INFO("%s(): Enabling runtime pm", __func__);


### PR DESCRIPTION
The original commit introduced a new property to avoid setting
the autosuspend, though, the check at init time was wrong and
it was actually doing the inverse of what was intended to do.