### PR TITLE
[2.3.2.r1.4] arm64: DT: Loire: Fix reserved memory overlaps

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -34,12 +34,6 @@
 	};
 
 	reserved-memory {
-		pstore_reserve_mem: pstore_reserve_mem_region@57f00000 {
-			compatible = "removed-dma-pool";
-			no-map;
-			reg = <0 0x57f00000 0 0x00100000>;
-		};
-
 		tz_app_mem: tz_app_mem@8dd00000 {
 			compatible = "removed-dma-pool";
 			no-map;


### PR DESCRIPTION
pstore_reserve_mem_region is not needed for pstore on k4.9 anymore.
Moreover, it causes reserved memory overlaps, hence remove it to fix it.

[    0.000000] OF: reserved mem: OVERLAP DETECTED!
[    0.000000] ramoops (0x0000000057f00000--0x0000000058000000) overlaps with
pstore_reserve_mem_region@57f00000 (0x0000000057f00000--0x0000000058000000)

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>