### PR TITLE
power: reset: msm-poweroff: set a restart reason when probing

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -776,6 +776,9 @@ skip_sysfs_create:
 #ifdef TARGET_SOMC_XBOOT
 	__raw_writel(0xC0DEDEAD, restart_reason);
 	qpnp_pon_set_restart_reason(PON_RESTART_REASON_KERNEL_PANIC);
+#elif defined(TARGET_SOMC_S1BOOT)
+	__raw_writel(0x77665501, restart_reason);
+	qpnp_pon_set_restart_reason(PON_RESTART_REASON_UNKNOWN);
 #endif
 
 	return 0;


### PR DESCRIPTION
If a device using an S1 bootloader crashes due to a hardware failure, then the restart reason does not get set by the kernel.
For some devices, the default in this case is to throw a verification failure, which is not quite accurate as the hardware failure is not related to verity and other verification methods. After the message is shown, the device is shut down.
To achieve some robustness, set a restart reason at probe time that ensures the bootloader will not show a misleading error message and will instead reboot the device.

Change-Id: Id7507bb29fee1ff23584801d95f3e07402a5fe29