### PR TITLE
[2.3.2.r1.4] sdfat: Update default configuration

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_td4322/Kconfig
+++ b/drivers/input/touchscreen/synaptics_dsx_td4322/Kconfig
@@ -1,7 +1,7 @@
 #
 # Synaptics DSX touchscreen driver configuration
 #
-menuconfig TOUCHSCREEN_SYNAPTICS_DSX
+menuconfig TOUCHSCREEN_SYNAPTICS_DSX_TD
 	bool "Synaptics DSX touchscreen"
 	default n
 	help
@@ -10,23 +10,23 @@ menuconfig TOUCHSCREEN_SYNAPTICS_DSX
 
 	  If unsure, say N.
 
-if TOUCHSCREEN_SYNAPTICS_DSX
+if TOUCHSCREEN_SYNAPTICS_DSX_TD
 
 choice
-	default TOUCHSCREEN_SYNAPTICS_DSX_I2C
+	default TOUCHSCREEN_SYNAPTICS_DSX_TD_I2C
 	prompt "Synaptics DSX bus interface"
-config TOUCHSCREEN_SYNAPTICS_DSX_I2C
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_I2C
 	bool "RMI over I2C"
 	depends on I2C
-config TOUCHSCREEN_SYNAPTICS_DSX_SPI
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_SPI
 	bool "RMI over SPI"
 	depends on SPI_MASTER
-config TOUCHSCREEN_SYNAPTICS_DSX_RMI_HID_I2C
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_RMI_HID_I2C
 	bool "HID over I2C"
 	depends on I2C
 endchoice
 
-config TOUCHSCREEN_SYNAPTICS_DSX_CORE
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	tristate "Synaptics DSX core driver module"
 	depends on I2C || SPI_MASTER
 	help
@@ -35,94 +35,94 @@ config TOUCHSCREEN_SYNAPTICS_DSX_CORE
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_core.
+	  module will be called synaptics_dsx_td_core.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_RMI_DEV
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_RMI_DEV
 	tristate "Synaptics DSX RMI device module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for direct RMI register access.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_rmi_dev.
+	  module will be called synaptics_dsx_td_rmi_dev.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_FW_UPDATE
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_FW_UPDATE
 	tristate "Synaptics DSX firmware update module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for doing firmware update.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_fw_update.
+	  module will be called synaptics_dsx_td_fw_update.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_TEST_REPORTING
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_TEST_REPORTING
 	tristate "Synaptics DSX test reporting module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for retrieving production test reports.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_test_reporting.
+	  module will be called synaptics_dsx_td_test_reporting.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_PROXIMITY
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_PROXIMITY
 	tristate "Synaptics DSX proximity module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for proximity functionality.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_proximity.
+	  module will be called synaptics_dsx_td_proximity.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_ACTIVE_PEN
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_ACTIVE_PEN
 	tristate "Synaptics DSX active pen module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for active pen functionality.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_active_pen.
+	  module will be called synaptics_dsx_td_active_pen.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_GESTURE
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_GESTURE
 	tristate "Synaptics DSX user defined gesture module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for user defined gesture functionality.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_gesture.
+	  module will be called synaptics_dsx_td_gesture.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_VIDEO
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_VIDEO
 	tristate "Synaptics DSX video module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for video communication functionality.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_video.
+	  module will be called synaptics_dsx_td_video.
 
-config TOUCHSCREEN_SYNAPTICS_DSX_DEBUG
+config TOUCHSCREEN_SYNAPTICS_DSX_TD_DEBUG
 	tristate "Synaptics DSX debug module"
-	depends on TOUCHSCREEN_SYNAPTICS_DSX_CORE
+	depends on TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE
 	help
 	  Say Y here to enable support for firmware debug functionality.
 
 	  If unsure, say N.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called synaptics_dsx_debug.
+	  module will be called synaptics_dsx_td_debug.
 
 endif

--- a/drivers/input/touchscreen/synaptics_dsx_td4322/Makefile
+++ b/drivers/input/touchscreen/synaptics_dsx_td4322/Makefile
@@ -4,15 +4,15 @@
 
 # Each configuration option enables a list of files.
 
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_I2C) += synaptics_dsx_i2c.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_SPI) += synaptics_dsx_spi.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_RMI_HID_I2C) += synaptics_dsx_rmi_hid_i2c.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_CORE) += synaptics_dsx_core.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_RMI_DEV) += synaptics_dsx_rmi_dev.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_FW_UPDATE) += synaptics_dsx_fw_update.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TEST_REPORTING) += synaptics_dsx_test_reporting.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_PROXIMITY) += synaptics_dsx_proximity.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_ACTIVE_PEN) += synaptics_dsx_active_pen.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_GESTURE) += synaptics_dsx_gesture.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_VIDEO) += synaptics_dsx_video.o
-obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_DEBUG) += synaptics_dsx_debug.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_I2C) += synaptics_dsx_i2c.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_SPI) += synaptics_dsx_spi.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_RMI_HID_I2C) += synaptics_dsx_rmi_hid_i2c.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_CORE) += synaptics_dsx_core.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_RMI_DEV) += synaptics_dsx_rmi_dev.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_FW_UPDATE) += synaptics_dsx_fw_update.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_TEST_REPORTING) += synaptics_dsx_test_reporting.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_PROXIMITY) += synaptics_dsx_proximity.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_ACTIVE_PEN) += synaptics_dsx_active_pen.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_GESTURE) += synaptics_dsx_gesture.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_VIDEO) += synaptics_dsx_video.o
+obj-$(CONFIG_TOUCHSCREEN_SYNAPTICS_DSX_TD_DEBUG) += synaptics_dsx_debug.o

--- a/fs/sdfat/Kconfig
+++ b/fs/sdfat/Kconfig
@@ -25,7 +25,7 @@ config SDFAT_DELAYED_META_DIRTY
 
 config SDFAT_SUPPORT_DIR_SYNC
 	bool "Enable supporting dir sync"
-	default n
+	default y
 	depends on SDFAT_FS
 	help
 	  If you enable this feature, the modification for directory operation
@@ -50,7 +50,7 @@ config SDFAT_DEFAULT_IOCHARSET
 
 config SDFAT_CHECK_RO_ATTR
 	bool "Check read-only attribute"
-	default n
+	default y
 	depends on SDFAT_FS
 
 config SDFAT_ALIGNED_MPAGE_WRITE
@@ -67,7 +67,7 @@ config SDFAT_VIRTUAL_XATTR
 
 config SDFAT_VIRTUAL_XATTR_SELINUX_LABEL
 	string "Default string for SELinux label"
-	default "u:object_r:sdcard_external:s0"
+	default "u:object_r:vfat:s0"
 	depends on SDFAT_FS && SDFAT_VIRTUAL_XATTR
 	help
 	  Set this to the default string for SELinux label.
@@ -80,7 +80,7 @@ config SDFAT_SUPPORT_STLOG
 config SDFAT_DEBUG
 	bool "enable debug features"
 	depends on SDFAT_FS
-	default y
+	default n
 
 config SDFAT_DBG_IOCTL
 	bool "enable debug-ioctl features"


### PR DESCRIPTION
* Check for RO attr and enable dirsync
* Update SELinux label to match one from upstream AOSP
* Disable debug

Signed-off-by: Artem Labazov <123321artyom@gmail.com>