### PR TITLE
[2.3.2.r1.4] URGENT! Nile eMMC hardware bug workaround

### DIFF
--- a/drivers/mmc/card/queue.c
+++ b/drivers/mmc/card/queue.c
@@ -106,6 +106,8 @@ static inline void mmc_cmdq_ready_wait(struct mmc_host *host,
 		|| (mmc_peek_request(mq) &&
 		!(mmc_req_is_special(mq->cmdq_req_peeked)
 		  && test_bit(CMDQ_STATE_DCMD_ACTIVE, &ctx->curr_state))
+		&& !(mmc_req_is_special(mq->cmdq_req_peeked)
+		     && ctx->active_reqs)
 		&& !(!host->card->part_curr && !mmc_card_suspended(host->card)
 		     && mmc_host_halt(host))
 		&& !(!host->card->part_curr && mmc_host_cq_disable(host) &&

--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -441,9 +441,16 @@ static int mmc_decode_ext_csd(struct mmc_card *card, u8 *ext_csd)
 			card->ext_csd.part_time = MMC_MIN_PART_SWITCH_TIME;
 
 		/* Sleep / awake timeout in 100ns units */
-		if (sa_shift > 0 && sa_shift <= 0x17)
+		if (sa_shift > 0 && sa_shift <= 0x17) {
+#ifdef CONFIG_ARCH_SONY_NILE
+			/* HACK: Set sa_timeout for bad CSD on SoMC Nile */
+			card->ext_csd.sa_timeout = 1 << 0x17;
+#else
 			card->ext_csd.sa_timeout =
 					1 << ext_csd[EXT_CSD_S_A_TIMEOUT];
+#endif
+		}
+
 		card->ext_csd.erase_group_def =
 			ext_csd[EXT_CSD_ERASE_GROUP_DEF];
 		card->ext_csd.hc_erase_timeout = 300 *


### PR DESCRIPTION
The SoMC Nile platform may not advertise the right S_A
(Sleep/Awake) timeout for its eMMC, resulting in possible
data corruption during write while doing Sleep/Awake.

Address this hardware bug by forcing the SA timeout to
a fixed value.