### PR TITLE
Discovery: enable front flash

### DIFF
--- a/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm630-nile-discovery_camera.dtsi
@@ -41,7 +41,7 @@
 		qcom,flash-source = <&pm660l_flash1>;
 		qcom,torch-source = <&pm660l_torch1>;
 		qcom,switch-source = <&pm660l_switch1>;
-		status = "disabled";
+		status = "ok";
 	};
 
 	cam_vdig_imx300_219_vreg: cam_vdig_imx300_219_vreg {

--- a/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash.h
+++ b/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash.h
@@ -82,6 +82,7 @@ struct msm_flash_ctrl_t {
 	uint32_t flash_op_current[MAX_LED_TRIGGERS];
 	uint32_t flash_max_current[MAX_LED_TRIGGERS];
 	uint32_t flash_max_duration[MAX_LED_TRIGGERS];
+	struct led_classdev flash_cdev;
 
 	/* Torch */
 	uint32_t torch_num_sources;
@@ -89,6 +90,7 @@ struct msm_flash_ctrl_t {
 	struct led_trigger *torch_trigger[MAX_LED_TRIGGERS];
 	uint32_t torch_op_current[MAX_LED_TRIGGERS];
 	uint32_t torch_max_current[MAX_LED_TRIGGERS];
+	struct led_classdev torch_cdev;
 
 	void *data;
 	enum msm_camera_device_type_t flash_device_type;


### PR DESCRIPTION
By pulling in the latest changes to `msm_flash.c` (from 50.1.A.3xxx), front flash now functions correctly.

The commit description might be off as I am not certain what this change exactly adds and how this prevents bootloops when the front flash is enabled (I have not been able to pull logs from the device). I assume something that requires the new functionality in order 

Note that the bodies of `msm_flash_high_brightness_set` and `msm_flash_low_brightness_set` are almost identical. This has intentionally not been refactored to stay in line with "our upstream" (Sony's copyleft kernel).

This change should also be tested and pull-requested for K4.9.