### PR TITLE
techpack: msm8998: tasha: fix yoshino conditional

### DIFF
--- a/techpack/audio/asoc/msm8998.c
+++ b/techpack/audio/asoc/msm8998.c
@@ -3854,17 +3854,17 @@ static void *def_tasha_mbhc_cal(void)
 		(sizeof(btn_cfg->_v_btn_low[0]) * btn_cfg->num_btn);
 
 	btn_high[0] = 75;
+#ifdef CONFIG_ARCH_SONY_YOSHINO
+	btn_high[1] = 137;
+#else
 	btn_high[1] = 150;
+#endif
 	btn_high[2] = 237;
 	btn_high[3] = 500;
 	btn_high[4] = 500;
 	btn_high[5] = 500;
 	btn_high[6] = 500;
 	btn_high[7] = 500;
-
-#ifdef CONFIG_ARCH_SONY_YOSHINO
-	btn_high[1] = 137;
-#endif
 
 	return tasha_wcd_cal;
 }


### PR DESCRIPTION
yoshino should pick right btn_high[1] for tasha not both

Signed-off-by: David Viteri <davidteri91@gmail.com>