### PR TITLE
Egistec reset stability and initial enroll

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -117,7 +117,6 @@
 		et51x,gpio_rst    = <&tlmm 20 0>;
 		et51x,gpio_irq    = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
-		et51x,enable-wakeup;
 
 		// TODO: This is most likely just a hack
 		// because the HAL doesn't enable on the right scope?
@@ -139,7 +138,6 @@
 		fpc,gpio_rst    = <&tlmm 20 0x0>;
 		fpc,gpio_irq    = <&tlmm 72 0x0>;
 		vdd_ana-supply = <&pm660l_l6>;
-		fpc,enable-wakeup;
 
 		pinctrl-names = "fpc1145_reset_reset",
 			"fpc1145_reset_active",

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -118,8 +118,11 @@
 		et51x,gpio_irq    = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
 
-		// TODO: This is most likely just a hack
-		// because the HAL doesn't enable on the right scope?
+		/*
+		 * The device has to stay enabled until the HAL initializes,
+		 * otherwise it'll not send out any IRQ signals even though the
+		 * rest of the initialization runs without errors.
+		 */
 		et51x,enable-on-boot;
 
 		pinctrl-names = "et51x_reset_reset",

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -90,7 +90,6 @@ struct et51x_data {
 	struct regulator *vdd_ana;
 
 	int irq_gpio;
-	int rst_gpio;
 
 	int irq;
 	bool irq_fired;
@@ -530,10 +529,6 @@ static int et51x_probe(struct platform_device *pdev)
 
 	rc = et51x_request_named_gpio(et51x, "et51x,gpio_irq",
 				      &et51x->irq_gpio);
-	if (rc)
-		goto exit;
-	rc = et51x_request_named_gpio(et51x, "et51x,gpio_rst",
-				      &et51x->rst_gpio);
 	if (rc)
 		goto exit;
 

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -225,24 +225,11 @@ static int device_prepare(struct et51x_data *et51x, bool enable)
 	mutex_lock(&et51x->lock);
 	if (enable && !et51x->prepared) {
 		et51x->prepared = true;
-		select_pin_ctl(et51x, "et51x_reset_reset");
 
 		rc = vreg_setup(et51x, true);
 		if (rc)
 			goto exit;
-
-		usleep_range(PWR_ON_STEP_SLEEP,
-			     PWR_ON_STEP_SLEEP + PWR_ON_STEP_RANGE2);
-
-		(void)select_pin_ctl(et51x, "et51x_reset_active");
-		usleep_range(PWR_ON_STEP_SLEEP,
-			     PWR_ON_STEP_SLEEP + PWR_ON_STEP_RANGE1);
-
 	} else if (!enable && et51x->prepared) {
-		(void)select_pin_ctl(et51x, "et51x_reset_reset");
-		usleep_range(PWR_ON_STEP_SLEEP,
-			     PWR_ON_STEP_SLEEP + PWR_ON_STEP_RANGE2);
-
 		(void)vreg_setup(et51x, false);
 	exit:
 		et51x->prepared = false;

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -120,7 +120,8 @@ static int vreg_setup(struct et51x_data *et51x, bool enable)
 	if (!vreg)
 		return -EINVAL;
 
-	dev_info(dev, "%d'ing regulator %s\n", enable, ET51X_REGULATOR_VDD_ANA);
+	dev_dbg(dev, "%s regulator %s\n", enable ? "enabling" : "disabling",
+		ET51X_REGULATOR_VDD_ANA);
 
 	if (enable) {
 		if (regulator_count_voltages(vreg) > 0) {
@@ -213,7 +214,7 @@ static int hw_reset(struct et51x_data *et51x)
 	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 100);
 
 	irq_gpio = et51x_get_gpio_triggered(et51x);
-	dev_info(dev, "IRQ after reset %d\n", irq_gpio);
+	dev_dbg(dev, "IRQ after reset %d\n", irq_gpio);
 exit:
 	return rc;
 }
@@ -354,7 +355,7 @@ static unsigned int et51x_poll_interrupt(struct file *fp,
 	val = et51x_get_gpio_triggered(et51x);
 	if (val) {
 		/* Early out */
-		dev_info(dev, "gpio already triggered\n");
+		dev_dbg(dev, "gpio already triggered\n");
 		pm_wakeup_event(dev, ET51X_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}
@@ -370,7 +371,7 @@ static unsigned int et51x_poll_interrupt(struct file *fp,
 
 	val = et51x_get_gpio_triggered(et51x);
 	if (val) {
-		dev_info(dev, "gpio triggered after poll_wait\n");
+		dev_dbg(dev, "gpio triggered after poll_wait\n");
 		pm_wakeup_event(dev, ET51X_MAX_HAL_PROCESSING_TIME);
 		return POLLIN | POLLRDNORM;
 	}

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -116,7 +116,6 @@ struct fpc1145_data {
 	struct regulator *vreg[ARRAY_SIZE(vreg_conf)];
 
 	int irq_gpio;
-	int rst_gpio;
 #ifdef CONFIG_ARCH_SONY_LOIRE
 	int ldo_gpio;
 #endif
@@ -609,10 +608,6 @@ static int fpc1145_probe(struct platform_device *pdev)
 
 	rc = fpc1145_request_named_gpio(fpc1145, "fpc,gpio_irq",
 					&fpc1145->irq_gpio);
-	if (rc)
-		goto exit;
-	rc = fpc1145_request_named_gpio(fpc1145, "fpc,gpio_rst",
-					&fpc1145->rst_gpio);
 	if (rc)
 		goto exit;
 #ifdef CONFIG_ARCH_SONY_LOIRE


### PR DESCRIPTION
These commits clean some of the et51x and fpc driver (removing unused GPIO's), while at the same ensuring that et51x fingerprint operations keep functioning properly.

In particular, this aims to get rid of the requested device resets during normal operation. There is no other pattern than to leave the device enabled until the HAL initializes - even toggling power quickly in the driver (which was the case when detecting the HW type) results in such resets.
Likewise, turning power off after initializing shows no obvious errors (beside the reset) but the IRQ will not be firing afterwards, rendering the device unusable. While this error could be fixed by restarting the HAL (thus requiring an extra reset or similar) this results in the same reset requests all the time.

In the end, initializing the device properly to get rid of such resets - which are not harmful - might also be the solution to the dreaded error `-59` when enrolling the first fingerprint.
In the future, the TZ app can be analyzed further to identify what exactly causes these requests/errors.