### PR TITLE
[6.4.r1] [URGENT] rqbalance: Schedule CFL setting on hotplug if cluster unavailable

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -98,6 +98,7 @@ struct cpu_limits {
 	unsigned int main_cpu;
 	unsigned int freq_min;
 	unsigned int freq_max;
+	bool cpuhp_scheduled;
 };
 
 static DEFINE_PER_CPU(struct idle_info, idleinfo);
@@ -690,6 +691,20 @@ static struct notifier_block frequency_limits_nb = {
 	.notifier_call = frequency_limits_set,
 };
 
+static int cfl_hotplug_notify(unsigned int cpu)
+{
+	unsigned int cluster;
+
+	cluster = topology_physical_package_id(cpu);
+	if (!rqb_freq_limits[cluster].cpuhp_scheduled)
+		return 0;
+
+	rqb_freq_limits[cluster].cpuhp_scheduled = false;
+	cpufreq_update_policy(rqb_freq_limits[cluster].main_cpu);
+
+	return 0;
+}
+
 static ssize_t store_ulong_delay(struct cpuquiet_attribute *cattr, const char *buf,
 				size_t count)
 {
@@ -779,6 +794,24 @@ static ssize_t show_uint_array(struct cpuquiet_attribute *cattr,
 	return temp - buf;
 }
 
+static inline void __set_cluster_vote(unsigned int cluster)
+{
+	struct cpufreq_policy cfpol;
+
+	if (cpufreq_get_policy(&cfpol, rqb_freq_limits[cluster].main_cpu)) {
+		/* The cluster is down. Schedule for the next upcore event */
+		rqb_freq_limits[cluster].cpuhp_scheduled = true;
+
+		/* Make sure we upcore ASAP to set the limits */
+		cpuquiet_wake_cpu(rqb_freq_limits[cluster].main_cpu, false);
+	} else {
+		/* The cluster is available. Set limits right now! */
+		get_online_cpus();
+		cpufreq_update_policy(rqb_freq_limits[cluster].main_cpu);
+		put_online_cpus();
+	}
+}
+
 /*
  * Set a vote for MAX cluster frequency.
  * The function wants a string that contains "NCLUSTER FREQUENCY(KHz)".
@@ -795,13 +828,9 @@ static ssize_t show_uint_array(struct cpuquiet_attribute *cattr,
 static ssize_t set_cluster_vote_max(struct cpuquiet_attribute *cattr,
 					const char *buf, size_t count)
 {
-	struct cpufreq_policy cfpol;
 	unsigned int cluster, req_freq;
 
 	if (sscanf(buf, "%u %u", &cluster, &req_freq) != 2)
-		return -EINVAL;
-
-	if (cpufreq_get_policy(&cfpol, rqb_freq_limits[cluster].main_cpu))
 		return -EINVAL;
 
 	if (req_freq == 0)
@@ -809,9 +838,7 @@ static ssize_t set_cluster_vote_max(struct cpuquiet_attribute *cattr,
 
 	rqb_freq_limits[cluster].freq_max = req_freq;
 
-	get_online_cpus();
-	cpufreq_update_policy(rqb_freq_limits[cluster].main_cpu);
-	put_online_cpus();
+	__set_cluster_vote(cluster);
 
 	return count;
 }
@@ -819,20 +846,14 @@ static ssize_t set_cluster_vote_max(struct cpuquiet_attribute *cattr,
 static ssize_t set_cluster_vote_min(struct cpuquiet_attribute *cattr,
 					const char *buf, size_t count)
 {
-	struct cpufreq_policy cfpol;
 	unsigned int cluster, req_freq;
 
 	if (sscanf(buf, "%u %u", &cluster, &req_freq) != 2)
 		return -EINVAL;
 
-	if (cpufreq_get_policy(&cfpol, rqb_freq_limits[cluster].main_cpu))
-		return -EINVAL;
-
 	rqb_freq_limits[cluster].freq_min = req_freq;
 
-	get_online_cpus();
-	cpufreq_update_policy(rqb_freq_limits[cluster].main_cpu);
-	put_online_cpus();
+	__set_cluster_vote(cluster);
 
 	return count;
 }
@@ -1022,6 +1043,15 @@ static void rqbalance_stop(void)
 	rqbalance_sysfs_exit();
 }
 
+static int rqbalance_cfl_start(void)
+{
+	cpufreq_register_notifier(&frequency_limits_nb,
+		CPUFREQ_POLICY_NOTIFIER);
+	
+	return cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE,
+		"rqbalance_cpuhp", cfl_hotplug_notify, NULL);
+}
+
 static int rqbalance_start(void)
 {
 	int err, i, max_cpu_id = 0;
@@ -1061,8 +1091,9 @@ static int rqbalance_start(void)
 	cpufreq_register_notifier(&balanced_cpufreq_nb,
 		CPUFREQ_TRANSITION_NOTIFIER);
 
-	cpufreq_register_notifier(&frequency_limits_nb,
-		CPUFREQ_POLICY_NOTIFIER);
+	err = rqbalance_cfl_start();
+	if (err)
+		pr_warn("%s: Couldn't start RQB-CFL!\n", __func__);
 
 	init_timer(&load_timer);
 	load_timer.function = calculate_load_timer;

--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -120,6 +120,7 @@ static unsigned long recheck_delay;
 static unsigned long last_change_time;
 static unsigned int  load_sample_rate = 20; /* msec */
 static struct cpu_limits rqb_freq_limits[MAX_CLUSTERS];
+static enum cpuhp_state rqb_hp_online;
 static struct workqueue_struct *rqbalance_wq;
 static struct delayed_work rqbalance_work;
 static RQBALANCE_STATE rqbalance_state;
@@ -1029,6 +1030,11 @@ static void rqbalance_stop(void)
 	cpufreq_unregister_notifier(&balanced_cpufreq_nb,
 		CPUFREQ_TRANSITION_NOTIFIER);
 
+	cpufreq_unregister_notifier(&frequency_limits_nb,
+		CPUFREQ_POLICY_NOTIFIER);
+
+	cpuhp_remove_state_nocalls(rqb_hp_online);
+
 	unregister_pm_notifier(&pm_notifier_block);
 
 	/* now we can force the governor to be idle */
@@ -1045,11 +1051,19 @@ static void rqbalance_stop(void)
 
 static int rqbalance_cfl_start(void)
 {
+	int rc = 0;
+
 	cpufreq_register_notifier(&frequency_limits_nb,
 		CPUFREQ_POLICY_NOTIFIER);
 	
-	return cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE,
+	rc = cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE,
 		"rqbalance_cpuhp", cfl_hotplug_notify, NULL);
+	if (rc < 0)
+		goto end;
+	rqb_hp_online = rc;
+	rc = 0;
+end:
+	return rc;
 }
 
 static int rqbalance_start(void)


### PR DESCRIPTION
If a cluster is totally down, it is impossible to set a cpufreq
policy on it.

Change the logic so that, if the cluster is currently up we set
the limits right in the sysfs handler but, if the cluster is
unavailable, schedule the setting for the next upcore event and
artificially produce a non-blocking upcore event on the
navailable cluster: this will make us get into the newly
introduced hotplugging notifier that will take care of updating
the policy (thus setting the frequency limits) as soon as the
cluster will come up.