### PR TITLE
[2.3.2.r1.4] somc_panel: Introduce Adaptive Color Management and bugfix

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-akatsuki-id5_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-akatsuki-id5_pcc.dtsi
@@ -19,6 +19,22 @@
 
 /* pcc-table for Akatsuki */
 &dsi_5{
+	somc,mdss-dsi-use-picadj;
+	somc,mdss-dsi-picadj-sat = <3>;
+	somc,mdss-dsi-picadj-hue = <0>;
+	somc,mdss-dsi-picadj-val = <0>;
+	somc,mdss-dsi-picadj-cont = <0>;
+
+	somc,panel-adaptivecolor-enable;
+	somc,panel-adacolor-sat-max = <50>;
+	somc,panel-adacolor-hue-max = <0>;
+	somc,panel-adacolor-val-max = <5>;
+	somc,panel-adacolor-cont-max = <5>;
+
+	somc,panel-adacolor-br-min = <7>;
+	somc,panel-adacolor-br-max = <20>;
+	somc,panel-adacolor-pa-invert;
+
 	somc,mdss-dsi-pcc-enable;
 	somc,mdss-dsi-uv-command = [
 		06 01 00 00 00 00 01 DA

--- a/arch/arm64/boot/dts/qcom/dsi-panel-akatsuki-id5_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-akatsuki-id5_pcc.dtsi
@@ -35,6 +35,8 @@
 	somc,panel-adacolor-br-max = <20>;
 	somc,panel-adacolor-pa-invert;
 
+	somc,panel-colormgr-pcc-prof-avail;
+
 	somc,mdss-dsi-pcc-enable;
 	somc,mdss-dsi-uv-command = [
 		06 01 00 00 00 00 01 DA

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -815,6 +815,9 @@ int dsi_panel_set_backlight(struct dsi_panel *panel, u32 bl_lvl)
 			dsi_panel_driver_toggle_light_off(panel,
 				DISPLAY_BL_ON);
 			rc = dsi_panel_update_backlight(panel, bl_lvl);
+			if (rc == 0)
+				somc_panel_colormgr_update_backlight(panel,
+								     bl_lvl);
 		}
 		break;
 #else

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/Makefile
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/Makefile
@@ -8,7 +8,7 @@ somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= dsi_panel_driver.o
 somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= panel_detect.o
 #somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= panel_polling.o
 somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= panel_fps_manager.o
-somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= panel_color_manager.o
+somc_panel-$(CONFIG_DRM_MSM_DSI_SOMC_PANEL)	+= panel_color_manager.o panel_adaptive_color.o
 somc_panel-$(CONFIG_SOMC_PANEL_LABIBB)		+= panel_regulators.o
 somc_panel-$(CONFIG_SOMC_PANEL_INCELL)		+= incell.o
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_adaptive_color.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_adaptive_color.c
@@ -1,0 +1,187 @@
+/*
+ * Restructured unified display panel driver for Xperia Open Devices
+ *               *** Adaptive Color Management ***
+ *
+ * This driver is based on various SoMC implementations found in
+ * copyleft archives for various devices.
+ *
+ * Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) Sony Mobile Communications Inc. All rights reserved.
+ * Copyright (C) 2014-2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/sysfs.h>
+#include <linux/device.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+#include <linux/notifier.h>
+#include <linux/export.h>
+#include "somc_panel_exts.h"
+#include "dsi_display.h"
+#include "dsi_panel.h"
+#include "../sde/sde_crtc.h"
+#include "../sde/sde_plane.h"
+
+
+int somc_panel_parse_dt_adaptivecolor_config(struct dsi_panel *panel,
+			struct device_node *np)
+{
+	struct somc_panel_color_mgr *color_mgr = NULL;
+	struct somc_panel_adaptive_color *ad_col = NULL;
+	u32 tmp = 0;
+	int rc = 0;
+
+	if (!panel) {
+		pr_err("%s: Invalid input panel\n", __func__);
+		return -EINVAL;
+	}
+
+	if (!panel->spec_pdata) {
+		pr_err("%s: spec_pdata not initialized!!\n", __func__);
+		return -EINVAL;
+	}
+
+	color_mgr = panel->spec_pdata->color_mgr;
+	ad_col = &color_mgr->adaptive_color;
+
+	color_mgr->dsi_pcc_applied = false;
+	ad_col->enable =
+		of_property_read_bool(np, "somc,panel-adaptivecolor-enable");
+
+	/* Picture Adjustment (PicAdj) Parameters */
+	if (!of_find_property(np, "somc,mdss-dsi-use-picadj", NULL))
+		goto end;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-sat-max", &tmp);
+	ad_col->picadj_data_br_max.saturation = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-hue-max", &tmp);
+	ad_col->picadj_data_br_max.hue = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-val-max", &tmp);
+	ad_col->picadj_data_br_max.value = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-cont-max", &tmp);
+	ad_col->picadj_data_br_max.contrast = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-br-min", &tmp);
+	ad_col->picadj_br_min = !rc ? tmp : -1;
+
+	rc = of_property_read_u32(np, "somc,panel-adacolor-br-max", &tmp);
+	ad_col->picadj_br_max = !rc ? tmp : -1;
+
+	ad_col->pa_invert =
+		of_property_read_bool(np, "somc,panel-adacolor-pa-invert");
+
+	rc = 0;
+
+	/* AdaptiveColor is enabled: copy the default PicAdj values! */
+	ad_col->picadj_data_default.hue = color_mgr->picadj_data.hue;
+	ad_col->picadj_data_default.saturation =
+					color_mgr->picadj_data.saturation;
+	ad_col->picadj_data_default.value = color_mgr->picadj_data.value;
+	ad_col->picadj_data_default.contrast = color_mgr->picadj_data.contrast;
+
+end:
+	return rc;
+}
+
+static inline void somc_panel_colormgr_set_ac_pa(
+	struct somc_panel_color_mgr *color_mgr, struct drm_msm_pa_hsic *pa)
+{
+	color_mgr->picadj_data.hue = pa->hue;
+	color_mgr->picadj_data.saturation = pa->saturation;
+	color_mgr->picadj_data.value = pa->value;
+	color_mgr->picadj_data.contrast = pa->contrast;
+}
+			
+
+/*
+ * Set a percentual of the "data_br_max" PicAdj settings based on
+ * backlight percentage.
+ * This should require a different way to calculate things, since the
+ * algorithm to calculate backlight based color adjustment should
+ * scientifically not be linear, but for our usecases this linear
+ * calculation is definitely sufficient, as we don't care of very
+ * small deviations (since that's how our displays are reacting for now).
+ *
+ * \params
+ * bl_lvl - Backlight brightness level
+ * invert - Invert the calculation (higher PA values on lower BL values)
+ */
+static void somc_panel_colormgr_adj_pa(struct dsi_panel *panel,
+					u32 bl_lvl, bool invert)
+{
+	struct somc_panel_color_mgr *color_mgr =
+			panel->spec_pdata->color_mgr;
+	struct somc_panel_adaptive_color *ad_col =
+			&color_mgr->adaptive_color;
+	struct drm_msm_pa_hsic *data_br_max = NULL;
+	struct drm_msm_pa_hsic *data_br_default = NULL;
+	u8 bl_percent = 0;
+	u8 pa_percent = 100;
+
+	if (invert) {
+		data_br_default = &ad_col->picadj_data_br_max;
+		data_br_max = &ad_col->picadj_data_default;
+	}
+
+	/* Processing shortcuts for imposed algorithm limits */
+	if (bl_lvl < ad_col->picadj_br_min) {
+		somc_panel_colormgr_set_ac_pa(color_mgr, data_br_default);
+		return;
+	} else if (bl_lvl > ad_col->picadj_br_max) {
+		somc_panel_colormgr_set_ac_pa(color_mgr, data_br_max);
+		return;
+	}
+
+	bl_percent = (bl_lvl * 100) / ad_col->picadj_br_max;
+
+	if (invert)
+		pa_percent -= bl_percent;
+	else
+		pa_percent = bl_percent;
+
+	color_mgr->picadj_data.hue = (u32)
+		(ad_col->picadj_data_br_max.hue * pa_percent) / 100;
+	color_mgr->picadj_data.saturation = (u32)
+		(ad_col->picadj_data_br_max.saturation * pa_percent) / 100;
+	color_mgr->picadj_data.contrast = (u32)
+		(ad_col->picadj_data_br_max.contrast * pa_percent) / 100;
+	color_mgr->picadj_data.value = (u32)
+		(ad_col->picadj_data_br_max.value * pa_percent) / 100;
+
+	return;
+}
+
+void somc_panel_colormgr_update_backlight(struct dsi_panel *panel, u32 bl_lvl)
+{
+	struct dsi_display *display = NULL;
+	struct somc_panel_color_mgr *color_mgr = NULL;
+
+	if (!color_mgr->adaptive_color.enable)
+		return;
+
+	display = dsi_display_get_main_display();
+	if (!display) {
+		pr_err("ERROR: Cannot update for Adaptive Color\n");
+		return;
+	}
+
+	color_mgr = panel->spec_pdata->color_mgr;
+
+	/* PA adjustment */
+	somc_panel_colormgr_adj_pa(panel, bl_lvl,
+		color_mgr->adaptive_color.pa_invert);
+
+	somc_panel_send_pa(display);
+}

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -281,6 +281,15 @@ struct dsi_panel_labibb_data {
 	bool ibb_pd_full;
 };
 
+struct somc_panel_adaptive_color {
+	struct drm_msm_pa_hsic picadj_data_br_max;
+	struct drm_msm_pa_hsic picadj_data_default;
+	unsigned int picadj_br_min;
+	unsigned int picadj_br_max;
+	unsigned int pa_invert;
+	bool enable;
+};
+
 struct somc_panel_color_mgr {
 	struct dsi_panel_cmds pre_uv_read_cmds;
 	struct dsi_panel_cmds uv_read_cmds;
@@ -290,10 +299,12 @@ struct somc_panel_color_mgr {
 	struct dsi_pcc_data vivid_pcc_data;
 	struct dsi_pcc_data hdr_pcc_data;
 	struct drm_msm_pa_hsic picadj_data;
+	struct somc_panel_adaptive_color adaptive_color;
 
 	u32 u_data;
 	u32 v_data;
 	int color_mode;
+	unsigned int   cal_bl_point;
 	unsigned short pcc_profile;
 	bool standard_pcc_enable;
 	bool srgb_pcc_enable;
@@ -373,9 +384,16 @@ int somc_panel_pcc_setup(struct dsi_display *display);
 int somc_panel_parse_dt_colormgr_config(struct dsi_panel *panel,
 			struct device_node *np);
 int somc_panel_colormgr_register_attr(struct device *dev);
+int somc_panel_send_pa(struct dsi_display *display);
 int somc_panel_colormgr_apply_calibrations(void);
 int somc_panel_color_manager_init(struct dsi_display *display);
 
+/* ColorManager: Adaptive Color */
+int somc_panel_parse_dt_adaptivecolor_config(struct dsi_panel *panel,
+			struct device_node *np);
+void somc_panel_colormgr_update_backlight(struct dsi_panel *panel, u32 bl_lvl);
+
+/* Main */
 void somc_panel_fps_cmd_send(struct dsi_panel *panel);
 int somc_panel_fps_check_state(struct dsi_display *display, int mode_type);
 int somc_panel_parse_dt_chgfps_config(struct dsi_panel *panel,


### PR DESCRIPTION
Introducing Adaptive Color Management "adacolor":
this is a neat trick to adjust display colors through the SDE HSIC
based on the device's backlight level.

It supports a minimum and maximum brightness for adacolor
adjustments: out of that range there will be no adjustment.

It is also supported to invert the calculations: by default
adacolor will set the adj-MAX values on increasing backlight
brightness; by inverting the calculation, it will set the
adj-MAX values on decreasing backlight brightness.

WARNING!
This algorithm is linear and it is obviously wrong and not
working for wide adjustments: not every screen reacts the same
and the right equation for this is never linear!

Why is this driver wrongly engineered on purpose?
Simply because this is meant to be very very light on the CPU
and to fix colors for a small range(s?) of backlight brightness:
it's just enough for us in this precise moment in time, since
we have no display that needs any wide color adjustment based
on backlight values.

HELP:
The adacolor feature gets activated and configurated through DT:
somc,panel-adaptivecolor-enable    -- Enable adacolor

somc,panel-adacolor-sat-max = <1>;  -- Maximum saturation variation
somc,panel-adacolor-hue-max = <2>;  -- Maximum hue shift variation
somc,panel-adacolor-val-max = <3>;  -- Maximum value variation
somc,panel-adacolor-cont-max = <4>; -- Maximum contrast variation

somc,panel-adacolor-br-min = <7>;   -- Minimum backlight brightness
somc,panel-adacolor-br-max = <20>;  -- Maximum backlight brightness
somc,panel-adacolor-pa-invert;      -- Invert calculations
