### PR TITLE
[2.3.2.r1.4] Audio fixup for legacy SoC

### DIFF
--- a/techpack/audio/asoc/msm8952-dai-links.c
+++ b/techpack/audio/asoc/msm8952-dai-links.c
@@ -953,7 +953,6 @@ static struct snd_soc_dai_link msm8952_common_fe_dai[] = {
 		.codec_dai_name = "snd-soc-dummy-dai",
 		.codec_name = "snd-soc-dummy",
 	},
-#if 0
 	{/* hw:x,28 */
 		.name = "MSM8X16 Compress3",
 		.stream_name = "Compress3",
@@ -970,7 +969,6 @@ static struct snd_soc_dai_link msm8952_common_fe_dai[] = {
 		 /* this dai link has playback support */
 		.id = MSM_FRONTEND_DAI_MULTIMEDIA10,
 	},
-#endif
 	{/* hw:x,29 */
 		.name = "MSM8X16 Compress4",
 		.stream_name = "Compress4",

--- a/techpack/audio/asoc/msm8952.c
+++ b/techpack/audio/asoc/msm8952.c
@@ -1889,7 +1889,6 @@ static struct snd_soc_dai_link msm8952_dai[] = {
 		.dpcm_capture = 1,
 		.ignore_pmdown_time = 1,
 	},
-#if 0
 	{/* hw:x,27 */
 		.name = "MSM8X16 Compress3",
 		.stream_name = "Compress3",
@@ -1906,7 +1905,6 @@ static struct snd_soc_dai_link msm8952_dai[] = {
 		 /* this dai link has playback support */
 		.id = MSM_FRONTEND_DAI_MULTIMEDIA10,
 	},
-#endif
 	{/* hw:x,28 */
 		.name = "MSM8X16 Compress4",
 		.stream_name = "Compress4",

--- a/techpack/audio/asoc/msm8996.c
+++ b/techpack/audio/asoc/msm8996.c
@@ -2513,7 +2513,6 @@ static struct snd_soc_dai_link msm8996_common_dai_links[] = {
 		 /* this dainlink has playback support */
 		.id = MSM_FRONTEND_DAI_MULTIMEDIA7,
 	},
-#if 0 /* TODO: Kernel panic with that one! */
 	{
 		.name = "MSM8996 Compress3",
 		.stream_name = "Compress3",
@@ -2530,7 +2529,6 @@ static struct snd_soc_dai_link msm8996_common_dai_links[] = {
 		 /* this dainlink has playback support */
 		.id = MSM_FRONTEND_DAI_MULTIMEDIA10,
 	},
-#endif
 	{
 		.name = "MSM8996 ULL NOIRQ",
 		.stream_name = "MM_NOIRQ",


### PR DESCRIPTION
This re-enables compress offload on MM10 and should fix
some issues with the adsprpc on MSM8956, APQ8056, MSM8996.