### PR TITLE
arm64: DT: MSM8956: Declare wakegic as interrupt controller

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -490,6 +490,7 @@
 		clock-names = "xo";
 		qcom,num-mpm-irqs = <96>;
 		qcom,ipc-bit-offset = <1>;
+		interrupt-controller;
 		interrupt-parent = <&intc>;
 		#interrupt-cells = <3>;
 	};


### PR DESCRIPTION
Add the missing property "interrupt-controller" to wakegic node.
Without the property, the kernel reports the following error:
[    0.000000] OF: of_irq_init: children remain, but no parents
It subsequently skips the wakegic node, which causes mpm to route irqs to QGIC2 without processing.
As a side effect, sys_pm_ops is not registered by mpm in the lpm driver.
That then leads the lpm driver to skip over any lpm level that notifies rpm.
Avoid this chain of events by correcting the wakegic node declaration.