### PR TITLE
dts: msm8998: fix mmss clock

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -850,7 +850,7 @@
 	};
 
 	clock_mmss: qcom,mmsscc@c8c0000 {
-		compatible = "qcom,mmcc-msm8998";
+		compatible = "qcom,mmsscc-8998";
 		reg = <0xc8c0000 0x40000>;
 		reg-names = "cc_base";
 		vdd_dig-supply = <&pm8998_s1_level>;


### PR DESCRIPTION
see drivers/clk/qcom/mmcc-msm8998.c

Signed-off-by: David Viteri <davidteri91@gmail.com>