### PR TITLE
[2.3.2.r1.4] [URGENT] clk: qcom: gcc-sdm660: Assign xo_board parent to xo to workaround bug

### DIFF
--- a/drivers/clk/qcom/gcc-sdm660.c
+++ b/drivers/clk/qcom/gcc-sdm660.c
@@ -190,7 +190,7 @@ static struct clk_fixed_factor xo = {
 	.div = 1,
 	.hw.init = &(struct clk_init_data){
 		.name = "xo",
-		.parent_names = (const char *[]){ "cxo" },
+		.parent_names = (const char *[]){ "xo_board" },
 		.num_parents = 1,
 		.ops = &clk_fixed_factor_ops,
 	},


### PR DESCRIPTION
The "Yoshino bug" is all over again: cxo gets shut down for some
reason even if the refcount is more than 1 when we use it as
the XO parent.

Accounting for the fact that CXO is not that much of a battery
eater, keep it always on until the bug is fixed properly for both
MSM8998 and SDM630/660.