### PR TITLE
[2.3.2.r1.4] Remove unused cores in 8956 DT

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-coresight.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-coresight.dtsi
@@ -312,42 +312,6 @@
 		clock-names = "core_clk", "core_a_clk";
 	};
 
-	etm6: etm@6e40000 {
-		compatible = "arm,coresight-etmv4";
-		reg = <0x6e40000 0x1000>;
-		reg-names = "etm-base";
-
-		coresight-id = <16>;
-		coresight-name = "coresight-etm6";
-		coresight-nr-inports = <0>;
-		coresight-outports = <0>;
-		coresight-child-list = <&funnel_apps_l0>;
-		coresight-child-ports = <6>;
-		coresight-etm-cpu = <&CPU6>;
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-			 <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-	};
-
-	etm7: etm@6f40000 {
-		compatible = "arm,coresight-etmv4";
-		reg = <0x6f40000 0x1000>;
-		reg-names = "etm-base";
-
-		coresight-id = <17>;
-		coresight-name = "coresight-etm7";
-		coresight-nr-inports = <0>;
-		coresight-outports = <0>;
-		coresight-child-list = <&funnel_apps_l0>;
-		coresight-child-ports = <7>;
-		coresight-etm-cpu = <&CPU7>;
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-			 <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-	};
-
 	stm: stm@6002000 {
 		compatible = "arm,coresight-stm";
 		reg = <0x6002000 0x1000>,
@@ -684,35 +648,6 @@
 		clock-names = "core_clk", "core_a_clk";
 	};
 
-	cti_cpu6: cti@6e20000 {
-		compatible = "arm,coresight-cti";
-		reg = <0x6e20000 0x1000>;
-		reg-names = "cti-base";
-
-		coresight-id = <41>;
-		coresight-name = "coresight-cti-cpu6";
-		coresight-nr-inports = <0>;
-		coresight-cti-cpu = <&CPU6>;
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-			 <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-	};
-
-	cti_cpu7: cti@6f20000 {
-		compatible = "arm,coresight-cti";
-		reg = <0x6f20000 0x1000>;
-		reg-names = "cti-base";
-
-		coresight-id = <42>;
-		coresight-name = "coresight-cti-cpu7";
-		coresight-nr-inports = <0>;
-		coresight-cti-cpu = <&CPU7>;
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-			 <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-	};
 
 	cti_isdb: cti@6141000 {
 		compatible = "arm,coresight-cti";

--- a/arch/arm64/boot/dts/qcom/msm8956-jtag.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-jtag.dtsi
@@ -95,30 +95,4 @@
 
 		qcom,coresight-jtagmm-cpu = <&CPU5>;
 	};
-
-	jtag_mm6: jtagmm@6e40000 {
-		compatible = "qcom,jtagv8-mm";
-		reg = <0x6e40000 0x1000>,
-		      <0x6e10000 0x1000>;
-		reg-names = "etm-base", "debug-base";
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-		         <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-
-		qcom,coresight-jtagmm-cpu = <&CPU6>;
-	};
-
-	jtag_mm7: jtagmm@6f40000 {
-		compatible = "qcom,jtagv8-mm";
-		reg = <0x6f40000 0x1000>,
-		      <0x6f10000 0x1000>;
-		reg-names = "etm-base", "debug-base";
-
-		clocks = <&clock_rpmcc RPM_QDSS_CLK>,
-		         <&clock_rpmcc RPM_QDSS_A_CLK>;
-		clock-names = "core_clk", "core_a_clk";
-
-		qcom,coresight-jtagmm-cpu = <&CPU7>;
-	};
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-pm.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-pm.dtsi
@@ -41,7 +41,7 @@
 		qcom,saw2-cfg = <0x14>;
 		qcom,saw2-spm-dly = <0x3c11840a>;
 		qcom,saw2-spm-ctl = <0x8>;
-		qcom,cpu-vctl-list = <&CPU4 &CPU5 &CPU6 &CPU7>;
+		qcom,cpu-vctl-list = <&CPU4 &CPU5>;
 		qcom,vctl-timeout-us = <50>;
 		qcom,vctl-port = <0x0>;
 		qcom,phase-port = <0x1>;
@@ -196,7 +196,7 @@
 				label = "a72";
 				qcom,spm-device-names = "l2";
 				qcom,default-level=<0>;
-				qcom,cpu = <&CPU4 &CPU5 &CPU6 &CPU7>;
+				qcom,cpu = <&CPU4 &CPU5>;
 				qcom,psci-mode-shift = <4>;
 				qcom,psci-mode-mask = <0xf>;
 
@@ -249,7 +249,7 @@
 					#size-cells = <0>;
 					qcom,psci-mode-shift = <0>;
 					qcom,psci-mode-mask = <0xf>;
-					qcom,cpu = <&CPU4 &CPU5 &CPU6 &CPU7>;
+					qcom,cpu = <&CPU4 &CPU5>;
 
 					qcom,pm-cpu-level@0 {
 						reg = <0>;

--- a/arch/arm64/boot/dts/qcom/msm8956-thermal.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-thermal.dtsi
@@ -309,18 +309,6 @@
 					<&CPU5 THERMAL_NO_LIMIT
 						(THERMAL_MAX_LIMIT-1)>;
 			};
-			cpu6_cdev {
-				trip = <&avg_cpu_trip1>;
-				cooling-device =
-					<&CPU6 THERMAL_NO_LIMIT
-						(THERMAL_MAX_LIMIT-1)>;
-			};
-			cpu7_cdev {
-				trip = <&avg_cpu_trip1>;
-				cooling-device =
-					<&CPU7 THERMAL_NO_LIMIT
-						(THERMAL_MAX_LIMIT-1)>;
-			};
 		};
 	};
 
@@ -373,18 +361,6 @@
 					<&CPU5 THERMAL_NO_LIMIT
 						(THERMAL_MAX_LIMIT-1)>;
 			};
-			pop_cdev6 {
-				trip = <&pop_trip>;
-				cooling-device =
-					<&CPU6 THERMAL_NO_LIMIT
-						(THERMAL_MAX_LIMIT-1)>;
-			};
-			pop_cdev7 {
-				trip = <&pop_trip>;
-				cooling-device =
-					<&CPU7 THERMAL_NO_LIMIT
-						(THERMAL_MAX_LIMIT-1)>;
-			};
 		};
 	};
 
@@ -427,50 +403,6 @@
 				trip = <&apc1_cpu1_trip>;
 				cooling-device =
 					<&CPU5 THERMAL_MAX_LIMIT
-						THERMAL_MAX_LIMIT>;
-			};
-		};
-	};
-
-	apc1-cpu2-step {
-		polling-delay-passive = <0>;
-		polling-delay = <0>;
-		thermal-sensors = <&tsens 6>;
-		thermal-governor = "step_wise";
-		trips {
-			apc1_cpu2_trip: apc1-cpu2-trip {
-				temperature = <105000>;
-				hysteresis = <15000>;
-				type = "passive";
-			};
-		};
-		cooling-maps {
-			cpu6_cdev {
-				trip = <&apc1_cpu2_trip>;
-				cooling-device =
-					<&CPU6 THERMAL_MAX_LIMIT
-						THERMAL_MAX_LIMIT>;
-			};
-		};
-	};
-
-	apc1-cpu3-step {
-		polling-delay-passive = <0>;
-		polling-delay = <0>;
-		thermal-sensors = <&tsens 7>;
-		thermal-governor = "step_wise";
-		trips {
-			apc1_cpu3_trip: apc1-cpu3-trip {
-				temperature = <105000>;
-				hysteresis = <15000>;
-				type = "passive";
-			};
-		};
-		cooling-maps {
-			cpu7_cdev {
-				trip = <&apc1_cpu3_trip>;
-				cooling-device =
-					<&CPU7 THERMAL_MAX_LIMIT
 						THERMAL_MAX_LIMIT>;
 			};
 		};
@@ -668,74 +600,6 @@
 		};
 	};
 
-	apc1-cpu2-lowf {
-		polling-delay-passive = <0>;
-		polling-delay = <0>;
-		thermal-governor = "low_limits_floor";
-		thermal-sensors = <&tsens 6>;
-		tracks-low;
-		trips {
-			cpu6_trip: apc1-cpu2-trip {
-				temperature = <5000>;
-				hysteresis = <5000>;
-				type = "passive";
-			};
-		};
-		cooling-maps {
-			cpu0_vdd_cdev {
-				trip = <&cpu6_trip>;
-				cooling-device = <&CPU0 (THERMAL_MAX_LIMIT - 4)
-						(THERMAL_MAX_LIMIT - 4)>;
-			};
-			gpu_vdd_cdev {
-				trip = <&cpu6_trip>;
-				cooling-device = <&msm_gpu 2 2>;
-			};
-			cx_vdd_cdev {
-				trip = <&cpu6_trip>;
-				cooling-device = <&cx_cdev 0 0>;
-			};
-			modem_vdd_cdev {
-				trip = <&cpu6_trip>;
-				cooling-device = <&modem_vdd 0 0>;
-			};
-		};
-	};
-
-	apc1-cpu3-lowf {
-		polling-delay-passive = <0>;
-		polling-delay = <0>;
-		thermal-governor = "low_limits_floor";
-		thermal-sensors = <&tsens 7>;
-		tracks-low;
-		trips {
-			cpu7_trip: apc1-cpu3-trip {
-				temperature = <5000>;
-				hysteresis = <5000>;
-				type = "passive";
-			};
-		};
-		cooling-maps {
-			cpu0_vdd_cdev {
-				trip = <&cpu7_trip>;
-				cooling-device = <&CPU0 (THERMAL_MAX_LIMIT - 4)
-						(THERMAL_MAX_LIMIT - 4)>;
-			};
-			gpu_vdd_cdev {
-				trip = <&cpu7_trip>;
-				cooling-device = <&msm_gpu 2 2>;
-			};
-			cx_vdd_cdev {
-				trip = <&cpu7_trip>;
-				cooling-device = <&cx_cdev 0 0>;
-			};
-			modem_vdd_cdev {
-				trip = <&cpu7_trip>;
-				cooling-device = <&modem_vdd 0 0>;
-			};
-		};
-	};
-
 	apc1-l2-lowf {
 		polling-delay-passive = <0>;
 		polling-delay = <0>;
@@ -906,14 +770,6 @@
 			skin_cpu5 {
 				trip = <&cpus_trip>;
 				cooling-device = <&CPU5 THERMAL_NO_LIMIT 3>;
-			};
-			skin_cpu6 {
-				trip = <&cpus_trip>;
-				cooling-device = <&CPU6 THERMAL_NO_LIMIT 3>;
-			};
-			skin_cpu7 {
-				trip = <&cpus_trip>;
-				cooling-device = <&CPU7 THERMAL_NO_LIMIT 3>;
 			};
 			modem_lvl1 {
 				trip = <&modem_trip1>;

--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -215,52 +215,6 @@
 			};
 		};
 
-		CPU6: cpu@102 {
-			device_type = "cpu";
-			compatible = "arm,armv8";
-			reg = <0x102>;
-			enable-method = "psci";
-			qcom,limits-info = <&mitigation_profile3>;
-			qcom,ea = <&ea6>;
-			efficiency = <1830>;
-			next-level-cache = <&L2_1>;
-			#cooling-cells = <2>;
-			L1_I_102: l1-icache {
-				compatible = "arm,arch-cache";
-				qcom,dump-size = <0x12000>;
-			};
-			L1_D_102: l1-dcache {
-				compatible = "arm,arch-cache";
-				qcom,dump-size = <0x12000>;
-			};
-			L1_TLB_102: l1-tlb {
-				qcom,dump-size = <0x4800>;
-			};
-		};
-
-		CPU7: cpu@103 {
-			device_type = "cpu";
-			compatible = "arm,armv8";
-			reg = <0x103>;
-			enable-method = "psci";
-			qcom,limits-info = <&mitigation_profile4>;
-			qcom,ea = <&ea7>;
-			efficiency = <1830>;
-			next-level-cache = <&L2_1>;
-			#cooling-cells = <2>;
-			L1_I_103: l1-icache {
-				compatible = "arm,arch-cache";
-				qcom,dump-size = <0x12000>;
-			};
-			L1_D_103: l1-dcache {
-				compatible = "arm,arch-cache";
-				qcom,dump-size = <0x12000>;
-			};
-			L1_TLB_103: l1-tlb {
-				qcom,dump-size = <0x4800>;
-			};
-		};
-
 		cpu-map {
 			cluster0 {
 				core0 {
@@ -287,14 +241,6 @@
 
 				core1 {
 					cpu = <&CPU5>;
-				};
-
-				core2 {
-					cpu = <&CPU6>;
-				};
-
-				core3 {
-					cpu = <&CPU7>;
 				};
 			};
 		};


### PR DESCRIPTION
MSM8956 has 6 cores whereas DT contained 8.