### PR TITLE
[2.3.2.r1.4] arch: arm64: DT: fixup references to 100K_PULLUP_DECI scaling function

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -1053,7 +1053,7 @@
 
 &pm8950_vadc {
 	chan@13 { /* case_therm */
-		qcom,scale-function = <17>; /* 100K_PULLUP_DECI */
+		qcom,scale-function = <26>; /* 100K_PULLUP_DECI */
 	};
 };
 
@@ -1064,7 +1064,7 @@
 		qcom,decimation = <0>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <17>; /* 100K_PULLUP_DECI */
+		qcom,scale-function = <26>; /* 100K_PULLUP_DECI */
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -3246,18 +3246,18 @@
 		qcom,decimation = <0>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;
 	};
 
 	chan@73 { /* msm_therm */
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 	};
 
 	chan@74 { /* emmc_therm */
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -1043,7 +1043,7 @@
 	};
 
 	chan@4d { /* msm_therm */
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 	};
 
 	chan@4e {
@@ -1052,7 +1052,7 @@
 		qcom,decimation = <2>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;
@@ -1083,7 +1083,7 @@
 	};
 
 	chan@51 { /* quiet_therm */
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 	};
 
 	chan@53 {
@@ -1092,7 +1092,7 @@
 		qcom,decimation = <2>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -430,7 +430,7 @@
 	};
 
 	chan@4d {
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 	};
 
 	chan@50 {
@@ -451,7 +451,7 @@
 		qcom,decimation = <2>;
 		qcom,pre-div-channel-scaling = <0>;
 		qcom,calibration-type = "ratiometric";
-		qcom,scale-function = <17>;
+		qcom,scale-function = <26>;
 		qcom,hw-settle-time = <2>;
 		qcom,fast-avg-setup = <0>;
 		qcom,vadc-thermal-node;


### PR DESCRIPTION
The "qcom,scale-function" value of 17 does not correspond to 100K_PULLUP_DECI on 4.9
Replace with 26 to correctly apply the 100K_PULLUP_DECI function