### PR TITLE
[2.3.2.r1.4] sdfat: Assign variables after ifdef'd return

### DIFF
--- a/fs/sdfat/core_fat.c
+++ b/fs/sdfat/core_fat.c
@@ -1239,12 +1239,16 @@ static FS_FUNC_T amap_fat_fs_func = {
 
 s32 mount_fat16(struct super_block *sb, pbr_t *p_pbr)
 {
+	s32 num_root_sectors;
+	bpb16_t *p_bpb;
+	FS_INFO_T *fsi;
+
 #ifdef CONFIG_SDFAT_DISALLOW_FAT16
 	return -ENXIO;
 #endif
-	s32 num_root_sectors;
-	bpb16_t *p_bpb = &(p_pbr->bpb.f16);
-	FS_INFO_T *fsi = &(SDFAT_SB(sb)->fsi);
+
+	p_bpb = &(p_pbr->bpb.f16);
+	fsi = &(SDFAT_SB(sb)->fsi);
 
 	if (!p_bpb->num_fats) {
 		sdfat_msg(sb, KERN_ERR, "bogus number of FAT structure");
@@ -1345,11 +1349,15 @@ out:
 
 s32 mount_fat32(struct super_block *sb, pbr_t *p_pbr)
 {
+	pbr32_t *p_bpb;
+	FS_INFO_T *fsi;
+
 #ifdef CONFIG_SDFAT_DISALLOW_FAT32
 	return -ENXIO;
 #endif
-	pbr32_t *p_bpb = (pbr32_t *)p_pbr;
-	FS_INFO_T *fsi = &(SDFAT_SB(sb)->fsi);
+
+	p_bpb = (pbr32_t *)p_pbr;
+	fsi = &(SDFAT_SB(sb)->fsi);
 
 	if (!p_bpb->bpb.num_fats) {
 		sdfat_msg(sb, KERN_ERR, "bogus number of FAT structure");


### PR DESCRIPTION
AOSP's GCC warns:

../fs/sdfat/core_fat.c:1245:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
../fs/sdfat/core_fat.c:1351:2: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]