### PR TITLE
[2.3.2.r1] Tama IPA fix, MSM8956 power+thermal improvement

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -579,6 +579,22 @@
 		     <GIC_SPI 390 IRQ_TYPE_EDGE_RISING>;
 };
 
+&ipa_hw {
+	/delete-property/ qcom,smmu-fast-map;
+};
+
+&ipa_smmu_ap {
+	qcom,smmu-s1-bypass;
+};
+
+&ipa_smmu_wlan {
+	qcom,smmu-s1-bypass;
+};
+
+&ipa_smmu_uc {
+	qcom,smmu-s1-bypass;
+};
+
 &qupv3_se3_i2c {
 	status = "disabled";
 };

--- a/drivers/clk/qcom/clk-cpu-8976.c
+++ b/drivers/clk/qcom/clk-cpu-8976.c
@@ -1550,8 +1550,9 @@ static int clock_cpu_probe(struct platform_device *pdev)
 				"Unable to Turn on CCI clock");
 		WARN(clk_prepare_enable(a53ssmux.clkr.hw.clk),
 				"Unable to Turn on A53 clock");
-		WARN(clk_prepare_enable(a72ssmux.clkr.hw.clk),
-				"Unable to Turn on A72 clock");
+		if (cpu >= 4)
+			WARN(clk_prepare_enable(a72ssmux.clkr.hw.clk),
+					"Unable to Turn on A72 clock");
 	}
 
 	rc = clk_set_rate(a53ssmux.clkr.hw.clk, a53ss_boot_rate);


### PR DESCRIPTION
Tama: Set S1 bypass to allow IPA SMMU probe

Loire:
The refcount for the A72 MUX can reach zero when the CPUs are
down: this way the API will also shut down the APC1 regulator
and the A72 cluster will go totally down and save power.