### PR TITLE
[CRITICAL] arm64: DT: Tone: Fix PMIC GPIOs drive strengths and init

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-mtp.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-mtp.dtsi
@@ -566,14 +566,14 @@
 	};
 
 	/* GPIO 10 - HPH_EN1 */
-	hph_en0 {
-		pmi8994_gpio_10: hph0_enable {
+	hph_en1 {
+		pmi8994_gpio_10: hph1_enable {
 			pins = "gpio10";
 			function = "normal";
 			output-low;
 			drive-push-pull;
 			bias-disable;
-			//qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
 			power-source = <PM8994_VPP_1P8>;
 		};
 	};
@@ -809,7 +809,7 @@
 			drive-push-pull;
 			//qcom,pull-up-strength = <PMIC_GPIO_PULL_UP_NO>;
 			bias-disable;
-			qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
 			power-source = <PM8994_VPP_1P8>;
 		};
 	};
@@ -836,7 +836,7 @@
 			output-high;
 			drive-push-pull;
 			bias-pull-down;
-			qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
 			power-source = <PM8994_VPP_VPH>;
 		};
 	};
@@ -874,10 +874,10 @@
 		pm8994_gpio_13: hph0_enable {
 			pins = "gpio13";
 			function = "normal";
-			output-low;
+			output-high;
 			drive-push-pull;
 			bias-disable;
-			qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
 			power-source = <PM8994_VPP_1P8>;
 		};
 	};
@@ -890,7 +890,7 @@
 			output-high;
 			drive-push-pull;
 			bias-pull-down;
-			qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
 			power-source = <PM8994_VPP_1P8>;
 		};
 	};
@@ -902,7 +902,7 @@
 			output-low;
 			drive-push-pull;
 			bias-pull-down;
-			qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
 			power-source = <PM8994_VPP_1P8>;
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -350,7 +350,7 @@
 			<45 512 500 5448000>; /* High Vote */
 	};
 
-	somc_pinctrl: somc_pinctrl {
+	somc_pinctrl: somc_pinctrl@0 {
 		compatible = "somc-pinctrl";
 		pinctrl-names = "platform_common_default",
 				"product_common_default",
@@ -391,6 +391,33 @@
 
 		/* If variant specific default setting is needed,
 		   fill pinctrl-3 value in <variant>.dtsi */
+		pinctrl-3 = <>;
+	};
+
+	somc_pinctrl_pmic: somc_pinctrl_pmic@1 {
+		compatible = "somc-pinctrl";
+		pinctrl-names = "platform_common_default",
+				"product_common_default",
+				"variant_default";
+		pinctrl-0 = </* PM8994 */
+			     &pm8994_gpio_1 &pm8994_gpio_2 &pm8994_gpio_3
+			     &pm8994_gpio_4 &pm8994_gpio_5 &pm8994_gpio_6
+			     &pm8994_gpio_7 &pm8994_gpio_8 &pm8994_gpio_9
+			     &pm8994_gpio_10 &pm8994_gpio_11 &pm8994_gpio_11
+			     &pm8994_gpio_13 &pm8994_gpio_14 &pm8994_gpio_15
+			     &pm8994_gpio_16 &pm8994_gpio_17 &pm8994_gpio_18
+			     &pm8994_gpio_19
+			     &pm_mpp2_def &pm_mpp4_def &pm_mpp5_def
+			     &pm_mpp6_def &pm_mpp8_def
+			     /* PMI8994 */
+			     &pmi8994_gpio_1 &pmi8994_gpio_2 &pmi8994_gpio_3
+			     &pmi8994_gpio_4 &pmi8994_gpio_5 &pmi8994_gpio_6
+			     &pmi8994_gpio_7 &pmi8994_gpio_8 &pmi8994_gpio_9
+			     &pmi8994_gpio_10
+			     &pmi_mpp1_def &pmi_mpp2_def &pmi_mpp4_def>;
+
+		pinctrl-1 = <>;
+		pinctrl-2 = <>;
 		pinctrl-3 = <>;
 	};
 
@@ -875,10 +902,14 @@
 	power-source = <PM8994_VPP_1P8>;
 };
 
+&pm8994_gpios {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+};
+
 &pm8994_mpps {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pm_mpp2_def &pm_mpp4_def &pm_mpp5_def
-		     &pm_mpp6_def &pm_mpp8_def>;
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
 
 	/* MPP_1: SDC_UIM_VBIAS */
 	/* Follow QTI */
@@ -935,10 +966,14 @@
 	bias-high-impedance;
 };
 
+&pmi8994_gpios {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+};
+
 &pmi8994_mpps {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pmi_mpp1_def &pmi_mpp2_def
-		     &pmi_mpp4_def>;
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
 	
 	/* MPP_2: FLASH_LED_NOW */
 	pmi8994_mpp2 {

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-dora_generic.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-dora_generic.dtsi
@@ -18,13 +18,6 @@
  */
 
 &soc {
-	somc_pinctrl: somc_pinctrl {
-		/* If variant specific default setting is needed,
-		   fill pinctrl-3 value in <variant>.dtsi */
-		pinctrl-3 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
-				&msm_gpio_77>;
-	};
-
 	/* I2C : BLSP12 */
 	i2c@75ba000 {
 		synaptics_clearpad@2c {
@@ -32,6 +25,13 @@
 			noise_det_retrytime_ms = <200>;
 		};
 	};
+};
+
+&somc_pinctrl {
+	/* If variant specific default setting is needed,
+	   fill pinctrl-3 value in <variant>.dtsi */
+	pinctrl-3 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
+			&msm_gpio_77>;
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-kagura-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-kagura-common.dtsi
@@ -18,16 +18,6 @@
  */
 
 &soc {
-	somc_pinctrl: somc_pinctrl {
-		/* If variant specific default setting is needed,
-		   fill pinctrl-1 value in <variant>.dtsi */
-		pinctrl-1 = <&msm_gpio_25 &msm_gpio_47 &msm_gpio_47_suspend
-			&msm_gpio_48 &msm_gpio_48_suspend
-			&msm_gpio_59 &msm_gpio_60 &msm_gpio_61 &msm_gpio_78
-			&msm_gpio_85_suspend &msm_gpio_86_suspend &msm_gpio_104
-			&msm_gpio_127 &msm_gpio_131>;
-	};
-
 	/* I2C : BLSP3 */
 	i2c_3: i2c@7577000 { /* BLSP1 QUP2 */
 		pinctrl-1 = <&msm_gpio_47_suspend &msm_gpio_48_suspend>;
@@ -72,6 +62,17 @@
 	};
 
 };
+
+&somc_pinctrl {
+	/* If variant specific default setting is needed,
+	   fill pinctrl-1 value in <variant>.dtsi */
+	pinctrl-1 = <&msm_gpio_25 &msm_gpio_47 &msm_gpio_47_suspend
+		&msm_gpio_48 &msm_gpio_48_suspend
+		&msm_gpio_59 &msm_gpio_60 &msm_gpio_61 &msm_gpio_78
+		&msm_gpio_85_suspend &msm_gpio_86_suspend &msm_gpio_104
+		&msm_gpio_127 &msm_gpio_131>;
+};
+
 
 /{
 	tone_kagura_batterydata: qcom,battery-data {

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-kagura_generic.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-kagura_generic.dtsi
@@ -17,13 +17,11 @@
  * published by the Free Software Foundation.
  */
 
-&soc {
-	somc_pinctrl: somc_pinctrl {
-		/* If variant specific default setting is needed,
-		   fill pinctrl-2 value in <variant>.dtsi */
-		pinctrl-2 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
-				&msm_gpio_77>;
-	};
+&somc_pinctrl {
+	/* If variant specific default setting is needed,
+	   fill pinctrl-2 value in <variant>.dtsi */
+	pinctrl-2 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
+			&msm_gpio_77>;
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki-common.dtsi
@@ -18,15 +18,6 @@
  */
 
 &soc {
-	somc_pinctrl: somc_pinctrl {
-		/* If variant specific default setting is needed,
-		   fill pinctrl-1 value in <variant>.dtsi */
-		pinctrl-1 = <&msm_gpio_25 &msm_gpio_47 &msm_gpio_48
-			&msm_gpio_59 &msm_gpio_60 &msm_gpio_61 &msm_gpio_69
-			&msm_gpio_78 &msm_gpio_85 &msm_gpio_86 &msm_gpio_104
-			&msm_gpio_127 &msm_gpio_131>;
-	};
-
 	/* I2C : BLSP3 */
 	i2c_3: i2c@7577000 { /* BLSP1 QUP2 */
 		pinctrl-1 = <&msm_gpio_47_suspend &msm_gpio_48_suspend>;
@@ -73,6 +64,15 @@
 		};
 	};
 
+};
+
+&somc_pinctrl {
+	/* If variant specific default setting is needed,
+	   fill pinctrl-1 value in <variant>.dtsi */
+	pinctrl-1 = <&msm_gpio_25 &msm_gpio_47 &msm_gpio_48
+		&msm_gpio_59 &msm_gpio_60 &msm_gpio_61 &msm_gpio_69
+		&msm_gpio_78 &msm_gpio_85 &msm_gpio_86 &msm_gpio_104
+		&msm_gpio_127 &msm_gpio_131>;
 };
 
 /{

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki_generic.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki_generic.dtsi
@@ -17,13 +17,11 @@
  * published by the Free Software Foundation.
  */
 
-&soc {
-	somc_pinctrl: somc_pinctrl {
-		/* If variant specific default setting is needed,
-		   fill pinctrl-2 value in <variant>.dtsi */
-		pinctrl-2 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
-				&msm_gpio_77>;
-	};
+&somc_pinctrl {
+	/* If variant specific default setting is needed,
+	   fill pinctrl-2 value in <variant>.dtsi */
+	pinctrl-2 = <&msm_gpio_49 &msm_gpio_73 &msm_gpio_74
+			&msm_gpio_77>;
 };
 
 &tlmm {


### PR DESCRIPTION
The PMIC GPIOs drive strengths were "inverted" during early
development. A bad mistake.

Fix everything and also add them to a PMIC-dedicated somc_pinctrl
node to initialize them at pinctrl init.