### PR TITLE
[2.3.2.r1.4] input: gpio_keys: Fix legacy pinctrl for new platforms

### DIFF
--- a/drivers/input/keyboard/gpio_keys.c
+++ b/drivers/input/keyboard/gpio_keys.c
@@ -598,6 +598,23 @@ static void gpio_keys_report_state(struct gpio_keys_drvdata *ddata)
 	input_sync(input);
 }
 
+static bool gpio_keys_pinctrl_conf_valid(struct gpio_keys_drvdata *ddata)
+{
+	struct pinctrl_state *state;
+
+	state = pinctrl_lookup_state(ddata->key_pinctrl,
+						"tlmm_gpio_key_active");
+	if (IS_ERR(state))
+		return false;
+
+	state = pinctrl_lookup_state(ddata->key_pinctrl,
+						"tlmm_gpio_key_suspend");
+	if (IS_ERR(state))
+		return false;
+
+	return true;
+}
+
 static int gpio_keys_pinctrl_configure(struct gpio_keys_drvdata *ddata,
 							bool active)
 {
@@ -831,6 +848,12 @@ static int gpio_keys_probe(struct platform_device *pdev)
 
 		pr_debug("Target does not use pinctrl\n");
 		ddata->key_pinctrl = NULL;
+	} else {
+		if (!gpio_keys_pinctrl_conf_valid(ddata)) {
+			dev_info(dev, "Invalid pinctrl configuration. "
+					"Skipping pinctrl usage.");
+			ddata->key_pinctrl = NULL;
+		}
 	}
 
 	if (ddata->key_pinctrl) {


### PR DESCRIPTION
New SoCs are using only one "default" pinctrl state and they do
not differentiate between active and suspend states.
Add a function to check if the pinctrl configuration is valid
and if it's not, assume that we are using a new platform, throw
an informative message about it and unset the pinctrl handle to
avoid erroring out and continue driver probe.

This will make us to skip the legacy pinctrl on new SoCs, such
as SDM845.