### PR TITLE
msm-audio: dtsi: remove double pcm2: qcom,msm-ultra-low-latency

### DIFF
--- a/arch/arm/boot/dts/qcom/msm-audio.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-audio.dtsi
@@ -29,13 +29,6 @@
 		compatible = "qcom,msm-compr-dsp";
 	};
 
-	pcm2: qcom,msm-ultra-low-latency {
-		compatible = "qcom,msm-pcm-dsp";
-		qcom,msm-pcm-dsp-id = <2>;
-		qcom,msm-pcm-low-latency;
-		qcom,latency-level = "ultra";
-	};
-
 	pcm1: qcom,msm-pcm-low-latency {
 		compatible = "qcom,msm-pcm-dsp";
 		qcom,msm-pcm-dsp-id = <1>;


### PR DESCRIPTION
already defined after

pcm1: qcom,msm-pcm-low-latency

Signed-off-by: David Viteri <davidteri91@gmail.com>