### PR TITLE
clk: cpu-8976: Fix refcount for A72ss MUX clock

### DIFF
--- a/drivers/clk/qcom/clk-cpu-8976.c
+++ b/drivers/clk/qcom/clk-cpu-8976.c
@@ -1515,8 +1515,9 @@ static int clock_cpu_probe(struct platform_device *pdev)
 				"Unable to Turn on CCI clock");
 		WARN(clk_prepare_enable(a53ssmux.clkr.hw.clk),
 				"Unable to Turn on A53 clock");
-		WARN(clk_prepare_enable(a72ssmux.clkr.hw.clk),
-				"Unable to Turn on A72 clock");
+		if (cpu >= 4)
+			WARN(clk_prepare_enable(a72ssmux.clkr.hw.clk),
+					"Unable to Turn on A72 clock");
 	}
 
 	rc = clk_set_rate(a53ssmux.clkr.hw.clk, a53ss_boot_rate);


### PR DESCRIPTION
The refcount for the A72 MUX can reach zero when the CPUs are
down: this way the API will also shut down the APC1 regulator
and the A72 cluster will go totally down and save power.