### PR TITLE
uapi: Define __BITS_PER_LONG based on compiler target

### DIFF
--- a/arch/arm64/include/uapi/asm/bitsperlong.h
+++ b/arch/arm64/include/uapi/asm/bitsperlong.h
@@ -16,7 +16,11 @@
 #ifndef __ASM_BITSPERLONG_H
 #define __ASM_BITSPERLONG_H
 
+#ifdef __aarch64__
 #define __BITS_PER_LONG 64
+#else
+#define __BITS_PER_LONG 32
+#endif
 
 #include <asm-generic/bitsperlong.h>
 


### PR DESCRIPTION
* We may compile 32-bit ARM code against these kernel headers in many
  situations, so provide a compiler-defined method of obtaining the width
  of long.

Change-Id: Iac5e48200d70f1258ab3caca1a8f1eb6e8f7f2d3