### PR TITLE
fbdev: msm: somc_panel: correct machine barrier to not allow incompat…

### DIFF
--- a/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_color_manager.c
@@ -334,8 +334,8 @@ static int somc_panel_pcc_setup(struct mdss_panel_data *pdata)
 		goto exit;
 	}
 
-	if (!of_machine_is_compatible("qcom,msm8956") ||
-	    !of_machine_is_compatible("qcom,apq8056") ||
+	if (!of_machine_is_compatible("qcom,msm8956") &&
+	    !of_machine_is_compatible("qcom,apq8056") &&
 	    !of_machine_is_compatible("qcom,msm8939"))
 		mdss_dsi_op_mode_config(DSI_CMD_MODE, pdata);
 


### PR DESCRIPTION
…ible devices

The logic of the if barrier was allowing all devices in except those that weren't compatible with all three given values.
AND the seperate statements instead of ORing to receive the needed result.