### PR TITLE
Build fixes for use in GNU/Linux distributions

### DIFF
--- a/drivers/bluetooth/hci_ldisc.c
+++ b/drivers/bluetooth/hci_ldisc.c
@@ -480,7 +480,6 @@ static int hci_uart_tty_open(struct tty_struct *tty)
 	INIT_WORK(&hu->init_ready, hci_uart_init_work);
 	INIT_WORK(&hu->write_work, hci_uart_write_work);
 
-	spin_lock_init(&hu->rx_lock);
 	mutex_init(&hu->proto_lock);
 
 	/* Flush any pending characters in the driver and line discipline. */

--- a/drivers/usb/gadget/configfs.c
+++ b/drivers/usb/gadget/configfs.c
@@ -1623,6 +1623,8 @@ static int android_device_create(struct gadget_info *gi)
 
 	INIT_WORK(&gi->work, android_work);
 	snprintf(str, sizeof(str), "android%d", gadget_index - 1);
+
+#ifdef CONFIG_USB_CONFIGFS_UEVENT
 	pr_debug("Creating android device %s\n", str);
 	gi->dev = device_create(android_class, NULL,
 				MKDEV(0, 0), NULL, str);
@@ -1644,6 +1646,7 @@ static int android_device_create(struct gadget_info *gi)
 			return err;
 		}
 	}
+#endif
 
 	return 0;
 }
@@ -1716,6 +1719,7 @@ static struct config_group *gadgets_make(
 	if (!gi->composite.gadget_driver.function)
 		goto err;
 
+#ifdef CONFIG_USB_CONFIGFS_UEVENT
 	gadget_index++;
 	pr_debug("Creating gadget index %d\n", gadget_index);
 	if (android_device_create(gi) < 0)
@@ -1724,6 +1728,7 @@ static struct config_group *gadgets_make(
 	config_group_init_type_name(&gi->group, name,
 				&gadget_root_type);
 	return &gi->group;
+#endif
 
 err:
 	kfree(gi);
@@ -1736,10 +1741,13 @@ static void gadgets_drop(struct config_group *group, struct config_item *item)
 
 	gi = container_of(to_config_group(item), struct gadget_info, group);
 	config_item_put(item);
+
+#ifdef CONFIG_USB_CONFIGFS_UEVENT
 	if (gi->dev) {
 		android_device_destroy(gi->dev);
 		gi->dev = NULL;
 	}
+#endif
 }
 
 static struct configfs_group_operations gadgets_ops = {


### PR DESCRIPTION
The fixes provided in this PR are intended for using the kernel in non-Android environments, i.e Ubuntu Touch, SailfishOS.

~Changes to the suzu defconfig were reverted but give an idea on how to trigger the build failures addressed in this pull request.~

Changes of interest:

bluetooth: remove use of non-existing hci_uart->rx_lock within hci_ldisc

gadget: fix building configfs.o in the case of disabled CONFIG_USB_CONFIGFS_UEVENT
Avoid accessing gadget_info->dev and gadget_index when CONFIG_USB_CONFIGFS_UEVENT is not enabled.