### PR TITLE
kernel: Fix missed audio header include

### DIFF
--- a/include/uapi/sound/asound.h
+++ b/include/uapi/sound/asound.h
@@ -24,6 +24,7 @@
 #define _UAPI__SOUND_ASOUND_H
 
 #if defined(__KERNEL__) || defined(__linux__)
+#include <linux/time.h>
 #include <linux/types.h>
 #else
 #include <sys/ioctl.h>


### PR DESCRIPTION
Make clang happy (vndk rules).

Change-Id: I8284ca3da6f806d98fec75af4f3c198f6b16d08d
Signed-off-by: Humberto Borba <humberos@omnirom.org>