### PR TITLE
drivers: misc: tcs3490: add input reporting

### DIFF
--- a/drivers/misc/tcs3490.c
+++ b/drivers/misc/tcs3490.c
@@ -965,7 +965,7 @@ static ssize_t tcs3490_als_red_show(struct device *dev,
     struct tcs3490_chip *chip = dev_get_drvdata(dev);
 	mutex_lock(&chip->lock);
 	ret = snprintf(buf, PAGE_SIZE, "%d", chip->als_inf.red_raw);
-	mutex_lock(&chip->lock);
+	mutex_unlock(&chip->lock);
 	return ret;
 }
 


### PR DESCRIPTION
The driver registers an input but never actually reports anything...
Add a workqueue to handle reporting RGBC-IR values using the input device.
As a precaution, advertise ABS_X and ABS_Y with 0 range to avoid misdetection by the operating system.