### PR TITLE
drivers: mmc: Move zero-length array to end of struct.

### DIFF
--- a/drivers/mmc/core/slot-gpio.c
+++ b/drivers/mmc/core/slot-gpio.c
@@ -28,14 +28,14 @@ struct mmc_gpio {
 	bool override_ro_active_level;
 	bool override_cd_active_level;
 	irqreturn_t (*cd_gpio_isr)(int irq, void *dev_id);
-	char *ro_label;
-	char cd_label[0];
 	bool status;
 	int uim2_gpio;
 #ifdef CONFIG_MMC_SD_DEFERRED_RESUME
 	bool pending_detect;
 	bool suspended;
 #endif
+	char *ro_label;
+	char cd_label[0];
 };
 
 int mmc_gpio_get_status(struct mmc_host *host)


### PR DESCRIPTION
Zero-length arrays should always be placed at the end of the struct.
If not they use the same memory as the fields that come after it,
resulting in corrupted data.

See #1757