### PR TITLE
[6.4.r1] Enable Bluetooth functionality on SoMC Blanc

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -118,6 +118,7 @@
 		/delete-property/ qcom,rx-char-to-inject;
 		qcom,bam-tx-ep-pipe-index = <2>;
 		qcom,bam-rx-ep-pipe-index = <3>;
+		qcom,bluetooth-serial-port;
 		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&msm_gpio_4_act &msm_gpio_5_def &msm_gpio_6_def &msm_gpio_7_act>;
 		pinctrl-1 = <&msm_gpio_4_sus &msm_gpio_5_def &msm_gpio_6_def &msm_gpio_7_sus>;

--- a/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -123,6 +123,7 @@
 		/delete-property/ qcom,rx-char-to-inject;
 		qcom,bam-tx-ep-pipe-index = <2>;
 		qcom,bam-rx-ep-pipe-index = <3>;
+		qcom,bluetooth-serial-port;
 		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&msm_gpio_41 &msm_gpio_42 &msm_gpio_43 &msm_gpio_44_active>;
 		pinctrl-1 = <&msm_gpio_41 &msm_gpio_42 &msm_gpio_43 &msm_gpio_44_suspend>;


### PR DESCRIPTION
This patchset introduces a new property that identifies the Bluetooth serial port and makes the serial driver to call the bluesleep functions only if the port is used for BT: this eliminates any possible conflicts with other devices using the High-Speed Serial port.

Tested on SoMC Blanc.
- Keyboard/Mouse BT pairing and connection works normally.