### PR TITLE
[2.3.2.r1.4] net: wireless: bcmdhd: Disable firmware core dump

### DIFF
--- a/drivers/net/wireless/bcmdhd/Makefile
+++ b/drivers/net/wireless/bcmdhd/Makefile
@@ -77,7 +77,7 @@ ifeq ($(BUS_IFACE_PCIE),y)
 	# Enable Link down recovery
 	DHDCFLAGS += -DSUPPORT_LINKDOWN_RECOVERY
 	# Enable Firmware Coredump
-	DHDCFLAGS += -DDHD_FW_COREDUMP
+	#DHDCFLAGS += -DDHD_FW_COREDUMP
 	# Enable PKTID AUDIT
 	DHDCFLAGS += -DDHD_PKTID_AUDIT_ENABLED
 	# Enable Load Balancing support by default.


### PR DESCRIPTION
This function is faulty and anyway unnecessary since our HW
is stable.

Solves random issues during PCI-E recovery on SoMC Tone