### PR TITLE
[2.3.2.r1.4] [Yoshino] Introduce SDE, fix FBDEV display resume bug, spare fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-base-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-base-sde.dtsi
@@ -20,9 +20,9 @@
 #include "dsi-panel-somc-lilac-id5_pcc.dtsi"
 #include "dsi-panel-somc-lilac-id8_pcc.dtsi"
 
-&mdss_mdp {
+&sde_kms {
 	/* LGD ID5 */
-	dsi_5: somc,5_panel {
+	sde_dsi_5: somc,5_panel {
 		qcom,mdss-dsi-panel-name = "5";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
@@ -195,7 +195,7 @@
 	};
 
 	/* JDI ID8 */
-	dsi_8: somc,8_panel {
+	sde_dsi_8: somc,8_panel {
 		qcom,mdss-dsi-panel-name = "8";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
@@ -388,7 +388,7 @@
 	};
 
 	/* Default */
-	dsi_default_panel: somc,default_cmd_panel {
+	sde_dsi_default_panel: somc,default_cmd_panel {
 		qcom,mdss-dsi-panel-name = "default";
 		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-sde.dtsi
@@ -1,0 +1,66 @@
+/* Copyright (c) 2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+&sde_dsi_5 {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 15>, <1 20>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		720p60 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&sde_dsi_8 {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 15>, <1 16>, <0 15>, <1 20>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		720p60 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&sde_dsi_default_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,display-topology = <1 0 1>;
+	qcom,default-topology-index = <0>;
+};
+

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
@@ -1,0 +1,109 @@
+/* Copyright (c) 2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&dsi_dual0_default_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+		
+		4k {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&dsi_dual1_default_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+		
+		4k {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&dsi_dual0_6_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+		
+		4k {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&dsi_dual1_6_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 0>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+		
+		4k {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm-arm-smmu-8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-arm-smmu-8998.dtsi
@@ -125,9 +125,11 @@
 			   <GIC_SPI 272 IRQ_TYPE_LEVEL_HIGH>;
 		vdd-supply = <&gdsc_bimc_smmu>;
 		clocks = <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			 <&clock_rpmcc MMSSNOC_AXI_CLK>,
 			<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
 			<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
 		clock-names = "mmss_mnoc_ahb_clk",
+			      "mmssnoc_axi_clk",
 			"mmss_bimc_smmu_ahb_clk",
 			"mmss_bimc_smmu_axi_clk";
 		#clock-cells = <1>;

--- a/arch/arm64/boot/dts/qcom/msm8998-bus.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-bus.dtsi
@@ -140,6 +140,7 @@
 			qcom,node-qos-clks {
 				clock-names =
 				"clk-noc-cfg-ahb-no-rate",
+				"clk-mmss-noc-cfg-ahb-no-rate",
 				"clk-mnoc-ahb-no-rate",
 				"clk-camss-ahb-no-rate",
 				"clk-video-ahb-no-rate",

--- a/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
@@ -316,8 +316,8 @@
 			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
 			 <&clock_mmss MMSS_MISC_AHB_CLK>,
-			 <&mdss_dsi0_pll BYTECLK_SRC_0_CLK>,
-			 <&mdss_dsi1_pll BYTECLK_SRC_1_CLK>,
+			 <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>,
+			 <&mdss_dsi1_pll BYTECLK_MUX_1_CLK>,
 			 <&mdss_dsi0_pll PCLK_MUX_0_CLK>,
 			 <&mdss_dsi1_pll PCLK_MUX_1_CLK>;
 		clock-names = "mdp_core_clk",

--- a/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
@@ -390,6 +390,7 @@
 			qcom,mdss-fb-map = <&mdss_fb0>;
 
 			qcom,null-insertion-enabled;
+			qcom,link-clks-reconf-platform-hack;
 
 			clocks = <&clock_mmss MMSS_MDSS_BYTE0_CLK>,
 				 <&clock_mmss MMSS_MDSS_PCLK0_CLK>,
@@ -430,6 +431,7 @@
 			qcom,mdss-fb-map = <&mdss_fb0>;
 
 			qcom,null-insertion-enabled;
+			qcom,link-clks-reconf-platform-hack;
 
 			clocks = <&clock_mmss MMSS_MDSS_BYTE1_CLK>,
 				 <&clock_mmss MMSS_MDSS_PCLK1_CLK>,

--- a/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
@@ -316,8 +316,8 @@
 			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
 			 <&clock_mmss MMSS_MISC_AHB_CLK>,
-			 <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>,
-			 <&mdss_dsi1_pll BYTECLK_MUX_1_CLK>,
+			 <&mdss_dsi0_pll BYTECLK_SRC_0_CLK>,
+			 <&mdss_dsi1_pll BYTECLK_SRC_1_CLK>,
 			 <&mdss_dsi0_pll PCLK_MUX_0_CLK>,
 			 <&mdss_dsi1_pll PCLK_MUX_1_CLK>;
 		clock-names = "mdp_core_clk",

--- a/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-mdss.dtsi
@@ -609,7 +609,7 @@
 		qcom,mdss-default-ot-rd-limit = <32>;
 		qcom,mdss-default-ot-wr-limit = <32>;
 
-		smmu_rot_unsec: qcom,smmu_rot_unsec_cb {
+		smmu_mdss_rot_unsec: qcom,smmu_rot_unsec_cb {
 			compatible = "qcom,smmu_sde_rot_unsec";
 			iommus = <&mmss_smmu 0xe00>;
 			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
@@ -623,7 +623,7 @@
 					"mmss_smmu_axi_clk";
 		};
 
-		smmu_rot_sec: qcom,smmu_rot_sec_cb {
+		smmu_mdss_rot_sec: qcom,smmu_rot_sec_cb {
 			compatible = "qcom,smmu_sde_rot_sec";
 			iommus = <&mmss_smmu 0xe01>;
 			gdsc-mdss-supply = <&gdsc_bimc_smmu>;

--- a/arch/arm64/boot/dts/qcom/msm8998-sde-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde-display.dtsi
@@ -18,12 +18,12 @@
 		label = "wb_display";
 	};
 
-	msm_ext_disp: qcom,msm_ext_disp {
+	msm_sde_ext_disp: qcom,msm_ext_disp {
 		compatible = "qcom,msm-ext-disp";
 
 		ext_disp_audio_codec: qcom,msm-ext-disp-audio-codec-rx {
 			compatible = "qcom,msm-ext-disp-audio-codec-rx";
-			qcom,msm_ext_disp = <&msm_ext_disp>;
+			qcom,msm_ext_disp = <&msm_sde_ext_disp>;
 		};
 	};
 
@@ -31,7 +31,7 @@
 		compatible = "qcom,hdmi-display";
 		label = "sde_hdmi";
 		qcom,display-type = "secondary";
-		qcom,msm_ext_disp = <&msm_ext_disp>;
+		qcom,msm_ext_disp = <&msm_sde_ext_disp>;
 	};
 
 	sde_hdmi_cec: qcom,hdmi-cec@c9a0000 {

--- a/arch/arm64/boot/dts/qcom/msm8998-sde-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde-display.dtsi
@@ -71,5 +71,5 @@
 };
 
 &sde_kms {
-	connectors = <&sde_hdmi_tx &sde_hdmi &sde_wb>;
+	connectors = <&sde_wb>; //<&sde_hdmi_tx &sde_hdmi &sde_wb>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde-overlay.dtsi
@@ -1,0 +1,48 @@
+/* Copyright (c) 2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/* Remove all FBDEV related configuration */
+/delete-node/ &mdss_mdp;
+/delete-node/ &mdss_dsi0;
+/delete-node/ &mdss_dsi1;
+/delete-node/ &mdss_dsi;
+/delete-node/ &msm_ext_disp;
+/delete-node/ &mdss_dp_ctrl;
+/delete-node/ &mdss_hdmi_tx;
+/delete-node/ &mdss_rotator;
+
+&soc {
+	/delete-node/ qcom,mdss_wb_panel;
+
+	mdss_hdmi_tx: mdss_hdmi_tx {
+	};
+
+	mdss_dp_ctrl: dummy-fb-mdss_dp {
+	};
+
+	mdss_dsi: dummy-fb-mdss_dsi {
+	};
+
+	mdss_mdp: mdss_mdp {
+	};
+
+	mdss_fb0: mdss_fb0 {
+	};
+
+	mdss_fb2: mdss_fb2 {
+	};
+};
+
+#include "msm8998-sde.dtsi"
+#include "msm8998-sde-display.dtsi"
+
+

--- a/arch/arm64/boot/dts/qcom/msm8998-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde-overlay.dtsi
@@ -12,27 +12,21 @@
 
 /* Remove all FBDEV related configuration */
 /delete-node/ &mdss_mdp;
+
 /delete-node/ &mdss_dsi0;
 /delete-node/ &mdss_dsi1;
 /delete-node/ &mdss_dsi;
+
 /delete-node/ &msm_ext_disp;
 /delete-node/ &mdss_dp_ctrl;
 /delete-node/ &mdss_hdmi_tx;
-/delete-node/ &mdss_rotator;
+
+// /delete-node/ &mdss_rotator;
 
 &soc {
 	/delete-node/ qcom,mdss_wb_panel;
 
-	mdss_hdmi_tx: mdss_hdmi_tx {
-	};
-
 	mdss_dp_ctrl: dummy-fb-mdss_dp {
-	};
-
-	mdss_dsi: dummy-fb-mdss_dsi {
-	};
-
-	mdss_mdp: mdss_mdp {
 	};
 
 	mdss_fb0: mdss_fb0 {

--- a/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
@@ -14,14 +14,17 @@
 	sde_kms: qcom,sde_kms@c900000 {
 		compatible = "qcom,sde-kms";
 		reg = <0x0c900000 0x90000>,
-		      <0x0c9b0000 0x2008>;
-		reg-names = "mdp_phys", "vbif_phys";
+		      <0x0c9b0000 0x2008>,
+		      <0x0c9b8000 0x1040>;
+		reg-names = "mdp_phys", "vbif_phys",
+			    "vbif_nrt_phys";
 
 		/* clock and supply entries */
 		clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
 			<&clock_mmss MMSS_MNOC_AHB_CLK>,
 			<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
 			<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>,
+			 <&clock_mmss MMSS_MISC_AHB_CLK>,
 			<&clock_mmss MMSS_MNOC_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
@@ -33,11 +36,12 @@
 					"mmss_noc_ahb_clk",
 					"mmss_smmu_ahb_clk",
 					"mmss_smmu_axi_clk",
+				"core_mmss_clk",
 			    "mnoc_clk", "iface_clk", "bus_clk",
 				"core_clk_src", "core_clk", "vsync_clk",
 				"lut_clk";
-		clock-rate = <0 0 0 0 0 0 0 330000000 0 0 0 0>;
-		clock-max-rate = <0 0 0 0 0 0 412500000 412500000 0 0 0 0>;
+		clock-rate = <0 0 0 0 0 0 0 0 330000000 0 0 0 0>;
+		clock-max-rate = <0 0 0 0 0 0 0 412500000 412500000 0 0 0 0>;
 		qcom,sde-max-bw-low-kbps = <6700000>;
 		qcom,sde-max-bw-high-kbps = <6700000>;
 
@@ -65,7 +69,13 @@
 		qcom,sde-mixer-size = <0x31c>;
 		qcom,sde-mixer-display-pref = "primary", "primary", "none",
 					      "none", "none", "none";
-									
+		qcom,sde-mixer-pair-mask = <2 1 6 0 0 3>;
+		qcom,sde-mixer-blend-op-off = <0x20 0x38 0x50 0x68 0x80 0x98
+						0xb0 0xc8 0xe0 0xf8 0x110>;
+
+		qcom,sde-dspp-top-off = <0x1300>;
+		qcom,sde-dspp-top-size = <0xc>;
+
 		qcom,sde-dspp-off = <0x55000 0x57000>;
 		qcom,sde-dspp-size = <0x17e0>;
 
@@ -74,7 +84,8 @@
 
 		qcom,sde-wb-id = <2>;
 		qcom,sde-wb-xin-id = <6>;
-		qcom,sde-wb-clk-ctrl = <0x2bc 0x10>;
+		qcom,sde-wb-clk-ctrl = <0x2bc 16>;
+
 		qcom,sde-intf-off = <0x6b000 0x6b800
 					0x6c000 0x6c800>;
 		qcom,sde-intf-size = <0x280>;
@@ -84,14 +95,14 @@
 		qcom,sde-pp-off = <0x71000 0x71800
 				0x72000 0x72800 0x73000>;
 		qcom,sde-pp-slave = <0x0 0x0 0x0 0x0 0x1>;
-
 		qcom,sde-pp-size = <0xd4>;
 
 		qcom,sde-te2-off = <0x2000 0x2000 0x0 0x0 0x0>;
+
 		qcom,sde-cdm-off = <0x7a200>;
 		qcom,sde-cdm-size = <0x224>;
 
-		qcom,sde-dsc-off = <0x81000 0x81400>;
+		qcom,sde-dsc-off = <0x81000 0x81400 0x0 0x0 0x0>;
 		qcom,sde-dsc-size = <0x140>;
 
 		qcom,sde-intf-max-prefetch-lines = <0x15 0x15 0x15 0x15>;
@@ -103,14 +114,22 @@
 		qcom,sde-sspp-off = <0x5000 0x7000 0x9000 0xb000
 						0x25000 0x27000 0x29000 0x2b000>;
 						//0x35000 0x37000>;
-		qcom,sde-sspp-src-size = <0x1ac>;
+		qcom,sde-sspp-src-size = <0x184>; //<0x1ac>;
 
-		qcom,sde-sspp-xin-id = <0 4 8 12 1 5 9 13 2 10>;
+		qcom,sde-sspp-xin-id = <0 4 8 12 1 5 9 13>; // 2 10>;
+		qcom,sde-sspp-excl-rect = <1 1 1 1
+						1 1 1 1>;
+		qcom,sde-sspp-smart-dma-priority = <5 6 7 8 1 2 3 4>;
+		qcom,sde-smart-dma-rev = "smart_dma_v2";
 
 		/* offsets are relative to "mdp_phys + qcom,sde-off */
-		qcom,sde-sspp-clk-ctrl = <0x2ac 0x8>, <0x2b4 0x8>,
+/*		qcom,sde-sspp-clk-ctrl = <0x2ac 0x8>, <0x2b4 0x8>,
 				  <0x2c4 0x8>, <0x2c4 0xc>, <0x3a8 0x10>,
 				  <0x3b0 0x10>;
+*/
+		qcom,sde-sspp-clk-ctrl =
+				<0x2ac 0>, <0x2b4 0>, <0x2bc 0>, <0x2c4 0>,
+				 <0x2ac 8>, <0x2b4 8>, <0x2bc 8>, <0x2c4 8>;
 
 		qcom,sde-qseed-type = "qseedv3";
 		qcom,sde-mixer-linewidth = <2560>;
@@ -122,6 +141,58 @@
 		qcom,sde-has-src-split;
 		qcom,sde-sspp-danger-lut = <0x000f 0xffff 0x0000>;
 		qcom,sde-sspp-safe-lut = <0xfffc 0xff00 0xffff>;
+
+		qcom,sde-vbif-qos-rt-remap = <3 3 4 4 5 5 6 6>;
+		qcom,sde-vbif-qos-nrt-remap = <3 3 3 3 3 3 3 3>;
+
+		qcom,sde-danger-lut = <0x0000000f 0x0000ffff 0x00000000
+			0x00000000>;
+		qcom,sde-safe-lut-linear =
+			<4 0xfff8>,
+			<0 0xfff0>;
+		qcom,sde-safe-lut-macrotile =
+			<10 0xfe00>,
+			<11 0xfc00>,
+			<12 0xf800>,
+			<0 0xf000>;
+		qcom,sde-safe-lut-nrt =
+			<0 0xffff>;
+		qcom,sde-safe-lut-cwb =
+			<0 0xffff>;
+		qcom,sde-qos-lut-linear =
+			<4 0x00000000 0x00000357>,
+			<5 0x00000000 0x00003357>,
+			<6 0x00000000 0x00023357>,
+			<7 0x00000000 0x00223357>,
+			<8 0x00000000 0x02223357>,
+			<9 0x00000000 0x22223357>,
+			<10 0x00000002 0x22223357>,
+			<11 0x00000022 0x22223357>,
+			<12 0x00000222 0x22223357>,
+			<13 0x00002222 0x22223357>,
+			<14 0x00012222 0x22223357>,
+			<0 0x00112222 0x22223357>;
+		qcom,sde-qos-lut-macrotile =
+			<10 0x00000003 0x44556677>,
+			<11 0x00000033 0x44556677>,
+			<12 0x00000233 0x44556677>,
+			<13 0x00002233 0x44556677>,
+			<14 0x00012233 0x44556677>,
+			<0 0x00112233 0x44556677>;
+		qcom,sde-qos-lut-nrt =
+			<0 0x00000000 0x00000000>;
+		qcom,sde-qos-lut-cwb =
+			<0 0x75300000 0x00000000>;
+
+		qcom,sde-cdp-setting = <1 1>, <1 0>;
+
+		qcom,sde-qos-cpu-mask = <0x3>;
+		qcom,sde-qos-cpu-dma-latency = <300>;
+
+		qcom,sde-inline-rotator = <&mdss_rotator 0>;
+		qcom,sde-inline-rot-xin = <10 11>;
+		qcom,sde-inline-rot-xin-type = "sspp", "wb";
+
 
 		qcom,sde-vbif-off = <0>;
 		qcom,sde-vbif-id = <0>;
@@ -141,7 +212,20 @@
 			qcom,sde-vig-qseed-off = <0xa00>;
 			qcom,sde-vig-qseed-size = <0xa0>;
 		};
-
+/*
+		qcom,sde-dspp-blocks {
+			qcom,sde-dspp-igc = <0x0 0x00030001>;
+			qcom,sde-dspp-hsic = <0x800 0x00010007>;
+			qcom,sde-dspp-memcolor = <0x880 0x00010007>;
+			qcom,sde-dspp-sixzone= <0x900 0x00010007>;
+			qcom,sde-dspp-vlut = <0xa00 0x00010008>;
+			qcom,sde-dspp-gamut = <0x1000 0x00040000>;
+			qcom,sde-dspp-pcc = <0x1700 0x00040000>;
+			qcom,sde-dspp-gc = <0x17c0 0x00010008>;
+			qcom,sde-dspp-hist = <0x800 0x00010007>;
+			qcom,sde-dspp-dither = <0x82c 0x00010007>;
+		};
+*/
 		qcom,platform-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -168,11 +252,29 @@
 		smmu_kms_unsec: qcom,smmu_kms_unsec_cb {
 			compatible = "qcom,smmu_sde_unsec";
 			iommus = <&mmss_smmu 0>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
 		};
 
 		smmu_kms_sec: qcom,smmu_kms_sec_cb {
 			compatible = "qcom,smmu_sde_sec";
 			iommus = <&mmss_smmu 1>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
 		};
 		
 		smmu_sde_unsec: qcom,smmu_sde_nrt_unsec_cb {
@@ -213,6 +315,7 @@
 				<22 512 0 6400000>, <23 512 0 6400000>,
 				<22 512 0 6400000>, <23 512 0 6400000>;
 		};
+/*
 		qcom,sde-reg-bus {
 			qcom,msm-bus,name = "mdss_reg";
 			qcom,msm-bus,num-cases = <4>;
@@ -224,28 +327,73 @@
 				<1 590 0 160000>,
 				<1 590 0 320000>;
 		};
+*/
 	};
 
-	mdss_dsi0: qcom,mdss_dsi_ctrl0@c994000 {
+	sde_dsi0: qcom,mdss_dsi_ctrl0@c994000 {
 		compatible = "qcom,dsi-ctrl-hw-v2.0";
 		label = "dsi-ctrl-0";
 		cell-index = <0>;
 		reg = <0xc994000 0x400>,
-			  <0xc828000 0xac>;
+			<0xc828000 0xac>;
 		reg-names = "dsi_ctrl", "mmss_misc";
 		interrupt-parent = <&sde_kms>;
 		interrupts = <4 0>;
+
+		gdsc-supply = <&gdsc_mdss>;
 		vdda-1p2-supply = <&pm8998_l2>;
-		clocks = <&clock_mmss MMSS_MDSS_BYTE0_CLK>,
-		<&clock_mmss BYTE0_CLK_SRC>,
-		<&clock_mmss MMSS_MDSS_BYTE0_INTF_CLK>,
-		<&clock_mmss MMSS_MDSS_PCLK0_CLK>,
-		<&clock_mmss PCLK0_CLK_SRC>,
-		<&clock_mmss MMSS_MDSS_ESC0_CLK>;
-		clock-names = "byte_clk", "byte_clk_rcg", "byte_intf_clk",
+		vdda-0p9-supply = <&pm8998_l1>;
+
+/*		clocks = <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AHB_CLK>,                         
+			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
+*/
+		//clocks =	 <&clock_mmss MMSS_MISC_AHB_CLK>,
+		clocks =
+			 <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
+			 <&clock_mmss MMSS_MISC_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
+
+			 <&clock_mmss MMSS_MDSS_BYTE0_CLK>,
+			 <&clock_mmss BYTE0_CLK_SRC>,
+			 <&clock_mmss MMSS_MDSS_BYTE0_INTF_CLK>,
+			 <&clock_mmss MMSS_MDSS_PCLK0_CLK>,
+			 <&clock_mmss PCLK0_CLK_SRC>,
+			 <&clock_mmss MMSS_MDSS_ESC0_CLK>;
+		clock-names = /*"mdp_core_clk", "mnoc_clk", "iface_clk", "bus_clk", */ //"core_mmss_clk",
+
+				"mdp_core_clk", "iface_clk",
+			"core_mmss_clk", "bus_clk",
+			      "byte_clk", "byte_clk_rcg", "byte_intf_clk",
 					"pixel_clk", "pixel_clk_rcg",
 					"esc_clk";
 		qcom,null-insertion-enabled;
+
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_dsi";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<22 512 0 0>,
+			<22 512 0 1000>;
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
+
 		qcom,ctrl-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -258,10 +406,20 @@
 				qcom,supply-enable-load = <12560>;
 				qcom,supply-disable-load = <4>;
 			};
+
+			qcom,ctrl-supply-entry@1 {
+				reg = <1>;
+				qcom,supply-name = "vdda-0p9";
+				qcom,supply-min-voltage = <880000>;
+				qcom,supply-max-voltage = <880000>;
+				qcom,supply-enable-load = <73400>;
+				qcom,supply-disable-load = <32>;
+				//qcom,supply-lp-mode-disable-allowed;
+			};
 		};
 	};
 
-	mdss_dsi1: qcom,mdss_dsi_ctrl1@c996000 {
+	sde_dsi1: qcom,mdss_dsi_ctrl1@c996000 {
 		compatible = "qcom,dsi-ctrl-hw-v2.0";
 		label = "dsi-ctrl-1";
 		cell-index = <1>;
@@ -271,15 +429,47 @@
 		interrupt-parent = <&sde_kms>;
 		interrupts = <5 0>;
 		vdda-1p2-supply = <&pm8998_l2>;
-		clocks = <&clock_mmss MMSS_MDSS_BYTE1_CLK>,
-		<&clock_mmss BYTE1_CLK_SRC>,
-		<&clock_mmss MMSS_MDSS_BYTE1_INTF_CLK>,
-		<&clock_mmss MMSS_MDSS_PCLK1_CLK>,
-		<&clock_mmss PCLK1_CLK_SRC>,
-		<&clock_mmss MMSS_MDSS_ESC1_CLK>;
-		clock-names = "byte_clk", "byte_clk_rcg", "byte_intf_clk",
+		vdda-0p9-supply = <&pm8998_l1>;
+		/*clocks = <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
+			 <&clock_mmss MMSS_MISC_AHB_CLK>,*/
+		clocks =
+			 <&clock_mmss MMSS_MDSS_BYTE1_CLK>,
+			 <&clock_mmss BYTE1_CLK_SRC>,
+			 <&clock_mmss MMSS_MDSS_BYTE1_INTF_CLK>,
+			 <&clock_mmss MMSS_MDSS_PCLK1_CLK>,
+			 <&clock_mmss PCLK1_CLK_SRC>,
+			 <&clock_mmss MMSS_MDSS_ESC1_CLK>;
+		clock-names =   /*"mdp_core_clk", "mnoc_clk", "iface_clk",
+				"bus_clk", "core_mmss_clk", */
+				"byte_clk", "byte_clk_rcg", "byte_intf_clk",
 				"pixel_clk", "pixel_clk_rcg", "esc_clk";
 		qcom,null-insertion-enabled;
+
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_dsi1";
+		qcom,msm-bus,num-cases = <2>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<22 512 0 0>,
+			<22 512 0 1000>;
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
 		qcom,ctrl-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -292,17 +482,36 @@
 				qcom,supply-enable-load = <12560>;
 				qcom,supply-disable-load = <4>;
 			};
+
+			qcom,ctrl-supply-entry@1 {
+				reg = <1>;
+				qcom,supply-name = "vdda-0p9";
+				qcom,supply-min-voltage = <880000>;
+				qcom,supply-max-voltage = <880000>;
+				qcom,supply-enable-load = <73400>;
+				qcom,supply-disable-load = <32>;
+				//qcom,supply-lp-mode-disable-allowed;
+			};
 		};
 	};
 
 	mdss_dsi_phy0: qcom,mdss_dsi_phy0@ae94400 {
-		compatible = "qcom,dsi-phy-v3.0";
+		compatible = "qcom,dsi-phy-v3.0"; //"qcom,dsi-phy-v2.0"; //"qcom,dsi-phy-v3.0";
 		label = "dsi-phy-0";
 		cell-index = <0>;
-		reg = <0x994400 0x558>;
+		reg = <0x994400 0x7c0>;
 		reg-names = "dsi_phy";
 		gdsc-supply = <&gdsc_mdss>;
 		vdda-0p9-supply = <&pm8998_l1>;
+
+		clocks = <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AHB_CLK>,                         
+			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
+			 <&clock_mmss MMSS_MISC_AHB_CLK>;
+		clock-names =   "mdp_core_clk", "mnoc_clk", "iface_clk",
+				"bus_clk", "core_mmss_clk";
+
 		qcom,platform-strength-ctrl =  [55 03
 						55 03
 						55 03
@@ -313,7 +522,23 @@
 					00 00 00 00
 					00 00 00 00
 					00 00 00 80];
-		qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+		// PHY V3 doesn't need this.
+		//qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
 		qcom,phy-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -324,7 +549,7 @@
 				qcom,supply-max-voltage = <880000>;
 				qcom,supply-enable-load = <73400>;
 				qcom,supply-disable-load = <32>;
-				qcom,supply-lp-mode-disable-allowed;
+				//qcom,supply-lp-mode-disable-allowed;
 			};
 		};
 	};
@@ -333,10 +558,20 @@
 		compatible = "qcom,dsi-phy-v3.0";
 		label = "dsi-phy-1";
 		cell-index = <1>;
-		reg = <0x996400 0x558>;
+		reg = <0x996400 0x7c0>;
 		reg-names = "dsi_phy";
+
 		gdsc-supply = <&gdsc_mdss>;
 		vdda-0p9-supply = <&pm8998_l1>;
+
+		clocks = <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			 <&clock_mmss MMSS_MDSS_AHB_CLK>,                         
+			 <&clock_mmss MMSS_MDSS_AXI_CLK>,
+			 <&clock_mmss MMSS_MISC_AHB_CLK>;
+		clock-names =   "mdp_core_clk", "mnoc_clk", "iface_clk",
+				"bus_clk", "core_mmss_clk";
+
 		qcom,platform-strength-ctrl =  [55 03
 						55 03
 						55 03
@@ -347,7 +582,21 @@
 					00 00 00 00
 					00 00 00 00
 					00 00 00 80];
-		qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+		//qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+
+		qcom,core-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			qcom,core-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "gdsc";
+				qcom,supply-min-voltage = <0>;
+				qcom,supply-max-voltage = <0>;
+				qcom,supply-enable-load = <0>;
+				qcom,supply-disable-load = <0>;
+			};
+		};
+
 		qcom,phy-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -358,7 +607,7 @@
 				qcom,supply-max-voltage = <880000>;
 				qcom,supply-enable-load = <74300>;
 				qcom,supply-disable-load = <32>;
-				qcom.supply-lp-mode-disable-allowed;
+				//qcom.supply-lp-mode-disable-allowed;
 			};
 		};
 	};
@@ -411,12 +660,14 @@
 		qcom,pluggable;
 	};
 
-	mdss_rotator: qcom,mdss_rotator {
+	sde_rotator: qcom,sde_rotator {
 		compatible = "qcom,sde_rotator";
 		reg = <0x0c900000 0xab100>,
 		      <0x0c9b8000 0x1040>;
 		reg-names = "mdp_phys",
 			"rot_vbif_phys";
+
+		status = "disabled";
 
 		qcom,mdss-rot-mode = <1>;
 		qcom,mdss-highest-bank-bit = <0x2>;
@@ -442,7 +693,7 @@
 			"iface_clk", "rot_core_clk",
 			"rot_clk", "axi_clk";
 
-		interrupt-parent = <&mdss_mdp>;
+		interrupt-parent = <&sde_kms>;
 		interrupts = <2 0>;
 
 		/* VBIF QoS remapper settings*/

--- a/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
@@ -48,7 +48,7 @@
 		#interrupt-cells = <1>;
 		iommus = <&mmss_smmu 0>;
 
-		gpus = <&msm_gpu>;
+		//gpus = <&msm_gpu>;
 
 		/* hw blocks */
 		qcom,sde-off = <0x1000>;
@@ -57,11 +57,15 @@
 		qcom,sde-ctl-off = <0x2000 0x2200 0x2400
 				     0x2600 0x2800>;
 		qcom,sde-ctl-size = <0x94>;
+		qcom,sde-ctl-display-pref = "primary", "primary", "none",
+					    "none", "none";
 
 		qcom,sde-mixer-off = <0x45000 0x46000 0x47000
 				      0x48000 0x49000 0x4a000>;
 		qcom,sde-mixer-size = <0x31c>;
-
+		qcom,sde-mixer-display-pref = "primary", "primary", "none",
+					      "none", "none", "none";
+									
 		qcom,sde-dspp-off = <0x55000 0x57000>;
 		qcom,sde-dspp-size = <0x17e0>;
 
@@ -93,12 +97,12 @@
 		qcom,sde-intf-max-prefetch-lines = <0x15 0x15 0x15 0x15>;
 
 		qcom,sde-sspp-type =  "vig", "vig", "vig", "vig",
-						"dma", "dma", "dma", "dma",
-						"cursor", "cursor";
+						"dma", "dma", "dma", "dma";
+						//"cursor", "cursor";
 
 		qcom,sde-sspp-off = <0x5000 0x7000 0x9000 0xb000
-						0x25000 0x27000 0x29000 0x2b000
-						0x35000 0x37000>;
+						0x25000 0x27000 0x29000 0x2b000>;
+						//0x35000 0x37000>;
 		qcom,sde-sspp-src-size = <0x1ac>;
 
 		qcom,sde-sspp-xin-id = <0 4 8 12 1 5 9 13 2 10>;
@@ -170,6 +174,34 @@
 			compatible = "qcom,smmu_sde_sec";
 			iommus = <&mmss_smmu 1>;
 		};
+		
+		smmu_sde_unsec: qcom,smmu_sde_nrt_unsec_cb {
+			compatible = "qcom,smmu_sde_nrt_unsec";
+			iommus = <&mmss_smmu 0xe00>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
+		};
+
+		smmu_sde_sec: qcom,smmu_sde_nrt_sec_cb {
+			compatible = "qcom,smmu_sde_nrt_sec";
+			iommus = <&mmss_smmu 0xe01>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
+		};
 
 		/* data and reg bus scale settings */
 		qcom,sde-data-bus {
@@ -191,6 +223,143 @@
 				<1 590 0 76800>,
 				<1 590 0 160000>,
 				<1 590 0 320000>;
+		};
+	};
+
+	mdss_dsi0: qcom,mdss_dsi_ctrl0@c994000 {
+		compatible = "qcom,dsi-ctrl-hw-v2.0";
+		label = "dsi-ctrl-0";
+		cell-index = <0>;
+		reg = <0xc994000 0x400>,
+			  <0xc828000 0xac>;
+		reg-names = "dsi_ctrl", "mmss_misc";
+		interrupt-parent = <&sde_kms>;
+		interrupts = <4 0>;
+		vdda-1p2-supply = <&pm8998_l2>;
+		clocks = <&clock_mmss MMSS_MDSS_BYTE0_CLK>,
+		<&clock_mmss BYTE0_CLK_SRC>,
+		<&clock_mmss MMSS_MDSS_BYTE0_INTF_CLK>,
+		<&clock_mmss MMSS_MDSS_PCLK0_CLK>,
+		<&clock_mmss PCLK0_CLK_SRC>,
+		<&clock_mmss MMSS_MDSS_ESC0_CLK>;
+		clock-names = "byte_clk", "byte_clk_rcg", "byte_intf_clk",
+					"pixel_clk", "pixel_clk_rcg",
+					"esc_clk";
+		qcom,null-insertion-enabled;
+		qcom,ctrl-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,ctrl-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-1p2";
+				qcom,supply-min-voltage = <1200000>;
+				qcom,supply-max-voltage = <1200000>;
+				qcom,supply-enable-load = <12560>;
+				qcom,supply-disable-load = <4>;
+			};
+		};
+	};
+
+	mdss_dsi1: qcom,mdss_dsi_ctrl1@c996000 {
+		compatible = "qcom,dsi-ctrl-hw-v2.0";
+		label = "dsi-ctrl-1";
+		cell-index = <1>;
+		reg = <0xc996000 0x400>,
+			<0xc828000 0xac>;
+		reg-names = "dsi_ctrl", "mmss_misc";
+		interrupt-parent = <&sde_kms>;
+		interrupts = <5 0>;
+		vdda-1p2-supply = <&pm8998_l2>;
+		clocks = <&clock_mmss MMSS_MDSS_BYTE1_CLK>,
+		<&clock_mmss BYTE1_CLK_SRC>,
+		<&clock_mmss MMSS_MDSS_BYTE1_INTF_CLK>,
+		<&clock_mmss MMSS_MDSS_PCLK1_CLK>,
+		<&clock_mmss PCLK1_CLK_SRC>,
+		<&clock_mmss MMSS_MDSS_ESC1_CLK>;
+		clock-names = "byte_clk", "byte_clk_rcg", "byte_intf_clk",
+				"pixel_clk", "pixel_clk_rcg", "esc_clk";
+		qcom,null-insertion-enabled;
+		qcom,ctrl-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			qcom,ctrl-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-1p2";
+				qcom,supply-min-voltage = <1200000>;
+				qcom,supply-max-voltage = <1200000>;
+				qcom,supply-enable-load = <12560>;
+				qcom,supply-disable-load = <4>;
+			};
+		};
+	};
+
+	mdss_dsi_phy0: qcom,mdss_dsi_phy0@ae94400 {
+		compatible = "qcom,dsi-phy-v3.0";
+		label = "dsi-phy-0";
+		cell-index = <0>;
+		reg = <0x994400 0x558>;
+		reg-names = "dsi_phy";
+		gdsc-supply = <&gdsc_mdss>;
+		vdda-0p9-supply = <&pm8998_l1>;
+		qcom,platform-strength-ctrl =  [55 03
+						55 03
+						55 03
+						55 03
+						55 00];
+		qcom,platform-lane-config = [00 00 00 00
+					00 00 00 00
+					00 00 00 00
+					00 00 00 00
+					00 00 00 80];
+		qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+		qcom,phy-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			qcom,phy-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-0p9";
+				qcom,supply-min-voltage = <880000>;
+				qcom,supply-max-voltage = <880000>;
+				qcom,supply-enable-load = <73400>;
+				qcom,supply-disable-load = <32>;
+				qcom,supply-lp-mode-disable-allowed;
+			};
+		};
+	};
+
+	mdss_dsi_phy1: qcom,mdss_dsi_phy1@ae96400 {
+		compatible = "qcom,dsi-phy-v3.0";
+		label = "dsi-phy-1";
+		cell-index = <1>;
+		reg = <0x996400 0x558>;
+		reg-names = "dsi_phy";
+		gdsc-supply = <&gdsc_mdss>;
+		vdda-0p9-supply = <&pm8998_l1>;
+		qcom,platform-strength-ctrl =  [55 03
+						55 03
+						55 03
+						55 03
+						55 00];
+		qcom,platform-lane-config = [00 00 00 00
+					00 00 00 00
+					00 00 00 00
+					00 00 00 00
+					00 00 00 80];
+		qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+		qcom,phy-supply-entries {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			qcom,phy-supply-entry@0 {
+				reg = <0>;
+				qcom,supply-name = "vdda-0p9";
+				qcom,supply-min-voltage = <880000>;
+				qcom,supply-max-voltage = <880000>;
+				qcom,supply-enable-load = <74300>;
+				qcom,supply-disable-load = <32>;
+				qcom.supply-lp-mode-disable-allowed;
+			};
 		};
 	};
 
@@ -241,5 +410,77 @@
 		/*qcom,mdss-fb-map = <&mdss_fb2>;*/
 		qcom,pluggable;
 	};
+
+	mdss_rotator: qcom,mdss_rotator {
+		compatible = "qcom,sde_rotator";
+		reg = <0x0c900000 0xab100>,
+		      <0x0c9b8000 0x1040>;
+		reg-names = "mdp_phys",
+			"rot_vbif_phys";
+
+		qcom,mdss-rot-mode = <1>;
+		qcom,mdss-highest-bank-bit = <0x2>;
+
+		/* Bus Scale Settings */
+		qcom,msm-bus,name = "mdss_rotator";
+		qcom,msm-bus,num-cases = <3>;
+		qcom,msm-bus,num-paths = <1>;
+		qcom,msm-bus,vectors-KBps =
+			<25 512 0 0>,
+			<25 512 0 6400000>,
+			<25 512 0 6400000>;
+
+		rot-vdd-supply = <&gdsc_mdss>;
+		qcom,supply-names = "rot-vdd";
+
+		clocks = <&clock_mmss MMSS_MNOC_AHB_CLK>,
+			<&clock_mmss MMSS_MDSS_AHB_CLK>,
+			<&clock_mmss ROT_CLK_SRC>,
+			<&clock_mmss MMSS_MDSS_ROT_CLK>,
+			<&clock_mmss MMSS_MDSS_AXI_CLK>;
+		clock-names = "mnoc_clk",
+			"iface_clk", "rot_core_clk",
+			"rot_clk", "axi_clk";
+
+		interrupt-parent = <&mdss_mdp>;
+		interrupts = <2 0>;
+
+		/* VBIF QoS remapper settings*/
+		qcom,mdss-rot-vbif-qos-setting = <1 1 1 1>;
+
+		qcom,mdss-default-ot-rd-limit = <32>;
+		qcom,mdss-default-ot-wr-limit = <32>;
+
+		smmu_rot_unsec: qcom,smmu_rot_unsec_cb {
+			compatible = "qcom,smmu_sde_rot_unsec";
+			iommus = <&mmss_smmu 0xe00>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
+		};
+
+		smmu_rot_sec: qcom,smmu_rot_sec_cb {
+			compatible = "qcom,smmu_sde_rot_sec";
+			iommus = <&mmss_smmu 0xe01>;
+			gdsc-mdss-supply = <&gdsc_bimc_smmu>;
+			clocks = <&clock_rpmcc MMSSNOC_AXI_CLK>,
+				<&clock_mmss MMSS_MNOC_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>,
+				<&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+			clock-names = "mmss_noc_axi_clk",
+					"mmss_noc_ahb_clk",
+					"mmss_smmu_ahb_clk",
+					"mmss_smmu_axi_clk";
+		};
+	};
+
+
 };
+#include "msm8998-mdss-panels.dtsi"
 #include "msm8998-sde-display.dtsi"

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
@@ -22,6 +22,7 @@
 
 #include "msm8998-v2.dtsi"
 #include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-lilac_generic.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
@@ -21,12 +21,28 @@
 /dts-v1/;
 
 #include "msm8998-v2.dtsi"
+#include "msm8998-sde-overlay.dtsi"
 #include "msm8998-mtp.dtsi"
 #include "msm8998-yoshino-common.dtsi"
+#include "msm8998-yoshino-common-sde-overlay.dtsi"
 #include "msm8998-yoshino-maple_generic.dtsi"
+#include "dsi-panel-somc-maple-sde.dtsi"
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2)";
 	compatible = "somc,maple-row", "qcom,msm8998";
 	qcom,board-id = <8 0>;
+};
+
+&dsi_panel_pwr_supply {
+	qcom,panel-supply-entry@0 {
+		qcom,supply-min-voltage = <1850000>;
+		qcom,supply-max-voltage = <1850000>;
+	};
+};
+
+&dsi_panel_cmd_display {
+	qcom,dsi-ctrl = <&mdss_dsi0 &mdss_dsi1>;
+	qcom,dsi-phy = <&mdss_dsi_phy0 &mdss_dsi_phy1>;
+	qcom,dsi-panel = <&dsi_dual0_default_panel>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
@@ -22,6 +22,7 @@
 
 #include "msm8998-v2.dtsi"
 #include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-poplar_generic.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
@@ -10,7 +10,7 @@
  * GNU General Public License for more details.
  */
 /*
- * Copyright (C) 2016 Sony Mobile Communications Inc.
+ * Copyright (C) 2017 Sony Mobile Communications Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2, as
@@ -20,13 +20,27 @@
 
 /dts-v1/;
 
-#include "msm8998-v2.dtsi"
+#include "msm8998-v2.1.dtsi"
+#include "msm8998-sde.dtsi"
+#include "msm8998-sde-display.dtsi"
 #include "msm8998-mtp.dtsi"
 #include "msm8998-yoshino-common.dtsi"
-#include "msm8998-yoshino-maple_generic.dtsi"
+#include "msm8998-yoshino-common-sde-overlay.dtsi"
+#include "msm8998-yoshino-lilac_generic.dtsi"
+#include "dsi-panel-somc-lilac-base-sde.dtsi"
+#include "dsi-panel-somc-lilac-sde.dtsi"
 
 / {
-	model = "SoMC Maple-ROW(MSM8998 v2)";
-	compatible = "somc,maple-row", "qcom,msm8998";
+	model = "SoMC Lilac-ROW(MSM8998 v2.1)";
+	compatible = "somc,lilac-row", "qcom,msm8998";
 	qcom,board-id = <8 0>;
+};
+
+/* Disable MDSS rotator node to use SDE rotator. */
+&mdss_rotator {
+	status = "disabled";
+};
+
+&sde_rotator {
+	status = "ok";
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
@@ -22,6 +22,7 @@
 
 #include "msm8998-v2.1.dtsi"
 #include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-lilac_generic.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
@@ -20,13 +20,29 @@
 
 /dts-v1/;
 
-#include "msm8998-v2.dtsi"
+#include "msm8998-v2.1.dtsi"
+#include "msm8998-sde-overlay.dtsi"
 #include "msm8998-mtp.dtsi"
 #include "msm8998-yoshino-common.dtsi"
+#include "msm8998-yoshino-common-sde-overlay.dtsi"
 #include "msm8998-yoshino-maple_generic.dtsi"
+#include "dsi-panel-somc-maple-sde.dtsi"
 
 / {
-	model = "SoMC Maple-ROW(MSM8998 v2)";
+	model = "SoMC Maple-ROW(MSM8998 v2.1)";
 	compatible = "somc,maple-row", "qcom,msm8998";
 	qcom,board-id = <8 0>;
+};
+
+&dsi_panel_pwr_supply {
+	qcom,panel-supply-entry@0 {
+		qcom,supply-min-voltage = <1850000>;
+		qcom,supply-max-voltage = <1850000>;
+	};
+};
+
+&dsi_panel_cmd_display {
+	qcom,dsi-ctrl = <&mdss_dsi0 &mdss_dsi1>;
+	qcom,dsi-phy = <&mdss_dsi_phy0 &mdss_dsi_phy1>;
+	qcom,dsi-panel = <&dsi_dual0_default_panel>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
@@ -21,7 +21,8 @@
 /dts-v1/;
 
 #include "msm8998-v2.1.dtsi"
-#include "msm8998-sde-overlay.dtsi"
+#include "msm8998-sde.dtsi"
+#include "msm8998-sde-display.dtsi"
 #include "msm8998-mtp.dtsi"
 #include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-common-sde-overlay.dtsi"

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
@@ -22,6 +22,7 @@
 
 #include "msm8998-v2.1.dtsi"
 #include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-maple_generic.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
@@ -22,6 +22,7 @@
 
 #include "msm8998-v2.1.dtsi"
 #include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-poplar_generic.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -1,0 +1,124 @@
+/* Copyright (c) 2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+//#include "msm8998-sde-overlay.dtsi"
+
+/ {
+	/* Bad indentation is required. Sorry. */
+	chosen {
+
+		bootargs = \
+"rcupdate.rcu_expedited=1 \
+video=vfb:640x400,bpp=32,memsize=3072000 \
+msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
+
+	};
+};
+
+/delete-node/ &dsi_panel_pwr_supply_hybrid_incell;
+/delete-node/ &dsi_panel_pwr_supply_full_incell;
+
+&soc {
+	dsi_panel_pwr_supply: dsi_panel_pwr_supply {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,panel-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "vddio";
+			qcom,supply-min-voltage = <1800000>;
+			qcom,supply-max-voltage = <1800000>;
+			qcom,supply-enable-load = <62000>;
+			qcom,supply-disable-load = <80>;
+		};
+	};
+
+	dsi_panel_pwr_supply_hybrid_incell: dummy-supply-hybrid {
+	};
+
+	dsi_panel_pwr_supply_full_incell: dummy-supply-full {
+	};
+
+	dsi_panel_vspvsn_pwr_supply: dsi_panel_vspvsn_pwr_supply {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,panel-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "lab";
+			qcom,supply-min-voltage = <4600000>;
+			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+
+		qcom,panel-supply-entry@1 {
+			reg = <1>;
+			qcom,supply-name = "ibb";
+			qcom,supply-min-voltage = <4600000>;
+			qcom,supply-max-voltage = <6000000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+	};
+
+	dsi_panel_touch_pwr_supply: dsi_panel_touch_pwr_supply {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		qcom,panel-supply-entry@0 {
+			reg = <0>;
+			qcom,supply-name = "touch-avdd";
+			qcom,supply-min-voltage = <3000000>;
+			qcom,supply-max-voltage = <3000000>;
+			qcom,supply-enable-load = <100000>;
+			qcom,supply-disable-load = <100>;
+		};
+	};
+
+	/* SDE */
+	dsi_panel_cmd_display: qcom,dsi-display@12 {
+		compatible = "somc,dsi-display";
+		label = "dsi_panel_cmd_display";
+		qcom,display-type = "primary";
+
+		qcom,dsi-ctrl = <&sde_dsi0>;
+		qcom,dsi-phy = <&mdss_dsi_phy0>;
+		clocks = <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>,
+			<&mdss_dsi0_pll PCLK_MUX_0_CLK>;
+		clock-names = "src_byte_clk", "src_pixel_clk";
+
+		pinctrl-names = "panel_active", "panel_suspend",
+				"sde_touch_active", "sde_touch_suspend";
+		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+		pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
+		pinctrl-2 = <&mdss_touch_active>;
+		pinctrl-3 = <&mdss_touch_suspend>;
+
+		qcom,dsi-display-active;
+
+		qcom,platform-te-gpio = <&tlmm 10 0>;
+		qcom,platform-reset-gpio = <&tlmm 94 0>;
+		qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+		qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+		somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+		qcom,dsi-panel = <&sde_dsi_8>;
+		vddio-supply = <&pm8998_l14>;
+		touch-avdd-supply = <&pm8998_l28>;
+		lab-supply = <&lab_regulator>;
+		ibb-supply = <&ibb_regulator>;
+	};
+};
+
+&sde_dsi0 {
+	qcom,cont-splash-enabled;
+};

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -345,15 +345,6 @@
 	};
 
 	mdss_dsi: qcom,mdss_dsi@0 {
-		mdss_dsi0: qcom,mdss_dsi_ctrl0@c994000 {
-			vddio-supply = <&pm8998_l14>;
-			touch-avdd-supply = <&pm8998_l28>;
-		};
-
-		mdss_dsi1: qcom,mdss_dsi_ctrl1@c996000 {
-			vddio-supply = <&pm8998_l14>;
-			touch-avdd-supply = <&pm8998_l28>;
-		};
 		qcom,core-supply-entries {
 			qcom,core-supply-entry@0 {
 				/delete-property/ qcom,supply-lp-mode-disable-allowed;
@@ -3140,11 +3131,15 @@
 	qcom,platform-touch-int-gpio = <&tlmm 125 0>;
 	qcom,platform-touch-vddio-gpio = <&tlmm 133 0>;
 	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	vddio-supply = <&pm8998_l14>;
+	touch-avdd-supply = <&pm8998_l28>;
 	/delete-property/ qcom,platform-bklight-en-gpio;
 	/delete-property/ qcom,panel-mode-gpio;
 };
 
 &mdss_dsi1 {
+	vddio-supply = <&pm8998_l14>;
+	touch-avdd-supply = <&pm8998_l28>;
 	/delete-property/ qcom,panel-mode-gpio;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
@@ -17,7 +17,6 @@
  * published by the Free Software Foundation.
  */
 
-#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-lilac_camera.dtsi"
 #include "dsi-panel-somc-lilac.dtsi"
 

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-maple_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-maple_common.dtsi
@@ -17,7 +17,6 @@
  * published by the Free Software Foundation.
  */
 
-#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-maple-camera.dtsi"
 #include "dsi-panel-somc-maple.dtsi"
 

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-poplar_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-poplar_common.dtsi
@@ -17,7 +17,6 @@
  * published by the Free Software Foundation.
  */
 
-#include "msm8998-yoshino-common.dtsi"
 #include "msm8998-yoshino-poplar_camera.dtsi"
 #include "dsi-panel-somc-poplar.dtsi"
 

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -515,6 +515,7 @@
 		interrupt-controller;
 		#interrupt-cells = <4>;
 		cell-index = <0>;
+		qcom,enable-ahb-bus-workaround;
 	};
 
 	qcom,sps {
@@ -3422,7 +3423,7 @@
 #include "msm8998-blsp.dtsi"
 #include "msm8998-audio.dtsi"
 #include "msm-smb138x.dtsi"
-#include "msm8998-sde.dtsi"
+//#include "msm8998-sde.dtsi"
 
 &pmi8998_pdphy {
 	vbus-supply = <&smb2_vbus>;

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -425,9 +425,9 @@
 			linux,cma-default;
 		};
 
-		cont_splash_mem: splash_region@9d600000 {
+		cont_splash_mem: cont_splash_region@9d600000 {
 			reg = <0x0 0x9d600000 0x0 0x02400000>;
-			label = "cont_splash_mem";
+			label = "cont_splash_region";
 		};
 	};
 };

--- a/drivers/clk/qcom/clk-rcg2.c
+++ b/drivers/clk/qcom/clk-rcg2.c
@@ -1059,6 +1059,15 @@ const struct clk_ops clk_byte2_ops = {
 };
 EXPORT_SYMBOL_GPL(clk_byte2_ops);
 
+#ifdef CONFIG_ARCH_MSM8998
+static const struct frac_entry frac_table_pixel[] = {
+	{ 3, 8 },
+	{ 2, 9 },
+	{ 4, 9 },
+	{ 1, 1 },
+	{ }
+};
+#else
 static const struct frac_entry frac_table_pixel[] = {
 	{ 1, 1 },
 	{ 2, 3 },
@@ -1067,6 +1076,7 @@ static const struct frac_entry frac_table_pixel[] = {
 	{ 2, 9 },
 	{ }
 };
+#endif
 
 static int clk_pixel_determine_rate(struct clk_hw *hw,
 				    struct clk_rate_request *req)

--- a/drivers/clk/qcom/clk-smd-rpm.c
+++ b/drivers/clk/qcom/clk-smd-rpm.c
@@ -738,8 +738,8 @@ static struct clk_hw *msm8998_clks[] = {
 	[RPM_CNOC_A_CLK]	= &msm8998_cnoc_a_clk.hw,
 	[RPM_CNOC_PERIPH_CLK]	= &msm8998_cnoc_periph_clk.hw,
 	[RPM_CNOC_PERIPH_A_CLK]	= &msm8998_cnoc_periph_a_clk.hw,
-	[RPM_MMAXI_CLK]		= &msm8998_mmssnoc_axi_rpm_clk.hw,
-	[RPM_MMAXI_A_CLK]	= &msm8998_mmssnoc_axi_rpm_a_clk.hw,
+	[MMSSNOC_AXI_CLK]	= &msm8998_mmssnoc_axi_rpm_clk.hw,
+	[MMSSNOC_AXI_A_CLK]	= &msm8998_mmssnoc_axi_rpm_a_clk.hw,
 	[RPM_IPA_CLK]		= &msm8998_ipa_clk.hw,
 	[RPM_IPA_A_CLK]		= &msm8998_ipa_a_clk.hw,
 	[RPM_CE1_CLK]		= &msm8998_ce1_clk.hw,
@@ -750,8 +750,6 @@ static struct clk_hw *msm8998_clks[] = {
 	[RPM_DIV_CLK2_AO]	= &msm8998_div_clk2_ao.hw,
 	[RPM_DIV_CLK3]		= &msm8998_div_clk3.hw,
 	[RPM_DIV_CLK3_AO]	= &msm8998_div_clk3_ao.hw,
-	[MMSSNOC_AXI_CLK]	= &mmssnoc_axi_clk.hw,
-	[MMSSNOC_AXI_A_CLK]	= &mmssnoc_axi_a_clk.hw,
 	[BIMC_MSMBUS_CLK]	= &bimc_msmbus_clk.hw,
 	[BIMC_MSMBUS_A_CLK]	= &bimc_msmbus_a_clk.hw,
 	[CNOC_MSMBUS_CLK]	= &cnoc_msmbus_clk.hw,
@@ -773,7 +771,7 @@ static struct clk_hw *msm8998_clks[] = {
 };
 static const struct rpm_smd_clk_desc rpm_clk_msm8998 = {
 	.clks = msm8998_clks,
-	.num_rpm_clks = RPM_CNOC_PERIPH_A_CLK,
+	.num_rpm_clks = MMSSNOC_AXI_A_CLK,
 	.num_clks = ARRAY_SIZE(msm8998_clks),
 };
 

--- a/drivers/clk/qcom/gpucc-msm8998.c
+++ b/drivers/clk/qcom/gpucc-msm8998.c
@@ -677,6 +677,9 @@ int gpucc_early_msm8998_probe(struct platform_device *pdev)
 		return rc;
 	}
 
+	/* Set the rate for GPU XO to make the clk API happy */
+	clk_set_rate(gpucc_xo.clkr.hw.clk, 19200000);
+
 	/*
 	 * gpucc_xo works as the root clock for all GPUCC RCGs and GDSCs.
 	 *  Keep it enabled always.

--- a/drivers/clk/qcom/mmcc-msm8998.c
+++ b/drivers/clk/qcom/mmcc-msm8998.c
@@ -1204,21 +1204,15 @@ static struct clk_rcg2 dp_gtc_clk_src = {
 	},
 };
 
-static struct freq_tbl ftbl_esc_clk_src[] = {
-	F(  19200000,      P_XO,         1,    0,     0),
-	{ }
-};
-
 static struct clk_rcg2 esc0_clk_src = {
 	.cmd_rcgr = 0x02160,
 	.hid_width = 5,
-	.parent_map = mmcc_parent_map_gcc_0,
-	.freq_tbl = ftbl_esc_clk_src,
+	.parent_map = disp_cc_parent_map_0,
 	.clkr.hw.init = &(struct clk_init_data) {
 		.name = "esc0_clk_src",
-		.parent_names = mmcc_parent_names_gcc_0,
-		.num_parents = ARRAY_SIZE(mmcc_parent_names_gcc_0),
-		.ops = &clk_rcg2_ops,
+		.parent_names = disp_cc_parent_names_0,
+		.num_parents = ARRAY_SIZE(disp_cc_parent_names_0),
+		.ops = &clk_esc_ops,
 		VDD_DIG_FMAX_MAP2(LOWER, 19200000, NOMINAL, 19200000),
 	},
 };
@@ -1226,13 +1220,12 @@ static struct clk_rcg2 esc0_clk_src = {
 static struct clk_rcg2 esc1_clk_src = {
 	.cmd_rcgr = 0x02180,
 	.hid_width = 5,
-	.parent_map = mmcc_parent_map_gcc_0,
-	.freq_tbl = ftbl_esc_clk_src,
+	.parent_map = disp_cc_parent_map_0,
 	.clkr.hw.init = &(struct clk_init_data) {
 		.name = "esc1_clk_src",
-		.parent_names = mmcc_parent_names_gcc_0,
-		.num_parents = ARRAY_SIZE(mmcc_parent_names_gcc_0),
-		.ops = &clk_rcg2_ops,
+		.parent_names = disp_cc_parent_names_0,
+		.num_parents = ARRAY_SIZE(disp_cc_parent_names_0),
+		.ops = &clk_esc_ops,
 		VDD_DIG_FMAX_MAP2(LOWER, 19200000, NOMINAL, 19200000),
 	},
 };

--- a/drivers/clk/qcom/mmcc-msm8998.c
+++ b/drivers/clk/qcom/mmcc-msm8998.c
@@ -2745,7 +2745,6 @@ static struct clk_branch mmss_mdss_mdp_lut_clk = {
 				"mdp_clk_src",
 			},
 			.num_parents = 1,
-			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_branch2_ops,
 		},
 	},

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
@@ -99,7 +99,7 @@ static void dsi_catalog_cmn_init(struct dsi_ctrl_hw *ctrl,
 		ctrl->ops.clamp_enable = NULL;
 		ctrl->ops.clamp_disable = NULL;
 		ctrl->ops.schedule_dma_cmd = NULL;
-		ctrl->ops.get_cont_splash_status = NULL;
+		ctrl->ops.get_cont_splash_status = dsi_ctrl_hw_14_get_cont_splash_status;
 		ctrl->ops.kickoff_command_non_embedded_mode = NULL;
 		break;
 	case DSI_CTRL_VERSION_2_2:

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
@@ -214,9 +214,13 @@ static void dsi_catalog_phy_3_0_init(struct dsi_phy_hw *phy)
 	phy->ops.ulps_ops.is_lanes_in_ulps =
 		dsi_phy_hw_v3_0_is_lanes_in_ulps;
 	phy->ops.phy_timing_val = dsi_phy_hw_timing_val_v3_0;
-	phy->ops.clamp_ctrl = dsi_phy_hw_v3_0_clamp_ctrl;
 	phy->ops.phy_lane_reset = dsi_phy_hw_v3_0_lane_reset;
-	phy->ops.toggle_resync_fifo = dsi_phy_hw_v3_0_toggle_resync_fifo;
+
+	if (!of_machine_is_compatible("qcom,msm8998")) {
+		phy->ops.clamp_ctrl = dsi_phy_hw_v3_0_clamp_ctrl;
+		phy->ops.toggle_resync_fifo =
+			dsi_phy_hw_v3_0_toggle_resync_fifo;
+	}
 }
 
 /**

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw_cmn.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw_cmn.c
@@ -452,9 +452,14 @@ void dsi_ctrl_hw_cmn_video_engine_setup(struct dsi_ctrl_hw *ctrl,
 	reg |= (common_cfg->bit_swap_green ? BIT(4) : 0);
 	reg |= (common_cfg->bit_swap_blue ? BIT(8) : 0);
 	DSI_W32(ctrl, DSI_VIDEO_MODE_DATA_CTRL, reg);
-	/* Disable Timing double buffering */
-	DSI_W32(ctrl, DSI_DSI_TIMING_DB_MODE, 0x0);
 
+	if (of_machine_is_compatible("qcom,msm8998")) {
+		/* Enable Timing double buffering */
+		DSI_W32(ctrl, DSI_DSI_TIMING_DB_MODE, 0x1);
+	} else {
+		/* Disable Timing double buffering */
+		DSI_W32(ctrl, DSI_DSI_TIMING_DB_MODE, 0x0);
+	}
 
 	pr_debug("[DSI_%d] Video engine setup done\n", ctrl->index);
 }
@@ -620,8 +625,14 @@ void dsi_ctrl_hw_cmn_kickoff_command(struct dsi_ctrl_hw *ctrl,
 	DSI_W32(ctrl, DSI_COMMAND_MODE_DMA_CTRL, reg);
 
 	reg = DSI_R32(ctrl, DSI_DMA_FIFO_CTRL);
-	reg |= BIT(20);/* Disable write watermark*/
-	reg |= BIT(16);/* Disable read watermark */
+
+	if (of_machine_is_compatible("qcom,msm8998")) {
+		reg &= ~BIT(20);/* Enable write watermark*/
+		reg &= ~BIT(16);/* Enable read watermark */
+	} else {
+		reg |= BIT(20);/* Disable write watermark*/
+		reg |= BIT(16);/* Disable read watermark */
+	}
 
 	DSI_W32(ctrl, DSI_DMA_FIFO_CTRL, reg);
 	DSI_W32(ctrl, DSI_DMA_CMD_OFFSET, cmd->offset);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
@@ -171,6 +171,10 @@ static void dsi_phy_hw_v3_0_lane_settings(struct dsi_phy_hw *phy,
 	int i;
 	u8 tx_dctrl[] = {0x00, 0x00, 0x00, 0x04, 0x01};
 
+	if (of_machine_is_compatible("qcom,msm8998")) {
+		tx_dctrl[3] = 0x02;
+	}
+
 	/* Strength ctrl settings */
 	for (i = DSI_LOGICAL_LANE_0; i < DSI_LANE_MAX; i++) {
 		DSI_W32(phy, DSIPHY_LNX_LPTX_STR_CTRL(i),

--- a/drivers/video/fbdev/msm/mdss_dsi.c
+++ b/drivers/video/fbdev/msm/mdss_dsi.c
@@ -4612,6 +4612,10 @@ int dsi_panel_device_register(struct platform_device *ctrl_pdev,
 	mdss_dsi_ctrl_init(&ctrl_pdev->dev, ctrl_pdata);
 	mdss_dsi_set_prim_panel(ctrl_pdata);
 
+	ctrl_pdata->platform_clk_reconf_hack = of_property_read_bool(
+				ctrl_pdev->dev.of_node,
+				"qcom,link-clks-reconf-platform-hack");
+
 	ctrl_pdata->dsi_irq_line = of_property_read_bool(
 				ctrl_pdev->dev.of_node, "qcom,dsi-irq-line");
 

--- a/drivers/video/fbdev/msm/mdss_dsi.h
+++ b/drivers/video/fbdev/msm/mdss_dsi.h
@@ -606,6 +606,8 @@ struct mdss_dsi_ctrl_pdata {
 	bool update_phy_timing; /* flag to recalculate PHY timings */
 
 	bool phy_power_off;
+
+	bool platform_clk_reconf_hack; /* MSM8998 link clocks hack */
 };
 
 struct dsi_status_data {

--- a/drivers/video/fbdev/msm/mdss_dsi_clk.c
+++ b/drivers/video/fbdev/msm/mdss_dsi_clk.c
@@ -201,6 +201,20 @@ static int dsi_link_clk_set_rate(struct dsi_link_clks *l_clks)
 	if (ctrl->panel_data.panel_info.cont_splash_enabled)
 		return 0;
 
+	/*
+	 * MSM8998 on common clk framework requires the mmcc clocks
+	 * to get fully reconfigured after suspend due to an unknown
+	 * bug.
+	 * This hack will be fully removed as soon as the bug on this
+	 * SoC will get solved.
+	 */
+	if (ctrl->platform_clk_reconf_hack) {
+		rc = clk_set_rate(l_clks->clks.byte_clk,
+					l_clks->byte_clk_rate / 2);
+		rc = clk_set_rate(l_clks->clks.pixel_clk,
+					l_clks->pix_clk_rate / 2);
+	}
+
 	rc = clk_set_rate(l_clks->clks.esc_clk, l_clks->esc_clk_rate);
 	if (rc) {
 		pr_err("clk_set_rate failed for esc_clk rc = %d\n", rc);


### PR DESCRIPTION
This patchset introduces spare fixes for MSM8998, plus SDE DTs, even though it's not working fine, yet.

This also fixes a critical bug that made the kernel to be unable to resume display operation after a full suspend cycle.

Sorry, the PR description is rushed, but you'll understand.