### PR TITLE
[2.3.2.r1.4] Fix clearpad on SDE for Tone/Yoshino/Tama devices

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -329,14 +329,6 @@ static int dsi_panel_driver_touch_power_on(struct dsi_panel *panel)
 	struct panel_specific_pdata *spec_pdata = panel->spec_pdata;
 	int rc = 0;
 
-	if (gpio_is_valid(spec_pdata->disp_vddio_gpio)) {
-		rc = gpio_direction_output(spec_pdata->disp_vddio_gpio, 0);
-		if (rc) {
-			pr_err("unable to set dir for disp_vddio gpio rc=%d\n", rc);
-			goto exit;
-		}
-	}
-
 	if (gpio_is_valid(spec_pdata->touch_vddio_en_gpio)) {
 		rc = gpio_direction_output(spec_pdata->touch_vddio_en_gpio, 0);
 		if (rc) {
@@ -352,14 +344,6 @@ static int dsi_panel_driver_touch_power_off(struct dsi_panel *panel)
 {
 	struct panel_specific_pdata *spec_pdata = panel->spec_pdata;
 	int rc = 0;
-
-	if (gpio_is_valid(spec_pdata->disp_vddio_gpio)) {
-		rc = gpio_direction_output(spec_pdata->disp_vddio_gpio, 1);
-		if (rc) {
-			pr_err("unable to set dir for disp_vddio gpio rc=%d\n", rc);
-			goto exit;
-		}
-	}
 
 	if (gpio_is_valid(spec_pdata->touch_vddio_en_gpio)) {
 		rc = gpio_direction_output(spec_pdata->touch_vddio_en_gpio, 1);
@@ -531,6 +515,12 @@ int dsi_panel_driver_post_power_off(struct dsi_panel *panel)
 	if (rc)
 		pr_err("%s: failed to disable vddio, rc=%d\n", __func__, rc);
 
+	if (gpio_is_valid(spec_pdata->disp_vddio_gpio)) {
+		rc = gpio_direction_output(spec_pdata->disp_vddio_gpio, 1);
+		if (rc)
+			pr_err("unable to set dir for disp_vddio gpio rc=%d\n", rc);
+	}
+
 	if (rc)
 		pr_err("%s: failed to power off\n", __func__);
 	else
@@ -592,6 +582,14 @@ int dsi_panel_driver_pre_power_on(struct dsi_panel *panel)
 	if (rc) {
 		pr_err("%s: failed to enable touch-avdd, rc=%d\n", __func__, rc);
 		goto exit;
+	}
+
+	if (gpio_is_valid(spec_pdata->disp_vddio_gpio)) {
+		rc = gpio_direction_output(spec_pdata->disp_vddio_gpio, 0);
+		if (rc) {
+			pr_err("unable to set dir for disp_vddio gpio rc=%d\n", rc);
+			goto exit;
+		}
 	}
 
 	rc = dsi_panel_driver_touch_power(panel, true);

--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -4752,10 +4752,18 @@ static irqreturn_t clearpad_hard_handler(int irq, void *dev_id)
 	struct clearpad_t *this = dev_id;
 	unsigned long flags;
 	irqreturn_t ret;
+	bool val;
 
 	get_monotonic_boottime(&this->interrupt.hard_handler_ts);
 
 	spin_lock_irqsave(&this->slock, flags);
+
+	val = gpio_get_value(this->pdata->irq_gpio);
+	if (val) {
+		spin_unlock_irqrestore(&this->slock, flags);
+		return IRQ_HANDLED;
+	}
+
 	if (unlikely(this->dev_busy)) {
 		this->irq_pending = true;
 		ret = IRQ_HANDLED;


### PR DESCRIPTION
Tone and Yoshino devices, mainly the ones with HYBRID INCELL, need different handling for the touchscreen power rail: address the probe issues with continuous splash enabled on these devices by changing the power sequence.

Also, fix the SDE support in Clearpad for all platforms, including SoMC Tama.

This also fixes a bug that appeared a long time ago with clearpad wakeup gestures on hybrid incell.