### PR TITLE
[2.3.2.r1.4] fs: sdfat: Register sdFAT filesystem as exFAT

### DIFF
--- a/fs/sdfat/sdfat.c
+++ b/fs/sdfat/sdfat.c
@@ -4969,7 +4969,7 @@ static void sdfat_debug_kill_sb(struct super_block *sb)
 
 static struct file_system_type sdfat_fs_type = {
 	.owner       = THIS_MODULE,
-	.name        = "sdfat",
+	.name        = "exfat",
 	.mount       = sdfat_fs_mount,
 #ifdef CONFIG_SDFAT_DBG_IOCTL
 	.kill_sb    = sdfat_debug_kill_sb,


### PR DESCRIPTION
Since Android 9 there is native vold support for the exfat
driver [1], which expects the "exfat" driver name instead
of sdfat, so in order to avoid patching the vold source code,
and to respect the AOSP decisions [2], let's register this
filesystem as "exfat".

Signed-off-by: Daniel Vasquez <danielgusvt@yahoo.com>