### PR TITLE
[LE.UM.2.3.2] input: misc: vl53l0: advertise ABS_X and ABS_Y

### DIFF
--- a/drivers/input/misc/vl53L0/stmvl53l0_module.c
+++ b/drivers/input/misc/vl53L0/stmvl53l0_module.c
@@ -2912,6 +2912,13 @@ int stmvl53l0_setup(struct stmvl53l0_data *data)
 
 	input_set_abs_params(data->input_dev_ps, ABS_GAS, 0, 0xffffffff,
 		0, 0);
+
+	/* advertise coordinates
+	 * this makes android not mistake the input device for a stylus
+	 */
+	input_set_abs_params(data->input_dev_ps, ABS_X, 0, 0, 0, 0);
+	input_set_abs_params(data->input_dev_ps, ABS_Y, 0, 0, 0, 0);
+
 	data->input_dev_ps->name = "STM VL53L0 proximity sensor";
 
 	rc = input_register_device(data->input_dev_ps);


### PR DESCRIPTION
Android mistakenly detects the input device of the sensor as a stylus.
The sensor reports EffectiveSpadRtnCount as ABS_PRESSURE.
This conflicts with pressure reporting from the actual touch input device.
Advertising the coordinates stops Android from making this mistake, and avoids the conflict.