### PR TITLE
[1/2] input: misc: fpc1145: Add poll interface for IO multiplexing in fp HAL

### DIFF
--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -67,6 +67,7 @@
 #define FPC_IOCWPREPARE	_IOW(FPC_IOC_MAGIC, 0x01, int)
 #define FPC_IOCWDEVWAKE	_IOW(FPC_IOC_MAGIC, 0x02, int)
 #define FPC_IOCWRESET	_IOW(FPC_IOC_MAGIC, 0x03, int)
+#define FPC_IOCWAWAKE	_IOW(FPC_IOC_MAGIC, 0x04, int)
 #define FPC_IOCRPREPARE	_IOR(FPC_IOC_MAGIC, 0x81, int)
 #define FPC_IOCRDEVWAKE	_IOR(FPC_IOC_MAGIC, 0x82, int)
 #define FPC_IOCRIRQ	_IOR(FPC_IOC_MAGIC, 0x83, int)
@@ -125,6 +126,11 @@ struct fpc1145_data {
 
 	struct mutex lock;
 	bool prepared;
+};
+
+struct fpc1145_awake_args {
+	int awake;
+	unsigned int timeout;
 };
 
 static struct fpc1145_data *fpc1145_drvdata = NULL;
@@ -319,6 +325,8 @@ static long fpc1145_device_ioctl(struct file *fp,
 {
 	int8_t val = 0;
 	int rc = -EINVAL;
+	unsigned int timeout = 0;
+	struct fpc1145_awake_args awake_args;
 	void __user *usr = (void __user*)arg;
 
 	switch (cmd) {
@@ -334,6 +342,24 @@ static long fpc1145_device_ioctl(struct file *fp,
 	case FPC_IOCWRESET:
 		dev_dbg(fpc1145_drvdata->dev, "Resetting device\n");
 		rc = hw_reset(fpc1145_drvdata);
+		break;
+	case FPC_IOCWAWAKE:
+		rc = copy_from_user(&awake_args,
+				(struct fpc1145_awake_args *)usr,
+				sizeof(awake_args));
+		if (rc)
+			break;
+		timeout = min(awake_args.timeout,
+				(unsigned int)FPC_MAX_HAL_PROCESSING_TIME);
+		if (awake_args.awake) {
+			dev_dbg(fpc1145_drvdata->dev,
+					"Extending wakelock for %dms\n",
+					timeout);
+			pm_wakeup_event(fpc1145_drvdata->dev, timeout);
+		} else {
+			dev_dbg(fpc1145_drvdata->dev, "Relaxing wakelock\n");
+			pm_relax(fpc1145_drvdata->dev);
+		}
 		break;
 	case FPC_IOCRPREPARE:
 		rc = put_user((int8_t)fpc1145_drvdata->prepared,

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -419,11 +419,7 @@ static int fpc1145_device_suspend(struct device *dev)
 {
 	struct fpc1145_data *fpc1145 = dev_get_drvdata(dev);
 
-	dev_dbg(dev, "Suspending device; irq_fired is %d\n", fpc1145->irq_fired);
-
-	/* HAL will already resume once the IRQ IOCTL is called */
-	if (fpc1145->irq_fired)
-		return 0;
+	dev_dbg(dev, "Suspending device\n");
 
 	/* Wakeup when finger detected */
 	enable_irq_wake(fpc1145->irq);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -415,7 +415,15 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 		return POLLIN | POLLRDNORM;
 	}
 
-	/* Nothing happened yet; make the poll wait for irq_evt. */
+	/*
+	 * Nothing happened yet; make the poll wait for irq_evt.
+	 * The wakelock can be relaxed preemptively, as no processing has to
+	 * be done until the next wake-enabled IRQ fires.
+	 */
+
+	if (fpc1145_drvdata->wakelock.active)
+		__pm_relax(&fpc1145_drvdata->wakelock);
+
 	return 0;
 }
 


### PR DESCRIPTION
This poll interface allows the HAL to multiplex on the fingerprint device and other event sources simultaneously, instead of calling the ioctl that wakes up every .5 seconds to check other events (such as cancellation). See commit descriptions for further details.

Tested on Suzu, android 9.0 and k4.9.
Partially tested on Tama, also android 9.0 and k4.9.
Build-tested in an Android 8.1 tree with k4.9 and k4.4 (the latter which requires commit 9b25a132cc021 except the addition of `#include <linux/pm_wakeup.h>`: https://github.com/sonyxperiadev/kernel/pull/1847).

This needs futher testing on all other platforms before merging!
- [x] Loire
- [x] Tone
- [x] Yoshino
- [x] Nile
- [ ] Tama