### PR TITLE
[2.3.2.r1.4] arm64: DT: Loire: do not enable wakeup_gesture_lpm_disabled

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -217,7 +217,7 @@
 			preset_y_max = <1919>;
 			preset_n_fingers = <10>;
 			wakeup_gesture_supported = <0>;
-			wakeup_gesture_lpm_disabled = <1>;
+			wakeup_gesture_lpm_disabled = <0>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {
 				double_tap {


### PR DESCRIPTION
Wakeup gestures aren't enabled for clearpad, hence there is no need to disable lpm.
Set wakeup_gesture_lpm_disabled to 0 to reflect that.