### PR TITLE
[2.3.2.r1.4] [PARTIAL] msm: vidc_3x: Send timestamp as microsec during ETB

### DIFF
--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_common.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_common.c
@@ -3628,15 +3628,19 @@ int msm_vidc_comm_cmd(void *instance, union msm_v4l2_cmd *cmd)
 static void populate_frame_data(struct vidc_frame_data *data,
 		const struct vb2_buffer *vb, struct msm_vidc_inst *inst)
 {
+	u64 time_usec;
 	int extra_idx;
 	enum v4l2_buf_type type = vb->type;
 	enum vidc_ports port = type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE ?
 		OUTPUT_PORT : CAPTURE_PORT;
 	struct vb2_v4l2_buffer *vbuf = to_vb2_v4l2_buffer(vb);
 
+	time_usec = vb->timestamp;
+	do_div(time_usec, NSEC_PER_USEC);
+
 	data->alloc_len = vb->planes[0].length;
 	data->device_addr = vb->planes[0].m.userptr;
-	data->timestamp = vb->timestamp;
+	data->timestamp = time_usec;
 	data->flags = 0;
 	data->clnt_data = data->device_addr;
 


### PR DESCRIPTION
Apply the missing changes from commit e580033a3931 ("msm: vidc: Send timestamp as microsec during ETB").

Original commit message:
In v4l2 vb2_buffer timestamp is stored in nano secs.
This is converted to micro seconds before ETB to firmware.
Similarly during FBD timestamp in micro seconds is
converted to nano seconds while storing in vb2_buffer.