### PR TITLE
kernel: Fix missed audio header include

### DIFF
--- a/include/uapi/sound/asound.h
+++ b/include/uapi/sound/asound.h
@@ -23,6 +23,7 @@
 #ifndef _UAPI__SOUND_ASOUND_H
 #define _UAPI__SOUND_ASOUND_H
 
+#include <linux/time.h>
 #include <linux/types.h>
 
 #ifndef __KERNEL__


### PR DESCRIPTION
Make clang happy (vndk rules).

Change-Id: I8284ca3da6f806d98fec75af4f3c198f6b16d08d
Signed-off-by: Humberto Borba <humberos@omnirom.org>