### PR TITLE
[2.3.2.r1] SDE: Enable tearcheck (TE+TE2) on SDM630, MSM8998

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
@@ -41,8 +41,8 @@
 			"mmss_smmu_axi_clk",
 			"vsync_clk";
 
-		clock-rate = <0 0 0 412500000 412500000 0 0 0 0 0>;
-		clock-max-rate = <0 0 0 550000000 550000000 0 0 0 0 0>;
+		clock-rate = <0 0 0 412500000 412500000 0 0 0 0 19200000>;
+		clock-max-rate = <0 0 0 550000000 550000000 0 0 0 0 19200000>;
 
 		/* interrupt config */
 		interrupt-parent = <&intc>;
@@ -99,6 +99,8 @@
 		qcom,sde-dither-version = <0x00010000>;
 
 		qcom,sde-te2-off = <0x2000 0x2000 0x0 0x0 0x0>;
+
+		qcom,sde-te-source = <15 15 15 15 15>;
 
 		qcom,sde-cdm-off = <0x7a200>;
 		qcom,sde-cdm-size = <0x224>;

--- a/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-sde.dtsi
@@ -31,8 +31,8 @@
 			"mmss_smmu_ahb_clk",
 			"mmss_smmu_axi_clk",
 			"vsync_clk";
-		clock-rate = <0 0 0 412500000 412500000 0 0 0 0 0>;
-		clock-max-rate = <0 0 0  412500000 412500000 0 0 0 0 0>;
+		clock-rate = <0 0 0 412500000 412500000 0 0 0 0 19200000>;
+		clock-max-rate = <0 0 0  412500000 412500000 0 0 0 0 19200000>;
 
 		/* interrupt config */
 		interrupt-parent = <&intc>;
@@ -85,7 +85,14 @@
 		qcom,sde-pp-slave = <0x0 0x0 0x1>;
 		qcom,sde-pp-size = <0xd4>;
 
+		qcom,sde-te-off = <0x0 0x0 0x0>;
 		qcom,sde-te2-off = <0x2000 0x2000 0x0>;
+
+		qcom,sde-te-source = <15 15 15>;
+
+		qcom,sde-dither-off = <0x30e0 0x30e0 0x0>;
+		qcom,sde-dither-size = <0x20>;
+		qcom,sde-dither-version = <0x00010000>;
 
 		qcom,sde-cdm-off = <0x7a200>;
 		qcom,sde-cdm-size = <0x224>;

--- a/drivers/gpu/drm/msm/sde/sde_hw_top.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_top.c
@@ -16,6 +16,11 @@
 #include "sde_dbg.h"
 #include "sde_kms.h"
 
+#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996) || \
+    defined(CONFIG_ARCH_MSM8998) || defined(CONFIG_ARCH_SDM660)
+ #define RUN_ON_LEGACY_PLATFORM
+#endif
+
 #define SSPP_SPARE                        0x28
 #define UBWC_STATIC                       0x144
 
@@ -51,12 +56,16 @@
 #define MDP_WD_TIMER_4_CTL2               0x444
 #define MDP_WD_TIMER_4_LOAD_VALUE         0x448
 
+#define MDP_TICK_COUNT_LEGACY             64
 #define MDP_TICK_COUNT                    16
 #define XO_CLK_RATE                       19200
 #define MS_TICKS_IN_SEC                   1000
 
 #define CALCULATE_WD_LOAD_VALUE(fps) \
 	((uint32_t)((MS_TICKS_IN_SEC * XO_CLK_RATE)/(MDP_TICK_COUNT * fps)))
+
+#define CALCULATE_WD_LOAD_VALUE_LEGACY(fps) \
+	((uint32_t)((MS_TICKS_IN_SEC * XO_CLK_RATE)/(MDP_TICK_COUNT_LEGACY * fps)))
 
 #define DCE_SEL                           0x450
 
@@ -288,8 +297,19 @@ static void sde_hw_setup_vsync_source(struct sde_hw_mdp *mdp,
 		if (cfg->is_dummy) {
 			SDE_REG_WRITE(c, wd_ctl2, 0x0);
 		} else {
-			SDE_REG_WRITE(c, wd_load_value,
-				CALCULATE_WD_LOAD_VALUE(cfg->frame_rate));
+			if (of_machine_is_compatible("qcom,msm8956") ||
+			    of_machine_is_compatible("qcom,apq8056") ||
+			    of_machine_is_compatible("qcom,msm8996") ||
+			    of_machine_is_compatible("qcom,msm8998") ||
+			    of_machine_is_compatible("qcom,sdm630")  ||
+			    of_machine_is_compatible("qcom,sdm660"))
+				SDE_REG_WRITE(c, wd_load_value,
+						CALCULATE_WD_LOAD_VALUE_LEGACY(
+						cfg->frame_rate));
+			else
+				SDE_REG_WRITE(c, wd_load_value,
+						CALCULATE_WD_LOAD_VALUE(
+						cfg->frame_rate));
 
 			SDE_REG_WRITE(c, wd_ctl, BIT(0)); /* clear timer */
 			reg = SDE_REG_READ(c, wd_ctl2);


### PR DESCRIPTION
This enables tearcheck on CMD panels on SDE MSM8998 and SDM630 targets (SoMC Nile, Yoshino).

This code has been tested on:
- Nile Discovery DSDS
- Yoshino Lilac RoW

Please DON'T MERGE until tests are done on:
- Nile Pioneer
- Yoshino Maple (HIGH PRIORITY -- it's the only TE2 device)