### PR TITLE
arm64: DT: Loire: update configuration of interrupt controllers

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-pinctrl.dtsi
@@ -15,12 +15,11 @@
 	msm_gpio: pinctrl@1000000 {
 		compatible = "qcom,msm8976-pinctrl";
 		reg = <0x1000000 0x300000>;
-		interrupts = <0 208 0>;
 		interrupts-extended = <&wakegic GIC_SPI 208 IRQ_TYPE_NONE>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		interrupt-controller;
-		//interrupt-parent = <&wakegpio>;
+		interrupt-parent = <&wakegpio>;
 		#interrupt-cells = <2>;
 
 		cdc_reset_ctrl {

--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -27,7 +27,7 @@
 	compatible = "qcom,msm8956";
 	qcom,msm-id = <266 0x0>;
 	qcom,msm-name = "MSM8956";
-	interrupt-parent = <&intc>;
+	interrupt-parent = <&wakegic>;
 
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
@@ -485,11 +485,8 @@
 		reg = <0x601d0 0x1000>, /* MSM_RPM_MPM_BASE 4K */
 		    <0xb011008 0x4>;
 		reg-names = "vmpm", "ipc";
-		interrupts = <0 171 1>;
-		clocks = <&clock_rpmcc CXO_LPM_CLK>;
-		clock-names = "xo";
+		interrupts = <GIC_SPI 171 IRQ_TYPE_EDGE_RISING>;
 		qcom,num-mpm-irqs = <96>;
-		qcom,ipc-bit-offset = <1>;
 		interrupt-controller;
 		interrupt-parent = <&intc>;
 		#interrupt-cells = <3>;
@@ -498,7 +495,7 @@
 	wakegpio: wake-gpio {
 		compatible = "qcom,mpm-gpio-msm8956", "qcom,mpm-gpio";
 		interrupt-controller;
-		interrupt-parent = <&msm_gpio>;
+		interrupt-parent = <&intc>;
 		#interrupt-cells = <2>;
 	};
 

--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -486,7 +486,7 @@
 		    <0xb011008 0x4>;
 		reg-names = "vmpm", "ipc";
 		interrupts = <GIC_SPI 171 IRQ_TYPE_EDGE_RISING>;
-		qcom,num-mpm-irqs = <96>;
+		qcom,num-mpm-irqs = <64>;
 		interrupt-controller;
 		interrupt-parent = <&intc>;
 		#interrupt-cells = <3>;


### PR DESCRIPTION
This brings loire in-line with the other platforms concerning the migration to MPM wakegic and wakegpio
Implementations used as reference:
https://github.com/sonyxperiadev/kernel/commit/313802ff7034f43ce8cf1658ea27cbfa38054dc5
https://github.com/sonyxperiadev/kernel/commit/101d7af1bc58fb1c02536841e02a5460342c1f0b

Change-Id: Ie34651a26a94d7d396e78305d85fa53fe9615186