### PR TITLE
[2.3.2.r1] drm: somc_panel: Do a full TS reset on display bind if cont_splash

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -4591,12 +4591,6 @@ static int dsi_display_bind(struct device *dev,
 	/* register te irq handler */
 	dsi_display_register_te_irq(display);
 
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
-	if (display->is_cont_splash_enabled) {
-		dsi_panel_driver_active_touch_reset(display->panel);
-	}
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
 	goto error;
 
 error_host_deinit:
@@ -6062,6 +6056,9 @@ int dsi_display_prepare(struct dsi_display *display)
 		mod_timer(&display->det_timer,
 			jiffies + msecs_to_jiffies(DELAY_SET_BACKLIGHT_TIME));
 	}
+
+	if (display->is_cont_splash_enabled)
+		dsi_panel_driver_touch_reset(display->panel);
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 	goto error;
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/common.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/common.c
@@ -54,11 +54,11 @@ int somc_panel_vreg_ctrl(struct dsi_regulator_info *regs,
 	struct dsi_vreg vreg;
 	int num_of_v = 0;
 	int rc = 0;
-	int valid = 0;
+	int is_invalid = 0;
 
-	valid = vreg_name_to_config(regs, &vreg, vreg_name);
+	is_invalid = vreg_name_to_config(regs, &vreg, vreg_name);
 
-	if (!valid) {
+	if (!is_invalid) {
 		if (enable) {
 			pr_debug("%s: vreg on, name:%s\n", __func__,
 							vreg.vreg_name);

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -1841,21 +1841,6 @@ void dsi_panel_driver_reset_chargemon_exit(void)
 	s_chargemon_exit = 0;
 }
 
-int dsi_panel_driver_active_touch_reset(struct dsi_panel *panel)
-{
-	struct panel_specific_pdata *spec_pdata = NULL;
-	int rc = 0;
-
-	if (!panel) {
-		pr_err("%s: Invalid input panel\n", __func__);
-		return -EINVAL;
-	}
-	spec_pdata = panel->spec_pdata;
-	gpio_set_value(spec_pdata->reset_touch_gpio, 1);
-
-	return rc;
-}
-
 static irqreturn_t dsi_panel_driver_oled_short_det_handler(int irq, void *dev)
 {
 	struct dsi_display *display = dev;

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -409,7 +409,6 @@ int dsi_panel_driver_enable(struct dsi_panel *panel);
 void dsi_panel_driver_labibb_vreg_init(struct dsi_panel *panel);
 int dsi_panel_driver_get_chargemon_exit(void);
 void dsi_panel_driver_reset_chargemon_exit(void);
-int dsi_panel_driver_active_touch_reset(struct dsi_panel *panel);
 void dsi_panel_driver_oled_short_det_init_works(struct dsi_display *display);
 void dsi_panel_driver_oled_short_check_worker(struct work_struct *work);
 void dsi_panel_driver_oled_short_det_enable(


### PR DESCRIPTION
The bootloader holds the TS reset line LOW when booting Linux:
if continuous splash is enabled, reset the touchscreen to let
it probe and work without blanking and unblanking the display.