### PR TITLE
[6.4.r1] arm: DT: Loire: do not enable wakeup_gesture_lpm_disabled

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -202,7 +202,7 @@
 			preset_y_max = <1919>;
 			preset_n_fingers = <10>;
 			wakeup_gesture_supported = <0>;
-			wakeup_gesture_lpm_disabled = <1>;
+			wakeup_gesture_lpm_disabled = <0>;
 			wakeup_gesture_timeout = <0>;
 			wakeup_gesture {
 				double_tap {


### PR DESCRIPTION
Wakeup gestures aren't enabled for clearpad, hence there is no need to disable lpm.
Set wakeup_gesture_lpm_disabled to 0 to reflect that.