### PR TITLE
[URGENT] [2.3.2.r1.4] clk: qcom: gcc-msm8996: Set RPM cxo parent to XO clock

### DIFF
--- a/drivers/clk/qcom/gcc-msm8996.c
+++ b/drivers/clk/qcom/gcc-msm8996.c
@@ -229,7 +229,7 @@ static struct clk_fixed_factor xo = {
 	.div = 1,
 	.hw.init = &(struct clk_init_data){
 		.name = "xo",
-		.parent_names = (const char *[]){ "xo_board" },
+		.parent_names = (const char *[]){ "cxo" },
 		.num_parents = 1,
 		.ops = &clk_fixed_factor_ops,
 	},


### PR DESCRIPTION
To avoid shutting down CXO from RPM, set parent CXO to the XO clk.