### PR TITLE
techpack: audio: remove SND_SOC_MSM8X16

### DIFF
--- a/techpack/audio/Kconfig
+++ b/techpack/audio/Kconfig
@@ -111,12 +111,9 @@ config SND_SOC_SDM670
 config SND_SOC_WCD_CPE_SOMC_EXT
 	bool "WCD CPE SoMC Extensions"
 	depends on SND_SOC_WCD_CPE
-config SND_SOC_MSM8X16
-	tristate "SoC Machine driver for MSM8916"
 config SND_SOC_MSM8956
 	tristate "SND_SOC_MSM8956"
 config SND_SOC_MSM8996
 	tristate "SND_SOC_MSM8996"
 config SND_SOC_MSM8998
 	tristate "SND_SOC_MSM8998"
-


### PR DESCRIPTION
The SND_SOC_MSM8X16 is not used because it was replaced to SND_SOC_MSM8956

Signed-off-by: David Viteri <davidteri91@gmail.com>