### PR TITLE
[1/2] [4.4] input: misc: fpc1145: Add poll interface for IO multiplexing in fp HAL

### DIFF
--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -66,6 +66,7 @@
 #define FPC_IOCWPREPARE	_IOW(FPC_IOC_MAGIC, 0x01, int)
 #define FPC_IOCWDEVWAKE	_IOW(FPC_IOC_MAGIC, 0x02, int)
 #define FPC_IOCWRESET	_IOW(FPC_IOC_MAGIC, 0x03, int)
+#define FPC_IOCWAWAKE	_IOW(FPC_IOC_MAGIC, 0x04, int)
 #define FPC_IOCRPREPARE	_IOR(FPC_IOC_MAGIC, 0x81, int)
 #define FPC_IOCRDEVWAKE	_IOR(FPC_IOC_MAGIC, 0x82, int)
 #define FPC_IOCRIRQ	_IOR(FPC_IOC_MAGIC, 0x83, int)
@@ -124,6 +125,11 @@ struct fpc1145_data {
 
 	struct mutex lock;
 	bool prepared;
+};
+
+struct fpc1145_awake_args {
+	int awake;
+	unsigned int timeout;
 };
 
 static struct fpc1145_data *fpc1145_drvdata = NULL;
@@ -318,6 +324,8 @@ static long fpc1145_device_ioctl(struct file *fp,
 {
 	int8_t val = 0;
 	int rc = -EINVAL;
+	unsigned int timeout = 0;
+	struct fpc1145_awake_args awake_args;
 	void __user *usr = (void __user*)arg;
 
 	switch (cmd) {
@@ -333,6 +341,24 @@ static long fpc1145_device_ioctl(struct file *fp,
 	case FPC_IOCWRESET:
 		dev_dbg(fpc1145_drvdata->dev, "Resetting device\n");
 		rc = hw_reset(fpc1145_drvdata);
+		break;
+	case FPC_IOCWAWAKE:
+		rc = copy_from_user(&awake_args,
+				(struct fpc1145_awake_args *)usr,
+				sizeof(awake_args));
+		if (rc)
+			break;
+		timeout = min(awake_args.timeout,
+				(unsigned int)FPC_MAX_HAL_PROCESSING_TIME);
+		if (awake_args.awake) {
+			dev_dbg(fpc1145_drvdata->dev,
+					"Extending wakelock for %dms\n",
+					timeout);
+			pm_wakeup_event(fpc1145_drvdata->dev, timeout);
+		} else {
+			dev_dbg(fpc1145_drvdata->dev, "Relaxing wakelock\n");
+			pm_relax(fpc1145_drvdata->dev);
+		}
 		break;
 	case FPC_IOCRPREPARE:
 		rc = put_user((int8_t)fpc1145_drvdata->prepared,

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -47,7 +47,6 @@
 #include <linux/of.h>
 #include <linux/of_gpio.h>
 #include <linux/uaccess.h>
-#include <linux/wakelock.h>
 #include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
 
@@ -121,7 +120,7 @@ struct fpc1145_data {
 	bool irq_fired;
 	wait_queue_head_t irq_evt;
 
-	struct wake_lock wakelock;
+	struct wakeup_source wakelock;
 	struct mutex lock;
 	bool prepared;
 };
@@ -303,15 +302,14 @@ exit:
 
 static int fpc1145_device_open(struct inode *inode, struct file *fp)
 {
-	wake_lock_timeout(&fpc1145_drvdata->wakelock,
-				usecs_to_jiffies(250));
+	__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1);
 	return 0;
 }
 
 static int fpc1145_device_release(struct inode *inode, struct file *fp)
 {
-	if (wake_lock_active(&fpc1145_drvdata->wakelock))
-		wake_unlock(&fpc1145_drvdata->wakelock);
+	if (fpc1145_drvdata->wakelock.active)
+		__pm_relax(&fpc1145_drvdata->wakelock);
 	return 0;
 }
 
@@ -368,8 +366,7 @@ static long fpc1145_device_ioctl(struct file *fp,
 
 		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 		if (val)
-			wake_lock_timeout(&fpc1145_drvdata->wakelock,
-					msecs_to_jiffies(400));
+			__pm_wakeup_event(&fpc1145_drvdata->wakelock, 400);
 
 		rc = put_user(val, (int*) usr);
 		break;
@@ -432,7 +429,7 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 
 	fpc1145->irq_fired = true;
 
-	wake_lock_timeout(&fpc1145->wakelock, msecs_to_jiffies(20));
+	__pm_wakeup_event(&fpc1145->wakelock, 20);
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 
@@ -565,7 +562,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 	irqf = IRQF_TRIGGER_HIGH | IRQF_ONESHOT;
 	mutex_init(&fpc1145->lock);
 
-	wake_lock_init(&fpc1145->wakelock, WAKE_LOCK_SUSPEND, "fpc_wake");
+	wakeup_source_init(&fpc1145->wakelock, "fpc_wake");
 	init_waitqueue_head(&fpc1145->irq_evt);
 	fpc1145->irq_fired = false;
 
@@ -599,7 +596,7 @@ static int fpc1145_remove(struct platform_device *pdev)
 {
 	struct fpc1145_data *fpc1145 = platform_get_drvdata(pdev);
 
-	wake_lock_destroy(&fpc1145->wakelock);
+	wakeup_source_trash(&fpc1145->wakelock);
 	mutex_destroy(&fpc1145->lock);
 #ifdef CONFIG_ARCH_SONY_LOIRE
 	(void)vreg_setup(fpc1145, VCC_SPI, false);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -383,37 +383,42 @@ static long fpc1145_device_ioctl(struct file *fp,
 static unsigned int fpc1145_poll_interrupt(struct file *file,
 		struct poll_table_struct *wait)
 {
-	int mask = 0;
 	int val = 0;
 	struct device *dev = fpc1145_drvdata->dev;
 
 	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 	if (val) {
+		/* Early out */
 		dev_dbg(dev, "gpio already triggered\n");
+		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1000);
 		return POLLIN | POLLRDNORM;
 	}
 
+	/* Add current file to the waiting list  */
+	poll_wait(file, &fpc1145_drvdata->irq_evt, wait);
+
+	/* Enable the irq */
 	if (fpc1145_drvdata->irq_fired) {
 		fpc1145_drvdata->irq_fired = false;
 		enable_irq(fpc1145_drvdata->irq);
 	}
 
-	poll_wait(file, &fpc1145_drvdata->irq_evt, wait);
 	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
-	dev_dbg(dev, "gpio val %d, irq fired: %d\n", val, fpc1145_drvdata->irq_fired);
 	if (val) {
-		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 400);
-		mask |= POLLIN | POLLRDNORM;
+		dev_dbg(dev, "gpio triggered after poll_wait\n");
+		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1000);
+		return POLLIN | POLLRDNORM;
 	}
 
-	return mask;
+	/* Nothing happened yet; make the poll wait for irq_evt. */
+	return 0;
 }
 
 static int fpc1145_device_suspend(struct device *dev)
 {
 	struct fpc1145_data *fpc1145 = dev_get_drvdata(dev);
 
-	dev_dbg(dev, "Suspending device\n");
+	dev_dbg(dev, "Suspending device; irq_fired is %d\n", fpc1145->irq_fired);
 
 	/* HAL will already resume once the IRQ IOCTL is called */
 	if (fpc1145->irq_fired)
@@ -456,11 +461,13 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 {
 	struct fpc1145_data *fpc1145 = handle;
 
-	dev_dbg(fpc1145->dev, "%s\n", __func__);
+	int val = gpio_get_value(fpc1145->irq_gpio);
+
+	dev_dbg(fpc1145->dev, "%s: gpio=%d\n", __func__, val);
 
 	fpc1145->irq_fired = true;
 
-	__pm_wakeup_event(&fpc1145->wakelock, 20);
+	__pm_wakeup_event(&fpc1145->wakelock, 1000);
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -60,6 +60,7 @@
 #define NUM_PARAMS_REG_ENABLE_SET 2
 
 #define FPC_IRQPOLL_TIMEOUT_MS 500
+#define FPC_MAX_HAL_PROCESSING_TIME 400
 
 #define FPC_IOC_MAGIC	0x1145
 #define FPC_IOCWPREPARE	_IOW(FPC_IOC_MAGIC, 0x01, int)
@@ -367,7 +368,8 @@ static long fpc1145_device_ioctl(struct file *fp,
 
 		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 		if (val)
-			__pm_wakeup_event(&fpc1145_drvdata->wakelock, 400);
+			__pm_wakeup_event(&fpc1145_drvdata->wakelock,
+					FPC_MAX_HAL_PROCESSING_TIME);
 
 		rc = put_user(val, (int*) usr);
 		break;
@@ -390,7 +392,8 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 	if (val) {
 		/* Early out */
 		dev_dbg(dev, "gpio already triggered\n");
-		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1000);
+		__pm_wakeup_event(&fpc1145_drvdata->wakelock,
+				FPC_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
 
@@ -406,7 +409,8 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 	if (val) {
 		dev_dbg(dev, "gpio triggered after poll_wait\n");
-		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1000);
+		__pm_wakeup_event(&fpc1145_drvdata->wakelock,
+				FPC_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
 
@@ -463,7 +467,7 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 
 	fpc1145->irq_fired = true;
 
-	__pm_wakeup_event(&fpc1145->wakelock, 1000);
+	__pm_wakeup_event(&fpc1145->wakelock, FPC_MAX_HAL_PROCESSING_TIME);
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -414,7 +414,15 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 		return POLLIN | POLLRDNORM;
 	}
 
-	/* Nothing happened yet; make the poll wait for irq_evt. */
+	/*
+	 * Nothing happened yet; make the poll wait for irq_evt.
+	 * The wakelock can be relaxed preemptively, as no processing has to
+	 * be done until the next wake-enabled IRQ fires.
+	 */
+
+	if (fpc1145_drvdata->wakelock.active)
+		__pm_relax(&fpc1145_drvdata->wakelock);
+
 	return 0;
 }
 

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -49,6 +49,7 @@
 #include <linux/uaccess.h>
 #include <linux/regulator/consumer.h>
 #include <linux/platform_device.h>
+#include <linux/poll.h>
 
 #define FPC1145_RESET_LOW_US 1000
 #define FPC1145_RESET_HIGH1_US 100
@@ -379,6 +380,35 @@ static long fpc1145_device_ioctl(struct file *fp,
 	return rc;
 }
 
+static unsigned int fpc1145_poll_interrupt(struct file *file,
+		struct poll_table_struct *wait)
+{
+	int mask = 0;
+	int val = 0;
+	struct device *dev = fpc1145_drvdata->dev;
+
+	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
+	if (val) {
+		dev_dbg(dev, "gpio already triggered\n");
+		return POLLIN | POLLRDNORM;
+	}
+
+	if (fpc1145_drvdata->irq_fired) {
+		fpc1145_drvdata->irq_fired = false;
+		enable_irq(fpc1145_drvdata->irq);
+	}
+
+	poll_wait(file, &fpc1145_drvdata->irq_evt, wait);
+	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
+	dev_dbg(dev, "gpio val %d, irq fired: %d\n", val, fpc1145_drvdata->irq_fired);
+	if (val) {
+		__pm_wakeup_event(&fpc1145_drvdata->wakelock, 400);
+		mask |= POLLIN | POLLRDNORM;
+	}
+
+	return mask;
+}
+
 static int fpc1145_device_suspend(struct device *dev)
 {
 	struct fpc1145_data *fpc1145 = dev_get_drvdata(dev);
@@ -413,6 +443,7 @@ static const struct file_operations fpc1145_device_fops = {
 	.release = fpc1145_device_release,
 	.unlocked_ioctl = fpc1145_device_ioctl,
 	.compat_ioctl = fpc1145_device_ioctl,
+	.poll = fpc1145_poll_interrupt,
 };
 
 static struct miscdevice fpc1145_misc = {

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -122,7 +122,6 @@ struct fpc1145_data {
 	bool irq_fired;
 	wait_queue_head_t irq_evt;
 
-	struct wakeup_source wakelock;
 	struct mutex lock;
 	bool prepared;
 };
@@ -304,14 +303,13 @@ exit:
 
 static int fpc1145_device_open(struct inode *inode, struct file *fp)
 {
-	__pm_wakeup_event(&fpc1145_drvdata->wakelock, 1);
+	pm_wakeup_event(fpc1145_drvdata->dev, 1);
 	return 0;
 }
 
 static int fpc1145_device_release(struct inode *inode, struct file *fp)
 {
-	if (fpc1145_drvdata->wakelock.active)
-		__pm_relax(&fpc1145_drvdata->wakelock);
+	pm_relax(fpc1145_drvdata->dev);
 	return 0;
 }
 
@@ -368,7 +366,7 @@ static long fpc1145_device_ioctl(struct file *fp,
 
 		val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 		if (val)
-			__pm_wakeup_event(&fpc1145_drvdata->wakelock,
+			pm_wakeup_event(fpc1145_drvdata->dev,
 					FPC_MAX_HAL_PROCESSING_TIME);
 
 		rc = put_user(val, (int*) usr);
@@ -392,8 +390,7 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 	if (val) {
 		/* Early out */
 		dev_dbg(dev, "gpio already triggered\n");
-		__pm_wakeup_event(&fpc1145_drvdata->wakelock,
-				FPC_MAX_HAL_PROCESSING_TIME);
+		pm_wakeup_event(dev, FPC_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
 
@@ -409,8 +406,7 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 	val = gpio_get_value(fpc1145_drvdata->irq_gpio);
 	if (val) {
 		dev_dbg(dev, "gpio triggered after poll_wait\n");
-		__pm_wakeup_event(&fpc1145_drvdata->wakelock,
-				FPC_MAX_HAL_PROCESSING_TIME);
+		pm_wakeup_event(dev, FPC_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
 
@@ -420,8 +416,7 @@ static unsigned int fpc1145_poll_interrupt(struct file *file,
 	 * be done until the next wake-enabled IRQ fires.
 	 */
 
-	if (fpc1145_drvdata->wakelock.active)
-		__pm_relax(&fpc1145_drvdata->wakelock);
+	pm_relax(dev);
 
 	return 0;
 }
@@ -475,7 +470,7 @@ static irqreturn_t fpc1145_irq_handler(int irq, void *handle)
 
 	fpc1145->irq_fired = true;
 
-	__pm_wakeup_event(&fpc1145->wakelock, FPC_MAX_HAL_PROCESSING_TIME);
+	pm_wakeup_event(fpc1145->dev, FPC_MAX_HAL_PROCESSING_TIME);
 	wake_up_interruptible(&fpc1145->irq_evt);
 	disable_irq_nosync(fpc1145->irq);
 
@@ -608,7 +603,7 @@ static int fpc1145_probe(struct platform_device *pdev)
 	irqf = IRQF_TRIGGER_HIGH | IRQF_ONESHOT;
 	mutex_init(&fpc1145->lock);
 
-	wakeup_source_init(&fpc1145->wakelock, "fpc_wake");
+	device_init_wakeup(dev, true);
 	init_waitqueue_head(&fpc1145->irq_evt);
 	fpc1145->irq_fired = false;
 
@@ -642,7 +637,7 @@ static int fpc1145_remove(struct platform_device *pdev)
 {
 	struct fpc1145_data *fpc1145 = platform_get_drvdata(pdev);
 
-	wakeup_source_trash(&fpc1145->wakelock);
+	device_init_wakeup(fpc1145->dev, false);
 	mutex_destroy(&fpc1145->lock);
 #ifdef CONFIG_ARCH_SONY_LOIRE
 	(void)vreg_setup(fpc1145, VCC_SPI, false);

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -418,11 +418,7 @@ static int fpc1145_device_suspend(struct device *dev)
 {
 	struct fpc1145_data *fpc1145 = dev_get_drvdata(dev);
 
-	dev_dbg(dev, "Suspending device; irq_fired is %d\n", fpc1145->irq_fired);
-
-	/* HAL will already resume once the IRQ IOCTL is called */
-	if (fpc1145->irq_fired)
-		return 0;
+	dev_dbg(dev, "Suspending device\n");
 
 	/* Wakeup when finger detected */
 	enable_irq_wake(fpc1145->irq);


### PR DESCRIPTION
Kernel 4.4 compatibility version of #1846.

This poll interface allows the HAL to multiplex on the fingerprint device and other event sources simultaneously, instead of calling the ioctl that wakes up every .5 seconds to check other events (such as cancellation). See commit descriptions for further details.

This needs futher testing on all other platforms before merging!
- [ ] Loire
- [ ] Tone
- [ ] Yoshino
- [ ] Nile
- [ ] Tama