### PR TITLE
[2.3.2.r1.4] Support doze states on OLED panels and mXT640u

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
@@ -226,6 +226,12 @@ int incell_get_panel_name(void)
 }
 EXPORT_SYMBOL(incell_get_panel_name);
 
+int incell_get_display_pre_sod(void)
+{
+	return somc_panel_get_display_pre_sod_mode();
+}
+EXPORT_SYMBOL(incell_get_display_pre_sod);
+
 int incell_get_display_sod(void)
 {
 	return get_display_sod_mode();

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
@@ -123,5 +123,11 @@ extern int incell_get_display_sod(void);
 static inline int incell_get_display_sod(void) {return 0; }
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+extern int incell_get_display_pre_sod(void);
+#else
+static inline int incell_get_display_pre_sod(void) {return 0; }
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
 #endif /* __INCELL_H__ */
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -383,6 +383,9 @@ int somc_panel_parse_dt_chgfps_config(struct dsi_panel *panel,
 int somc_panel_fps_register_attr(struct device *dev);
 int somc_panel_fps_manager_init(struct dsi_display *display);
 
+int somc_panel_get_display_pre_sod_mode(void);
+int somc_panel_set_doze_mode(struct drm_connector *connector,
+		int power_mode, void *disp);
 int somc_panel_allocate(struct device *dev, struct dsi_panel *panel);
 int somc_panel_init(struct dsi_display *display);
 

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -49,6 +49,10 @@
 #include <soc/qcom/scm.h>
 #include "soc/qcom/secure_buffer.h"
 
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+#include "../dsi-staging/somc_panel/somc_panel_exts.h"
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
 #define CREATE_TRACE_POINTS
 #include "sde_trace.h"
 
@@ -1275,7 +1279,11 @@ static int _sde_kms_setup_displays(struct drm_device *dev,
 		.soft_reset   = dsi_display_soft_reset,
 		.pre_kickoff  = dsi_conn_pre_kickoff,
 		.clk_ctrl = dsi_display_clk_ctrl,
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+		.set_power = somc_panel_set_doze_mode,
+#else
 		.set_power = dsi_display_set_power,
+#endif
 		.get_mode_info = dsi_conn_get_mode_info,
 		.get_dst_format = dsi_display_get_dst_format,
 		.post_kickoff = dsi_conn_post_kickoff,

--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -9225,6 +9225,7 @@ static int mxt_drm_suspend(struct mxt_data *data)
 	LOGN("%s\n", __func__);
 
 	data->sod_mode.status = incell_get_display_sod();
+	data->sod_mode.pre_status = incell_get_display_pre_sod();
 	if (data->sod_mode.pre_status && data->sod_mode.status == SOD_POWER_OFF) {
 		LOGN("%s　power off\n", __func__);
 	} else if (data->sod_mode.pre_status) {


### PR DESCRIPTION
This enables Doze/DozeSuspend (LP1, LP2) states for the OLED panels
in order to save power when AlwaysOn Display is enabled in the Android
userspace.
