### PR TITLE
[2.3.2.r1.4] DSP fixes for legacy SoC

### DIFF
--- a/techpack/audio/Kconfig
+++ b/techpack/audio/Kconfig
@@ -69,6 +69,8 @@ config SND_SOC_WCD_MBHC_LEGACY
 	tristate "SND_SOC_WCD_MBHC_LEGACY"
 config QTI_PP
 	tristate "QTI_PP"
+config QTI_PP_AUDIOSPHERE
+        tristate "QTI_PP_AUDIOSPHERE"
 config SND_SOC_CPE
 	tristate "CPE"
 config SND_HWDEP_ROUTING

--- a/techpack/audio/dsp/audio_pdr.h
+++ b/techpack/audio/dsp/audio_pdr.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2016-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -82,6 +82,10 @@ static inline int audio_pdr_register(struct notifier_block *nb)
 	return -ENODEV;
 }
 
+static inline int audio_pdr_deregister(struct notifier_block *nb)
+{
+	return -ENODEV;
+}
 
 static inline void *audio_pdr_service_register(int domain_id,
 					       struct notifier_block *nb,

--- a/techpack/audio/dsp/msm_audio_ion.c
+++ b/techpack/audio/dsp/msm_audio_ion.c
@@ -179,6 +179,7 @@ int msm_audio_ion_alloc(const char *name, struct ion_client **client,
 	*vaddr = ion_map_kernel(*client, *handle);
 	if (IS_ERR_OR_NULL((void *)*vaddr)) {
 		pr_err("%s: ION memory mapping for AUDIO failed\n", __func__);
+		rc = -ENOMEM;
 		goto err_ion_handle;
 	}
 	pr_debug("%s: mapped address = %pK, size=%zd\n", __func__,

--- a/techpack/audio/dsp/q6afe.c
+++ b/techpack/audio/dsp/q6afe.c
@@ -725,7 +725,7 @@ int afe_q6_interface_prepare(void)
 			0xFFFFFFFF, &this_afe);
 		if (this_afe.apr == NULL) {
 			pr_err("%s: Unable to register AFE\n", __func__);
-			ret = -ENODEV;
+			ret = -ENETRESET;
 		}
 		rtac_set_afe_handle(this_afe.apr);
 	}

--- a/techpack/audio/dsp/q6asm.c
+++ b/techpack/audio/dsp/q6asm.c
@@ -955,7 +955,7 @@ int q6asm_unmap_rtac_block(uint32_t *mem_map_handle)
 			__func__, result2);
 		result = result2;
 	} else {
-		mem_map_handle = 0;
+		*mem_map_handle = 0;
 	}
 
 	result2 = q6asm_mmap_apr_dereg();

--- a/techpack/audio/dsp/q6asm.c
+++ b/techpack/audio/dsp/q6asm.c
@@ -22,6 +22,7 @@
 #include <linux/miscdevice.h>
 #include <linux/delay.h>
 #include <linux/slab.h>
+#include <linux/of.h>
 
 #include <linux/debugfs.h>
 #include <linux/time.h>
@@ -2733,13 +2734,17 @@ EXPORT_SYMBOL(q6asm_open_read_v3);
 int q6asm_open_read_v4(struct audio_client *ac, uint32_t format,
 			uint16_t bits_per_sample, bool ts_mode)
 {
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return q6asm_open_read_v3(ac, format, bits_per_sample);
-#else
+
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return q6asm_open_read_v2(ac, format, bits_per_sample);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return q6asm_open_read_v3(ac, format, bits_per_sample);
+
 	return __q6asm_open_read(ac, format, bits_per_sample,
 				 PCM_MEDIA_FORMAT_V4 /*media fmt block ver*/,
 				 ts_mode);
-#endif
 }
 EXPORT_SYMBOL(q6asm_open_read_v4);
 
@@ -3053,13 +3058,17 @@ EXPORT_SYMBOL(q6asm_open_write_v3);
 int q6asm_open_write_v4(struct audio_client *ac, uint32_t format,
 			uint16_t bits_per_sample)
 {
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return q6asm_open_write_v3(ac, format, bits_per_sample);
-#else
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return q6asm_open_write_v3(ac, format, bits_per_sample);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return q6asm_open_write_v3(ac, format, bits_per_sample);
+
 	return __q6asm_open_write(ac, format, bits_per_sample,
 				  ac->stream_id, false /*gapless*/,
 				  PCM_MEDIA_FORMAT_V4 /*pcm_format_block_ver*/);
-#endif
+
 }
 EXPORT_SYMBOL(q6asm_open_write_v4);
 
@@ -3104,14 +3113,19 @@ int q6asm_stream_open_write_v4(struct audio_client *ac, uint32_t format,
 			       uint16_t bits_per_sample, int32_t stream_id,
 			       bool is_gapless_mode)
 {
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return q6asm_stream_open_write_v3(ac, format, bits_per_sample,
+
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return q6asm_stream_open_write_v2(ac, format, bits_per_sample,
 						stream_id, is_gapless_mode);
-#else
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return q6asm_stream_open_write_v3(ac, format, bits_per_sample,
+						stream_id, is_gapless_mode);
+
 	return __q6asm_open_write(ac, format, bits_per_sample,
 				  stream_id, is_gapless_mode,
 				  PCM_MEDIA_FORMAT_V4 /*pcm_format_block_ver*/);
-#endif
 }
 EXPORT_SYMBOL(q6asm_stream_open_write_v4);
 
@@ -4143,6 +4157,10 @@ fail_cmd:
 		return rc;
 }
 
+int q6asm_enc_cfg_blk_pcm_v2(struct audio_client *ac,
+		uint32_t rate, uint32_t channels, uint16_t bits_per_sample,
+		bool use_default_chmap, bool use_back_flavor, u8 *channel_map);
+
 int q6asm_enc_cfg_blk_pcm_v3(struct audio_client *ac,
 			     uint32_t rate, uint32_t channels,
 			     uint16_t bits_per_sample, bool use_default_chmap,
@@ -4176,11 +4194,16 @@ int q6asm_enc_cfg_blk_pcm_v4(struct audio_client *ac,
 	u32 frames_per_buf = 0;
 	int rc;
 
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return q6asm_enc_cfg_blk_pcm_v3(ac, rate, channels, bits_per_sample,
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return q6asm_enc_cfg_blk_pcm_v2(ac, rate, channels, bits_per_sample,
+					use_default_chmap, use_back_flavor,
+					channel_map);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return q6asm_enc_cfg_blk_pcm_v3(ac, rate, channels, bits_per_sample,
 					use_default_chmap, use_back_flavor,
 					channel_map, sample_word_size);
-#endif
 
 	if (!use_default_chmap && (channel_map == NULL)) {
 		pr_err("%s: No valid chan map and can't use default\n",
@@ -4513,6 +4536,14 @@ int q6asm_enc_cfg_blk_pcm_format_support_v4(struct audio_client *ac,
 					    uint16_t endianness,
 					    uint16_t mode)
 {
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return __q6asm_enc_cfg_blk_pcm(ac, rate, channels, bits_per_sample);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+	 	return __q6asm_enc_cfg_blk_pcm_v3(ac, rate, channels,
+					   bits_per_sample, sample_word_size);
+
 	return __q6asm_enc_cfg_blk_pcm_v4(ac, rate, channels,
 					   bits_per_sample, sample_word_size,
 					   endianness, mode);
@@ -5180,12 +5211,17 @@ static int __q6asm_media_format_block_pcm_v4(struct audio_client *ac,
 	u8 *channel_mapping;
 	int rc;
 
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return __q6asm_media_format_block_pcm_v3(ac, rate, channels,
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return __q6asm_media_format_block_pcm(ac, rate, channels,
+					stream_id, bits_per_sample,
+					use_default_chmap, channel_map);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return __q6asm_media_format_block_pcm_v3(ac, rate, channels,
 					bits_per_sample, stream_id,
 					use_default_chmap, channel_map,
 					sample_word_size);
-#endif
 
 	pr_debug("%s: session[%d]rate[%d]ch[%d]bps[%d]wordsize[%d]\n", __func__,
 		 ac->session, rate, channels,
@@ -5513,11 +5549,16 @@ static int __q6asm_media_format_block_multi_ch_pcm_v4(struct audio_client *ac,
 	u8 *channel_mapping;
 	int rc;
 
-#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996)
-	return __q6asm_media_format_block_multi_ch_pcm_v3(ac, rate, channels,
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056"))
+		return __q6asm_media_format_block_multi_ch_pcm(ac, rate, channels,
+					use_default_chmap, channel_map,
+					bits_per_sample);
+
+	if (of_machine_is_compatible("qcom,msm8996"))
+		return __q6asm_media_format_block_multi_ch_pcm_v3(ac, rate, channels,
 					use_default_chmap, channel_map,
 					bits_per_sample, sample_word_size);
-#endif
 
 	pr_debug("%s: session[%d]rate[%d]ch[%d]bps[%d]wordsize[%d]\n", __func__,
 		 ac->session, rate, channels,

--- a/techpack/audio/dsp/q6core.c
+++ b/techpack/audio/dsp/q6core.c
@@ -377,7 +377,7 @@ void ocm_core_open(void)
 					aprv2_core_fn_q, 0xFFFFFFFF, NULL);
 	pr_debug("%s: Open_q %pK\n", __func__, q6core_lcl.core_handle_q);
 	if (q6core_lcl.core_handle_q == NULL)
-		pr_err("%s: Unable to register CORE\n", __func__);
+		pr_err_ratelimited("%s: Unable to register CORE\n", __func__);
 }
 
 struct cal_block_data *cal_utils_get_cal_block_by_key(
@@ -753,7 +753,7 @@ bool q6core_is_adsp_ready(void)
 		q6core_lcl.bus_bw_resp_received = 0;
 		rc = apr_send_pkt(q6core_lcl.core_handle_q, (uint32_t *)&hdr);
 		if (rc < 0) {
-			pr_err("%s: Get ADSP state APR packet send event %d\n",
+			pr_err_ratelimited("%s: Get ADSP state APR packet send event %d\n",
 				__func__, rc);
 			goto bail;
 		}

--- a/techpack/audio/dsp/q6lsm.c
+++ b/techpack/audio/dsp/q6lsm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2018, Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -323,6 +323,11 @@ struct lsm_client *q6lsm_client_alloc(lsm_app_cb cb, void *priv)
 		kfree(client);
 		return NULL;
 	}
+
+	init_waitqueue_head(&client->cmd_wait);
+	mutex_init(&client->cmd_lock);
+	atomic_set(&client->cmd_state, CMD_STATE_CLEARED);
+
 	pr_debug("%s: Client Session %d\n", __func__, client->session);
 	client->apr = apr_register("ADSP", "LSM", q6lsm_callback,
 				   ((client->session) << 8 | client->session),
@@ -340,9 +345,6 @@ struct lsm_client *q6lsm_client_alloc(lsm_app_cb cb, void *priv)
 		goto fail;
 	}
 
-	init_waitqueue_head(&client->cmd_wait);
-	mutex_init(&client->cmd_lock);
-	atomic_set(&client->cmd_state, CMD_STATE_CLEARED);
 	pr_debug("%s: New client allocated\n", __func__);
 	return client;
 fail:

--- a/techpack/audio/dsp/q6voice.c
+++ b/techpack/audio/dsp/q6voice.c
@@ -38,6 +38,7 @@
 #define NUM_CHANNELS_STEREO 2
 #define NUM_CHANNELS_THREE 3
 #define NUM_CHANNELS_QUAD 4
+#define CVP_VERSION_1 1
 #define CVP_VERSION_2 2
 #define GAIN_Q14_FORMAT(a) (a << 14)
 
@@ -4251,6 +4252,14 @@ static int voice_get_avcs_version_per_service(uint32_t service_id)
 		       AVCS_SERVICE_ID_ALL);
 		return -EINVAL;
 	}
+
+	if (of_machine_is_compatible("qcom,msm8956") ||
+	    of_machine_is_compatible("qcom,apq8056") ||
+	    of_machine_is_compatible("qcom,msm8996") ||
+	    of_machine_is_compatible("qcom,msm8998") ||
+	    of_machine_is_compatible("qcom,sdm630")  ||
+	    of_machine_is_compatible("qcom,sdm660"))
+		return CVP_VERSION_1;
 
 	ver_size = sizeof(struct avcs_get_fwk_version) +
 		   sizeof(struct avs_svc_api_info);

--- a/techpack/audio/dsp/rtac.c
+++ b/techpack/audio/dsp/rtac.c
@@ -125,6 +125,10 @@ struct mutex			rtac_asm_apr_mutex;
 struct mutex			rtac_voice_mutex;
 struct mutex			rtac_voice_apr_mutex;
 struct mutex			rtac_afe_apr_mutex;
+struct mutex			rtac_asm_cal_mutex;
+struct mutex			rtac_adm_cal_mutex;
+struct mutex			rtac_afe_cal_mutex;
+struct mutex			rtac_voice_cal_mutex;
 
 int rtac_clear_mapping(uint32_t cal_type)
 {
@@ -1723,42 +1727,62 @@ static long rtac_ioctl_shared(struct file *f,
 	}
 
 	case AUDIO_GET_RTAC_ADM_CAL:
+		mutex_lock(&rtac_adm_cal_mutex);
 		result = send_adm_apr((void *)arg, ADM_CMD_GET_PP_PARAMS_V5);
+		mutex_unlock(&rtac_adm_cal_mutex);
 		break;
 	case AUDIO_SET_RTAC_ADM_CAL:
+		mutex_lock(&rtac_adm_cal_mutex);
 		result = send_adm_apr((void *)arg, ADM_CMD_SET_PP_PARAMS_V5);
+		mutex_unlock(&rtac_adm_cal_mutex);
 		break;
 	case AUDIO_GET_RTAC_ASM_CAL:
+		mutex_lock(&rtac_asm_cal_mutex);
 		result = send_rtac_asm_apr((void *)arg,
 			ASM_STREAM_CMD_GET_PP_PARAMS_V2);
+		mutex_unlock(&rtac_asm_cal_mutex);
 		break;
 	case AUDIO_SET_RTAC_ASM_CAL:
+		mutex_lock(&rtac_asm_cal_mutex);
 		result = send_rtac_asm_apr((void *)arg,
 			ASM_STREAM_CMD_SET_PP_PARAMS_V2);
+		mutex_unlock(&rtac_asm_cal_mutex);
 		break;
 	case AUDIO_GET_RTAC_CVS_CAL:
+		mutex_lock(&rtac_voice_cal_mutex);
 		result = send_voice_apr(RTAC_CVS, (void *) arg,
 					VSS_ICOMMON_CMD_GET_PARAM_V2);
+		mutex_unlock(&rtac_voice_cal_mutex);
 		break;
 	case AUDIO_SET_RTAC_CVS_CAL:
+		mutex_lock(&rtac_voice_cal_mutex);
 		result = send_voice_apr(RTAC_CVS, (void *) arg,
 					VSS_ICOMMON_CMD_SET_PARAM_V2);
+		mutex_unlock(&rtac_voice_cal_mutex);
 		break;
 	case AUDIO_GET_RTAC_CVP_CAL:
+		mutex_lock(&rtac_voice_cal_mutex);
 		result = send_voice_apr(RTAC_CVP, (void *) arg,
 					VSS_ICOMMON_CMD_GET_PARAM_V2);
+		mutex_unlock(&rtac_voice_cal_mutex);
 		break;
 	case AUDIO_SET_RTAC_CVP_CAL:
+		mutex_lock(&rtac_voice_cal_mutex);
 		result = send_voice_apr(RTAC_CVP, (void *) arg,
 					VSS_ICOMMON_CMD_SET_PARAM_V2);
+		mutex_unlock(&rtac_voice_cal_mutex);
 		break;
 	case AUDIO_GET_RTAC_AFE_CAL:
+		mutex_lock(&rtac_afe_cal_mutex);
 		result = send_rtac_afe_apr((void *)arg,
 			AFE_PORT_CMD_GET_PARAM_V2);
+		mutex_unlock(&rtac_afe_cal_mutex);
 		break;
 	case AUDIO_SET_RTAC_AFE_CAL:
+		mutex_lock(&rtac_afe_cal_mutex);
 		result = send_rtac_afe_apr((void *)arg,
 			AFE_PORT_CMD_SET_PARAM_V2);
+		mutex_unlock(&rtac_afe_cal_mutex);
 		break;
 	default:
 		pr_err("%s: Invalid IOCTL, command = %d!\n",
@@ -1890,6 +1914,7 @@ static int __init rtac_init(void)
 	init_waitqueue_head(&rtac_adm_apr_data.cmd_wait);
 	mutex_init(&rtac_adm_mutex);
 	mutex_init(&rtac_adm_apr_mutex);
+	mutex_init(&rtac_adm_cal_mutex);
 
 	rtac_adm_buffer = kzalloc(
 		rtac_cal[ADM_RTAC_CAL].map_data.map_size, GFP_KERNEL);
@@ -1903,6 +1928,7 @@ static int __init rtac_init(void)
 		init_waitqueue_head(&rtac_asm_apr_data[i].cmd_wait);
 	}
 	mutex_init(&rtac_asm_apr_mutex);
+	mutex_init(&rtac_asm_cal_mutex);
 
 	rtac_asm_buffer = kzalloc(
 		rtac_cal[ASM_RTAC_CAL].map_data.map_size, GFP_KERNEL);
@@ -1916,6 +1942,7 @@ static int __init rtac_init(void)
 	atomic_set(&rtac_afe_apr_data.cmd_state, 0);
 	init_waitqueue_head(&rtac_afe_apr_data.cmd_wait);
 	mutex_init(&rtac_afe_apr_mutex);
+	mutex_init(&rtac_afe_cal_mutex);
 
 	rtac_afe_buffer = kzalloc(
 		rtac_cal[AFE_RTAC_CAL].map_data.map_size, GFP_KERNEL);
@@ -1934,6 +1961,7 @@ static int __init rtac_init(void)
 	}
 	mutex_init(&rtac_voice_mutex);
 	mutex_init(&rtac_voice_apr_mutex);
+	mutex_init(&rtac_voice_cal_mutex);
 
 	rtac_voice_buffer = kzalloc(
 		rtac_cal[VOICE_RTAC_CAL].map_data.map_size, GFP_KERNEL);


### PR DESCRIPTION
This patchset fixes various bugs appearing on legacy SoCs,
hence fixing the parameters for:
- Q6ASM read/write
- Q6ASM PCM configuration
- Q6ASM Media - Format Block
- Compress offloading
- Anything using Q6ASM.........
- Q6Voice Version Query (in-call audio and not only).

These fixes are for legacy SoCs, including:
MSM8956, APQ8056, MSM8996, MSM8998, SDM630, SDM660.