### PR TITLE
[2.3.2.r1.4] techpack: audio: q6asm: Fixup q6asm_open_write call

### DIFF
--- a/techpack/audio/dsp/q6asm.c
+++ b/techpack/audio/dsp/q6asm.c
@@ -3060,7 +3060,7 @@ int q6asm_open_write_v4(struct audio_client *ac, uint32_t format,
 {
 	if (of_machine_is_compatible("qcom,msm8956") ||
 	    of_machine_is_compatible("qcom,apq8056"))
-		return q6asm_open_write_v3(ac, format, bits_per_sample);
+		return q6asm_open_write_v2(ac, format, bits_per_sample);
 
 	if (of_machine_is_compatible("qcom,msm8996"))
 		return q6asm_open_write_v3(ac, format, bits_per_sample);


### PR DESCRIPTION
q6asm_open_write_v3 was being incorrectly called instead of q6asm_open_write_v2.
This resulted in various audio related issues like the phone not ringing when receiving calls.
MSM8956 and APQ8056 use V2 DSP structures.