### PR TITLE
[2.3.2.r1.4] somc_panel: Implement Polynomial Color Correction (PCC) and PicADJ

### DIFF
--- a/drivers/gpu/drm/msm/sde/sde_plane.c
+++ b/drivers/gpu/drm/msm/sde/sde_plane.c
@@ -4640,6 +4640,44 @@ static void _sde_plane_set_excl_rect_v1(struct sde_plane *psde,
 			pstate->excl_rect.w, pstate->excl_rect.h);
 }
 
+#ifdef CONFIG_DRM_MSM_DSI_SOMC_PANEL
+int sde_plane_set_property(struct drm_plane *plane,
+		struct drm_plane_state *state, struct drm_property *property,
+		uint64_t val)
+{
+	struct sde_plane *psde = plane ? to_sde_plane(plane) : NULL;
+	struct sde_plane_state *pstate;
+	int idx, ret = -EINVAL;
+
+	SDE_DEBUG_PLANE(psde, "\n");
+
+	if (!plane) {
+		SDE_ERROR("invalid plane\n");
+	} else if (!state) {
+		SDE_ERROR_PLANE(psde, "invalid state\n");
+	} else {	
+		pstate = to_sde_plane_state(state);
+		idx = msm_property_index(&psde->property_info,
+				property);
+		switch (idx) {
+		case PLANE_PROP_HUE_ADJUST:
+		case PLANE_PROP_SATURATION_ADJUST:
+		case PLANE_PROP_VALUE_ADJUST:
+		case PLANE_PROP_CONTRAST_ADJUST:
+			ret = msm_property_set_property(&psde->property_info,
+				&pstate->property_state, idx, val);
+			break;
+
+		default:
+			/* nothing to do */
+			break;
+		}
+	}
+
+	return ret;
+}
+#endif
+
 static int sde_plane_atomic_set_property(struct drm_plane *plane,
 		struct drm_plane_state *state, struct drm_property *property,
 		uint64_t val)

--- a/drivers/gpu/drm/msm/sde/sde_plane.h
+++ b/drivers/gpu/drm/msm/sde/sde_plane.h
@@ -270,6 +270,20 @@ int sde_plane_kickoff_rot(struct drm_plane *plane);
  */
 void sde_plane_set_error(struct drm_plane *plane, bool error);
 
+#ifdef CONFIG_DRM_MSM_DSI_SOMC_PANEL
+/**
+ * sde_plane_set_property: Set property on SDE planes
+ * @plane: Pointer to DRM plane object
+ * @state: Pointer to DRM plane state object
+ * @property: Pointer to DRM property to set
+ * @val: Value to set to the DRM property
+ * Returns: Zero on success
+ */
+int sde_plane_set_property(struct drm_plane *plane,
+		struct drm_plane_state *state, struct drm_property *property,
+		uint64_t val);
+#endif
+
 /**
  * sde_plane_init - create new sde plane for the given pipe
  * @dev:   Pointer to DRM device


### PR DESCRIPTION
On the DRM version of somc_panel PCC and PA weren't still
implemented, despite it being a direct port of the fbdev somc_panel.

Implement the Polynomial Color Correction and PicADJ following
the same setting way of the fbdev counterpart (so, from DT) and
automatically apply the values at display poweron on both (where
needed) SSPP and DSPP blocks.

This will work on both legacy and new color processing blocks.
Tested on SoMC Tone Keyaki (DRM-SDE).