### PR TITLE
msm: camera_v2: Populate timecode type in vb2_v4l2_buffer

### DIFF
--- a/drivers/media/platform/msm/camera_v2/msm_vb2/msm_vb2.c
+++ b/drivers/media/platform/msm/camera_v2/msm_vb2/msm_vb2.c
@@ -399,7 +399,7 @@ static int msm_vb2_put_buf(struct vb2_v4l2_buffer *vb, int session_id,
 
 static int msm_vb2_buf_done(struct vb2_v4l2_buffer *vb, int session_id,
 				unsigned int stream_id, uint32_t sequence,
-				struct timeval *ts, uint32_t reserved)
+				struct timeval *ts, uint32_t buf_type)
 {
 	unsigned long flags, rl_flags;
 	struct msm_vb2_buffer *msm_vb2;
@@ -440,6 +440,7 @@ static int msm_vb2_buf_done(struct vb2_v4l2_buffer *vb, int session_id,
 		/* put buf before buf done */
 		if (msm_vb2->in_freeq) {
 			vb2_v4l2_buf->sequence = sequence;
+			vb2_v4l2_buf->timecode.type = buf_type;
 			vb2_v4l2_buf->timestamp = *ts;
 			vb2_buffer_done(&vb2_v4l2_buf->vb2_buf,
 				VB2_BUF_STATE_DONE);


### PR DESCRIPTION
Populates timecode.type in vb2_v4l2_buffer. It will be used to pass
ub subsampling info to user space.

Change-Id: I824a36799a212f5e84a32d6ba42aea8e938ddb13
Signed-off-by: Trishansh Bhardwaj <tbhardwa@codeaurora.org>