### PR TITLE
[6.4.r1] Make BCL power mitigation less harsh for MSM8996

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996.dtsi
@@ -2933,12 +2933,10 @@
 		qcom,bcl-enable;
 		qcom,bcl-framework-interface;
 		qcom,bcl-freq-control-list = <&CPU2 &CPU3>;
-		qcom,bcl-hotplug-list = <&CPU2 &CPU3>;
-		qcom,bcl-soc-hotplug-list = <&CPU2 &CPU3>;
 		qcom,ibat-monitor {
 			qcom,low-threshold-uamp = <3400000>;
 			qcom,high-threshold-uamp = <4200000>;
-			qcom,mitigation-freq-khz = <576000>;
+			qcom,mitigation-freq-khz = <1132800>;
 			qcom,vph-high-threshold-uv = <3500000>;
 			qcom,vph-low-threshold-uv = <3300000>;
 			qcom,soc-low-threshold = <10>;


### PR DESCRIPTION
When battery level hits qcom,soc-low-threshold BCL hotplugs out
range of CPUs and limits max CPU frequency to qcom,mitigation-freq-khz.
Unfortunately, this makes our MSM8996 devices hardly usable in low
battery state.
Disable BCL hotplugging and increase frequency cap to ~1.1 GHz

Signed-off-by: Artem Labazov <123321artyom@gmail.com>