### PR TITLE
[LA.UM.6.4.r1] usb: gadget: enable wireless RNDIS by default

### DIFF
--- a/drivers/usb/gadget/function/f_gsi.c
+++ b/drivers/usb/gadget/function/f_gsi.c
@@ -2929,6 +2929,8 @@ static struct f_gsi *gsi_function_init(enum ipa_usb_teth_prot prot_id)
 		goto error;
 	}
 
+	gsi->rndis_use_wceis = true;
+
 	spin_lock_init(&gsi->d_port.lock);
 
 	init_waitqueue_head(&gsi->d_port.wait_for_ipa_ready);

--- a/drivers/usb/gadget/function/f_qc_rndis.c
+++ b/drivers/usb/gadget/function/f_qc_rndis.c
@@ -1448,6 +1448,8 @@ static int qcrndis_set_inst_name(struct usb_function_instance *fi,
 		return -ENOMEM;
 	}
 
+	rndis->use_wceis = true;
+
 	spin_lock_init(&rndis_lock);
 	opts->rndis = rndis;
 	ret = misc_register(&rndis_qc_device);


### PR DESCRIPTION
Use default parameters suitable for both Windows and Linux hosts.

Signed-off-by: Oleksiy Avramchenko <oleksiy.avramchenko@sony.com>