### PR TITLE
[2.3.2.r1.4] SoMC Nile: Fix clock bugs, redo SDE support

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-nile-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-nile-sde.dtsi
@@ -7,8 +7,8 @@
 	somc,pw-on-rst-seq = "after_power_on";
 
 	qcom,mdss-dsi-display-timings {
-		1080p60 {
-			qcom,mdss-dsi-panel-framerate = <60>;
+		1080p120 {
+			qcom,mdss-dsi-panel-framerate = <120>;
 			qcom,mdss-dsi-panel-width = <1080>;
 			qcom,mdss-dsi-panel-height = <1920>;
 			qcom,mdss-dsi-h-front-porch = <100>;
@@ -25,6 +25,8 @@
 			qcom,mdss-dsi-h-sync-pulse = <0>;
 			qcom,mdss-dsi-t-clk-post = <0x0D>;
 			qcom,mdss-dsi-t-clk-pre = <0x2E>;
+
+			qcom,mdss-dsi-panel-clockrate = <1998000000>;
 
 			qcom,mdss-dsi-on-command = [29 01 00 00 00 00 02 B0 00
 						    29 01 00 00 00 00 04 B3 00 00 06
@@ -108,8 +110,8 @@
 	somc,pw-on-rst-seq = "after_power_on";
 
 	qcom,mdss-dsi-display-timings {
-		1080p60 {
-			qcom,mdss-dsi-panel-framerate = <60>;
+		1080p120 {
+			qcom,mdss-dsi-panel-framerate = <120>;
 			qcom,mdss-dsi-panel-width = <1080>;
 			qcom,mdss-dsi-panel-height = <1920>;
 			qcom,mdss-dsi-h-front-porch = <104>;
@@ -126,6 +128,8 @@
 			qcom,mdss-dsi-h-sync-pulse = <0>;
 			qcom,mdss-dsi-t-clk-post = <0x0D>;
 			qcom,mdss-dsi-t-clk-pre = <0x2F>;
+
+			qcom,mdss-dsi-panel-clockrate = <1998000000>;
 
 			qcom,mdss-dsi-off-command = [05 01 00 00 14 00 02 28 00
 						     05 01 00 00 78 00 02 10 00];
@@ -172,8 +176,8 @@
 	somc,pw-on-rst-seq = "after_power_on";
 
 	qcom,mdss-dsi-display-timings {
-		1080p60 {
-			qcom,mdss-dsi-panel-framerate = <60>;
+		1080p120 {
+			qcom,mdss-dsi-panel-framerate = <120>;
 			qcom,mdss-dsi-panel-width = <1080>;
 			qcom,mdss-dsi-panel-height = <1920>;
 			qcom,mdss-dsi-h-front-porch = <96>;
@@ -190,6 +194,8 @@
 			qcom,mdss-dsi-h-sync-pulse = <0>;
 			qcom,mdss-dsi-t-clk-post = <0x0D>;
 			qcom,mdss-dsi-t-clk-pre = <0x2F>;
+
+			qcom,mdss-dsi-panel-clockrate = <1998000000>;
 
 			qcom,mdss-dsi-on-command = [05 01 00 00 00 00 02 29 00
 						    05 01 00 00 46 00 02 11 00];

--- a/arch/arm64/boot/dts/qcom/sdm630-gpu.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-gpu.dtsi
@@ -80,12 +80,12 @@
 		clocks = <&clock_gfx GPUCC_GFX3D_CLK>,
 			<&clock_gcc GCC_GPU_CFG_AHB_CLK>,
 			<&clock_gfx GPUCC_RBBMTIMER_CLK>,
-			<&clock_gcc GCC_GPU_BIMC_GFX_CLK>,
 			<&clock_gcc GCC_BIMC_GFX_CLK>,
+			<&clock_gcc GCC_GPU_BIMC_GFX_CLK>,
 			<&clock_gpu GPUCC_RBCPR_CLK>;
 
 		clock-names = "core_clk", "iface_clk", "rbbmtimer_clk",
-			"mem_clk", "alt_mem_iface_clk", "rbcpr_clk";
+			"mem_clk", "mem_iface_clk", "rbcpr_clk";
 
 		/* Bus Scale Settings */
 		qcom,gpubw-dev = <&gpubw>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -125,8 +125,8 @@
 		qcom,sde-panic-per-pipe;
 		qcom,sde-has-cdp;
 		qcom,sde-has-src-split;
-		qcom,sde-max-bw-low-kbps = <4100000>;
-		qcom,sde-max-bw-high-kbps = <4100000>;
+		qcom,sde-max-bw-low-kbps = <6400000>;
+		qcom,sde-max-bw-high-kbps = <6400000>;
 		qcom,sde-min-core-ib-kbps = <2400000>;
 		qcom,sde-min-llcc-ib-kbps = <800000>;
 		qcom,sde-min-dram-ib-kbps = <800000>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -107,7 +107,7 @@
 		qcom,sde-sspp-clk-ctrl = <0x2ac 0>, <0x2ac 8>, <0x2b4 8>,
 					 <0x2c4 8>, <0x3a8 16>;
 
-		qcom,sde-qseed-type = "qseedv2";
+		qcom,sde-qseed-type = "qseedv3";
 		qcom,sde-csc-type = "csc";
 		qcom,sde-mixer-linewidth = <2048>;
 		qcom,sde-sspp-linewidth = <2048>;
@@ -120,6 +120,9 @@
 		qcom,sde-max-bw-high-kbps = <4100000>;
 		qcom,sde-dram-channels = <2>;
 		qcom,sde-num-nrt-paths = <1>;
+
+		qcom,sde-vbif-qos-rt-remap = <1 2 2 2>;
+		qcom,sde-vbif-qos-nrt-remap = <1 1 1 1>;
 
 		qcom,sde-sspp-danger-lut = <0x000f 0xffff 0x0000>;
 		qcom,sde-sspp-safe-lut = <0xfffc 0xff00 0xffff>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -131,7 +131,7 @@
 		qcom,sde-vbif-size = <0x1040>;
 		qcom,sde-vbif-id = <0 1>;
 		qcom,sde-vbif-default-ot-rd-limit = <32>;
-		qcom,sde-vbif-default-ot-wr-limit = <16>;
+		qcom,sde-vbif-default-ot-wr-limit = <32>;
 		qcom,sde-vbif-dynamic-ot-rd-limit = <62208000 2>,
 			<124416000 4>, <248832000 16>;
 		qcom,sde-vbif-dynamic-ot-wr-limit = <62208000 2>,

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -173,9 +173,9 @@
 		qcom,sde-qos-lut-cwb =
 			<0 0x00000000 0x00000000>;
 
-		qcom,sde-vbif-off = <0 0>;
+		qcom,sde-vbif-off = <0>;
 		qcom,sde-vbif-size = <0x1040>;
-		qcom,sde-vbif-id = <0 1>;
+		qcom,sde-vbif-id = <0>;
 		qcom,sde-vbif-default-ot-rd-limit = <32>;
 		qcom,sde-vbif-default-ot-wr-limit = <32>;
 /*		qcom,sde-vbif-dynamic-ot-rd-limit = <62208000 2>,

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -127,6 +127,9 @@
 		qcom,sde-has-src-split;
 		qcom,sde-max-bw-low-kbps = <4100000>;
 		qcom,sde-max-bw-high-kbps = <4100000>;
+		qcom,sde-min-core-ib-kbps = <2400000>;
+		qcom,sde-min-llcc-ib-kbps = <800000>;
+		qcom,sde-min-dram-ib-kbps = <800000>;
 		qcom,sde-dram-channels = <2>;
 		qcom,sde-num-nrt-paths = <1>;
 
@@ -267,7 +270,7 @@
 	};
 
 	mdss_dsi0: qcom,sde_dsi_ctrl0@c994000 {
-		compatible = "qcom,dsi-ctrl-hw-v1.4";
+		compatible = "qcom,dsi-ctrl-hw-v2.0";
 		label = "dsi-ctrl-0";
 		cell-index = <0>;
 		reg =   <0xc994000 0x400>,
@@ -285,12 +288,14 @@
 			 <&clock_mmss MMSS_MDSS_PCLK0_CLK>,
 			 <&clock_mmss MMSS_MDSS_ESC0_CLK>,
 			 <&clock_mmss BYTE0_CLK_SRC>,
-			 <&clock_mmss PCLK0_CLK_SRC>;
+			 <&clock_mmss PCLK0_CLK_SRC>,
+			 <&clock_mmss MMSS_MDSS_BYTE0_INTF_CLK>;
 
 		clock-names = "mdp_core_clk", "iface_clk",
 			"core_mmss_clk", "bus_clk",
 			"byte_clk", "pixel_clk", "esc_clk",
-			"byte_clk_rcg", "pixel_clk_rcg";
+			"byte_clk_rcg", "pixel_clk_rcg",
+			"byte_intf_clk";
 
 		/* axi bus scale settings */
 		qcom,msm-bus,name = "mdss_dsi0";
@@ -343,10 +348,11 @@
 		vdda-supply = <&pm660l_l1>;
 
 		clocks = <&clock_mmss MMSS_MDSS_MDP_CLK>,
+			 <&clock_mmss MMSS_MNOC_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AHB_CLK>,
 			 <&clock_mmss MMSS_MISC_AHB_CLK>,
 			 <&clock_mmss MMSS_MDSS_AXI_CLK>;
-		clock-names = "mdp_core_clk", "iface_clk",
+		clock-names = "mdp_core_clk", "mnoc_clk", "iface_clk",
 			"core_mmss_clk", "bus_clk";
 
 		qcom,platform-strength-ctrl = [ff 06

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -115,8 +115,9 @@
 		qcom,sde-sspp-clk-ctrl = <0x2ac 0>, <0x2ac 8>, <0x2b4 8>,
 					 <0x2c4 8>, <0x3a8 16>;
 
+		qcom,sde-sspp-csc-off = <0x1a00>;
+		qcom,sde-csc-type = "csc-10bit";
 		qcom,sde-qseed-type = "qseedv3";
-		qcom,sde-csc-type = "csc";
 		qcom,sde-mixer-linewidth = <2048>;
 		qcom,sde-sspp-linewidth = <2048>;
 		qcom,sde-mixer-blendstages = <0x7>;
@@ -183,8 +184,9 @@
 		vdd-supply = <&gdsc_mdss>;
 
 		qcom,sde-sspp-vig-blocks {
-			qcom,sde-vig-csc-off = <0x320>;
-			qcom,sde-vig-qseed-off = <0x200>;
+			qcom,sde-vig-csc-off = <0x1a00>;
+			qcom,sde-vig-qseed-off = <0xa00>;
+			qcom,sde-vig-qseed-size = <0xa0>;
 			/* Offset from vig top, version of HSIC */
 			qcom,sde-vig-hsic = <0x200 0x00010007>;
 			qcom,sde-vig-memcolor = <0x200 0x00010007>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -132,8 +132,42 @@
 		qcom,sde-vbif-qos-rt-remap = <1 2 2 2>;
 		qcom,sde-vbif-qos-nrt-remap = <1 1 1 1>;
 
-		qcom,sde-sspp-danger-lut = <0x000f 0xffff 0x0000>;
-		qcom,sde-sspp-safe-lut = <0xfffc 0xff00 0xffff>;
+		qcom,sde-danger-lut = <0x0000000f 0x0000ffff 0x00000000
+			0x00000000>;
+		qcom,sde-safe-lut-linear =
+			<0 0xfffc>;
+		qcom,sde-safe-lut-macrotile =
+			<0 0xff00>;
+		qcom,sde-safe-lut-nrt =
+			<0 0xffff>;
+		qcom,sde-safe-lut-cwb =
+			<0 0xffff>;
+
+		qcom,sde-qos-lut-linear =
+			<4 0x00000000 0x0000001B>,
+			<5 0x00000000 0x0000005B>,
+			<6 0x00000000 0x0000015B>,
+			<7 0x00000000 0x0000055B>,
+			<8 0x00000000 0x0000155B>,
+			<9 0x00000000 0x0000555B>,
+			<10 0x00000000 0x0001555B>,
+			<11 0x00000000 0x0005555B>,
+			<12 0x00000000 0x0015555B>,
+			<13 0x00000000 0x0055555B>,
+			<14 0x00000000 0x00000000>,
+			<1 0x00000000 0x0000001B>,
+			<0 0x00000000 0x00000000>;
+		qcom,sde-qos-lut-macrotile =
+			<10 0x00000000 0x0001AAFF>,
+			<11 0x00000000 0x0005AAFF>,
+			<12 0x00000000 0x0015AAFF>,
+			<13 0x00000000 0x0055AAFF>,
+			<1  0x00000000 0x0001AAFF>,
+			<0  0x00000000 0x00000000>;
+		qcom,sde-qos-lut-nrt =
+			<0 0x00000000 0x00000000>;
+		qcom,sde-qos-lut-cwb =
+			<0 0x00000000 0x00000000>;
 
 		qcom,sde-vbif-off = <0 0>;
 		qcom,sde-vbif-size = <0x1040>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -125,6 +125,8 @@
 		qcom,sde-panic-per-pipe;
 		qcom,sde-has-cdp;
 		qcom,sde-has-src-split;
+		qcom,sde-has-idle-pc;
+
 		qcom,sde-max-bw-low-kbps = <6400000>;
 		qcom,sde-max-bw-high-kbps = <6400000>;
 		qcom,sde-min-core-ib-kbps = <2400000>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -99,6 +99,14 @@
 
 		qcom,sde-sspp-xin-id = <0 1 5 9 2>;
 
+		qcom,sde-has-dest-scaler;
+		qcom,sde-max-dest-scaler-input-linewidth = <2048>;
+		qcom,sde-max-dest-scaler-output-linewidth = <2560>;
+		qcom,sde-dest-scaler-top-off = <0x00061000>;
+		qcom,sde-dest-scaler-top-size = <0xc>;
+		qcom,sde-dest-scaler-off = <0x800 0x1000>;
+		qcom,sde-dest-scaler-size = <0x800>;
+
 		qcom,sde-mixer-pair-mask = <2 1>;
 		qcom,sde-mixer-blend-op-off = <0x20 0x50 0x80 0xb0
 					       0x230 0x260 0x290>;
@@ -132,11 +140,11 @@
 		qcom,sde-vbif-id = <0 1>;
 		qcom,sde-vbif-default-ot-rd-limit = <32>;
 		qcom,sde-vbif-default-ot-wr-limit = <32>;
-		qcom,sde-vbif-dynamic-ot-rd-limit = <62208000 2>,
+/*		qcom,sde-vbif-dynamic-ot-rd-limit = <62208000 2>,
 			<124416000 4>, <248832000 16>;
 		qcom,sde-vbif-dynamic-ot-wr-limit = <62208000 2>,
 			<124416000 4>, <248832000 16>;
-
+*/
 		mmagic-supply = <&gdsc_bimc_smmu>;
 		vdd-supply = <&gdsc_mdss>;
 

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -341,7 +341,7 @@
 		compatible = "qcom,dsi-phy-v2.0";
 		label = "dsi-phy-0";
 		cell-index = <0>;
-		reg = <0x994400 0x588>;
+		reg = <0xc994400 0x588>;
 		reg-names = "dsi_phy";
 
 		gdsc-supply = <&gdsc_mdss>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -276,7 +276,7 @@
 			qcom,ctrl-supply-entry@1 {
 				reg = <0>;
 				qcom,supply-name = "vdda";
-				qcom,supply-min-voltage = <1250000>;
+				qcom,supply-min-voltage = <1200000>;
 				qcom,supply-max-voltage = <1250000>;
 				qcom,supply-enable-load = <12560>;
 				qcom,supply-disable-load = <4>;

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1064,6 +1064,8 @@
 	clock_gpu: qcom,gpucc@5065000 {
 		compatible = "qcom,gpu-sdm660";
 		reg = <0x5065000 0x10000>;
+		clocks = <&clock_gcc GPLL0>;
+		clock-names = "gpll0";
 		#clock-cells = <1>;
 		#reset-cells = <1>;
 	};

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -1093,6 +1093,8 @@
 	clock_gpu: qcom,gpucc@5065000 {
 		compatible = "qcom,gpu-sdm660";
 		reg = <0x5065000 0x10000>;
+		clocks = <&clock_gcc GPLL0>;
+		clock-names = "gpll0";
 		#clock-cells = <1>;
 		#reset-cells = <1>;
 	};

--- a/drivers/clk/qcom/gcc-sdm660.c
+++ b/drivers/clk/qcom/gcc-sdm660.c
@@ -1769,9 +1769,8 @@ static struct clk_gate2 gpll0_out_msscc = {
 	},
 };
 
-static struct clk_branch gcc_gpu_gpll0_clk = {
-	.halt_reg = 0x5200c,
-	.halt_check = BRANCH_HALT_DELAY,
+static struct clk_gate2 gcc_gpu_gpll0_clk = {
+	.udelay = 500,
 	.clkr = {
 		.enable_reg = 0x5200c,
 		.enable_mask = BIT(4),
@@ -1781,14 +1780,14 @@ static struct clk_branch gcc_gpu_gpll0_clk = {
 				"gpll0_out_main",
 			},
 			.num_parents = 1,
-			.ops = &clk_branch2_ops,
+			.flags = CLK_SET_RATE_PARENT,
+			.ops = &clk_gate2_ops,
 		},
 	},
 };
 
-static struct clk_branch gcc_gpu_gpll0_div_clk = {
-	.halt_reg = 0x5200c,
-	.halt_check = BRANCH_HALT_DELAY,
+static struct clk_gate2 gcc_gpu_gpll0_div_clk = {
+	.udelay = 500,
 	.clkr = {
 		.enable_reg = 0x5200c,
 		.enable_mask = BIT(3),
@@ -1798,7 +1797,8 @@ static struct clk_branch gcc_gpu_gpll0_div_clk = {
 				"gpll0_out_early_div",
 			},
 			.num_parents = 1,
-			.ops = &clk_branch2_ops,
+			.flags = CLK_SET_RATE_PARENT,
+			.ops = &clk_gate2_ops,
 		},
 	},
 };

--- a/drivers/clk/qcom/gcc-sdm660.c
+++ b/drivers/clk/qcom/gcc-sdm660.c
@@ -1764,6 +1764,10 @@ static struct clk_gate2 gpll0_out_msscc = {
 		.enable_mask = BIT(2),
 		.hw.init = &(struct clk_init_data){
 			.name = "gpll0_out_msscc",
+			.parent_names = (const char *[]){
+				"gpll0_out_main",
+			},
+			.num_parents = 1,
 			.ops = &clk_gate2_ops,
 		},
 	},

--- a/drivers/clk/qcom/gcc-sdm660.c
+++ b/drivers/clk/qcom/gcc-sdm660.c
@@ -1835,9 +1835,8 @@ static struct clk_branch gcc_hmss_rbcpr_clk = {
 	},
 };
 
-static struct clk_branch gcc_mmss_gpll0_clk = {
-	.halt_reg = 0x5200c,
-	.halt_check = BRANCH_HALT_DELAY,
+static struct clk_gate2 gcc_mmss_gpll0_clk = {
+	.udelay = 500,
 	.clkr = {
 		.enable_reg = 0x5200c,
 		.enable_mask = BIT(1),
@@ -1847,14 +1846,14 @@ static struct clk_branch gcc_mmss_gpll0_clk = {
 				"gpll0_out_main",
 			},
 			.num_parents = 1,
-			.ops = &clk_branch2_ops,
+			.flags = CLK_SET_RATE_PARENT,
+			.ops = &clk_gate2_ops,
 		},
 	},
 };
 
-static struct clk_branch gcc_mmss_gpll0_div_clk = {
-	.halt_reg = 0x5200c,
-	.halt_check = BRANCH_HALT_DELAY,
+static struct clk_gate2 gcc_mmss_gpll0_div_clk = {
+	.udelay = 500,
 	.clkr = {
 		.enable_reg = 0x5200c,
 		.enable_mask = BIT(0),
@@ -1864,7 +1863,8 @@ static struct clk_branch gcc_mmss_gpll0_div_clk = {
 				"gpll0_out_early_div",
 			},
 			.num_parents = 1,
-			.ops = &clk_branch2_ops,
+			.flags = CLK_SET_RATE_PARENT,
+			.ops = &clk_gate2_ops,
 		},
 	},
 };

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -37,7 +37,7 @@
 
 static DEFINE_VDD_REGULATORS(vdd_dig, VDD_DIG_NUM, 1, vdd_corner);
 static DEFINE_VDD_REGULATORS(vdd_mx, VDD_DIG_NUM, 1, vdd_corner);
-static DEFINE_VDD_REGS_INIT(vdd_gfx, 1);
+static DEFINE_VDD_REGULATORS(vdd_gfx, VDD_DIG_NUM, 1, vdd_corner);
 
 enum {
 	P_CORE_BI_PLL_TEST_SE,
@@ -45,25 +45,25 @@ enum {
 	P_GPLL0_OUT_MAIN_DIV,
 	P_GPU_PLL0_PLL_OUT_MAIN,
 	P_GPU_PLL1_PLL_OUT_MAIN,
-	P_XO,
+	P_GPU_XO,
 };
 
 static const struct parent_map gpucc_parent_map_0[] = {
-	{ P_XO, 0 },
+	{ P_GPU_XO, 0 },
 	{ P_GPLL0_OUT_MAIN, 5 },
 	{ P_GPLL0_OUT_MAIN_DIV, 6 },
 	{ P_CORE_BI_PLL_TEST_SE, 7 },
 };
 
 static const char * const gpucc_parent_names_0[] = {
-	"cxo_a",
+	"gpucc_cxo_clk",
 	"gcc_gpu_gpll0_clk",
 	"gcc_gpu_gpll0_div_clk",
 	"core_bi_pll_test_se",
 };
 
 static const struct parent_map gpucc_parent_map_1[] = {
-	{ P_XO, 0 },
+	{ P_GPU_XO, 0 },
 	{ P_GPU_PLL0_PLL_OUT_MAIN, 1 },
 	{ P_GPU_PLL1_PLL_OUT_MAIN, 3 },
 	{ P_GPLL0_OUT_MAIN, 5 },
@@ -71,7 +71,7 @@ static const struct parent_map gpucc_parent_map_1[] = {
 };
 
 static const char * const gpucc_parent_names_1[] = {
-	"xo",
+	"gpucc_cxo_clk",
 	"gpu_pll0_pll_out_main",
 	"gpu_pll1_pll_out_main",
 	"gcc_gpu_gpll0_clk",
@@ -111,7 +111,7 @@ static struct clk_alpha_pll gpu_pll0_pll_out_main = {
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "gpu_pll0_pll_out_main",
-			.parent_names = (const char *[]){ "xo" },
+			.parent_names = (const char *[]){ "gpucc_cxo_clk" },
 			.num_parents = 1,
 			.ops = &clk_alpha_pll_ops,
 			VDD_GPU_PLL_FMAX_MAP1(LOW_L1, 1500000000),
@@ -129,7 +129,7 @@ static struct clk_alpha_pll gpu_pll1_pll_out_main = {
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "gpu_pll1_pll_out_main",
-			.parent_names = (const char *[]){ "xo" },
+			.parent_names = (const char *[]){ "gpucc_cxo_clk" },
 			.num_parents = 1,
 			.ops = &clk_alpha_pll_ops,
 			VDD_GPU_PLL_FMAX_MAP1(LOW_L1, 1500000000),
@@ -143,7 +143,7 @@ static struct clk_init_data gpu_clks_init[] = {
 		.name = "gfx3d_clk_src",
 		.parent_names = gpucc_parent_names_1,
 		.num_parents = 3,
-		.ops = &clk_gfx3d_src_ops,
+		.ops = &clk_rcg2_ops,
 		.flags = CLK_SET_RATE_PARENT,
 	},
 	[1] = {
@@ -177,31 +177,30 @@ static struct clk_init_data gpu_clks_init[] = {
 */
 
 static const struct freq_tbl ftbl_gfx3d_clk_src[] = {
-	F_GFX( 19200000, 0,  1, 0, 0,         0),
-	F_GFX(160000000, 0,  2, 0, 0,  640000000),
-	F_GFX(266000000, 0,  2, 0, 0,  532000000),
-	F_GFX(370000000, 0,  2, 0, 0,  740000000),
-	F_GFX(430000000, 0,  2, 0, 0,  860000000),
-	F_GFX(465000000, 0,  2, 0, 0,  930000000),
-	F_GFX(588000000, 0,  2, 0, 0, 1176000000),
-	F_GFX(647000000, 0,  2, 0, 0, 1294000000),
-	F_GFX(700000000, 0,  2, 0, 0, 1400000000),
-	F_GFX(750000000, 0,  2, 0, 0, 1500000000),
+	F(160000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(266000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(370000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(430000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(465000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(588000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(647000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(700000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(750000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	{ }
 };
 
 static const struct freq_tbl ftbl_gfx3d_clk_src_630[] = {
-	F_GFX( 19200000, 0,  1, 0, 0,         0),
-	F_GFX(160000000, 0,  2, 0, 0,  640000000),
-	F_GFX(240000000, 0,  2, 0, 0,  480000000),
-	F_GFX(370000000, 0,  2, 0, 0,  740000000),
-	F_GFX(465000000, 0,  2, 0, 0,  930000000),
-	F_GFX(588000000, 0,  2, 0, 0, 1176000000),
-	F_GFX(647000000, 0,  2, 0, 0, 1294000000),
-	F_GFX(700000000, 0,  2, 0, 0, 1400000000),
-	F_GFX(775000000, 0,  2, 0, 0, 1550000000),
+	F(160000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(240000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(370000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(465000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(588000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(647000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(700000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(775000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	{ }
 };
+
 
 static struct clk_rcg2 gfx3d_clk_src = {
 	.cmd_rcgr = 0x1070,
@@ -213,8 +212,18 @@ static struct clk_rcg2 gfx3d_clk_src = {
 	.clkr.hw.init = &gpu_clks_init[0],
 };
 
+static struct clk_branch gpucc_gfx3d_clk = {
+	.halt_reg = 0x1098,
+	.halt_check = BRANCH_HALT,
+	.clkr = {
+		.enable_reg = 0x1098,
+		.enable_mask = BIT(0),
+		.hw.init = &gpu_clks_init[1],
+	},
+};
+
 static const struct freq_tbl ftbl_rbbmtimer_clk_src[] = {
-	F(19200000, P_XO, 1, 0, 0),
+	F(19200000, P_GPU_XO, 1, 0, 0),
 	{ }
 };
 
@@ -234,7 +243,7 @@ static struct clk_rcg2 rbbmtimer_clk_src = {
 };
 
 static const struct freq_tbl ftbl_rbcpr_clk_src[] = {
-	F(19200000, P_XO, 1, 0, 0),
+	F(19200000, P_GPU_XO, 1, 0, 0),
 	F(50000000, P_GPLL0_OUT_MAIN_DIV, 6, 0, 0),
 	{ }
 };
@@ -265,18 +274,9 @@ static struct clk_branch gpucc_cxo_clk = {
 				"cxo_a",
 			},
 			.num_parents = 1,
+			.flags = CLK_ENABLE_HAND_OFF,
 			.ops = &clk_branch2_ops,
 		},
-	},
-};
-
-static struct clk_branch gpucc_gfx3d_clk = {
-	.halt_reg = 0x1098,
-	.halt_check = BRANCH_HALT,
-	.clkr = {
-		.enable_reg = 0x1098,
-		.enable_mask = BIT(0),
-		.hw.init = &gpu_clks_init[1],
 	},
 };
 
@@ -323,7 +323,6 @@ static struct clk_regmap *gpucc_660_clocks[] = {
 	[GPUCC_GFX3D_CLK] = &gpucc_gfx3d_clk.clkr,
 	[GPUCC_RBBMTIMER_CLK] = &gpucc_rbbmtimer_clk.clkr,
 	[RBBMTIMER_CLK_SRC] = &rbbmtimer_clk_src.clkr,
-	[GPUCC_CXO_CLK] = &gpucc_cxo_clk.clkr,
 };
 
 static const struct regmap_config gpucc_660_regmap_config = {
@@ -480,8 +479,6 @@ static int gpucc_660_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	clk_prepare_enable(gpucc_cxo_clk.clkr.hw.clk);
-
 	dev_info(&pdev->dev, "Registered GPUCC clocks\n");
 
 	return ret;
@@ -509,6 +506,7 @@ module_exit(gpucc_660_exit);
 
 /* GPU RBCPR Clocks */
 static struct clk_regmap *gpucc_rbcpr_660_clocks[] = {
+	[GPUCC_CXO_CLK] = &gpucc_cxo_clk.clkr,
 	[RBCPR_CLK_SRC] = &rbcpr_clk_src.clkr,
 	[GPUCC_RBCPR_CLK] = &gpucc_rbcpr_clk.clkr,
 };
@@ -528,8 +526,16 @@ MODULE_DEVICE_TABLE(of, gpucc_rbcpr_660_match_table);
 static int gpu_660_probe(struct platform_device *pdev)
 {
 	int ret = 0;
-
+	struct clk *tmp;
 	struct regmap *regmap;
+
+	tmp = devm_clk_get(&pdev->dev, "gpll0");
+	if (IS_ERR(tmp)) {
+		if (PTR_ERR(tmp) != -EPROBE_DEFER)
+			dev_err(&pdev->dev,
+				"The GPLL0 clock cannot be found.\n");
+		return PTR_ERR(tmp);
+	}
 
 	regmap = qcom_cc_map(pdev, &gpu_660_desc);
 	if (IS_ERR(regmap))
@@ -541,6 +547,14 @@ static int gpu_660_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	/* Set the rate for GPU XO to make the clk API happy */
+	clk_set_rate(gpucc_cxo_clk.clkr.hw.clk, 19200000);
+
+	/*
+	 * gpucc_xo works as the root clock for all GPUCC RCGs and GDSCs.
+	 *  Keep it enabled always.
+	 */
+	clk_prepare_enable(gpucc_cxo_clk.clkr.hw.clk);
 
 	dev_info(&pdev->dev, "Registered GPU RBCPR clocks\n");
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -584,7 +584,7 @@ int somc_panel_pcc_setup(struct dsi_display *display)
 
 	if (color_mgr->u_data == 0 && color_mgr->v_data == 0) {
 		pr_err("%s (%d): u,v is flashed 0.\n", __func__, __LINE__);
-		goto exit;
+		return -EINVAL;
 	}
 	pr_notice("%s (%d) udata = %x vdata = %x \n", __func__, __LINE__,
 		color_mgr->u_data, color_mgr->v_data);
@@ -1134,16 +1134,22 @@ int somc_panel_colormgr_apply_calibrations(void)
 	if (!display)
 		return -EINVAL;
 
+	if (!display->panel)
+		return -EINVAL;
+
+	if (!display->panel->spec_pdata->color_mgr)
+		return -EINVAL;
+
 	color_mgr = display->panel->spec_pdata->color_mgr;
 
 	rc = somc_panel_pcc_setup(display);
 	if (rc) {
 		pr_err("%s: Couldn't apply PCC calibration\n", __func__);
-	}
-
-	rc = somc_panel_send_pcc(display, color_mgr->pcc_profile);
-	if (rc) {
-		pr_err("%s: Cannot send PCC calibration\n", __func__);
+	} else {
+		rc = somc_panel_send_pcc(display, color_mgr->pcc_profile);
+		if (rc) {
+			pr_err("%s: Cannot send PCC calibration\n", __func__);
+		}
 	}
 
 	rc += somc_panel_send_pa(display);

--- a/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
@@ -3248,11 +3248,11 @@ static int _sde_hardware_pre_caps(struct sde_mdss_cfg *sde_cfg, uint32_t hw_rev)
 
 	rc = sde_hardware_format_caps(sde_cfg, hw_rev);
 
-	if (IS_MSM8996_TARGET(hw_rev) || IS_SDM630_TARGET(hw_rev)) {
+	if (IS_MSM8996_TARGET(hw_rev)) {
 		/* update msm8996/sdm630 target here */
 		sde_cfg->has_wb_ubwc = true;
 		sde_cfg->perf.min_prefill_lines = 21;
-	} else if (IS_MSM8998_TARGET(hw_rev)) {
+	} else if (IS_MSM8998_TARGET(hw_rev) || IS_SDM630_TARGET(hw_rev)) {
 		/* update msm8998 target here */
 		sde_cfg->has_wb_ubwc = true;
 		sde_cfg->perf.min_prefill_lines = 25;

--- a/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.h
+++ b/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.h
@@ -373,8 +373,12 @@ struct synaptics_rmi4_data {
 	struct mutex rmi4_irq_enable_mutex;
 	struct delayed_work rb_work;
 	struct workqueue_struct *rb_workqueue;
-#ifdef CONFIG_FB
+#if defined(CONFIG_FB) && !defined(CONFIG_DRM_MSM_DSI_SOMC_PANEL)
 	struct notifier_block fb_notifier;
+#elif defined(CONFIG_DRM) && defined(CONFIG_DRM_MSM_DSI_SOMC_PANEL)
+	struct notifier_block drm_notifier;
+#endif
+#ifdef CONFIG_FB
 	struct work_struct reset_work;
 	struct workqueue_struct *reset_workqueue;
 #endif


### PR DESCRIPTION
This platform had a GPU bug that was producing hardware resets,
moreover, the clock driver(s) had some bad bugs that were either
preventing some branches to get back up or totally screwing the
rates calculation for some RCGs.
Fixed that.

Last, the SDE configuration for the SDM630 SoC and for this
platform was also in some cases invalid and in some other cases
very underoptimized: partially refactor the SDE configuration for
SDM630 and fix some bits in the panel configuration for Nile.

Also, while at it, bring Nile panels in 120Hz land.

Tested on SoMC Nile Discovery DSDS, k4.9, Android 9.0.0, SDE HAL.