### PR TITLE
[64r1] clk: qcom: Kconfig: Fix typo in MSM8976 GCC description

### DIFF
--- a/drivers/clk/qcom/Kconfig
+++ b/drivers/clk/qcom/Kconfig
@@ -141,7 +141,7 @@ config MSM_GCC_8976
 	select QCOM_GDSC
 	depends on COMMON_CLK_QCOM
 	help
-	  Support for the global clock controller on msm8974 devices.
+	  Support for the global clock controller on msm8976 devices.
 	  Say Y if you want to use peripheral devices such as UART, SPI,
 	  i2c, USB, SD/eMMC, SATA, PCIe, etc.
 


### PR DESCRIPTION
This is just cosmetic typo fix.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>