### PR TITLE
[2.3.2.r1.4] arm64: Kconfig: ARM64_SSBD depends on PSCI_BP_HARDENING

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -897,6 +897,7 @@ config PSCI_BP_HARDENING
 
 config ARM64_SSBD
 	bool "Speculative Store Bypass Disable" if EXPERT
+	depends on HARDEN_BRANCH_PREDICTOR
 	default y
 	help
 	  This enables mitigation of the bypassing of previous stores


### PR DESCRIPTION
ARM64 Speculative Store Bypass Disable currently works through
PSCI SMCC calls, which are supported only if the Branch Predictor
Hardening using PSCI is enabled.

Failing to comply will render the kernel unbuildable.