### PR TITLE
[2.3.2.r1.4] [TAMA] Reconfigure LAB and IBB regulator and QPNP-LABIBB safety measures.

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_common.dtsi
@@ -225,3 +225,7 @@
 	qcom,fg-sys-term-current = <(-180)>;
 	qcom,fg-chg-term-current = <155>;
 };
+
+&labibb {
+	qcom,qpnp-labibb-mode = "lcd";
+};

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_common.dtsi
@@ -229,3 +229,11 @@
 &labibb {
 	qcom,qpnp-labibb-mode = "lcd";
 };
+
+&lab_regulator {
+	regulator-max-microvolt = <5600000>;
+};
+
+&ibb_regulator {
+	regulator-max-microvolt = <5500000>;
+};

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
@@ -156,3 +156,7 @@
 	qcom,fg-sys-term-current = <(-160)>;
 	qcom,fg-chg-term-current = <135>;
 };
+
+&labibb {
+	qcom,qpnp-labibb-mode = "lcd";
+};

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
@@ -160,3 +160,11 @@
 &labibb {
 	qcom,qpnp-labibb-mode = "lcd";
 };
+
+&lab_regulator {
+	regulator-max-microvolt = <5500000>;
+};
+
+&ibb_regulator {
+	regulator-max-microvolt = <5500000>;
+};

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -3269,11 +3269,61 @@
 	interrupts = <0x3 0xde 0x0 IRQ_TYPE_LEVEL_LOW>,
 			<0x3 0xde 0x1 IRQ_TYPE_EDGE_RISING>;
 	interrupt-names = "lab_vreg_not_ok_interrupt", "lab-vreg-ok";
+
+	/* Set LAB max uV to 5.5V as a safety measure */
+	regulator-max-microvolt = <5500000>;
+
+	/* When kernel boots with LAB OFF, set 5.5V */
+	qcom,qpnp-lab-init-voltage = <5500000>;
+
+	/* For OLED mode, set 4.6V */
+	qcom,qpnp-lab-init-amoled-voltage = <4600000>;
+
+	/* For LCD mode, set 5.5V */
+	qcom,qpnp-lab-init-lcd-voltage = <5500000>;
+
+	/* LAB maximum current limit: 200mA */
+	qcom,qpnp-lab-limit-maximum-current = <200>;
+	qcom,qpnp-lab-limit-max-current-enable;
+
+	/* 800uS soft start for LAB regulator to prevent inrush current */
+	qcom,qpnp-lab-soft-start = <800>;
+
+	/* Enable pull down at full strength */
+	qcom,qpnp-lab-full-pull-down;
+	qcom,qpnp-lab-pull-down-enable;
+
+	/* Precharge time for LAB regulator: 500uS */
+	qcom,qpnp-lab-max-precharge-time = <500>;
 };
 
 &ibb_regulator {
 	interrupts = <0x3 0xdc 0x0 IRQ_TYPE_LEVEL_HIGH>;
 	interrupt-names = "ibb_vreg_not_ok_interrupt";
+
+	/* Set IBB max uV to 5.5V as a safety measure */
+	regulator-max-microvolt = <5500000>;
+
+	/* When kernel boots with LAB OFF, set 5.5V */
+	qcom,qpnp-ibb-init-voltage = <5500000>;
+
+	/* For OLED mode, set 4.6V */
+	qcom,qpnp-ibb-init-amoled-voltage = <4600000>;
+
+	/* For LCD mode, set 5.5V */
+	qcom,qpnp-ibb-init-lcd-voltage = <5500000>;
+
+	/* IBB maximum current limit: 800mA */
+	qcom,qpnp-ibb-limit-maximum-current = <800>;
+	qcom,qpnp-ibb-limit-max-current-enable;
+
+	/* Enable IBB discharge with 300KOhms resistor for soft start */
+	qcom,qpnp-ibb-discharge-resistor = <300>;
+	qcom,qpnp-ibb-en-discharge;
+
+	/* Enable pull down at full strength */
+	qcom,qpnp-ibb-full-pull-down;
+	qcom,qpnp-ibb-pull-down-enable;
 };
 
 &led_flash_rear {

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -3262,15 +3262,18 @@
 	};};
 
 &labibb {
-	qcom,lab@de00 {
-		interrupts = <0x3 0xde 0x0 IRQ_TYPE_LEVEL_LOW>,
-				<0x3 0xde 0x1 IRQ_TYPE_EDGE_RISING>;
-		interrupt-names = "lab_vreg_not_ok_interrupt", "lab-vreg-ok";
-	};
-	qcom,ibb@dc00 {
-		interrupts = <0x3 0xdc 0x0 IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "ibb_vreg_not_ok_interrupt";
-	};
+	status = "ok";
+};
+
+&lab_regulator {
+	interrupts = <0x3 0xde 0x0 IRQ_TYPE_LEVEL_LOW>,
+			<0x3 0xde 0x1 IRQ_TYPE_EDGE_RISING>;
+	interrupt-names = "lab_vreg_not_ok_interrupt", "lab-vreg-ok";
+};
+
+&ibb_regulator {
+	interrupts = <0x3 0xdc 0x0 IRQ_TYPE_LEVEL_HIGH>;
+	interrupt-names = "ibb_vreg_not_ok_interrupt";
 };
 
 &led_flash_rear {

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -2771,14 +2771,14 @@ static int qpnp_labibb_regulator_enable(struct qpnp_labibb *labibb)
 		return rc;
 	}
 
+#ifdef CONFIG_SOMC_LCD_OCP_ENABLED
+try_agn:
+#endif
 	/* total delay time */
 	dly = labibb->lab_vreg.soft_start + labibb->ibb_vreg.soft_start
 				+ labibb->ibb_vreg.pwrup_dly;
 	usleep_range(dly, dly + 100);
 
-#ifdef CONFIG_SOMC_LCD_OCP_ENABLED
-try_agn:
-#endif
 	/* after this delay, lab should be enabled */
 	rc = qpnp_labibb_read(labibb, labibb->lab_base + REG_LAB_STATUS1,
 			&val, 1);

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -3900,11 +3900,13 @@ status_error:
 		/* shutdown */
 		do {
 			pm_power_off();
+#ifdef SOMC_LABIBB_LEGACY_TARGET
 			rc = qpnp_pon_dvdd_shutdown();
 			if (rc) {
 				pr_debug("%s: qpnp_pon_dvdd_shutdown failed rc=%d\n",
 						__func__, rc);
 			}
+#endif
 			msleep(DVDD_SHUTDOWN_RETRY_INTERVAL);
 		} while (1);
 		goto exit;

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -5230,7 +5230,12 @@ static int qpnp_labibb_regulator_probe(struct platform_device *pdev)
 		case QPNP_IBB_TYPE:
 			labibb->ibb_base = base;
 			labibb->ibb_dig_major = revision;
-			qpnp_ibb_register_irq(child, labibb);
+			rc = qpnp_ibb_register_irq(child, labibb);
+			if (rc) {
+				pr_err("Failed to register IBB IRQ rc=%d\n",
+							rc);
+				goto fail_registration;
+			}
 			rc = register_qpnp_ibb_regulator(labibb, child);
 			if (rc < 0)
 				goto fail_registration;

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -3325,8 +3325,10 @@ static bool is_lab_vreg_ok_irq_available(struct qpnp_labibb *labibb)
 
 	if (labibb->pmic_rev_id->pmic_subtype == PMI8998_SUBTYPE &&
 		labibb->mode == QPNP_LABIBB_LCD_MODE) {
+#ifndef CONFIG_SOMC_LCD_OCP_ENABLED
 		if (labibb->ttw_en)
 			return false;
+#endif
 		return true;
 	}
 

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -2853,10 +2853,6 @@ static int qpnp_labibb_regulator_disable(struct qpnp_labibb *labibb)
 	int retries;
 	bool disabled = false;
 
-#ifdef CONFIG_SOMC_LCD_OCP_ENABLED
-	qpnp_labibb_interrupt_disable_ctl(labibb);
-#endif /* CONFIG_SOMC_LCD_OCP_ENABLED */
-
 	/*
 	 * When TTW mode is enabled and LABIBB regulators are disabled, it is
 	 * recommended not to disable IBB through IBB_ENABLE_CTL when switching
@@ -2979,6 +2975,10 @@ static int qpnp_lab_regulator_disable(struct regulator_dev *rdev)
 	int rc;
 	u8 val;
 	struct qpnp_labibb *labibb  = rdev_get_drvdata(rdev);
+
+#ifdef CONFIG_SOMC_LCD_OCP_ENABLED
+	qpnp_lab_interrupt_disable_ctl(labibb);
+#endif /* CONFIG_SOMC_LCD_OCP_ENABLED */
 
 	if (labibb->lab_vreg.vreg_enabled && !labibb->swire_control) {
 
@@ -4473,7 +4473,7 @@ static int qpnp_ibb_regulator_disable(struct regulator_dev *rdev)
 	struct qpnp_labibb *labibb  = rdev_get_drvdata(rdev);
 
 #ifdef CONFIG_SOMC_LCD_OCP_ENABLED
-		qpnp_lab_interrupt_disable_ctl(labibb);
+	qpnp_ibb_interrupt_disable_ctl(labibb);
 #endif /* CONFIG_SOMC_LCD_OCP_ENABLED */
 
 	if (labibb->ibb_vreg.vreg_enabled && !labibb->swire_control) {

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -42,6 +42,22 @@
 #include <linux/input/qpnp-power-on.h>
 #endif /* CONFIG_SOMC_LCD_OCP_ENABLED */
 
+/* Build barrier for SoMC legacy targets using LAB/IBB regulator */
+#ifdef CONFIG_REGULATOR_QPNP_LABIBB_SOMC
+ #undef SOMC_LABIBB_LEGACY_TARGET
+
+ #if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE) || \
+     defined(CONFIG_ARCH_SONY_NILE)  || defined(CONFIG_ARCH_SONY_YOSHINO)
+	#define SOMC_LABIBB_LEGACY_TARGET 1
+ #endif
+#endif
+
+/* Enforce IBB current limit for new SoMC targets */
+#if defined(CONFIG_REGULATOR_QPNP_LABIBB_SOMC) && \
+    !defined(SOMC_LABIBB_LEGACY_TARGET)
+#define IBB_CURRENT_LIMIT_VALUE		16	/* 800mA */
+#endif
+
 #define QPNP_LABIBB_REGULATOR_DRIVER_NAME	"qcom,qpnp-labibb-regulator"
 
 #define REG_REVISION_2			0x01
@@ -1947,6 +1963,10 @@ static int qpnp_lab_dt_init(struct qpnp_labibb *labibb,
 	if (of_property_read_bool(of_node,
 		"qcom,qpnp-lab-limit-max-current-enable")) {
 		val = LAB_CURRENT_LIMIT_EN_BIT;
+#if defined(CONFIG_REGULATOR_QPNP_LABIBB_SOMC) && \
+    !defined(SOMC_LABIBB_LEGACY_TARGET)
+		val |= LAB_CURRENT_LIMIT_OVERRIDE;
+#endif
 
 		rc = of_property_read_u32(of_node,
 			"qcom,qpnp-lab-limit-maximum-current", &tmp);
@@ -4120,9 +4140,20 @@ int qpnp_ibb_set_current_max(struct regulator *regulator, u32 limit)
 
 	labibb = regulator_get_drvdata(regulator);
 
+#if defined(CONFIG_REGULATOR_QPNP_LABIBB_SOMC) && \
+    !defined(SOMC_LABIBB_LEGACY_TARGET)
+	/* Not strictly required but let's be paranoid */
+	reg = IBB_CURRENT_LIMIT_VALUE;
+
+	if (!(ibb_current_limit_table[reg] == limit)) {
+		pr_err("%s value mismatch\n", __func__);
+		return rc;
+	}
+#else
 	for (reg = 0; reg < ARRAY_SIZE(ibb_current_limit_table); reg++)
 		if (ibb_current_limit_table[reg] == limit)
 			break;
+#endif
 
 	if (reg == ARRAY_SIZE(ibb_current_limit_table))
 		reg = ARRAY_SIZE(ibb_current_limit_table) - 1;

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -3941,7 +3941,7 @@ int qpnp_lab_set_precharge(struct regulator *regulator, u32 time, bool en)
 		if (lab_max_precharge_table[val] == time)
 			break;
 
-	if (val == ARRAY_SIZE(lab_soft_start_table))
+	if (val == ARRAY_SIZE(lab_max_precharge_table))
 		val = ARRAY_SIZE(lab_max_precharge_table) - 1;
 
 	if (en)


### PR DESCRIPTION
The LAB and IBB configuration may differ between devices.
Split it to clean it up and to set it on a per-device basis
to prepare the DTs for OLED panel (requiring LAB/IBB OLED mode)
and for a probe-time preconfiguration of the regulators.


Instead of forcefully relying on somc_panel setting the regulator
parameters on the first display powerup, pre-set the params
so that they get set at labibb driver probe.

Set:
- Max voltage 5.5V (5.6V for Akari only, for LGD panel)
- Init voltage 5.5V (5.6V LGD set by somc_panel on poweron)
- Current limits - LAB: 200mA, IBB: 800mA
- Soft start: 800uS, 300K discharge resistor (inrush prevention)
- Maximum precharge time: 500uS


Also, take safety measures in qpnp-labibb code.