### PR TITLE
[2.3.2.r1.4] Knock-knock! Always On Display enhancement

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
@@ -238,6 +238,12 @@ int incell_get_display_sod(void)
 }
 EXPORT_SYMBOL(incell_get_display_sod);
 
+int incell_get_display_aod(void)
+{
+	return somc_panel_get_display_aod_mode();
+}
+EXPORT_SYMBOL(incell_get_display_aod);
+
 bool incell_get_system_status(void)
 {
 	struct incell_ctrl *incell = incell_get_info();

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
@@ -118,6 +118,12 @@ static inline bool incell_get_system_status(void) {return true; }
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
 #ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+extern int incell_get_display_aod(void);
+#else
+static inline int incell_get_display_aod(void) {return 0; }
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_display_sod(void);
 #else
 static inline int incell_get_display_sod(void) {return 0; }

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -384,6 +384,7 @@ int somc_panel_fps_register_attr(struct device *dev);
 int somc_panel_fps_manager_init(struct dsi_display *display);
 
 int somc_panel_get_display_pre_sod_mode(void);
+int somc_panel_get_display_aod_mode(void);
 int somc_panel_set_doze_mode(struct drm_connector *connector,
 		int power_mode, void *disp);
 int somc_panel_allocate(struct device *dev, struct dsi_panel *panel);

--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -4990,7 +4990,10 @@ static void mxt_set_feature_status(struct mxt_data *data)
 
 	mxt_set_side_key(data);
 	mxt_set_stamina_mode(data);
+
+	data->aod_mode.status = incell_get_display_aod();
 	mxt_set_aod_mode(data);
+
 	mxt_set_cover_mode(data);
 	mxt_set_glove_mode(data);
 	mxt_patch_event(data, PATCH_EVENT_CODE_GRIP_SUPPRESSSION_PORTRAIT);

--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -9190,7 +9190,7 @@ static int mxt_resume(struct device *dev)
 
 static void mxt_prepare_sod_mode(struct mxt_data *data)
 {
-	int value[4] = {1, 0, 0, 0};
+	int value[4] = {1, 0, 1, 0};
 
 	if (!data->sod_mode.supported) {
 		LOGN("SOD mode is not supported\n");


### PR DESCRIPTION
Knock knock!
Now the display gets back on!

When Always-On Display is enabled (or Ambient Display for notifications), the driver will get to LP modes: enable the touchscreen knock-on feature to promptly get display back on without touching the power button.