### PR TITLE
arm64: DT: MSM8996: Use broadcast timer for aggregating sleep mode

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-pm.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-pm.dtsi
@@ -155,6 +155,7 @@
 						qcom,ss-power = <198>;
 						qcom,energy-overhead = <21850>;
 						qcom,time-overhead = <120>;
+						qcom,use-broadcast-timer;
 						qcom,hyp-psci;
 					};
 
@@ -167,6 +168,7 @@
 						qcom,ss-power = <196>;
 						qcom,energy-overhead = <62248>;
 						qcom,time-overhead = <210>;
+						qcom,use-broadcast-timer;
 						qcom,reset-level =
 							<LPM_RESET_LVL_PC>;
 					};
@@ -248,6 +250,7 @@
 						qcom,ss-power = <198>;
 						qcom,energy-overhead = <21850>;
 						qcom,time-overhead = <120>;
+						qcom,use-broadcast-timer;
 						qcom,hyp-psci;
 					};
 
@@ -260,6 +263,7 @@
 						qcom,ss-power = <196>;
 						qcom,energy-overhead = <62248>;
 						qcom,time-overhead = <210>;
+						qcom,use-broadcast-timer;
 						qcom,reset-level =
 							<LPM_RESET_LVL_PC>;
 					};


### PR DESCRIPTION
The CPU Power Collapse mode usually triggers L2/CCI (system)
Power Collapse (PC).
The system PC activates a low power module, which relies on
the external timer (also called "broadcast timer") to be
able to aggregate the next wakeup in a cluster: in this
case the CPU also switches to use the broadcast timer instead
of the architected timer hardware.

Without using the external timer, the system will deadlock,
as the architected timer hw will reset during power collapse.