### PR TITLE
[2.3.2.r1.4] [CRITICAL] URGENT: regulator: qpnp-labibb: Shut down machine immediately if VREG_NG

### DIFF
--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -3877,13 +3877,14 @@ status_error:
 		force_labibb_regulator_disable(labibb);
 		/* shutdown */
 		do {
+			pm_power_off();
 			rc = qpnp_pon_dvdd_shutdown();
 			if (rc) {
 				pr_debug("%s: qpnp_pon_dvdd_shutdown failed rc=%d\n",
 						__func__, rc);
-				msleep(DVDD_SHUTDOWN_RETRY_INTERVAL);
 			}
-		} while (rc);
+			msleep(DVDD_SHUTDOWN_RETRY_INTERVAL);
+		} while (1);
 		goto exit;
 	}
 


### PR DESCRIPTION
On VREG_NG detection, we are sure that there is something wrong
going on.
To try to avoid machine hardware damage, immediately cut power
by shutting it down.