### PR TITLE
arm64: tama: dt/camera: enable actuators

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari-camera.dtsi
@@ -147,6 +147,7 @@
 		sensor-position-roll = <90>;
 		sensor-position-pitch = <0>;
 		sensor-position-yaw = <180>;
+		actuator-src = <&actuator0>;
 		eeprom-src = <&eeprom0>;
 		led-flash-src = <&led_flash0>;
 		cam_vio-supply = <&cam_vio_vreg>;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki-camera.dtsi
@@ -1,4 +1,4 @@
-/* arch/arm64/boot/dts/qcom/sdm845-tama-akari-camera.dtsi
+/* arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki-camera.dtsi
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -147,9 +147,9 @@
 		sensor-position-roll = <90>;
 		sensor-position-pitch = <0>;
 		sensor-position-yaw = <180>;
+		actuator-src = <&actuator0>;
 		eeprom-src = <&eeprom0>;
 		led-flash-src = <&led_flash0>;
-		actuator-src = <&actuator0>;
 		cam_vio-supply = <&cam_vio_vreg>;
 		cam_vana-supply = <&cam_vana_rear_verg>;
 		cam_vdig-supply = <&cam_vdig_rear_verg>;
@@ -206,8 +206,8 @@
 		sensor-position-roll = <90>;
 		sensor-position-pitch = <0>;
 		sensor-position-yaw = <0>;
-		eeprom-src = <&eeprom1>;
 		actuator-src = <&actuator1>;
+		eeprom-src = <&eeprom1>;
 		cam_vio-supply = <&cam_vio_vreg>;
 		cam_vana-supply = <&cam_vana_front_verg>;
 		cam_vdig-supply = <&pm8998_s3>;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo-camera.dtsi
@@ -1,4 +1,4 @@
-/* arch/arm64/boot/dts/qcom/sdm845-tama-akari-camera.dtsi
+/* arch/arm64/boot/dts/qcom/sdm845-tama-apollo-camera.dtsi
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -147,6 +147,7 @@
 		sensor-position-roll = <90>;
 		sensor-position-pitch = <0>;
 		sensor-position-yaw = <180>;
+		actuator-src = <&actuator0>;
 		eeprom-src = <&eeprom0>;
 		led-flash-src = <&led_flash0>;
 		cam_vio-supply = <&cam_vio_vreg>;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_common.dtsi
@@ -19,7 +19,7 @@
 
 #include "sdm845-tama-common.dtsi"
 #include "sdm845-tama-common-display.dtsi"
-#include "sdm845-tama-akari-camera.dtsi"
+#include "sdm845-tama-apollo-camera.dtsi"
 #include "dsi-panel-somc-apollo.dtsi"
 
 &somc_pinctrl_pmic {

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
@@ -17,6 +17,18 @@
 #include "cam_trace.h"
 #include "cam_res_mgr_api.h"
 
+static struct cam_sensor_i2c_reg_array bu64747_set_dac_array[9] = {
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x55, 0, 0 },
+	{ 0x8A, 0xA8, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+	{ 0x8A, 0x00, 0, 0 },
+};
+
 int32_t cam_actuator_construct_default_power_setting(
 	struct cam_sensor_power_ctrl_t *power_info)
 {
@@ -158,6 +170,40 @@ static int32_t cam_actuator_i2c_modes_util(
 	uint32_t i, size;
 
 	if (i2c_list->op_code == CAM_SENSOR_I2C_WRITE_RANDOM) {
+		/* bu64747: override i2c commands for set_dac */
+		if (io_master_info->cci_client->sid == (0xEC >> 1) &&
+		    i2c_list->i2c_settings.reg_setting[0].reg_addr == 0x8A &&
+		    i2c_list->i2c_settings.addr_type == 1 &&
+		    i2c_list->i2c_settings.data_type == 2 &&
+		    i2c_list->i2c_settings.size == 1) {
+			struct cam_sensor_i2c_reg_array *orig = i2c_list->i2c_settings.reg_setting;
+			uint16_t bu64747_dac = i2c_list->i2c_settings.reg_setting[0].reg_data;
+
+			CAM_DBG(CAM_ACTUATOR, "bu64747: set new dac value %d.", bu64747_dac);
+			bu64747_set_dac_array[1].reg_data = bu64747_dac & 0x00FF;
+			bu64747_set_dac_array[2].reg_data = (bu64747_dac & 0x0300) >> 8;
+			i2c_list->i2c_settings.data_type = 1;
+			i2c_list->i2c_settings.size = 9;
+			i2c_list->i2c_settings.reg_setting = bu64747_set_dac_array;
+			rc = camera_io_dev_write_continuous(io_master_info, &(i2c_list->i2c_settings), 0);
+			i2c_list->i2c_settings.reg_setting = orig;
+			return rc;
+		}
+
+		/* bu64253: override i2c commands for set_dac */
+		if (io_master_info->cci_client->sid == (0x18 >> 1) &&
+		    i2c_list->i2c_settings.reg_setting[0].reg_addr == 0xC0 &&
+		    i2c_list->i2c_settings.addr_type == 1 &&
+		    i2c_list->i2c_settings.data_type == 2 &&
+		    i2c_list->i2c_settings.size == 1) {
+			uint16_t bu64253_dac = i2c_list->i2c_settings.reg_setting[0].reg_data;
+
+			CAM_DBG(CAM_ACTUATOR, "bu64253: set new dac value %d.", bu64253_dac);
+			i2c_list->i2c_settings.data_type = 1;
+			i2c_list->i2c_settings.reg_setting[0].reg_addr = 0xC0 | ((bu64253_dac & 0x0300) >> 8);
+			i2c_list->i2c_settings.reg_setting[0].reg_data = bu64253_dac & 0x00FF;
+		}
+
 		rc = camera_io_dev_write(io_master_info,
 			&(i2c_list->i2c_settings));
 		if (rc < 0) {


### PR DESCRIPTION
Add actuator device-tree nodes for Akari, Apollo and Akatsuki.

The bu64253 and bu64747 actuators require peculiar handling to set
the lens position, which is not supported by the userspace libraries.