### PR TITLE
[2.3.2.r1.4] mXT640u fixes

### DIFF
--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -9086,6 +9086,8 @@ static int mxt_probe(struct i2c_client *client, const struct i2c_device_id *id)
 		}
 	}
 
+	data->first_unblank = true;
+
 	return 0;
 
 err_create_sysfs_link:
@@ -9455,7 +9457,10 @@ static int drm_notifier_callback(struct notifier_block *self, unsigned long even
 					if (mxt_init_recover(ts->client, ts))
 						return 0;
 				}
-				if (!ts->charge_out) {
+				if (ts->first_unblank) {
+					ts->first_unblank = false;
+					ts->charge_out = true;
+				} else if (!ts->charge_out) {
 					LOGN("not already sleep out\n");
 					return 0;
 				}

--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -8574,8 +8574,6 @@ ts_rest_init:
 	}
 
 out:
-	if (fw)
-		release_firmware(fw);
 	mxt_power_unblock(data, POWERLOCK_FW_UP);
 	return error;
 }
@@ -8887,6 +8885,10 @@ skip_fw:
 	/* power unlock */
 	ret = mxt_pw_lock(INCELL_DISPLAY_POWER_UNLOCK);
 	data->after_work = true;
+
+	if (fw)
+		release_firmware(fw);
+
 	return ret;
 
 err_free_irq:

--- a/drivers/input/touchscreen/atmel_mxt640u.h
+++ b/drivers/input/touchscreen/atmel_mxt640u.h
@@ -1148,6 +1148,7 @@ struct mxt_data {
 
 	bool after_work;
 	bool charge_out;
+	bool first_unblank;
 	bool wireless_charge;
 	bool landscape;
 


### PR DESCRIPTION
Solves kernel panic on firmware load retry.
Starts the touchscreen in kernel at the first unblank event.