### PR TITLE
[2.3.2.r1.4] Fix memleak with IPC_LOGGING disabled

### DIFF
--- a/net/ipc_router/ipc_router_core.c
+++ b/net/ipc_router/ipc_router_core.c
@@ -3947,13 +3947,13 @@ static void debugfs_init(void) {}
  */
 static void *ipc_router_create_log_ctx(char *name)
 {
+#ifdef CONFIG_IPC_LOGGING
 	struct ipc_rtr_log_ctx *sub_log_ctx;
 
 	sub_log_ctx = kmalloc(sizeof(*sub_log_ctx), GFP_KERNEL);
 	if (!sub_log_ctx)
 		return NULL;
 
-#ifdef CONFIG_IPC_LOGGING
 	sub_log_ctx->log_ctx = ipc_log_context_create(
 				IPC_RTR_INFO_PAGES, name, 0);
 	if (!sub_log_ctx->log_ctx) {
@@ -3962,14 +3962,14 @@ static void *ipc_router_create_log_ctx(char *name)
 		kfree(sub_log_ctx);
 		return NULL;
 	}
-#else
-		return NULL;
-#endif
 
 	strlcpy(sub_log_ctx->log_ctx_name, name, LOG_CTX_NAME_LEN);
 	INIT_LIST_HEAD(&sub_log_ctx->list);
 	list_add_tail(&sub_log_ctx->list, &log_ctx_list);
 	return sub_log_ctx->log_ctx;
+#else
+	return NULL;
+#endif
 }
 
 static void ipc_router_log_ctx_init(void)


### PR DESCRIPTION
Was introduced in 80ea1b0b68f6eefaebc6efb6050a2146dc1cf170