### PR TITLE
power: reset: msm-poweroff: Add Tama platform to XBOOT AB ifdef

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -56,7 +56,7 @@
 #if defined(CONFIG_ARCH_SONY_YOSHINO) || defined(CONFIG_ARCH_SONY_NILE) || \
     defined(CONFIG_ARCH_SONY_TAMA)
  #define TARGET_SOMC_XBOOT
-#if defined(CONFIG_ARCH_SONY_NILE)
+#if defined(CONFIG_ARCH_SONY_NILE) || defined(CONFIG_ARCH_SONY_TAMA)
  #define TARGET_SOMC_XBOOT_FEATURE_AB
 #endif
 #endif


### PR DESCRIPTION
Like nile, tama also uses the standard recovery command