### PR TITLE
[2.3.2.r1.4] drm: somc_panel: Continue searching if fallback panel detected

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_detect.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_detect.c
@@ -81,6 +81,10 @@ static int adc_panel_detect(struct platform_device *pdev,
 			continue;
 
 		*node = next;
+
+		/* If we have just detected the default panel, go on */
+		if (res[ADC_RNG_MIN] == 0 && res[ADC_RNG_MAX] == 0x7fffffff)
+			continue;
 		break;
 	}
 


### PR DESCRIPTION
If we have just detected the failsafe fallback panel and we
still have other nodes we didn't consider, go on to check them
all: one of them may match our ADC.


Solves issues with an experimental Tama configuration :) :) :)