### PR TITLE
[2.3.2.r1.4] Encryption upgrades, F2FS hwcrypto support, hardening

### DIFF
--- a/block/bio.c
+++ b/block/bio.c
@@ -568,8 +568,11 @@ EXPORT_SYMBOL(bio_phys_segments);
 static inline void bio_clone_crypt_key(struct bio *dst, const struct bio *src)
 {
 #ifdef CONFIG_PFK
-	dst->bi_crypt_key = src->bi_crypt_key;
 	dst->bi_iter.bi_dun = src->bi_iter.bi_dun;
+#ifdef CONFIG_DM_DEFAULT_KEY
+	dst->bi_crypt_key = src->bi_crypt_key;
+	dst->bi_crypt_skip = src->bi_crypt_skip;
+#endif
 	dst->bi_dio_inode = src->bi_dio_inode;
 #endif
 }

--- a/block/bio.c
+++ b/block/bio.c
@@ -570,8 +570,8 @@ static inline void bio_clone_crypt_key(struct bio *dst, const struct bio *src)
 #ifdef CONFIG_PFK
 	dst->bi_crypt_key = src->bi_crypt_key;
 	dst->bi_iter.bi_dun = src->bi_iter.bi_dun;
-#endif
 	dst->bi_dio_inode = src->bi_dio_inode;
+#endif
 }
 
 /**

--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -1526,6 +1526,7 @@ bool bio_attempt_front_merge(struct request_queue *q, struct request *req,
 	bio->bi_next = req->bio;
 	req->bio = bio;
 
+	WARN_ON(req->__dun || bio->bi_iter.bi_dun);
 	req->__sector = bio->bi_iter.bi_sector;
 	req->__data_len += bio->bi_iter.bi_size;
 	req->ioprio = ioprio_best(req->ioprio, bio_prio(bio));
@@ -1641,6 +1642,7 @@ void init_request_from_bio(struct request *req, struct bio *bio)
 
 	req->errors = 0;
 	req->__sector = bio->bi_iter.bi_sector;
+	req->__dun = bio->bi_iter.bi_dun;
 	req->ioprio = bio_prio(bio);
 	blk_rq_bio_prep(req->q, req, bio);
 }
@@ -2643,8 +2645,11 @@ bool blk_update_request(struct request *req, int error, unsigned int nr_bytes)
 	req->__data_len -= total_bytes;
 
 	/* update sector only for requests with clear definition of sector */
-	if (req->cmd_type == REQ_TYPE_FS)
+	if (req->cmd_type == REQ_TYPE_FS) {
 		req->__sector += total_bytes >> 9;
+		if (req->__dun)
+			req->__dun += total_bytes >> 12;
+	}
 
 	/* mixed attributes always follow the first bio */
 	if (req->cmd_flags & REQ_MIXED_MERGE) {
@@ -3045,6 +3050,7 @@ static void __blk_rq_prep_clone(struct request *dst, struct request *src)
 			 (src->cmd_flags & REQ_CLONE_MASK) | REQ_NOMERGE);
 	dst->cmd_type = src->cmd_type;
 	dst->__sector = blk_rq_pos(src);
+	dst->__dun = blk_rq_dun(src);
 	dst->__data_len = blk_rq_bytes(src);
 	dst->nr_phys_segments = src->nr_phys_segments;
 	dst->ioprio = src->ioprio;

--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -1526,7 +1526,9 @@ bool bio_attempt_front_merge(struct request_queue *q, struct request *req,
 	bio->bi_next = req->bio;
 	req->bio = bio;
 
+#ifdef CONFIG_PFK
 	WARN_ON(req->__dun || bio->bi_iter.bi_dun);
+#endif
 	req->__sector = bio->bi_iter.bi_sector;
 	req->__data_len += bio->bi_iter.bi_size;
 	req->ioprio = ioprio_best(req->ioprio, bio_prio(bio));
@@ -1642,7 +1644,9 @@ void init_request_from_bio(struct request *req, struct bio *bio)
 
 	req->errors = 0;
 	req->__sector = bio->bi_iter.bi_sector;
+#ifdef CONFIG_PFK
 	req->__dun = bio->bi_iter.bi_dun;
+#endif
 	req->ioprio = bio_prio(bio);
 	blk_rq_bio_prep(req->q, req, bio);
 }
@@ -2647,8 +2651,10 @@ bool blk_update_request(struct request *req, int error, unsigned int nr_bytes)
 	/* update sector only for requests with clear definition of sector */
 	if (req->cmd_type == REQ_TYPE_FS) {
 		req->__sector += total_bytes >> 9;
+#ifdef CONFIG_PFK
 		if (req->__dun)
 			req->__dun += total_bytes >> 12;
+#endif
 	}
 
 	/* mixed attributes always follow the first bio */
@@ -3050,7 +3056,9 @@ static void __blk_rq_prep_clone(struct request *dst, struct request *src)
 			 (src->cmd_flags & REQ_CLONE_MASK) | REQ_NOMERGE);
 	dst->cmd_type = src->cmd_type;
 	dst->__sector = blk_rq_pos(src);
+#ifdef CONFIG_PFK
 	dst->__dun = blk_rq_dun(src);
+#endif
 	dst->__data_len = blk_rq_bytes(src);
 	dst->nr_phys_segments = src->nr_phys_segments;
 	dst->ioprio = src->ioprio;

--- a/block/blk-merge.c
+++ b/block/blk-merge.c
@@ -876,6 +876,8 @@ bool blk_rq_merge_ok(struct request *rq, struct bio *bio)
 
 int blk_try_merge(struct request *rq, struct bio *bio)
 {
+	if (blk_rq_dun(rq) || bio_dun(bio))
+		return ELEVATOR_NO_MERGE;
 	if (blk_rq_pos(rq) + blk_rq_sectors(rq) == bio->bi_iter.bi_sector)
 		return ELEVATOR_BACK_MERGE;
 	else if (blk_rq_pos(rq) - bio_sectors(bio) == bio->bi_iter.bi_sector)

--- a/block/blk-merge.c
+++ b/block/blk-merge.c
@@ -876,8 +876,10 @@ bool blk_rq_merge_ok(struct request *rq, struct bio *bio)
 
 int blk_try_merge(struct request *rq, struct bio *bio)
 {
+#ifdef CONFIG_PFK
 	if (blk_rq_dun(rq) || bio_dun(bio))
 		return ELEVATOR_NO_MERGE;
+#endif
 	if (blk_rq_pos(rq) + blk_rq_sectors(rq) == bio->bi_iter.bi_sector)
 		return ELEVATOR_BACK_MERGE;
 	else if (blk_rq_pos(rq) - bio_sectors(bio) == bio->bi_iter.bi_sector)

--- a/drivers/char/hw_random/msm_rng.c
+++ b/drivers/char/hw_random/msm_rng.c
@@ -53,7 +53,7 @@
 #define MAX_HW_FIFO_DEPTH 16                     /* FIFO is 16 words deep */
 #define MAX_HW_FIFO_SIZE (MAX_HW_FIFO_DEPTH * 4) /* FIFO is 32 bits wide  */
 
-#define RETRY_MAX_CNT		5	/* max retry times to read register */
+#define RETRY_MAX_CNT		20	/* max retry times to read register */
 #define RETRY_DELAY_INTERVAL	440	/* retry delay interval in us */
 
 struct msm_rng_device {

--- a/drivers/crypto/msm/ice.c
+++ b/drivers/crypto/msm/ice.c
@@ -31,7 +31,8 @@
 #else
 #include <linux/bio.h>
 static inline int pfk_load_key_start(const struct bio *bio,
-	struct ice_crypto_setting *ice_setting, bool *is_pfe, bool async)
+	struct ice_crypto_setting *ice_setting, bool *is_pfe,
+	bool async, int ice_ver)
 {
 	return 0;
 }
@@ -132,14 +133,10 @@ static int ice_fde_flag;
 static struct ice_crypto_setting ice_data;
 
 static int qti_ice_setting_config(struct request *req,
-		struct platform_device *pdev,
+		struct ice_device *ice_dev,
 		struct ice_crypto_setting *crypto_data,
 		struct ice_data_setting *setting)
 {
-	struct ice_device *ice_dev = NULL;
-
-	ice_dev = platform_get_drvdata(pdev);
-
 	if (!ice_dev) {
 		pr_debug("%s no ICE device\n", __func__);
 
@@ -1477,12 +1474,19 @@ static int qcom_ice_config_start(struct platform_device *pdev,
 	sector_t data_size;
 	union map_info *info;
 	unsigned long sec_end = 0;
+	struct ice_device *ice_dev = NULL;
+	int ice_rev = 0;
 
 	if (!pdev || !req) {
 		pr_err("%s: Invalid params passed\n", __func__);
 		return -EINVAL;
 	}
 
+	ice_dev = platform_get_drvdata(pdev);
+	if (!ice_dev) {
+		pr_err("%s: no ICE device\n", __func__);
+		return 0;
+	}
 	/*
 	 * It is not an error to have a request with no  bio
 	 * Such requests must bypass ICE. So first set bypass and then
@@ -1497,9 +1501,11 @@ static int qcom_ice_config_start(struct platform_device *pdev,
 		/* It is not an error to have a request with no  bio */
 		return 0;
 	}
-    //pr_err("%s bio is %pK\n", __func__, req->bio);
 
-	ret = pfk_load_key_start(req->bio, &pfk_crypto_data, &is_pfe, async);
+	ice_rev = ICE_REV(ice_dev->ice_hw_version, MAJOR);
+
+	ret = pfk_load_key_start(req->bio, &pfk_crypto_data,
+				&is_pfe, async, ice_rev);
 	if (is_pfe) {
 		if (ret) {
 			if (ret != -EBUSY && ret != -EAGAIN)
@@ -1508,7 +1514,7 @@ static int qcom_ice_config_start(struct platform_device *pdev,
 			return ret;
 		}
 
-		return qti_ice_setting_config(req, pdev,
+		return qti_ice_setting_config(req, ice_dev,
 				&pfk_crypto_data, setting);
 	}
 
@@ -1526,7 +1532,7 @@ static int qcom_ice_config_start(struct platform_device *pdev,
 							__func__);
 				return -EINVAL;
 			}
-			return qti_ice_setting_config(req, pdev,
+			return qti_ice_setting_config(req, ice_dev,
 						crypto_data, setting);
 		}
 		return 0;
@@ -1548,8 +1554,8 @@ static int qcom_ice_config_start(struct platform_device *pdev,
 				if ((req->__sector + data_size) > sec_end)
 					return 0;
 				else
-					return qti_ice_setting_config(req, pdev,
-						&ice_data, setting);
+					return qti_ice_setting_config(req,
+						ice_dev, &ice_data, setting);
 			}
 		}
 	}

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_clk_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_clk_manager.c
@@ -502,17 +502,24 @@ static int dsi_link_hs_clk_stop(struct dsi_link_hs_clk_info *link_hs_clks)
 	return 0;
 }
 
-static int dsi_link_lp_clk_start(struct dsi_link_lp_clk_info *link_lp_clks)
+static int dsi_link_lp_clk_start(struct dsi_link_lp_clk_info *link_lp_clks,
+	int index)
 {
 	int rc = 0;
 	struct dsi_clk_mngr *mngr;
 	struct dsi_link_clks *l_clks;
 
+	if (index >= MAX_DSI_CTRL) {
+		pr_err("Invalid DSI ctrl index\n");
+		return -EINVAL;
+	}
+
 	l_clks = container_of(link_lp_clks, struct dsi_link_clks, lp_clks);
 
-	mngr = container_of(l_clks, struct dsi_clk_mngr, link_clks[0]);
+	mngr = container_of(l_clks, struct dsi_clk_mngr, link_clks[index]);
 	if (!mngr)
 		return -EINVAL;
+
 	/*
 	 * In an ideal world, cont_splash_enabled should not be required inside
 	 * the clock manager. But, in the current driver cont_splash_enabled
@@ -630,7 +637,7 @@ static int dsi_display_link_clk_enable(struct dsi_link_clks *clks,
 	m_clks = &clks[master_ndx];
 
 	if (l_type & DSI_LINK_LP_CLK) {
-		rc = dsi_link_lp_clk_start(&m_clks->lp_clks);
+		rc = dsi_link_lp_clk_start(&m_clks->lp_clks, master_ndx);
 		if (rc) {
 			pr_err("failed to turn on master lp link clocks, rc=%d\n",
 				rc);
@@ -654,7 +661,7 @@ static int dsi_display_link_clk_enable(struct dsi_link_clks *clks,
 			continue;
 
 		if (l_type & DSI_LINK_LP_CLK) {
-			rc = dsi_link_lp_clk_start(&clk->lp_clks);
+			rc = dsi_link_lp_clk_start(&clk->lp_clks, i);
 			if (rc) {
 				pr_err("failed to turn on lp link clocks, rc=%d\n",
 					rc);
@@ -787,13 +794,12 @@ static int dsi_display_link_clk_disable(struct dsi_link_clks *clks,
 	return rc;
 }
 
-static int dsi_clk_update_link_clk_state(struct dsi_link_clks *l_clks,
-	enum dsi_lclk_type l_type, u32 l_state, bool enable)
+static int dsi_clk_update_link_clk_state(struct dsi_clk_mngr *mngr,
+	struct dsi_link_clks *l_clks, enum dsi_lclk_type l_type, u32 l_state,
+	bool enable)
 {
 	int rc = 0;
-	struct dsi_clk_mngr *mngr;
 
-	mngr = container_of(l_clks, struct dsi_clk_mngr, link_clks[0]);
 	if (!mngr)
 		return -EINVAL;
 
@@ -852,22 +858,12 @@ error:
 	return rc;
 }
 
-static int dsi_update_clk_state(struct dsi_core_clks *c_clks, u32 c_state,
-				struct dsi_link_clks *l_clks, u32 l_state)
+static int dsi_update_clk_state(struct dsi_clk_mngr *mngr,
+	struct dsi_core_clks *c_clks, u32 c_state,
+	struct dsi_link_clks *l_clks, u32 l_state)
 {
 	int rc = 0;
-	struct dsi_clk_mngr *mngr;
 	bool l_c_on = false;
-
-	if (c_clks) {
-		mngr =
-		container_of(c_clks, struct dsi_clk_mngr, core_clks[0]);
-	} else if (l_clks) {
-		mngr =
-		container_of(l_clks, struct dsi_clk_mngr, link_clks[0]);
-	} else {
-		mngr = NULL;
-	}
 
 	if (!mngr)
 		return -EINVAL;
@@ -910,12 +906,12 @@ static int dsi_update_clk_state(struct dsi_core_clks *c_clks, u32 c_state,
 
 	if (l_clks) {
 		if (l_state == DSI_CLK_ON) {
-			rc = dsi_clk_update_link_clk_state(l_clks,
+			rc = dsi_clk_update_link_clk_state(mngr, l_clks,
 				DSI_LINK_LP_CLK, l_state, true);
 			if (rc)
 				goto error;
 
-			rc = dsi_clk_update_link_clk_state(l_clks,
+			rc = dsi_clk_update_link_clk_state(mngr, l_clks,
 				DSI_LINK_HS_CLK, l_state, true);
 			if (rc)
 				goto error;
@@ -959,12 +955,12 @@ static int dsi_update_clk_state(struct dsi_core_clks *c_clks, u32 c_state,
 				pr_debug("ECG: core and Link_on\n");
 			}
 
-			rc = dsi_clk_update_link_clk_state(l_clks,
+			rc = dsi_clk_update_link_clk_state(mngr, l_clks,
 				DSI_LINK_HS_CLK, l_state, false);
 			if (rc)
 				goto error;
 
-			rc = dsi_clk_update_link_clk_state(l_clks,
+			rc = dsi_clk_update_link_clk_state(mngr, l_clks,
 				DSI_LINK_LP_CLK, l_state, false);
 			if (rc)
 				goto error;
@@ -1114,7 +1110,7 @@ static int dsi_recheck_clk_state(struct dsi_clk_mngr *mngr)
 		old_l_clk_state, new_link_clk_state);
 
 	if (c_clks || l_clks) {
-		rc = dsi_update_clk_state(c_clks, new_core_clk_state,
+		rc = dsi_update_clk_state(mngr, c_clks, new_core_clk_state,
 					  l_clks, new_link_clk_state);
 		if (rc) {
 			pr_err("failed to update clock state, rc = %d\n", rc);

--- a/drivers/gpu/msm/kgsl_gmu.c
+++ b/drivers/gpu/msm/kgsl_gmu.c
@@ -1662,7 +1662,7 @@ int adreno_gmu_fenced_write(struct adreno_device *adreno_dev,
 	if (!kgsl_gmu_isenabled(KGSL_DEVICE(adreno_dev)))
 		return 0;
 
-	for (i = 0; i < GMU_WAKEUP_RETRY_MAX; i++) {
+	for (i = 0; i < GMU_LONG_WAKEUP_RETRY_LIMIT; i++) {
 		adreno_read_gmureg(adreno_dev, ADRENO_REG_GMU_AHB_FENCE_STATUS,
 			&status);
 
@@ -1677,9 +1677,19 @@ int adreno_gmu_fenced_write(struct adreno_device *adreno_dev,
 
 		/* Try to write the fenced register again */
 		adreno_writereg(adreno_dev, offset, val);
+
+		if (i == GMU_SHORT_WAKEUP_RETRY_LIMIT)
+			dev_err(adreno_dev->dev.dev,
+				"Waited %d usecs to write fenced register 0x%x. Continuing to wait...\n",
+				(GMU_SHORT_WAKEUP_RETRY_LIMIT *
+				GMU_WAKEUP_DELAY_US),
+				reg_offset);
 	}
 
 	dev_err(adreno_dev->dev.dev,
-		"GMU fenced register write timed out: reg 0x%x\n", reg_offset);
+		"Timed out waiting %d usecs to write fenced register 0x%x\n",
+		GMU_LONG_WAKEUP_RETRY_LIMIT * GMU_WAKEUP_DELAY_US,
+		reg_offset);
+
 	return -ETIMEDOUT;
 }

--- a/drivers/gpu/msm/kgsl_gmu.h
+++ b/drivers/gpu/msm/kgsl_gmu.h
@@ -92,8 +92,15 @@
  * the GMU will start shutting down before we try again.
  */
 #define GMU_WAKEUP_DELAY_US 10
-/* Max amount of tries to wake up the GMU. */
-#define GMU_WAKEUP_RETRY_MAX 60
+
+/* Max amount of tries to wake up the GMU. The short retry
+ * limit is half of the long retry limit. After the short
+ * number of retries, we print an informational message to say
+ * exiting IFPC is taking longer than expected. We continue
+ * to retry after this until the long retry limit.
+ */
+#define GMU_SHORT_WAKEUP_RETRY_LIMIT 100
+#define GMU_LONG_WAKEUP_RETRY_LIMIT 200
 
 /* Bits for the flags field in the gmu structure */
 enum gmu_flags {

--- a/drivers/media/platform/msm/camera/cam_cdm/cam_cdm_hw_core.c
+++ b/drivers/media/platform/msm/camera/cam_cdm/cam_cdm_hw_core.c
@@ -624,7 +624,8 @@ static void cam_hw_cdm_work(struct work_struct *work)
 }
 
 static void cam_hw_cdm_iommu_fault_handler(struct iommu_domain *domain,
-	struct device *dev, unsigned long iova, int flags, void *token)
+	struct device *dev, unsigned long iova, int flags, void *token,
+	uint32_t buf_info)
 {
 	struct cam_hw_info *cdm_hw = NULL;
 	struct cam_cdm *core = NULL;
@@ -910,7 +911,7 @@ int cam_hw_cdm_probe(struct platform_device *pdev)
 		CAM_ERR(CAM_CDM, "cpas-cdm get iommu handle failed");
 		goto unlock_release_mem;
 	}
-	cam_smmu_reg_client_page_fault_handler(cdm_core->iommu_hdl.non_secure,
+	cam_smmu_set_client_page_fault_handler(cdm_core->iommu_hdl.non_secure,
 		cam_hw_cdm_iommu_fault_handler, cdm_hw);
 
 	rc = cam_smmu_ops(cdm_core->iommu_hdl.non_secure, CAM_SMMU_ATTACH);
@@ -1034,7 +1035,7 @@ release_platform_resource:
 	flush_workqueue(cdm_core->work_queue);
 	destroy_workqueue(cdm_core->work_queue);
 destroy_non_secure_hdl:
-	cam_smmu_reg_client_page_fault_handler(cdm_core->iommu_hdl.non_secure,
+	cam_smmu_set_client_page_fault_handler(cdm_core->iommu_hdl.non_secure,
 		NULL, cdm_hw);
 	if (cam_smmu_destroy_handle(cdm_core->iommu_hdl.non_secure))
 		CAM_ERR(CAM_CDM, "Release iommu secure hdl failed");
@@ -1106,8 +1107,8 @@ int cam_hw_cdm_remove(struct platform_device *pdev)
 
 	if (cam_smmu_destroy_handle(cdm_core->iommu_hdl.non_secure))
 		CAM_ERR(CAM_CDM, "Release iommu secure hdl failed");
-	cam_smmu_reg_client_page_fault_handler(cdm_core->iommu_hdl.non_secure,
-		NULL, cdm_hw);
+	cam_smmu_unset_client_page_fault_handler(
+		cdm_core->iommu_hdl.non_secure, cdm_hw);
 
 	mutex_destroy(&cdm_hw->hw_mutex);
 	kfree(cdm_hw->soc_info.soc_private);

--- a/drivers/media/platform/msm/camera/cam_core/cam_context.c
+++ b/drivers/media/platform/msm/camera/cam_core/cam_context.c
@@ -42,6 +42,7 @@ int cam_context_shutdown(struct cam_context *ctx)
 	int rc = 0;
 	int32_t ctx_hdl = ctx->dev_hdl;
 
+	mutex_lock(&ctx->ctx_mutex);
 	if (ctx->state_machine[ctx->state].ioctl_ops.stop_dev) {
 		rc = ctx->state_machine[ctx->state].ioctl_ops.stop_dev(
 			ctx, NULL);
@@ -54,6 +55,7 @@ int cam_context_shutdown(struct cam_context *ctx)
 		if (rc < 0)
 			CAM_ERR(CAM_CORE, "Error while dev release %d", rc);
 	}
+	mutex_unlock(&ctx->ctx_mutex);
 
 	if (!rc)
 		rc = cam_destroy_device_hdl(ctx_hdl);

--- a/drivers/media/platform/msm/camera/cam_core/cam_context.c
+++ b/drivers/media/platform/msm/camera/cam_core/cam_context.c
@@ -223,6 +223,27 @@ int cam_context_handle_crm_process_evt(struct cam_context *ctx,
 	return rc;
 }
 
+int cam_context_dump_pf_info(struct cam_context *ctx, unsigned long iova,
+	uint32_t buf_info)
+{
+	int rc = 0;
+
+	if (!ctx->state_machine) {
+		CAM_ERR(CAM_CORE, "Context is not ready");
+		return -EINVAL;
+	}
+
+	if (ctx->state_machine[ctx->state].pagefault_ops) {
+		rc = ctx->state_machine[ctx->state].pagefault_ops(ctx, iova,
+			buf_info);
+	} else {
+		CAM_WARN(CAM_CORE, "No dump ctx in dev %d, state %d",
+			ctx->dev_hdl, ctx->state);
+	}
+
+	return rc;
+}
+
 int cam_context_handle_acquire_dev(struct cam_context *ctx,
 	struct cam_acquire_dev_cmd *cmd)
 {

--- a/drivers/media/platform/msm/camera/cam_core/cam_context.h
+++ b/drivers/media/platform/msm/camera/cam_core/cam_context.h
@@ -57,23 +57,25 @@ enum cam_context_state {
  * @num_out_acked:         Number of out fence acked
  * @flushed:               Request is flushed
  * @ctx:                   The context to which this request belongs
+ * @pf_data                page fault debug data
  *
  */
 struct cam_ctx_request {
-	struct list_head              list;
-	uint32_t                      status;
-	uint64_t                      request_id;
+	struct list_head               list;
+	uint32_t                       status;
+	uint64_t                       request_id;
 	void                          *req_priv;
-	struct cam_hw_update_entry    hw_update_entries[CAM_CTX_CFG_MAX];
-	uint32_t                      num_hw_update_entries;
-	struct cam_hw_fence_map_entry in_map_entries[CAM_CTX_CFG_MAX];
-	uint32_t                      num_in_map_entries;
-	struct cam_hw_fence_map_entry out_map_entries[CAM_CTX_CFG_MAX];
-	uint32_t                      num_out_map_entries;
-	atomic_t                      num_in_acked;
-	uint32_t                      num_out_acked;
-	int                           flushed;
-	struct cam_context           *ctx;
+	struct cam_hw_update_entry     hw_update_entries[CAM_CTX_CFG_MAX];
+	uint32_t                       num_hw_update_entries;
+	struct cam_hw_fence_map_entry  in_map_entries[CAM_CTX_CFG_MAX];
+	uint32_t                       num_in_map_entries;
+	struct cam_hw_fence_map_entry  out_map_entries[CAM_CTX_CFG_MAX];
+	uint32_t                       num_out_map_entries;
+	atomic_t                       num_in_acked;
+	uint32_t                       num_out_acked;
+	int                            flushed;
+	struct cam_context            *ctx;
+	struct cam_hw_mgr_dump_pf_data pf_data;
 };
 
 /**
@@ -135,12 +137,14 @@ struct cam_ctx_crm_ops {
  * @ioctl_ops:             Ioctl funciton table
  * @crm_ops:               CRM to context interface function table
  * @irq_ops:               Hardware event handle function
+ * @pagefault_ops:         Function to be called on page fault
  *
  */
 struct cam_ctx_ops {
 	struct cam_ctx_ioctl_ops     ioctl_ops;
 	struct cam_ctx_crm_ops       crm_ops;
 	cam_hw_event_cb_func         irq_ops;
+	cam_hw_pagefault_cb_func     pagefault_ops;
 };
 
 /**
@@ -290,6 +294,19 @@ int cam_context_handle_crm_flush_req(struct cam_context *ctx,
  */
 int cam_context_handle_crm_process_evt(struct cam_context *ctx,
 	struct cam_req_mgr_link_evt_data *process_evt);
+
+/**
+ * cam_context_dump_pf_info()
+ *
+ * @brief:        Handle dump active request request command
+ *
+ * @ctx:          Object pointer for cam_context
+ * @iova:         Page fault address
+ * @buf_info:     Information about closest memory handle
+ *
+ */
+int cam_context_dump_pf_info(struct cam_context *ctx, unsigned long iova,
+	uint32_t buf_info);
 
 /**
  * cam_context_handle_acquire_dev()

--- a/drivers/media/platform/msm/camera/cam_core/cam_context_utils.h
+++ b/drivers/media/platform/msm/camera/cam_core/cam_context_utils.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -31,5 +31,8 @@ int32_t cam_context_flush_dev_to_hw(struct cam_context *ctx,
 int32_t cam_context_flush_ctx_to_hw(struct cam_context *ctx);
 int32_t cam_context_flush_req_to_hw(struct cam_context *ctx,
 	struct cam_flush_dev_cmd *cmd);
+int32_t cam_context_dump_pf_info_to_hw(struct cam_context *ctx,
+	struct cam_packet *packet, unsigned long iova, uint32_t buf_info,
+	bool *mem_found);
 
 #endif /* _CAM_CONTEXT_UTILS_H_ */

--- a/drivers/media/platform/msm/camera/cam_core/cam_hw_mgr_intf.h
+++ b/drivers/media/platform/msm/camera/cam_core/cam_hw_mgr_intf.h
@@ -29,6 +29,10 @@
 typedef int (*cam_hw_event_cb_func)(void *context, uint32_t evt_id,
 	void *evt_data);
 
+/* hardware page fault callback function type */
+typedef int (*cam_hw_pagefault_cb_func)(void *context, unsigned long iova,
+	uint32_t buf_info);
+
 /**
  * struct cam_hw_update_entry - Entry for hardware config
  *
@@ -131,6 +135,16 @@ struct cam_hw_stop_args {
 	void              *args;
 };
 
+
+/**
+ * struct cam_hw_mgr_dump_pf_data - page fault debug data
+ *
+ * packet:     pointer to packet
+ */
+struct cam_hw_mgr_dump_pf_data {
+	void    *packet;
+};
+
 /**
  * struct cam_hw_prepare_update_args - Payload for prepare command
  *
@@ -146,6 +160,7 @@ struct cam_hw_stop_args {
  * @in_map_entries:        Actual input fence mapping list (returned)
  * @num_in_map_entries:    Number of acutal input fence mapping (returned)
  * @priv:                  Private pointer of hw update
+ * @pf_data:               Debug data for page fault
  *
  */
 struct cam_hw_prepare_update_args {
@@ -161,6 +176,7 @@ struct cam_hw_prepare_update_args {
 	struct cam_hw_fence_map_entry  *in_map_entries;
 	uint32_t                        num_in_map_entries;
 	void                           *priv;
+	struct cam_hw_mgr_dump_pf_data *pf_data;
 };
 
 /**
@@ -204,6 +220,48 @@ struct cam_hw_flush_args {
 	uint32_t                        num_req_active;
 	void                           *flush_req_active[20];
 	enum flush_type_t               flush_type;
+};
+
+/**
+ * struct cam_hw_dump_pf_args - Payload for dump pf info command
+ *
+ * @pf_data:               Debug data for page fault
+ * @iova:                  Page fault address
+ * @buf_info:              Info about memory buffer where page
+ *                               fault occurred
+ * @mem_found:             If fault memory found in current
+ *                               request
+ *
+ */
+struct cam_hw_dump_pf_args {
+	struct cam_hw_mgr_dump_pf_data  pf_data;
+	unsigned long                   iova;
+	uint32_t                        buf_info;
+	bool                           *mem_found;
+};
+
+/* enum cam_hw_mgr_command - Hardware manager command type */
+enum cam_hw_mgr_command {
+	CAM_HW_MGR_CMD_INTERNAL,
+	CAM_HW_MGR_CMD_DUMP_PF_INFO,
+};
+
+/**
+ * struct cam_hw_cmd_args - Payload for hw manager command
+ *
+ * @ctxt_to_hw_map:        HW context from the acquire
+ * @cmd_type               HW command type
+ * @internal_args          Arguments for internal command
+ * @pf_args                Arguments for Dump PF info command
+ *
+ */
+struct cam_hw_cmd_args {
+	void                               *ctxt_to_hw_map;
+	uint32_t                            cmd_type;
+	union {
+		void                       *internal_args;
+		struct cam_hw_dump_pf_args  pf_args;
+	} u;
 };
 
 /**

--- a/drivers/media/platform/msm/camera/cam_core/cam_node.c
+++ b/drivers/media/platform/msm/camera/cam_core/cam_node.c
@@ -420,6 +420,9 @@ int cam_node_shutdown(struct cam_node *node)
 
 	for (i = 0; i < node->ctx_size; i++) {
 		if (node->ctx_list[i].dev_hdl > 0) {
+			CAM_DBG(CAM_CORE,
+				"Node [%s] invoking shutdown on context [%d]",
+				node->name, i);
 			rc = cam_context_shutdown(&(node->ctx_list[i]));
 			if (rc)
 				continue;

--- a/drivers/media/platform/msm/camera/cam_icp/cam_icp_subdev.c
+++ b/drivers/media/platform/msm/camera/cam_icp/cam_icp_subdev.c
@@ -35,6 +35,7 @@
 #include "cam_hw_mgr_intf.h"
 #include "cam_icp_hw_mgr_intf.h"
 #include "cam_debug_util.h"
+#include "cam_smmu_api.h"
 
 #define CAM_ICP_DEV_NAME        "cam-icp"
 
@@ -54,6 +55,25 @@ static const struct of_device_id cam_icp_dt_match[] = {
 	{.compatible = "qcom,cam-icp"},
 	{}
 };
+
+static void cam_icp_dev_iommu_fault_handler(
+	struct iommu_domain *domain, struct device *dev, unsigned long iova,
+	int flags, void *token, uint32_t buf_info)
+{
+	int i = 0;
+	struct cam_node *node = NULL;
+
+	if (!token) {
+		CAM_ERR(CAM_ICP, "invalid token in page handler cb");
+		return;
+	}
+
+	node = (struct cam_node *)token;
+
+	for (i = 0; i < node->ctx_size; i++)
+		cam_context_dump_pf_info(&(node->ctx_list[i]), iova,
+			buf_info);
+}
 
 static int cam_icp_subdev_open(struct v4l2_subdev *sd,
 	struct v4l2_subdev_fh *fh)
@@ -135,6 +155,7 @@ static int cam_icp_probe(struct platform_device *pdev)
 	int rc = 0, i = 0;
 	struct cam_node *node;
 	struct cam_hw_mgr_intf *hw_mgr_intf;
+	int iommu_hdl = -1;
 
 	if (!pdev) {
 		CAM_ERR(CAM_ICP, "pdev is NULL");
@@ -158,7 +179,8 @@ static int cam_icp_probe(struct platform_device *pdev)
 		goto hw_alloc_fail;
 	}
 
-	rc = cam_icp_hw_mgr_init(pdev->dev.of_node, (uint64_t *)hw_mgr_intf);
+	rc = cam_icp_hw_mgr_init(pdev->dev.of_node, (uint64_t *)hw_mgr_intf,
+		&iommu_hdl);
 	if (rc) {
 		CAM_ERR(CAM_ICP, "ICP HW manager init failed: %d", rc);
 		goto hw_init_fail;
@@ -180,6 +202,9 @@ static int cam_icp_probe(struct platform_device *pdev)
 		CAM_ERR(CAM_ICP, "ICP node init failed");
 		goto ctx_fail;
 	}
+
+	cam_smmu_set_client_page_fault_handler(iommu_hdl,
+		cam_icp_dev_iommu_fault_handler, node);
 
 	g_icp_dev.open_cnt = 0;
 	mutex_init(&g_icp_dev.icp_lock);

--- a/drivers/media/platform/msm/camera/cam_icp/cam_icp_subdev.c
+++ b/drivers/media/platform/msm/camera/cam_icp/cam_icp_subdev.c
@@ -96,7 +96,7 @@ static int cam_icp_subdev_close(struct v4l2_subdev *sd,
 
 	mutex_lock(&g_icp_dev.icp_lock);
 	if (g_icp_dev.open_cnt <= 0) {
-		CAM_ERR(CAM_ICP, "ICP subdev is already closed");
+		CAM_DBG(CAM_ICP, "ICP subdev is already closed");
 		rc = -EINVAL;
 		goto end;
 	}

--- a/drivers/media/platform/msm/camera/cam_icp/icp_hw/icp_hw_mgr/cam_icp_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_icp/icp_hw/icp_hw_mgr/cam_icp_hw_mgr.c
@@ -3388,10 +3388,11 @@ static int cam_icp_mgr_process_io_cfg(struct cam_icp_hw_mgr *hw_mgr,
 			prepare_args->num_out_map_entries++;
 		}
 		CAM_DBG(CAM_REQ,
-			"ctx_id: %u req_id: %llu dir[%d]: %u, fence: %u resource_type = %u",
+			"ctx_id: %u req_id: %llu dir[%d]: %u, fence: %u resource_type = %u memh %x",
 			ctx_data->ctx_id, packet->header.request_id, i,
 			io_cfg_ptr[i].direction, io_cfg_ptr[i].fence,
-			io_cfg_ptr[i].resource_type);
+			io_cfg_ptr[i].resource_type,
+			io_cfg_ptr[i].mem_handle[0]);
 	}
 
 	if (prepare_args->num_in_map_entries > 1)
@@ -3593,6 +3594,77 @@ static int cam_icp_mgr_update_hfi_frame_process(
 	return rc;
 }
 
+static void cam_icp_mgr_print_io_bufs(struct cam_packet *packet,
+	int32_t iommu_hdl, int32_t sec_mmu_hdl, uint32_t pf_buf_info,
+	bool *mem_found)
+{
+	uint64_t   iova_addr;
+	size_t     src_buf_size;
+	int        i;
+	int        j;
+	int        rc = 0;
+	int32_t    mmu_hdl;
+
+	struct cam_buf_io_cfg  *io_cfg = NULL;
+
+	if (mem_found)
+		*mem_found = false;
+
+	io_cfg = (struct cam_buf_io_cfg *)((uint32_t *)&packet->payload +
+		packet->io_configs_offset / 4);
+
+	for (i = 0; i < packet->num_io_configs; i++) {
+		for (j = 0; j < CAM_PACKET_MAX_PLANES; j++) {
+			if (!io_cfg[i].mem_handle[j])
+				break;
+
+			if (GET_FD_FROM_HANDLE(io_cfg[i].mem_handle[j]) ==
+				GET_FD_FROM_HANDLE(pf_buf_info)) {
+				CAM_INFO(CAM_ICP,
+					"Found PF at port: %d mem %x fd: %x",
+					io_cfg[i].resource_type,
+					io_cfg[i].mem_handle[j],
+					pf_buf_info);
+				if (mem_found)
+					*mem_found = true;
+			}
+
+			CAM_INFO(CAM_ICP, "port: %d f: %u format: %d dir %d",
+				io_cfg[i].resource_type,
+				io_cfg[i].fence,
+				io_cfg[i].format,
+				io_cfg[i].direction);
+
+			mmu_hdl = cam_mem_is_secure_buf(
+				io_cfg[i].mem_handle[j]) ? sec_mmu_hdl :
+				iommu_hdl;
+			rc = cam_mem_get_io_buf(io_cfg[i].mem_handle[j],
+				mmu_hdl, &iova_addr, &src_buf_size);
+			if (rc < 0) {
+				CAM_ERR(CAM_UTIL, "get src buf address fail");
+				continue;
+			}
+			if (iova_addr >> 32) {
+				CAM_ERR(CAM_ICP, "Invalid mapped address");
+				rc = -EINVAL;
+				continue;
+			}
+
+			CAM_INFO(CAM_ICP,
+				"pln %d w %d h %d size %d addr 0x%x offset 0x%x memh %x",
+				j, io_cfg[i].planes[j].width,
+				io_cfg[i].planes[j].height,
+				(int32_t)src_buf_size,
+				(unsigned int)iova_addr,
+				io_cfg[i].offsets[j],
+				io_cfg[i].mem_handle[j]);
+
+			iova_addr += io_cfg[i].offsets[j];
+
+		}
+	}
+}
+
 static int cam_icp_mgr_prepare_hw_update(void *hw_mgr_priv,
 	void *prepare_hw_update_args)
 {
@@ -3634,6 +3706,8 @@ static int cam_icp_mgr_prepare_hw_update(void *hw_mgr_priv,
 		mutex_unlock(&ctx_data->ctx_mutex);
 		return rc;
 	}
+
+	prepare_args->pf_data->packet = packet;
 
 	CAM_DBG(CAM_REQ, "req id = %lld for ctx = %u",
 		packet->header.request_id, ctx_data->ctx_id);
@@ -4551,7 +4625,35 @@ cmd_work_failed:
 	return rc;
 }
 
-int cam_icp_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
+static int cam_icp_mgr_cmd(void *hw_mgr_priv, void *cmd_args)
+{
+	int rc = 0;
+	struct cam_hw_cmd_args *hw_cmd_args = cmd_args;
+	struct cam_icp_hw_mgr  *hw_mgr = hw_mgr_priv;
+
+	if (!hw_mgr_priv || !cmd_args) {
+		CAM_ERR(CAM_ICP, "Invalid arguments");
+		return -EINVAL;
+	}
+
+	switch (hw_cmd_args->cmd_type) {
+	case CAM_HW_MGR_CMD_DUMP_PF_INFO:
+		cam_icp_mgr_print_io_bufs(
+			hw_cmd_args->u.pf_args.pf_data.packet,
+			hw_mgr->iommu_hdl,
+			hw_mgr->iommu_sec_hdl,
+			hw_cmd_args->u.pf_args.buf_info,
+			hw_cmd_args->u.pf_args.mem_found);
+		break;
+	default:
+		CAM_ERR(CAM_ICP, "Invalid cmd");
+	}
+
+	return rc;
+}
+
+int cam_icp_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl,
+	int *iommu_hdl)
 {
 	int i, rc = 0;
 	struct cam_hw_mgr_intf *hw_mgr_intf;
@@ -4574,6 +4676,7 @@ int cam_icp_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
 	hw_mgr_intf->hw_open = cam_icp_mgr_hw_open_u;
 	hw_mgr_intf->hw_close = cam_icp_mgr_hw_close_u;
 	hw_mgr_intf->hw_flush = cam_icp_mgr_hw_flush;
+	hw_mgr_intf->hw_cmd = cam_icp_mgr_cmd;
 
 	icp_hw_mgr.secure_mode = CAM_SECURE_MODE_NON_SECURE;
 	mutex_init(&icp_hw_mgr.hw_mgr_mutex);
@@ -4616,6 +4719,9 @@ int cam_icp_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
 	rc = cam_icp_mgr_create_wq();
 	if (rc)
 		goto icp_wq_create_failed;
+
+	if (iommu_hdl)
+		*iommu_hdl = icp_hw_mgr.iommu_hdl;
 
 	init_completion(&icp_hw_mgr.a5_complete);
 	return rc;

--- a/drivers/media/platform/msm/camera/cam_icp/icp_hw/include/cam_icp_hw_mgr_intf.h
+++ b/drivers/media/platform/msm/camera/cam_icp/icp_hw/include/cam_icp_hw_mgr_intf.h
@@ -28,7 +28,7 @@
 #define CPAS_IPE1_BIT            0x2000
 
 int cam_icp_hw_mgr_init(struct device_node *of_node,
-	uint64_t *hw_mgr_hdl);
+	uint64_t *hw_mgr_hdl, int *iommu_hdl);
 
 /**
  * struct cam_icp_cpas_vote

--- a/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
+++ b/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
@@ -167,6 +167,8 @@ static int cam_isp_dev_probe(struct platform_device *pdev)
 	cam_smmu_set_client_page_fault_handler(iommu_hdl,
 		cam_isp_dev_iommu_fault_handler, node);
 
+	mutex_init(&g_isp_dev.isp_mutex);
+
 	CAM_INFO(CAM_ISP, "Camera ISP probe complete");
 
 	return 0;

--- a/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
+++ b/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
@@ -36,23 +36,47 @@ static const struct of_device_id cam_isp_dt_match[] = {
 	{}
 };
 
-static int cam_isp_subdev_close(struct v4l2_subdev *sd,
+static int cam_isp_subdev_open(struct v4l2_subdev *sd,
 	struct v4l2_subdev_fh *fh)
 {
-	struct cam_node *node = v4l2_get_subdevdata(sd);
-
-	if (!node) {
-		CAM_ERR(CAM_ISP, "Node ptr is NULL");
-		return -EINVAL;
-	}
-
-	cam_node_shutdown(node);
+	mutex_lock(&g_isp_dev.isp_mutex);
+	g_isp_dev.open_cnt++;
+	mutex_unlock(&g_isp_dev.isp_mutex);
 
 	return 0;
 }
 
+static int cam_isp_subdev_close(struct v4l2_subdev *sd,
+	struct v4l2_subdev_fh *fh)
+{
+	int rc = 0;
+	struct cam_node *node = v4l2_get_subdevdata(sd);
+
+	mutex_lock(&g_isp_dev.isp_mutex);
+	if (g_isp_dev.open_cnt <= 0) {
+		CAM_DBG(CAM_ISP, "ISP subdev is already closed");
+		rc = -EINVAL;
+		goto end;
+	}
+
+	g_isp_dev.open_cnt--;
+	if (!node) {
+		CAM_ERR(CAM_ISP, "Node ptr is NULL");
+		rc = -EINVAL;
+		goto end;
+	}
+
+	if (g_isp_dev.open_cnt == 0)
+		cam_node_shutdown(node);
+
+end:
+	mutex_unlock(&g_isp_dev.isp_mutex);
+	return rc;
+}
+
 static const struct v4l2_subdev_internal_ops cam_isp_subdev_internal_ops = {
 	.close = cam_isp_subdev_close,
+	.open = cam_isp_subdev_open,
 };
 
 static int cam_isp_dev_remove(struct platform_device *pdev)

--- a/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
+++ b/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.c
@@ -26,8 +26,28 @@
 #include "cam_isp_hw_mgr_intf.h"
 #include "cam_node.h"
 #include "cam_debug_util.h"
+#include "cam_smmu_api.h"
 
 static struct cam_isp_dev g_isp_dev;
+
+static void cam_isp_dev_iommu_fault_handler(
+	struct iommu_domain *domain, struct device *dev, unsigned long iova,
+	int flags, void *token, uint32_t buf_info)
+{
+	int i = 0;
+	struct cam_node *node = NULL;
+
+	if (!token) {
+		CAM_ERR(CAM_ISP, "invalid token in page handler cb");
+		return;
+	}
+
+	node = (struct cam_node *)token;
+
+	for (i = 0; i < node->ctx_size; i++)
+		cam_context_dump_pf_info(&(node->ctx_list[i]), iova,
+			buf_info);
+}
 
 static const struct of_device_id cam_isp_dt_match[] = {
 	{
@@ -106,6 +126,7 @@ static int cam_isp_dev_probe(struct platform_device *pdev)
 	int i;
 	struct cam_hw_mgr_intf         hw_mgr_intf;
 	struct cam_node               *node;
+	int iommu_hdl = -1;
 
 	g_isp_dev.sd.internal_ops = &cam_isp_subdev_internal_ops;
 	/* Initialze the v4l2 subdevice first. (create cam_node) */
@@ -118,7 +139,7 @@ static int cam_isp_dev_probe(struct platform_device *pdev)
 	node = (struct cam_node *) g_isp_dev.sd.token;
 
 	memset(&hw_mgr_intf, 0, sizeof(hw_mgr_intf));
-	rc = cam_isp_hw_mgr_init(pdev->dev.of_node, &hw_mgr_intf);
+	rc = cam_isp_hw_mgr_init(pdev->dev.of_node, &hw_mgr_intf, &iommu_hdl);
 	if (rc != 0) {
 		CAM_ERR(CAM_ISP, "Can not initialized ISP HW manager!");
 		goto unregister;
@@ -142,6 +163,9 @@ static int cam_isp_dev_probe(struct platform_device *pdev)
 		CAM_ERR(CAM_ISP, "ISP node init failed!");
 		goto unregister;
 	}
+
+	cam_smmu_set_client_page_fault_handler(iommu_hdl,
+		cam_isp_dev_iommu_fault_handler, node);
 
 	CAM_INFO(CAM_ISP, "Camera ISP probe complete");
 

--- a/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.h
+++ b/drivers/media/platform/msm/camera/cam_isp/cam_isp_dev.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -24,12 +24,15 @@
  * @sd:                    Commone camera subdevice node
  * @ctx:                   Isp base context storage
  * @ctx_isp:               Isp private context storage
- *
+ * @isp_mutex:             ISP dev mutex
+ * @open_cnt:              Open device count
  */
 struct cam_isp_dev {
 	struct cam_subdev          sd;
 	struct cam_context         ctx[CAM_CTX_MAX];
 	struct cam_isp_context     ctx_isp[CAM_CTX_MAX];
+	struct mutex               isp_mutex;
+	int32_t                    open_cnt;
 };
 
 #endif /* __CAM_ISP_DEV_H__ */

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
@@ -28,6 +28,7 @@
 #include "cam_packet_util.h"
 #include "cam_debug_util.h"
 #include "cam_cpas_api.h"
+#include "cam_mem_mgr_api.h"
 
 #define CAM_IFE_HW_ENTRIES_MAX  20
 
@@ -2806,45 +2807,133 @@ static int cam_ife_mgr_sof_irq_debug(
 	return rc;
 }
 
+static void cam_ife_mgr_print_io_bufs(struct cam_packet *packet,
+	int32_t iommu_hdl, int32_t sec_mmu_hdl, uint32_t pf_buf_info,
+	bool *mem_found)
+{
+	uint64_t   iova_addr;
+	size_t     src_buf_size;
+	int        i;
+	int        j;
+	int        rc = 0;
+	int32_t    mmu_hdl;
+
+	struct cam_buf_io_cfg  *io_cfg = NULL;
+
+	if (mem_found)
+		*mem_found = false;
+
+	io_cfg = (struct cam_buf_io_cfg *)((uint32_t *)&packet->payload +
+		packet->io_configs_offset / 4);
+
+	for (i = 0; i < packet->num_io_configs; i++) {
+		for (j = 0; j < CAM_PACKET_MAX_PLANES; j++) {
+			if (!io_cfg[i].mem_handle[j])
+				break;
+
+			if (GET_FD_FROM_HANDLE(io_cfg[i].mem_handle[j]) ==
+				GET_FD_FROM_HANDLE(pf_buf_info)) {
+				CAM_INFO(CAM_ISP,
+					"Found PF at port: %d mem %x fd: %x",
+					io_cfg[i].resource_type,
+					io_cfg[i].mem_handle[j],
+					pf_buf_info);
+				if (mem_found)
+					*mem_found = true;
+			}
+
+			CAM_INFO(CAM_ISP, "port: %d f: %u format: %d dir %d",
+				io_cfg[i].resource_type,
+				io_cfg[i].fence,
+				io_cfg[i].format,
+				io_cfg[i].direction);
+
+			mmu_hdl = cam_mem_is_secure_buf(
+				io_cfg[i].mem_handle[j]) ? sec_mmu_hdl :
+				iommu_hdl;
+			rc = cam_mem_get_io_buf(io_cfg[i].mem_handle[j],
+				mmu_hdl, &iova_addr, &src_buf_size);
+			if (rc < 0) {
+				CAM_ERR(CAM_ISP, "get src buf address fail");
+				continue;
+			}
+			if (iova_addr >> 32) {
+				CAM_ERR(CAM_ISP, "Invalid mapped address");
+				rc = -EINVAL;
+				continue;
+			}
+
+			CAM_INFO(CAM_ISP,
+				"pln %d w %d h %d size %d addr 0x%x offset 0x%x memh %x",
+				j, io_cfg[i].planes[j].width,
+				io_cfg[i].planes[j].height,
+				(int32_t)src_buf_size,
+				(unsigned int)iova_addr,
+				io_cfg[i].offsets[j],
+				io_cfg[i].mem_handle[j]);
+		}
+	}
+}
+
 static int cam_ife_mgr_cmd(void *hw_mgr_priv, void *cmd_args)
 {
 	int rc = 0;
-	struct cam_isp_hw_cmd_args  *hw_cmd_args  = cmd_args;
-	struct cam_ife_hw_mgr_ctx   *ctx;
+	struct cam_hw_cmd_args *hw_cmd_args = cmd_args;
+	struct cam_ife_hw_mgr  *hw_mgr = hw_mgr_priv;
+	struct cam_ife_hw_mgr_ctx *ctx = (struct cam_ife_hw_mgr_ctx *)
+		hw_cmd_args->ctxt_to_hw_map;
 
 	if (!hw_mgr_priv || !cmd_args) {
 		CAM_ERR(CAM_ISP, "Invalid arguments");
 		return -EINVAL;
 	}
 
-	ctx = (struct cam_ife_hw_mgr_ctx *)hw_cmd_args->ctxt_to_hw_map;
 	if (!ctx || !ctx->ctx_in_use) {
 		CAM_ERR(CAM_ISP, "Fatal: Invalid context is used");
 		return -EPERM;
 	}
 
 	switch (hw_cmd_args->cmd_type) {
-	case CAM_ISP_HW_MGR_CMD_IS_RDI_ONLY_CONTEXT:
-		if (ctx->is_rdi_only_context)
-			hw_cmd_args->u.is_rdi_only_context = 1;
-		else
-			hw_cmd_args->u.is_rdi_only_context = 0;
+	case CAM_HW_MGR_CMD_INTERNAL: {
+		struct cam_isp_hw_cmd_args *isp_hw_cmd_args =
+			(struct cam_isp_hw_cmd_args *)hw_cmd_args->
+				u.internal_args;
 
+		switch (isp_hw_cmd_args->cmd_type) {
+		case CAM_ISP_HW_MGR_CMD_IS_RDI_ONLY_CONTEXT:
+			if (ctx->is_rdi_only_context)
+				isp_hw_cmd_args->u.is_rdi_only_context = 1;
+			else
+				isp_hw_cmd_args->u.is_rdi_only_context = 0;
+			break;
+		case CAM_ISP_HW_MGR_CMD_PAUSE_HW:
+			cam_ife_mgr_pause_hw(ctx);
+			break;
+		case CAM_ISP_HW_MGR_CMD_RESUME_HW:
+			cam_ife_mgr_resume_hw(ctx);
+			break;
+		case CAM_ISP_HW_MGR_CMD_SOF_DEBUG:
+			cam_ife_mgr_sof_irq_debug(ctx,
+				isp_hw_cmd_args->u.sof_irq_enable);
+			break;
+		default:
+			CAM_ERR(CAM_ISP, "Invalid HW mgr command:0x%x",
+				hw_cmd_args->cmd_type);
+			rc = -EINVAL;
+			break;
+		}
 		break;
-	case CAM_ISP_HW_MGR_CMD_PAUSE_HW:
-		cam_ife_mgr_pause_hw(ctx);
-		break;
-	case CAM_ISP_HW_MGR_CMD_RESUME_HW:
-		cam_ife_mgr_resume_hw(ctx);
-		break;
-	case CAM_ISP_HW_MGR_CMD_SOF_DEBUG:
-		cam_ife_mgr_sof_irq_debug(ctx, hw_cmd_args->u.sof_irq_enable);
+	}
+	case CAM_HW_MGR_CMD_DUMP_PF_INFO:
+		cam_ife_mgr_print_io_bufs(
+			hw_cmd_args->u.pf_args.pf_data.packet,
+			hw_mgr->mgr_common.img_iommu_hdl,
+			hw_mgr->mgr_common.img_iommu_hdl_secure,
+			hw_cmd_args->u.pf_args.buf_info,
+			hw_cmd_args->u.pf_args.mem_found);
 		break;
 	default:
-		CAM_ERR(CAM_ISP, "Invalid HW mgr command:0x%x",
-			hw_cmd_args->cmd_type);
-		rc = -EINVAL;
-		break;
+		CAM_ERR(CAM_ISP, "Invalid cmd");
 	}
 
 	return rc;
@@ -4210,7 +4299,7 @@ err:
 	return -ENOMEM;
 }
 
-int cam_ife_hw_mgr_init(struct cam_hw_mgr_intf *hw_mgr_intf)
+int cam_ife_hw_mgr_init(struct cam_hw_mgr_intf *hw_mgr_intf, int *iommu_hdl)
 {
 	int rc = -EFAULT;
 	int i, j;
@@ -4381,6 +4470,9 @@ int cam_ife_hw_mgr_init(struct cam_hw_mgr_intf *hw_mgr_intf)
 	hw_mgr_intf->hw_prepare_update = cam_ife_mgr_prepare_hw_update;
 	hw_mgr_intf->hw_config = cam_ife_mgr_config_hw;
 	hw_mgr_intf->hw_cmd = cam_ife_mgr_cmd;
+
+	if (iommu_hdl)
+		*iommu_hdl = g_ife_hw_mgr.mgr_common.img_iommu_hdl;
 
 	cam_ife_hw_mgr_debug_register();
 	CAM_DBG(CAM_ISP, "Exit");

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.h
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.h
@@ -203,9 +203,10 @@ struct cam_ife_hw_mgr {
  *                      etnry functinon for the IFE HW manager.
  *
  * @hw_mgr_intf:        IFE hardware manager object returned
+ * @iommu_hdl:          Iommu handle to be returned
  *
  */
-int cam_ife_hw_mgr_init(struct cam_hw_mgr_intf *hw_mgr_intf);
+int cam_ife_hw_mgr_init(struct cam_hw_mgr_intf *hw_mgr_intf, int *iommu_hdl);
 
 /**
  * cam_ife_mgr_do_tasklet_buf_done()

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_isp_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_isp_hw_mgr.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -16,7 +16,7 @@
 
 
 int cam_isp_hw_mgr_init(struct device_node *of_node,
-	struct cam_hw_mgr_intf *hw_mgr)
+	struct cam_hw_mgr_intf *hw_mgr, int *iommu_hdl)
 {
 	int rc = 0;
 	const char *compat_str = NULL;
@@ -25,7 +25,7 @@ int cam_isp_hw_mgr_init(struct device_node *of_node,
 		(const char **)&compat_str);
 
 	if (strnstr(compat_str, "ife", strlen(compat_str)))
-		rc = cam_ife_hw_mgr_init(hw_mgr);
+		rc = cam_ife_hw_mgr_init(hw_mgr, iommu_hdl);
 	else {
 		CAM_ERR(CAM_ISP, "Invalid ISP hw type");
 		rc = -EINVAL;

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/hw_utils/cam_isp_packet_parser.c
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/hw_utils/cam_isp_packet_parser.c
@@ -457,6 +457,7 @@ int cam_isp_add_io_buffers(
 	num_out_buf = 0;
 	num_in_buf  = 0;
 	io_cfg_used_bytes = 0;
+	prepare->pf_data->packet = prepare->packet;
 
 	/* Max one hw entries required for each base */
 	if (prepare->num_hw_update_entries + 1 >=

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/include/cam_isp_hw_mgr_intf.h
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/include/cam_isp_hw_mgr_intf.h
@@ -203,13 +203,11 @@ enum cam_isp_hw_mgr_command {
 /**
  * struct cam_isp_hw_cmd_args - Payload for hw manager command
  *
- * @ctxt_to_hw_map:        HW context from the acquire
  * @cmd_type               HW command type
  * @get_context            Get context type information
  */
 struct cam_isp_hw_cmd_args {
-	void                               *ctxt_to_hw_map;
-	uint32_t                            cmd_type;
+	uint32_t                              cmd_type;
 	union {
 		uint32_t                      is_rdi_only_context;
 		uint32_t                      sof_irq_enable;
@@ -225,9 +223,9 @@ struct cam_isp_hw_cmd_args {
  * @of_node:            Device node input
  * @hw_mgr:             Input/output structure for the ISP hardware manager
  *                          initialization
- *
+ * @iommu_hdl:          Iommu handle to be returned
  */
 int cam_isp_hw_mgr_init(struct device_node *of_node,
-	struct cam_hw_mgr_intf *hw_mgr);
+	struct cam_hw_mgr_intf *hw_mgr, int *iommu_hdl);
 
 #endif /* __CAM_ISP_HW_MGR_INTF_H__ */

--- a/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_context.c
+++ b/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_context.c
@@ -20,8 +20,48 @@
 #include "cam_jpeg_context.h"
 #include "cam_context_utils.h"
 #include "cam_debug_util.h"
+#include "cam_packet_util.h"
 
 static const char jpeg_dev_name[] = "jpeg";
+
+static int cam_jpeg_context_dump_active_request(void *data, unsigned long iova,
+	uint32_t buf_info)
+{
+
+	struct cam_context *ctx = (struct cam_context *)data;
+	struct cam_ctx_request          *req = NULL;
+	struct cam_ctx_request          *req_temp = NULL;
+	struct cam_hw_mgr_dump_pf_data  *pf_dbg_entry = NULL;
+	int rc = 0;
+	int closest_port;
+	bool b_mem_found = false;
+
+
+	if (!ctx) {
+		CAM_ERR(CAM_JPEG, "Invalid ctx");
+		return -EINVAL;
+	}
+
+	CAM_INFO(CAM_JPEG, "iommu fault for jpeg ctx %d state %d",
+		ctx->ctx_id, ctx->state);
+
+	list_for_each_entry_safe(req, req_temp,
+			&ctx->active_req_list, list) {
+		pf_dbg_entry = &(req->pf_data);
+		closest_port = -1;
+		CAM_INFO(CAM_JPEG, "req_id : %lld ", req->request_id);
+
+		rc = cam_context_dump_pf_info_to_hw(ctx, pf_dbg_entry->packet,
+			iova, buf_info, &b_mem_found);
+		if (rc)
+			CAM_ERR(CAM_JPEG, "Failed to dump pf info");
+
+		if (b_mem_found)
+			CAM_ERR(CAM_JPEG, "Found page fault in req %lld %d",
+				req->request_id, rc);
+	}
+	return rc;
+}
 
 static int __cam_jpeg_ctx_acquire_dev_in_available(struct cam_context *ctx,
 	struct cam_acquire_dev_cmd *cmd)
@@ -116,6 +156,7 @@ static struct cam_ctx_ops
 		},
 		.crm_ops = { },
 		.irq_ops = __cam_jpeg_ctx_handle_buf_done_in_acquired,
+		.pagefault_ops = cam_jpeg_context_dump_active_request,
 	},
 };
 

--- a/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.c
+++ b/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.c
@@ -34,23 +34,50 @@ static const struct of_device_id cam_jpeg_dt_match[] = {
 	{ }
 };
 
-static int cam_jpeg_subdev_close(struct v4l2_subdev *sd,
+static int cam_jpeg_subdev_open(struct v4l2_subdev *sd,
 	struct v4l2_subdev_fh *fh)
 {
-	struct cam_node *node = v4l2_get_subdevdata(sd);
 
-	if (!node) {
-		CAM_ERR(CAM_JPEG, "Node ptr is NULL");
-		return -EINVAL;
-	}
-
-	cam_node_shutdown(node);
+	mutex_lock(&g_jpeg_dev.jpeg_mutex);
+	g_jpeg_dev.open_cnt++;
+	mutex_unlock(&g_jpeg_dev.jpeg_mutex);
 
 	return 0;
 }
 
+static int cam_jpeg_subdev_close(struct v4l2_subdev *sd,
+	struct v4l2_subdev_fh *fh)
+{
+	int rc = 0;
+	struct cam_node *node = v4l2_get_subdevdata(sd);
+
+
+	mutex_lock(&g_jpeg_dev.jpeg_mutex);
+	if (g_jpeg_dev.open_cnt <= 0) {
+		CAM_DBG(CAM_JPEG, "JPEG subdev is already closed");
+		rc = -EINVAL;
+		goto end;
+	}
+
+	g_jpeg_dev.open_cnt--;
+
+	if (!node) {
+		CAM_ERR(CAM_JPEG, "Node ptr is NULL");
+		rc = -EINVAL;
+		goto end;
+	}
+
+	if (g_jpeg_dev.open_cnt == 0)
+		cam_node_shutdown(node);
+
+end:
+	mutex_unlock(&g_jpeg_dev.jpeg_mutex);
+	return rc;
+}
+
 static const struct v4l2_subdev_internal_ops cam_jpeg_subdev_internal_ops = {
 	.close = cam_jpeg_subdev_close,
+	.open = cam_jpeg_subdev_open,
 };
 
 static int cam_jpeg_dev_remove(struct platform_device *pdev)

--- a/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.c
+++ b/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.c
@@ -22,10 +22,30 @@
 #include "cam_jpeg_hw_mgr_intf.h"
 #include "cam_jpeg_dev.h"
 #include "cam_debug_util.h"
+#include "cam_smmu_api.h"
 
 #define CAM_JPEG_DEV_NAME "cam-jpeg"
 
 static struct cam_jpeg_dev g_jpeg_dev;
+
+static void cam_jpeg_dev_iommu_fault_handler(
+	struct iommu_domain *domain, struct device *dev, unsigned long iova,
+	int flags, void *token, uint32_t buf_info)
+{
+	int i = 0;
+	struct cam_node *node = NULL;
+
+	if (!token) {
+		CAM_ERR(CAM_JPEG, "invalid token in page handler cb");
+		return;
+	}
+
+	node = (struct cam_node *)token;
+
+	for (i = 0; i < node->ctx_size; i++)
+		cam_context_dump_pf_info(&(node->ctx_list[i]), iova,
+			buf_info);
+}
 
 static const struct of_device_id cam_jpeg_dt_match[] = {
 	{
@@ -105,6 +125,7 @@ static int cam_jpeg_dev_probe(struct platform_device *pdev)
 	int i;
 	struct cam_hw_mgr_intf hw_mgr_intf;
 	struct cam_node *node;
+	int iommu_hdl = -1;
 
 	g_jpeg_dev.sd.internal_ops = &cam_jpeg_subdev_internal_ops;
 	rc = cam_subdev_probe(&g_jpeg_dev.sd, pdev, CAM_JPEG_DEV_NAME,
@@ -116,7 +137,7 @@ static int cam_jpeg_dev_probe(struct platform_device *pdev)
 	node = (struct cam_node *)g_jpeg_dev.sd.token;
 
 	rc = cam_jpeg_hw_mgr_init(pdev->dev.of_node,
-		(uint64_t *)&hw_mgr_intf);
+		(uint64_t *)&hw_mgr_intf, &iommu_hdl);
 	if (rc) {
 		CAM_ERR(CAM_JPEG, "Can not initialize JPEG HWmanager %d", rc);
 		goto unregister;
@@ -140,6 +161,9 @@ static int cam_jpeg_dev_probe(struct platform_device *pdev)
 		CAM_ERR(CAM_JPEG, "JPEG node init failed %d", rc);
 		goto ctx_init_fail;
 	}
+
+	cam_smmu_set_client_page_fault_handler(iommu_hdl,
+		cam_jpeg_dev_iommu_fault_handler, node);
 
 	mutex_init(&g_jpeg_dev.jpeg_mutex);
 

--- a/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.h
+++ b/drivers/media/platform/msm/camera/cam_jpeg/cam_jpeg_dev.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -26,6 +26,7 @@
  * @ctx: JPEG base context storage
  * @ctx_jpeg: JPEG private context storage
  * @jpeg_mutex: Jpeg dev mutex
+ * @open_cnt: Open device count
  */
 struct cam_jpeg_dev {
 	struct cam_subdev sd;
@@ -33,5 +34,6 @@ struct cam_jpeg_dev {
 	struct cam_context ctx[CAM_CTX_MAX];
 	struct cam_jpeg_context ctx_jpeg[CAM_CTX_MAX];
 	struct mutex jpeg_mutex;
+	int32_t open_cnt;
 };
 #endif /* __CAM_JPEG_DEV_H__ */

--- a/drivers/media/platform/msm/camera/cam_jpeg/jpeg_hw/cam_jpeg_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_jpeg/jpeg_hw/cam_jpeg_hw_mgr.c
@@ -600,6 +600,74 @@ err_after_dq_free_list:
 	return rc;
 }
 
+static void cam_jpeg_mgr_print_io_bufs(struct cam_packet *packet,
+	int32_t iommu_hdl, int32_t sec_mmu_hdl, uint32_t pf_buf_info,
+	bool *mem_found)
+{
+	uint64_t   iova_addr;
+	size_t     src_buf_size;
+	int        i;
+	int        j;
+	int        rc = 0;
+	int32_t    mmu_hdl;
+	struct cam_buf_io_cfg  *io_cfg = NULL;
+
+	if (mem_found)
+		*mem_found = false;
+
+	io_cfg = (struct cam_buf_io_cfg *)((uint32_t *)&packet->payload +
+		packet->io_configs_offset / 4);
+
+	for (i = 0; i < packet->num_io_configs; i++) {
+		for (j = 0; j < CAM_PACKET_MAX_PLANES; j++) {
+			if (!io_cfg[i].mem_handle[j])
+				break;
+
+			if (GET_FD_FROM_HANDLE(io_cfg[i].mem_handle[j]) ==
+				GET_FD_FROM_HANDLE(pf_buf_info)) {
+				CAM_INFO(CAM_JPEG,
+					"Found PF at port: %d mem %x fd: %x",
+					io_cfg[i].resource_type,
+					io_cfg[i].mem_handle[j],
+					pf_buf_info);
+				if (mem_found)
+					*mem_found = true;
+			}
+
+			CAM_INFO(CAM_JPEG, "port: %d f: %u format: %d dir %d",
+				io_cfg[i].resource_type,
+				io_cfg[i].fence,
+				io_cfg[i].format,
+				io_cfg[i].direction);
+
+			mmu_hdl = cam_mem_is_secure_buf(
+				io_cfg[i].mem_handle[j]) ? sec_mmu_hdl :
+				iommu_hdl;
+			rc = cam_mem_get_io_buf(io_cfg[i].mem_handle[j],
+				mmu_hdl, &iova_addr, &src_buf_size);
+			if (rc < 0) {
+				CAM_ERR(CAM_UTIL, "get src buf address fail");
+				continue;
+			}
+			if (iova_addr >> 32) {
+				CAM_ERR(CAM_JPEG, "Invalid mapped address");
+				rc = -EINVAL;
+				continue;
+			}
+
+			CAM_INFO(CAM_JPEG,
+				"pln %d w %d h %d size %d addr 0x%x offset 0x%x memh %x",
+				j, io_cfg[i].planes[j].width,
+				io_cfg[i].planes[j].height,
+				(int32_t)src_buf_size,
+				(unsigned int)iova_addr,
+				io_cfg[i].offsets[j],
+				io_cfg[i].mem_handle[j]);
+
+			iova_addr += io_cfg[i].offsets[j];
+		}
+	}
+}
 
 static int cam_jpeg_mgr_prepare_hw_update(void *hw_mgr_priv,
 	void *prepare_hw_update_args)
@@ -675,6 +743,7 @@ static int cam_jpeg_mgr_prepare_hw_update(void *hw_mgr_priv,
 	CAM_DBG(CAM_JPEG, "packet = %pK io_cfg_ptr = %pK size = %lu",
 		(void *)packet, (void *)io_cfg_ptr,
 		sizeof(struct cam_buf_io_cfg));
+	prepare_args->pf_data->packet = packet;
 
 	prepare_args->num_out_map_entries = 0;
 
@@ -1410,7 +1479,35 @@ num_dev_failed:
 	return rc;
 }
 
-int cam_jpeg_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
+static int cam_jpeg_mgr_cmd(void *hw_mgr_priv, void *cmd_args)
+{
+	int rc = 0;
+	struct cam_hw_cmd_args *hw_cmd_args = cmd_args;
+	struct cam_jpeg_hw_mgr *hw_mgr = hw_mgr_priv;
+
+	if (!hw_mgr_priv || !cmd_args) {
+		CAM_ERR(CAM_JPEG, "Invalid arguments");
+		return -EINVAL;
+	}
+
+	switch (hw_cmd_args->cmd_type) {
+	case CAM_HW_MGR_CMD_DUMP_PF_INFO:
+		cam_jpeg_mgr_print_io_bufs(
+			hw_cmd_args->u.pf_args.pf_data.packet,
+			hw_mgr->iommu_hdl,
+			hw_mgr->iommu_sec_hdl,
+			hw_cmd_args->u.pf_args.buf_info,
+			hw_cmd_args->u.pf_args.mem_found);
+		break;
+	default:
+		CAM_ERR(CAM_JPEG, "Invalid cmd");
+	}
+
+	return rc;
+}
+
+int cam_jpeg_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl,
+	int *iommu_hdl)
 {
 	int i, rc;
 	uint32_t num_dev;
@@ -1434,6 +1531,7 @@ int cam_jpeg_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
 	hw_mgr_intf->hw_config = cam_jpeg_mgr_config_hw;
 	hw_mgr_intf->hw_flush = cam_jpeg_mgr_hw_flush;
 	hw_mgr_intf->hw_stop = cam_jpeg_mgr_hw_stop;
+	hw_mgr_intf->hw_cmd = cam_jpeg_mgr_cmd;
 
 	mutex_init(&g_jpeg_hw_mgr.hw_mgr_mutex);
 	spin_lock_init(&g_jpeg_hw_mgr.hw_mgr_lock);
@@ -1494,6 +1592,9 @@ int cam_jpeg_hw_mgr_init(struct device_node *of_node, uint64_t *hw_mgr_hdl)
 		CAM_ERR(CAM_JPEG, "setup work qs failed  %d", rc);
 		goto cdm_iommu_failed;
 	}
+
+	if (iommu_hdl)
+		*iommu_hdl = g_jpeg_hw_mgr.iommu_hdl;
 
 	return rc;
 

--- a/drivers/media/platform/msm/camera/cam_jpeg/jpeg_hw/include/cam_jpeg_hw_mgr_intf.h
+++ b/drivers/media/platform/msm/camera/cam_jpeg/jpeg_hw/include/cam_jpeg_hw_mgr_intf.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -17,8 +17,7 @@
 #include <uapi/media/cam_defs.h>
 #include <linux/of.h>
 
-
 int cam_jpeg_hw_mgr_init(struct device_node *of_node,
-	uint64_t *hw_mgr_hdl);
+	uint64_t *hw_mgr_hdl, int *iommu_hdl);
 
 #endif /* CAM_JPEG_HW_MGR_INTF_H */

--- a/drivers/media/platform/msm/camera/cam_lrme/cam_lrme_dev.c
+++ b/drivers/media/platform/msm/camera/cam_lrme/cam_lrme_dev.c
@@ -81,6 +81,7 @@ static int cam_lrme_dev_open(struct v4l2_subdev *sd,
 static int cam_lrme_dev_close(struct v4l2_subdev *sd,
 	struct v4l2_subdev_fh *fh)
 {
+	int rc = 0;
 	struct cam_lrme_dev *lrme_dev = g_lrme_dev;
 	struct cam_node *node = v4l2_get_subdevdata(sd);
 
@@ -90,18 +91,25 @@ static int cam_lrme_dev_close(struct v4l2_subdev *sd,
 	}
 
 	mutex_lock(&lrme_dev->lock);
-	lrme_dev->open_cnt--;
-	mutex_unlock(&lrme_dev->lock);
+	if (lrme_dev->open_cnt <= 0) {
+		CAM_DBG(CAM_LRME, "LRME subdev is already closed");
+		rc = -EINVAL;
+		goto end;
+	}
 
+	lrme_dev->open_cnt--;
 	if (!node) {
 		CAM_ERR(CAM_LRME, "Node is NULL");
-		return -EINVAL;
+		rc = -EINVAL;
+		goto end;
 	}
 
 	if (lrme_dev->open_cnt == 0)
 		cam_node_shutdown(node);
 
-	return 0;
+end:
+	mutex_unlock(&lrme_dev->lock);
+	return rc;
 }
 
 static const struct v4l2_subdev_internal_ops cam_lrme_subdev_internal_ops = {

--- a/drivers/media/platform/msm/camera/cam_req_mgr/cam_req_mgr_dev.c
+++ b/drivers/media/platform/msm/camera/cam_req_mgr/cam_req_mgr_dev.c
@@ -153,6 +153,10 @@ static unsigned int cam_req_mgr_poll(struct file *f,
 
 static int cam_req_mgr_close(struct file *filep)
 {
+	struct v4l2_subdev *sd;
+	struct v4l2_fh *vfh = filep->private_data;
+	struct v4l2_subdev_fh *subdev_fh = to_v4l2_subdev_fh(vfh);
+
 	mutex_lock(&g_dev.cam_lock);
 
 	if (g_dev.open_cnt <= 0) {
@@ -161,6 +165,17 @@ static int cam_req_mgr_close(struct file *filep)
 	}
 
 	cam_req_mgr_handle_core_shutdown();
+
+	list_for_each_entry(sd, &g_dev.v4l2_dev->subdevs, list) {
+		if (!(sd->flags & V4L2_SUBDEV_FL_HAS_DEVNODE))
+			continue;
+		if (sd->internal_ops && sd->internal_ops->close) {
+			CAM_DBG(CAM_CRM, "Invoke subdev close for device %s",
+				sd->name);
+			sd->internal_ops->close(sd, subdev_fh);
+		}
+	}
+
 	g_dev.open_cnt--;
 	v4l2_fh_release(filep);
 

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
@@ -397,6 +397,8 @@ int32_t cam_actuator_establish_link(
 		CAM_ERR(CAM_ACTUATOR, "Device data is NULL");
 		return -EINVAL;
 	}
+
+	mutex_lock(&(a_ctrl->actuator_mutex));
 	if (link->link_enable) {
 		a_ctrl->bridge_intf.link_hdl = link->link_hdl;
 		a_ctrl->bridge_intf.crm_cb = link->crm_cb;
@@ -404,6 +406,7 @@ int32_t cam_actuator_establish_link(
 		a_ctrl->bridge_intf.link_hdl = -1;
 		a_ctrl->bridge_intf.crm_cb = NULL;
 	}
+	mutex_unlock(&(a_ctrl->actuator_mutex));
 
 	return 0;
 }

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_actuator/cam_actuator_core.c
@@ -344,7 +344,7 @@ int32_t cam_actuator_apply_request(struct cam_req_mgr_apply_request *apply)
 	trace_cam_apply_req("Actuator", apply->request_id);
 
 	CAM_DBG(CAM_ACTUATOR, "Request Id: %lld", apply->request_id);
-
+	mutex_lock(&(a_ctrl->actuator_mutex));
 	if ((apply->request_id ==
 		a_ctrl->i2c_data.per_frame[request_id].request_id) &&
 		(a_ctrl->i2c_data.per_frame[request_id].is_settings_valid)
@@ -355,7 +355,7 @@ int32_t cam_actuator_apply_request(struct cam_req_mgr_apply_request *apply)
 			CAM_ERR(CAM_ACTUATOR,
 				"Failed in applying the request: %lld\n",
 				apply->request_id);
-			return rc;
+			goto release_mutex;
 		}
 	}
 	del_req_id = (request_id +
@@ -370,12 +370,14 @@ int32_t cam_actuator_apply_request(struct cam_req_mgr_apply_request *apply)
 			CAM_ERR(CAM_ACTUATOR,
 				"Fail deleting the req: %d err: %d\n",
 				del_req_id, rc);
-			return rc;
+			goto release_mutex;
 		}
 	} else {
 		CAM_DBG(CAM_ACTUATOR, "No Valid Req to clean Up");
 	}
 
+release_mutex:
+	mutex_unlock(&(a_ctrl->actuator_mutex));
 	return rc;
 }
 
@@ -911,7 +913,9 @@ int32_t cam_actuator_flush_request(struct cam_req_mgr_flush_request *flush_req)
 			continue;
 
 		if (i2c_set->is_settings_valid == 1) {
+			mutex_lock(&(a_ctrl->actuator_mutex));
 			rc = delete_request(i2c_set);
+			mutex_unlock(&(a_ctrl->actuator_mutex));
 			if (rc < 0)
 				CAM_ERR(CAM_ACTUATOR,
 					"delete request: %lld rc: %d",

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_flash/cam_flash_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_flash/cam_flash_core.c
@@ -859,6 +859,7 @@ int cam_flash_establish_link(struct cam_req_mgr_core_dev_link_setup *link)
 		return -EINVAL;
 	}
 
+	mutex_lock(&fctrl->flash_mutex);
 	if (link->link_enable) {
 		fctrl->bridge_intf.link_hdl = link->link_hdl;
 		fctrl->bridge_intf.crm_cb = link->crm_cb;
@@ -866,6 +867,7 @@ int cam_flash_establish_link(struct cam_req_mgr_core_dev_link_setup *link)
 		fctrl->bridge_intf.link_hdl = -1;
 		fctrl->bridge_intf.crm_cb = NULL;
 	}
+	mutex_unlock(&fctrl->flash_mutex);
 
 	return 0;
 }

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_sensor/cam_sensor_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_sensor/cam_sensor_core.c
@@ -918,6 +918,8 @@ int cam_sensor_establish_link(struct cam_req_mgr_core_dev_link_setup *link)
 		CAM_ERR(CAM_SENSOR, "Device data is NULL");
 		return -EINVAL;
 	}
+
+	mutex_lock(&s_ctrl->cam_sensor_mutex);
 	if (link->link_enable) {
 		s_ctrl->bridge_intf.link_hdl = link->link_hdl;
 		s_ctrl->bridge_intf.crm_cb = link->crm_cb;
@@ -925,6 +927,7 @@ int cam_sensor_establish_link(struct cam_req_mgr_core_dev_link_setup *link)
 		s_ctrl->bridge_intf.link_hdl = -1;
 		s_ctrl->bridge_intf.crm_cb = NULL;
 	}
+	mutex_unlock(&s_ctrl->cam_sensor_mutex);
 
 	return 0;
 }

--- a/drivers/media/platform/msm/camera/cam_smmu/Makefile
+++ b/drivers/media/platform/msm/camera/cam_smmu/Makefile
@@ -1,3 +1,4 @@
 ccflags-y += -Idrivers/media/platform/msm/camera/cam_utils
+ccflags-y += -Idrivers/media/platform/msm/camera/cam_req_mgr
 
 obj-$(CONFIG_SPECTRA_CAMERA) += cam_smmu_api.o

--- a/drivers/media/platform/msm/camera/cam_smmu/cam_smmu_api.h
+++ b/drivers/media/platform/msm/camera/cam_smmu/cam_smmu_api.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -49,6 +49,21 @@ enum cam_smmu_region_id {
 	CAM_SMMU_REGION_SECHEAP,
 	CAM_SMMU_REGION_QDSS
 };
+
+/**
+ * @brief        : Callback function type that gets called back on cam
+ *                     smmu page fault.
+ *
+ * @param domain   : Iommu domain received in iommu page fault handler
+ * @param dev      : Device received in iommu page fault handler
+ * @param iova     : IOVA where page fault occurred
+ * @param flags    : Flags received in iommu page fault handler
+ * @param token    : Userdata given during callback registration
+ * @param buf_info : Closest mapped buffer info
+ */
+typedef void (*cam_smmu_client_page_fault_handler)(struct iommu_domain *domain,
+	struct device *dev, unsigned long iova, int flags, void *token,
+	uint32_t buf_info);
 
 /**
  * @brief            : Structure to store region information
@@ -215,13 +230,19 @@ int cam_smmu_find_index_by_handle(int hdl);
  * @brief       : Registers smmu fault handler for client
  *
  * @param handle: Handle to identify the CAM SMMU client (VFE, CPP, FD etc.)
- * @param client_page_fault_handler: It is triggered in IOMMU page fault
+ * @param handler_cb: It is triggered in IOMMU page fault
  * @param token: It is input param when trigger page fault handler
  */
-void cam_smmu_reg_client_page_fault_handler(int handle,
-	void (*client_page_fault_handler)(struct iommu_domain *,
-	struct device *, unsigned long,
-	int, void*), void *token);
+void cam_smmu_set_client_page_fault_handler(int handle,
+	cam_smmu_client_page_fault_handler handler_cb, void *token);
+
+/**
+ * @brief       : Unregisters smmu fault handler for client
+ *
+ * @param handle: Handle to identify the CAM SMMU client (VFE, CPP, FD etc.)
+ * @param token: It is input param when trigger page fault handler
+ */
+void cam_smmu_unset_client_page_fault_handler(int handle, void *token);
 
 /**
  * @brief Maps memory from an ION fd into IOVA space

--- a/drivers/media/platform/msm/vidc/msm_vidc_platform.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc_platform.c
@@ -120,7 +120,7 @@ static struct msm_vidc_common_data sdm845_common_data[] = {
 	},
 	{
 		.key = "qcom,max-secure-instances",
-		.value = 5,
+		.value = 2,
 	},
 	{
 		.key = "qcom,max-hw-load",

--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -1175,7 +1175,7 @@ static int __iface_cmdq_write_relaxed(struct venus_hfi_device *device,
 	__strict_check(device);
 
 	if (!__core_in_valid_state(device)) {
-		dprintk(VIDC_DBG, "%s - fw not in init state\n", __func__);
+		dprintk(VIDC_ERR, "%s - fw not in init state\n", __func__);
 		result = -EINVAL;
 		goto err_q_null;
 	}
@@ -2896,8 +2896,6 @@ static void __process_sys_error(struct venus_hfi_device *device)
 {
 	struct hfi_sfr_struct *vsfr = NULL;
 
-	__set_state(device, VENUS_STATE_DEINIT);
-
 	if (__halt_axi(device))
 		dprintk(VIDC_WARN, "Failed to halt AXI after SYS_ERROR\n");
 
@@ -3155,6 +3153,10 @@ static int __response_handler(struct venus_hfi_device *device)
 					"Too many packets in message queue to handle at once, deferring read\n");
 			break;
 		}
+
+		/* do not read packets after sys error packet */
+		if (info->response_type == HAL_SYS_ERROR)
+			break;
 	}
 
 	if (requeue_pm_work && device->res->sw_power_collapsible) {

--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -3221,6 +3221,12 @@ err_no_work:
 		struct msm_vidc_cb_info *r = &device->response_pkt[i];
 		dprintk(VIDC_DBG, "Processing response %d of %d, type %d\n",
 			(i + 1), num_responses, r->response_type);
+		if (!__core_in_valid_state(device)) {
+			dprintk(VIDC_ERR,
+				"Ignore responses from %d to %d as device is in invalid state",
+				(i + 1), num_responses);
+			break;
+		}
 		device->callback(r->response_type, &r->response);
 	}
 

--- a/drivers/media/platform/msm/vidc_3x/msm_vdec.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vdec.c
@@ -24,6 +24,7 @@
 #define MSM_VDEC_DVC_NAME "msm_vdec_8974"
 #define MIN_NUM_OUTPUT_BUFFERS 4
 #define MIN_NUM_OUTPUT_BUFFERS_VP9 6
+#define MIN_NUM_OUTPUT_BUFFERS_HEVC 6
 #define MIN_NUM_CAPTURE_BUFFERS 6
 #define MIN_NUM_THUMBNAIL_MODE_CAPTURE_BUFFERS 1
 #define MAX_NUM_OUTPUT_BUFFERS VB2_MAX_FRAME
@@ -1478,6 +1479,10 @@ static int msm_vdec_queue_setup(struct vb2_queue *q,
 				V4L2_PIX_FMT_VP9 &&
 				*num_buffers < MIN_NUM_OUTPUT_BUFFERS_VP9)
 			*num_buffers = MIN_NUM_OUTPUT_BUFFERS_VP9;
+		else if (inst->fmts[OUTPUT_PORT].fourcc ==
+				V4L2_PIX_FMT_HEVC &&
+				*num_buffers < MIN_NUM_OUTPUT_BUFFERS_HEVC)
+			*num_buffers = MIN_NUM_OUTPUT_BUFFERS_HEVC;
 
 		for (i = 0; i < *num_planes; i++) {
 			sizes[i] = get_frame_size(inst,

--- a/drivers/mmc/host/sdhci-msm-ice.c
+++ b/drivers/mmc/host/sdhci-msm-ice.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2015, 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -244,8 +244,8 @@ int sdhci_msm_ice_get_cfg(struct sdhci_msm_host *msm_host, struct request *req,
 }
 
 static
-void sdhci_msm_ice_update_cfg(struct sdhci_host *host, u64 lba,
-			u32 slot, unsigned int bypass, short key_index)
+void sdhci_msm_ice_update_cfg(struct sdhci_host *host, u64 lba, u32 slot,
+		unsigned int bypass, short key_index, u32 cdu_sz)
 {
 	unsigned int ctrl_info_val = 0;
 
@@ -257,7 +257,7 @@ void sdhci_msm_ice_update_cfg(struct sdhci_host *host, u64 lba,
 
 	/* Configure data unit size of transfer request */
 	ctrl_info_val |=
-		(SDHCI_MSM_ICE_TR_DATA_UNIT_512_B &
+		(cdu_sz &
 		 MASK_SDHCI_MSM_ICE_CTRL_INFO_CDU)
 		 << OFFSET_SDHCI_MSM_ICE_CTRL_INFO_CDU;
 
@@ -336,8 +336,9 @@ int sdhci_msm_ice_cfg(struct sdhci_host *host, struct mmc_request *mrq,
 	struct sdhci_msm_host *msm_host = pltfm_host->priv;
 	int err = 0;
 	short key_index = 0;
-	sector_t lba = 0;
+	u64 dun = 0;
 	unsigned int bypass = SDHCI_MSM_ICE_ENABLE_BYPASS;
+	u32 cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_512_B;
 	struct request *req;
 
 	if (msm_host->ice.state != SDHCI_MSM_ICE_STATE_ACTIVE) {
@@ -350,8 +351,13 @@ int sdhci_msm_ice_cfg(struct sdhci_host *host, struct mmc_request *mrq,
 	if (!mrq)
 		return -EINVAL;
 	req = mrq->req;
-	if (req) {
-		lba = req->__sector;
+	if (req && req->bio) {
+		if (bio_dun(req->bio)) {
+			dun = bio_dun(req->bio);
+			cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_4_KB;
+		} else {
+			dun = req->__sector;
+		}
 		err = sdhci_msm_ice_get_cfg(msm_host, req, &bypass, &key_index);
 		if (err)
 			return err;
@@ -363,11 +369,12 @@ int sdhci_msm_ice_cfg(struct sdhci_host *host, struct mmc_request *mrq,
 
 	if (msm_host->ice_hci_support) {
 		/* For ICE HCI / ICE3.0 */
-		sdhci_msm_ice_hci_update_noncq_cfg(host, lba, bypass,
+		sdhci_msm_ice_hci_update_noncq_cfg(host, dun, bypass,
 						key_index);
 	} else {
 		/* For ICE versions earlier to ICE3.0 */
-		sdhci_msm_ice_update_cfg(host, lba, slot, bypass, key_index);
+		sdhci_msm_ice_update_cfg(host, dun, slot, bypass, key_index,
+					cdu_sz);
 	}
 	return 0;
 }
@@ -379,9 +386,10 @@ int sdhci_msm_ice_cmdq_cfg(struct sdhci_host *host,
 	struct sdhci_msm_host *msm_host = pltfm_host->priv;
 	int err = 0;
 	short key_index = 0;
-	sector_t lba = 0;
+	u64 dun = 0;
 	unsigned int bypass = SDHCI_MSM_ICE_ENABLE_BYPASS;
 	struct request *req;
+	u32 cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_512_B;
 
 	if (msm_host->ice.state != SDHCI_MSM_ICE_STATE_ACTIVE) {
 		pr_err("%s: ice is in invalid state %d\n",
@@ -393,8 +401,13 @@ int sdhci_msm_ice_cmdq_cfg(struct sdhci_host *host,
 	if (!mrq)
 		return -EINVAL;
 	req = mrq->req;
-	if (req) {
-		lba = req->__sector;
+	if (req && req->bio) {
+		if (bio_dun(req->bio)) {
+			dun = bio_dun(req->bio);
+			cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_4_KB;
+		} else {
+			dun = req->__sector;
+		}
 		err = sdhci_msm_ice_get_cfg(msm_host, req, &bypass, &key_index);
 		if (err)
 			return err;
@@ -406,11 +419,12 @@ int sdhci_msm_ice_cmdq_cfg(struct sdhci_host *host,
 
 	if (msm_host->ice_hci_support) {
 		/* For ICE HCI / ICE3.0 */
-		sdhci_msm_ice_hci_update_cmdq_cfg(lba, bypass, key_index,
+		sdhci_msm_ice_hci_update_cmdq_cfg(dun, bypass, key_index,
 						ice_ctx);
 	} else {
 		/* For ICE versions earlier to ICE3.0 */
-		sdhci_msm_ice_update_cfg(host, lba, slot, bypass, key_index);
+		sdhci_msm_ice_update_cfg(host, dun, slot, bypass, key_index,
+					cdu_sz);
 	}
 	return 0;
 }

--- a/drivers/mmc/host/sdhci-msm-ice.c
+++ b/drivers/mmc/host/sdhci-msm-ice.c
@@ -352,12 +352,16 @@ int sdhci_msm_ice_cfg(struct sdhci_host *host, struct mmc_request *mrq,
 		return -EINVAL;
 	req = mrq->req;
 	if (req && req->bio) {
+#ifdef CONFIG_PFK
 		if (bio_dun(req->bio)) {
 			dun = bio_dun(req->bio);
 			cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_4_KB;
 		} else {
 			dun = req->__sector;
 		}
+#else
+		dun = req->__sector;
+#endif
 		err = sdhci_msm_ice_get_cfg(msm_host, req, &bypass, &key_index);
 		if (err)
 			return err;
@@ -402,12 +406,16 @@ int sdhci_msm_ice_cmdq_cfg(struct sdhci_host *host,
 		return -EINVAL;
 	req = mrq->req;
 	if (req && req->bio) {
+#ifdef CONFIG_PFK
 		if (bio_dun(req->bio)) {
 			dun = bio_dun(req->bio);
 			cdu_sz = SDHCI_MSM_ICE_TR_DATA_UNIT_4_KB;
 		} else {
 			dun = req->__sector;
 		}
+#else
+		dun = req->__sector;
+#endif
 		err = sdhci_msm_ice_get_cfg(msm_host, req, &bypass, &key_index);
 		if (err)
 			return err;

--- a/drivers/platform/msm/ipa/ipa_clients/rndis_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_clients/rndis_ipa.c
@@ -458,6 +458,11 @@ struct rndis_pkt_hdr rndis_template_hdr = {
 	.zeroes = {0},
 };
 
+static void rndis_ipa_msg_free_cb(void *buff, u32 len, u32 type)
+{
+	kfree(buff);
+}
+
 /**
  * rndis_ipa_init() - create network device and initialize internal
  *  data structures
@@ -682,6 +687,8 @@ int rndis_ipa_pipe_connect_notify(
 	int result;
 	int ret;
 	unsigned long flags;
+	struct ipa_ecm_msg *rndis_msg;
+	struct ipa_msg_meta msg_meta;
 
 	RNDIS_IPA_LOG_ENTRY();
 
@@ -768,6 +775,26 @@ int rndis_ipa_pipe_connect_notify(
 		goto fail;
 	}
 	RNDIS_IPA_DEBUG("netif_carrier_on() was called\n");
+
+	rndis_msg = kzalloc(sizeof(*rndis_msg), GFP_KERNEL);
+	if (!rndis_msg) {
+		result = -ENOMEM;
+		goto fail;
+	}
+
+	memset(&msg_meta, 0, sizeof(struct ipa_msg_meta));
+	msg_meta.msg_type = ECM_CONNECT;
+	msg_meta.msg_len = sizeof(struct ipa_ecm_msg);
+	strlcpy(rndis_msg->name, rndis_ipa_ctx->net->name,
+		IPA_RESOURCE_NAME_MAX);
+	rndis_msg->ifindex = rndis_ipa_ctx->net->ifindex;
+
+	result = ipa_send_msg(&msg_meta, rndis_msg, rndis_ipa_msg_free_cb);
+	if (result) {
+		RNDIS_IPA_ERROR("fail to send ECM_CONNECT for rndis\n");
+		kfree(rndis_msg);
+		goto fail;
+	}
 
 	spin_lock_irqsave(&rndis_ipa_ctx->state_lock, flags);
 	next_state = rndis_ipa_next_state(rndis_ipa_ctx->state,
@@ -1231,6 +1258,8 @@ int rndis_ipa_pipe_disconnect_notify(void *private)
 	int retval;
 	int ret;
 	unsigned long flags;
+	struct ipa_ecm_msg *rndis_msg;
+	struct ipa_msg_meta msg_meta;
 
 	RNDIS_IPA_LOG_ENTRY();
 
@@ -1261,6 +1290,24 @@ int rndis_ipa_pipe_disconnect_notify(void *private)
 
 	netif_carrier_off(rndis_ipa_ctx->net);
 	RNDIS_IPA_DEBUG("carrier_off notification was sent\n");
+
+	rndis_msg = kzalloc(sizeof(*rndis_msg), GFP_KERNEL);
+	if (!rndis_msg)
+		return -ENOMEM;
+
+	memset(&msg_meta, 0, sizeof(struct ipa_msg_meta));
+	msg_meta.msg_type = ECM_DISCONNECT;
+	msg_meta.msg_len = sizeof(struct ipa_ecm_msg);
+	strlcpy(rndis_msg->name, rndis_ipa_ctx->net->name,
+		IPA_RESOURCE_NAME_MAX);
+	rndis_msg->ifindex = rndis_ipa_ctx->net->ifindex;
+
+	retval = ipa_send_msg(&msg_meta, rndis_msg, rndis_ipa_msg_free_cb);
+	if (retval) {
+		RNDIS_IPA_ERROR("fail to send ECM_DISCONNECT for rndis\n");
+		kfree(rndis_msg);
+		return -EPERM;
+	}
 
 	netif_stop_queue(rndis_ipa_ctx->net);
 	RNDIS_IPA_DEBUG("queue stopped\n");

--- a/drivers/platform/msm/ipa/ipa_v2/ipa_nat.c
+++ b/drivers/platform/msm/ipa/ipa_v2/ipa_nat.c
@@ -327,14 +327,18 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	size_t tmp;
 	gfp_t flag = GFP_KERNEL | (ipa_ctx->use_dma_zone ? GFP_DMA : 0);
 
+	mutex_lock(&ipa_ctx->nat_mem.lock);
+
 	if (!ipa_ctx->nat_mem.is_dev_init) {
 		IPAERR_RL("Nat table not initialized\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
 	IPADBG("\n");
 	if (init->table_entries == 0) {
 		IPADBG("Table entries is zero\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
@@ -342,6 +346,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	if (init->ipv4_rules_offset >
 		(UINT_MAX - (TBL_ENTRY_SIZE * (init->table_entries + 1)))) {
 		IPAERR_RL("Detected overflow\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 	/* Check Table Entry offset is not
@@ -354,6 +359,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAERR_RL("offset:%d entrys:%d size:%zu mem_size:%zu\n",
 			init->ipv4_rules_offset, (init->table_entries + 1),
 			tmp, ipa_ctx->nat_mem.size);
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
@@ -361,6 +367,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	if (init->expn_rules_offset >
 		UINT_MAX - (TBL_ENTRY_SIZE * init->expn_table_entries)) {
 		IPAERR_RL("Detected overflow\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 	/* Check Expn Table Entry offset is not
@@ -373,6 +380,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAERR_RL("offset:%d entrys:%d size:%zu mem_size:%zu\n",
 			init->expn_rules_offset, init->expn_table_entries,
 			tmp, ipa_ctx->nat_mem.size);
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
@@ -380,6 +388,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	if (init->index_offset >
 		UINT_MAX - (INDX_TBL_ENTRY_SIZE * (init->table_entries + 1))) {
 		IPAERR_RL("Detected overflow\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 	/* Check Indx Table Entry offset is not
@@ -392,6 +401,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAERR_RL("offset:%d entrys:%d size:%zu mem_size:%zu\n",
 			init->index_offset, (init->table_entries + 1),
 			tmp, ipa_ctx->nat_mem.size);
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
@@ -399,6 +409,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	if (init->index_expn_offset >
 		(UINT_MAX - (INDX_TBL_ENTRY_SIZE * init->expn_table_entries))) {
 		IPAERR_RL("Detected overflow\n");
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 	/* Check Expn Table entry offset is not
@@ -411,6 +422,7 @@ int ipa2_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAERR_RL("offset:%d entrys:%d size:%zu mem_size:%zu\n",
 			init->index_expn_offset, init->expn_table_entries,
 			tmp, ipa_ctx->nat_mem.size);
+		mutex_unlock(&ipa_ctx->nat_mem.lock);
 		return -EPERM;
 	}
 
@@ -559,6 +571,7 @@ free_mem:
 free_nop:
 	kfree(reg_write_nop);
 bail:
+	mutex_unlock(&ipa_ctx->nat_mem.lock);
 	return result;
 }
 

--- a/drivers/platform/msm/ipa/ipa_v2/ipa_nat.c
+++ b/drivers/platform/msm/ipa/ipa_v2/ipa_nat.c
@@ -790,7 +790,7 @@ int ipa2_nat_del_cmd(struct ipa_ioc_v4_nat_del *del)
 		return -EPERM;
 	}
 
-	if (ipa_ctx->nat_mem.public_ip_addr) {
+	if (!ipa_ctx->nat_mem.public_ip_addr) {
 		IPAERR_RL("Public IP addr not assigned and trying to delete\n");
 		return -EPERM;
 	}

--- a/drivers/platform/msm/ipa/ipa_v3/ipa_nat.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_nat.c
@@ -839,19 +839,24 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 
 	IPADBG("\n");
 
+	mutex_lock(&ipa3_ctx->nat_mem.dev.lock);
+
 	if (!ipa3_ctx->nat_mem.dev.is_mapped) {
 		IPAERR_RL("attempt to init %s before mmap\n",
 			ipa3_ctx->nat_mem.dev.name);
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return -EPERM;
 	}
 
 	if (init->tbl_index >= 1) {
 		IPAERR_RL("Unsupported table index %d\n", init->tbl_index);
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return -EPERM;
 	}
 
 	if (init->table_entries == 0) {
 		IPAERR_RL("Table entries is zero\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return -EPERM;
 	}
 
@@ -862,6 +867,7 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAHAL_NAT_IPV4);
 	if (result) {
 		IPAERR_RL("Bad params for NAT base table\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return result;
 	}
 
@@ -872,6 +878,7 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAHAL_NAT_IPV4);
 	if (result) {
 		IPAERR_RL("Bad params for NAT expansion table\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return result;
 	}
 
@@ -882,6 +889,7 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAHAL_NAT_IPV4_INDEX);
 	if (result) {
 		IPAERR_RL("Bad params for index table\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return result;
 	}
 
@@ -892,6 +900,7 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 		IPAHAL_NAT_IPV4_INDEX);
 	if (result) {
 		IPAERR_RL("Bad params for index expansion table\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return result;
 	}
 
@@ -925,6 +934,7 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 	result = ipa3_nat_send_init_cmd(&cmd, false);
 	if (result) {
 		IPAERR("Fail to send NAT init immediate command\n");
+		mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
 		return result;
 	}
 
@@ -950,6 +960,8 @@ int ipa3_nat_init_cmd(struct ipa_ioc_v4_nat_init *init)
 				 ipa3_ctx->nat_mem.index_table_expansion_addr);
 
 	ipa3_ctx->nat_mem.dev.is_hw_init = true;
+	mutex_unlock(&ipa3_ctx->nat_mem.dev.lock);
+
 	IPADBG("return\n");
 	return 0;
 }

--- a/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
@@ -1075,8 +1075,12 @@ static int __ipa_wwan_close(struct net_device *dev)
  */
 static int ipa3_wwan_stop(struct net_device *dev)
 {
+	struct ipa3_wwan_private *wwan_ptr = netdev_priv(dev);
+
 	IPAWANDBG("[%s] ipa3_wwan_stop()\n", dev->name);
 	__ipa_wwan_close(dev);
+	if (ipa3_rmnet_res.ipa_napi_enable)
+		napi_disable(&(wwan_ptr->napi));
 	netif_stop_queue(dev);
 	return 0;
 }

--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -732,6 +732,11 @@ static int ufs_qcom_config_vreg(struct device *dev,
 
 	reg = vreg->reg;
 	if (regulator_count_voltages(reg) > 0) {
+		uA_load = on ? vreg->max_uA : 0;
+		ret = regulator_set_load(vreg->reg, uA_load);
+		if (ret)
+			goto out;
+
 		min_uV = on ? vreg->min_uV : 0;
 		ret = regulator_set_voltage(reg, min_uV, vreg->max_uV);
 		if (ret) {
@@ -739,11 +744,6 @@ static int ufs_qcom_config_vreg(struct device *dev,
 					__func__, vreg->name, ret);
 			goto out;
 		}
-
-		uA_load = on ? vreg->max_uA : 0;
-		ret = regulator_set_load(vreg->reg, uA_load);
-		if (ret)
-			goto out;
 	}
 out:
 	return ret;

--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -902,17 +902,16 @@ static int ufs_qcom_crypto_req_setup(struct ufs_hba *hba,
 		req = lrbp->cmd->request;
 	else
 		return 0;
-	/*
-	 * Right now ICE do not support variable dun but can be
-	 * taken as future enhancement
-	 * if (bio_dun(req->bio)) {
-	 *      dun @bio can be split, so we have to adjust offset
-	 *      *dun = bio_dun(req->bio);
-	 * } else
-	 */
+
+	/* Use request LBA or given dun as the DUN value */
 	if (req->bio) {
-		*dun = req->bio->bi_iter.bi_sector;
-		*dun >>= UFS_QCOM_ICE_TR_DATA_UNIT_4_KB;
+		if (bio_dun(req->bio)) {
+			/* dun @bio can be split, so we have to adjust offset */
+			*dun = bio_dun(req->bio);
+		} else {
+			*dun = req->bio->bi_iter.bi_sector;
+			*dun >>= UFS_QCOM_ICE_TR_DATA_UNIT_4_KB;
+		}
 	}
 
 	ret = ufs_qcom_ice_req_setup(host, lrbp->cmd, cc_index, enable);

--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2018, Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -905,6 +905,7 @@ static int ufs_qcom_crypto_req_setup(struct ufs_hba *hba,
 
 	/* Use request LBA or given dun as the DUN value */
 	if (req->bio) {
+#ifdef CONFIG_PFK
 		if (bio_dun(req->bio)) {
 			/* dun @bio can be split, so we have to adjust offset */
 			*dun = bio_dun(req->bio);
@@ -912,6 +913,10 @@ static int ufs_qcom_crypto_req_setup(struct ufs_hba *hba,
 			*dun = req->bio->bi_iter.bi_sector;
 			*dun >>= UFS_QCOM_ICE_TR_DATA_UNIT_4_KB;
 		}
+#else
+		*dun = req->bio->bi_iter.bi_sector;
+		*dun >>= UFS_QCOM_ICE_TR_DATA_UNIT_4_KB;
+#endif
 	}
 
 	ret = ufs_qcom_ice_req_setup(host, lrbp->cmd, cc_index, enable);

--- a/drivers/scsi/ufs/ufshcd.c
+++ b/drivers/scsi/ufs/ufshcd.c
@@ -8432,7 +8432,7 @@ static int ufshcd_query_ioctl(struct ufs_hba *hba, u8 lun, void __user *buffer)
 		switch (ioctl_data->idn) {
 		case QUERY_ATTR_IDN_BOOT_LU_EN:
 			index = 0;
-			if (att > QUERY_ATTR_IDN_BOOT_LU_EN_MAX) {
+			if (!att || att > QUERY_ATTR_IDN_BOOT_LU_EN_MAX) {
 				dev_err(hba->dev,
 					"%s: Illegal ufs query ioctl data, opcode 0x%x, idn 0x%x, att 0x%x\n",
 					__func__, ioctl_data->opcode,

--- a/drivers/scsi/ufs/ufshcd.c
+++ b/drivers/scsi/ufs/ufshcd.c
@@ -8805,6 +8805,11 @@ static int ufshcd_config_vreg(struct device *dev,
 	name = vreg->name;
 
 	if (regulator_count_voltages(reg) > 0) {
+		uA_load = on ? vreg->max_uA : 0;
+		ret = ufshcd_config_vreg_load(dev, vreg, uA_load);
+		if (ret)
+			goto out;
+
 		min_uV = on ? vreg->min_uV : 0;
 		ret = regulator_set_voltage(reg, min_uV, vreg->max_uV);
 		if (ret) {
@@ -8812,11 +8817,6 @@ static int ufshcd_config_vreg(struct device *dev,
 					__func__, name, ret);
 			goto out;
 		}
-
-		uA_load = on ? vreg->max_uA : 0;
-		ret = ufshcd_config_vreg_load(dev, vreg, uA_load);
-		if (ret)
-			goto out;
 	}
 out:
 	return ret;

--- a/drivers/soc/qcom/bam_dmux.c
+++ b/drivers/soc/qcom/bam_dmux.c
@@ -1111,6 +1111,12 @@ int msm_bam_dmux_open(uint32_t id, void *priv,
 		kfree(hdr);
 		return -ENODEV;
 	}
+	if (in_global_reset) {
+		BAM_DMUX_LOG("%s: In SSR... ch_id[%d]\n", __func__, id);
+		spin_unlock_irqrestore(&bam_ch[id].lock, flags);
+		kfree(hdr);
+		return -ENODEV;
+	}
 
 	bam_ch[id].notify = notify;
 	bam_ch[id].priv = priv;
@@ -1186,6 +1192,12 @@ int msm_bam_dmux_close(uint32_t id)
 	if (bam_ch_is_in_reset(id)) {
 		read_unlock(&ul_wakeup_lock);
 		bam_ch[id].status &= ~BAM_CH_IN_RESET;
+		return 0;
+	}
+
+	if (in_global_reset) {
+		BAM_DMUX_LOG("%s: In SSR... ch_id[%d]\n", __func__, id);
+		read_unlock(&ul_wakeup_lock);
 		return 0;
 	}
 

--- a/drivers/soc/qcom/subsystem_restart.c
+++ b/drivers/soc/qcom/subsystem_restart.c
@@ -1889,7 +1889,8 @@ static int __init subsys_restart_init(void)
 {
 	int ret;
 
-	ssr_wq = alloc_workqueue("ssr_wq", WQ_CPU_INTENSIVE, 0);
+	ssr_wq = alloc_workqueue("ssr_wq",
+		WQ_UNBOUND | WQ_HIGHPRI | WQ_CPU_INTENSIVE, 0);
 	BUG_ON(!ssr_wq);
 
 	ret = bus_register(&subsys_bus_type);

--- a/drivers/staging/android/ion/ion_cma_secure_heap.c
+++ b/drivers/staging/android/ion/ion_cma_secure_heap.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) Linaro 2012
  * Author: <benjamin.gaignard@linaro.org> for ST-Ericsson.
- * Copyright (c) 2013-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2018, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -558,7 +558,7 @@ static struct ion_secure_cma_buffer_info *__ion_secure_cma_allocate_non_contig(
 	struct ion_secure_cma_buffer_info *info;
 	int ret;
 	unsigned long alloc_size = len;
-	struct ion_secure_cma_non_contig_info *nc_info, *temp;
+	struct ion_secure_cma_non_contig_info *nc_info;
 	unsigned long ncelems = 0;
 	struct scatterlist *sg;
 	unsigned long total_allocated = 0;
@@ -648,11 +648,7 @@ retry:
 err2:
 	mutex_unlock(&sheap->alloc_lock);
 err1:
-	list_for_each_entry_safe(nc_info, temp, &info->non_contig_list,
-				 entry) {
-		list_del(&nc_info->entry);
-		kfree(nc_info);
-	}
+	__ion_secure_cma_free_non_contig(sheap, info);
 	kfree(info->table);
 err:
 	kfree(info);

--- a/drivers/staging/android/ion/ion_page_pool.c
+++ b/drivers/staging/android/ion/ion_page_pool.c
@@ -2,7 +2,7 @@
  * drivers/staging/android/ion/ion_page_pool.c
  *
  * Copyright (C) 2011 Google, Inc.
- * Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2016, 2018 The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -65,6 +65,9 @@ static int ion_page_pool_add(struct ion_page_pool *pool, struct page *page)
 		list_add_tail(&page->lru, &pool->low_items);
 		pool->low_count++;
 	}
+
+	mod_node_page_state(page_pgdat(page), NR_INDIRECTLY_RECLAIMABLE_BYTES,
+			    (1 << (PAGE_SHIFT + pool->order)));
 	mutex_unlock(&pool->mutex);
 	return 0;
 }
@@ -84,6 +87,8 @@ static struct page *ion_page_pool_remove(struct ion_page_pool *pool, bool high)
 	}
 
 	list_del(&page->lru);
+	mod_node_page_state(page_pgdat(page), NR_INDIRECTLY_RECLAIMABLE_BYTES,
+			    -(1 << (PAGE_SHIFT + pool->order)));
 	return page;
 }
 

--- a/drivers/usb/gadget/ci13xxx_udc.c
+++ b/drivers/usb/gadget/ci13xxx_udc.c
@@ -3541,6 +3541,9 @@ static int ci13xxx_pullup(struct usb_gadget *_gadget, int is_active)
 		hw_device_state(udc->ep0out.qh.dma);
 	} else {
 		hw_device_state(0);
+		spin_unlock_irqrestore(udc->lock, flags);
+		_gadget_stop_activity(&udc->gadget);
+		spin_lock_irqsave(udc->lock, flags);
 	}
 	spin_unlock_irqrestore(udc->lock, flags);
 

--- a/drivers/usb/phy/phy-msm-usb.c
+++ b/drivers/usb/phy/phy-msm-usb.c
@@ -3676,6 +3676,11 @@ static int msm_otg_extcon_register(struct msm_otg *motg)
 	struct extcon_dev *edev;
 	int ret = 0;
 
+	if (motg->extcon_registered) {
+		dev_info(&motg->pdev->dev, "extcon_nb already registered\n");
+		return 0;
+	}
+
 	if (!of_property_read_bool(node, "extcon"))
 		return 0;
 
@@ -3712,6 +3717,7 @@ static int msm_otg_extcon_register(struct msm_otg *motg)
 			goto err;
 		}
 	}
+	motg->extcon_registered = true;
 
 	return 0;
 err:

--- a/drivers/usb/phy/phy-msm-usb.c
+++ b/drivers/usb/phy/phy-msm-usb.c
@@ -4300,7 +4300,7 @@ static int msm_otg_probe(struct platform_device *pdev)
 	INIT_DELAYED_WORK(&motg->sdp_check, check_for_sdp_connection);
 	INIT_WORK(&motg->notify_charger_work, msm_otg_notify_charger_work);
 	INIT_WORK(&motg->extcon_register_work, msm_otg_extcon_register_work);
-	motg->otg_wq = alloc_ordered_workqueue("k_otg", 0);
+	motg->otg_wq = alloc_ordered_workqueue("k_otg", WQ_FREEZABLE);
 	if (!motg->otg_wq) {
 		pr_err("%s: Unable to create workqueue otg_wq\n",
 			__func__);

--- a/fs/crypto/Makefile
+++ b/fs/crypto/Makefile
@@ -3,5 +3,6 @@ obj-$(CONFIG_FS_ENCRYPTION)	+= fscrypto.o
 ccflags-y += -Ifs/ext4
 ccflags-y += -Ifs/f2fs
 
-fscrypto-y := crypto.o fname.o hooks.o keyinfo.o policy.o fscrypt_ice.o
+fscrypto-y := crypto.o fname.o hooks.o keyinfo.o policy.o
 fscrypto-$(CONFIG_BLOCK) += bio.o
+fscrypto-$(CONFIG_PFK) += fscrypt_ice.o

--- a/fs/direct-io.c
+++ b/fs/direct-io.c
@@ -392,6 +392,7 @@ dio_bio_alloc(struct dio *dio, struct dio_submit *sdio,
 	sdio->logical_offset_in_bio = sdio->cur_page_fs_offset;
 }
 
+#ifdef CONFIG_PFK
 static bool is_inode_filesystem_type(const struct inode *inode,
 					const char *fs_type)
 {
@@ -406,6 +407,7 @@ static bool is_inode_filesystem_type(const struct inode *inode,
 
 	return (strcmp(inode->i_sb->s_type->name, fs_type) == 0);
 }
+#endif
 
 /*
  * In the AIO read case we speculatively dirty the pages before starting IO.
@@ -428,6 +430,7 @@ static inline void dio_bio_submit(struct dio *dio, struct dio_submit *sdio)
 	if (dio->is_async && dio->op == REQ_OP_READ && dio->should_dirty)
 		bio_set_pages_dirty(bio);
 
+#ifdef CONFIG_PFK
 	bio->bi_dio_inode = dio->inode;
 
 /* iv sector for security/pfe/pfk_fscrypt.c and f2fs in fs/f2fs/f2fs.h.*/
@@ -437,6 +440,7 @@ static inline void dio_bio_submit(struct dio *dio, struct dio_submit *sdio)
 	if (is_inode_filesystem_type(dio->inode, "f2fs"))
 		fscrypt_set_ice_dun(dio->inode, bio, PG_DUN_NEW(dio->inode,
 			(sdio->logical_offset_in_bio >> PAGE_SHIFT)));
+#endif
 	dio->bio_bdev = bio->bi_bdev;
 
 	if (sdio->submit_io) {
@@ -457,7 +461,9 @@ struct inode *dio_bio_get_inode(struct bio *bio)
 	if (bio == NULL)
 		return NULL;
 
+#ifdef CONFIG_PFK
 	inode = bio->bi_dio_inode;
+#endif
 
 	return inode;
 }

--- a/fs/direct-io.c
+++ b/fs/direct-io.c
@@ -37,6 +37,8 @@
 #include <linux/uio.h>
 #include <linux/atomic.h>
 #include <linux/prefetch.h>
+#define __FS_HAS_ENCRYPTION IS_ENABLED(CONFIG_F2FS_FS_ENCRYPTION)
+#include <linux/fscrypt.h>
 
 /*
  * How many user pages to map in one call to get_user_pages().  This determines
@@ -390,6 +392,21 @@ dio_bio_alloc(struct dio *dio, struct dio_submit *sdio,
 	sdio->logical_offset_in_bio = sdio->cur_page_fs_offset;
 }
 
+static bool is_inode_filesystem_type(const struct inode *inode,
+					const char *fs_type)
+{
+	if (!inode || !fs_type)
+		return false;
+
+	if (!inode->i_sb)
+		return false;
+
+	if (!inode->i_sb->s_type)
+		return false;
+
+	return (strcmp(inode->i_sb->s_type->name, fs_type) == 0);
+}
+
 /*
  * In the AIO read case we speculatively dirty the pages before starting IO.
  * During IO completion, any of these pages which happen to have been written
@@ -412,6 +429,14 @@ static inline void dio_bio_submit(struct dio *dio, struct dio_submit *sdio)
 		bio_set_pages_dirty(bio);
 
 	bio->bi_dio_inode = dio->inode;
+
+/* iv sector for security/pfe/pfk_fscrypt.c and f2fs in fs/f2fs/f2fs.h.*/
+#define PG_DUN_NEW(i,p)                                            \
+	(((((u64)(i)->i_ino) & 0xffffffff) << 32) | ((p) & 0xffffffff))
+
+	if (is_inode_filesystem_type(dio->inode, "f2fs"))
+		fscrypt_set_ice_dun(dio->inode, bio, PG_DUN_NEW(dio->inode,
+			(sdio->logical_offset_in_bio >> PAGE_SHIFT)));
 	dio->bio_bdev = bio->bi_bdev;
 
 	if (sdio->submit_io) {

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -451,7 +451,8 @@ int f2fs_submit_page_bio(struct f2fs_io_info *fio)
 				1, is_read_io(fio->op), fio->type, fio->temp);
 
 	if (f2fs_may_encrypt_bio(inode, fio))
-	fscrypt_set_ice_dun(inode, bio, PG_DUN(inode, fio->page));
+		fscrypt_set_ice_dun(inode, bio, PG_DUN(inode, fio->page));
+	fscrypt_set_ice_skip(bio, fio->encrypted_page ? 1 : 0);
 
 	if (bio_add_page(bio, page, PAGE_SIZE, 0) < PAGE_SIZE) {
 		bio_put(bio);
@@ -474,6 +475,7 @@ int f2fs_submit_page_write(struct f2fs_io_info *fio)
 	struct page *bio_page;
 	struct inode *inode;
 	bool bio_encrypted;
+	int bi_crypt_skip;
 	u64 dun;
 	int err = 0;
 
@@ -500,6 +502,7 @@ next:
 	bio_page = fio->encrypted_page ? fio->encrypted_page : fio->page;
 	inode = fio->page->mapping->host;
 	dun = PG_DUN(inode, fio->page);
+	bi_crypt_skip = fio->encrypted_page ? 1 : 0;
 	bio_encrypted = f2fs_may_encrypt_bio(inode, fio);
 
 	/* set submitted = true as a return value */
@@ -513,7 +516,7 @@ next:
 		__submit_merged_bio(io);
 
 	/* ICE support */
-	if (!fscrypt_mergeable_bio(io->bio, dun, bio_encrypted))
+	if (!fscrypt_mergeable_bio(io->bio, dun, bio_encrypted, bi_crypt_skip))
 		__submit_merged_bio(io);
 
 alloc_new:
@@ -529,7 +532,7 @@ alloc_new:
 						fio->type, fio->temp);
 		if (bio_encrypted)
 			fscrypt_set_ice_dun(inode, io->bio, dun);
-
+		fscrypt_set_ice_skip(io->bio, bi_crypt_skip);
 		io->fio = *fio;
 	}
 
@@ -1553,7 +1556,7 @@ submit_and_realloc:
 
 		dun = PG_DUN(inode, page);
 		bio_encrypted = f2fs_may_encrypt_bio(inode, NULL);
-		if (!fscrypt_mergeable_bio(bio, dun, bio_encrypted)) {
+		if (!fscrypt_mergeable_bio(bio, dun, bio_encrypted, 0)) {
 			__submit_bio(F2FS_I_SB(inode), bio, DATA);
 			bio = NULL;
 		}

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -574,7 +574,8 @@ static struct bio *f2fs_grab_read_bio(struct inode *inode, block_t blkaddr,
 	bio->bi_end_io = f2fs_read_end_io;
 	bio_set_op_attrs(bio, REQ_OP_READ, 0);
 
-	if (f2fs_encrypted_file(inode))
+        if (f2fs_encrypted_file(inode) &&
+            !fscrypt_using_hardware_encryption(inode))
 		post_read_steps |= 1 << STEP_DECRYPT;
 	if (post_read_steps) {
 		ctx = mempool_alloc(bio_post_read_ctx_pool, GFP_NOFS);

--- a/include/crypto/ice.h
+++ b/include/crypto/ice.h
@@ -49,6 +49,18 @@ struct ice_data_setting {
 	bool				encr_bypass;
 };
 
+/* MSM ICE Crypto Data Unit of target DUN of Transfer Request */
+enum ice_crypto_data_unit {
+	ICE_CRYPTO_DATA_UNIT_512_B          = 0,
+	ICE_CRYPTO_DATA_UNIT_1_KB           = 1,
+	ICE_CRYPTO_DATA_UNIT_2_KB           = 2,
+	ICE_CRYPTO_DATA_UNIT_4_KB           = 3,
+	ICE_CRYPTO_DATA_UNIT_8_KB           = 4,
+	ICE_CRYPTO_DATA_UNIT_16_KB          = 5,
+	ICE_CRYPTO_DATA_UNIT_32_KB          = 6,
+	ICE_CRYPTO_DATA_UNIT_64_KB          = 7,
+};
+
 typedef void (*ice_error_cb)(void *, u32 error);
 
 struct qcom_ice_variant_ops *qcom_ice_get_variant_ops(struct device_node *node);

--- a/include/crypto/ice.h
+++ b/include/crypto/ice.h
@@ -61,6 +61,13 @@ enum ice_crypto_data_unit {
 	ICE_CRYPTO_DATA_UNIT_64_KB          = 7,
 };
 
+enum ice_capability_index {
+	ICE_CRYPTO_MODE_XTS_128 = 0,
+	ICE_CRYPTO_MODE_CBC_128 = 1,
+	ICE_CRYPTO_MODE_XTS_256 = 3,
+	ICE_CRYPTO_MODE_CBC_256 = 4
+};
+
 typedef void (*ice_error_cb)(void *, u32 error);
 
 struct qcom_ice_variant_ops *qcom_ice_get_variant_ops(struct device_node *node);

--- a/include/linux/blk_types.h
+++ b/include/linux/blk_types.h
@@ -78,6 +78,9 @@ struct bio {
 	*/
 	struct inode            *bi_dio_inode;
 #endif
+#ifdef CONFIG_DM_DEFAULT_KEY
+	int bi_crypt_skip;
+#endif
 
 	unsigned short		bi_vcnt;	/* how many bio_vec's */
 

--- a/include/linux/blk_types.h
+++ b/include/linux/blk_types.h
@@ -66,9 +66,17 @@ struct bio {
 		struct bio_integrity_payload *bi_integrity; /* data integrity */
 #endif
 	};
+
 #ifdef CONFIG_PFK
 	/* Encryption key to use (NULL if none) */
 	const struct blk_encryption_key	*bi_crypt_key;
+
+	/*
+	* When using dircet-io (O_DIRECT), we can't get the inode from a bio
+	* by walking bio->bi_io_vec->bv_page->mapping->host
+	* since the page is anon.
+	*/
+	struct inode            *bi_dio_inode;
 #endif
 
 	unsigned short		bi_vcnt;	/* how many bio_vec's */
@@ -85,12 +93,6 @@ struct bio {
 
 	struct bio_set		*bi_pool;
 
-	/*
-	 * When using dircet-io (O_DIRECT), we can't get the inode from a bio
-	 * by walking bio->bi_io_vec->bv_page->mapping->host
-	 * since the page is anon.
-	 */
-	struct inode		*bi_dio_inode;
 	/*
 	 * We can inline a number of vecs at the end of the bio, to avoid
 	 * double allocations for a small number of bio_vecs. This member

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -103,6 +103,7 @@ struct request {
 	/* the following two fields are internal, NEVER access directly */
 	unsigned int __data_len;	/* total data len */
 	sector_t __sector;		/* sector cursor */
+	u64 __dun;			/* dun for UFS */
 
 	struct bio *bio;
 	struct bio *biotail;
@@ -864,6 +865,11 @@ static inline struct request_queue *bdev_get_queue(struct block_device *bdev)
 static inline sector_t blk_rq_pos(const struct request *rq)
 {
 	return rq->__sector;
+}
+
+static inline sector_t blk_rq_dun(const struct request *rq)
+{
+	return rq->__dun;
 }
 
 static inline unsigned int blk_rq_bytes(const struct request *rq)

--- a/include/linux/bvec.h
+++ b/include/linux/bvec.h
@@ -41,7 +41,9 @@ struct bvec_iter {
 
 	unsigned int            bi_bvec_done;	/* number of bytes completed in
 						   current bvec */
+#ifdef CONFIG_PFK
 	u64			bi_dun;		/* DUN setting for bio */
+#endif
 };
 
 /*

--- a/include/linux/fscrypt.h
+++ b/include/linux/fscrypt.h
@@ -260,7 +260,9 @@ static inline int fscrypt_encrypt_symlink(struct inode *inode,
 extern int fscrypt_using_hardware_encryption(const struct inode *inode);
 extern void fscrypt_set_ice_dun(const struct inode *inode,
 	struct bio *bio, u64 dun);
-extern bool fscrypt_mergeable_bio(struct bio *bio, u64 dun, bool bio_encrypted);
+extern bool fscrypt_mergeable_bio(struct bio *bio, u64 dun, bool bio_encrypted,
+		int bi_crypt_skip);
+extern void fscrypt_set_ice_skip(struct bio *bio, int bi_crypt_skip);
 #else
 static inline int fscrypt_using_hardware_encryption(const struct inode *inode)
 {
@@ -273,8 +275,12 @@ static inline void fscrypt_set_ice_dun(const struct inode *inode,
 	return;
 }
 
+static inline void fscrypt_set_ice_skip(struct bio *bio, int bi_crypt_skip)
+{
+}
+
 static inline bool fscrypt_mergeable_bio(struct bio *bio,
-	u64 dun, bool bio_encrypted)
+	u64 dun, bool bio_encrypted, int bi_crypt_skip)
 {
 	return true;
 }

--- a/include/linux/fscrypt.h
+++ b/include/linux/fscrypt.h
@@ -255,4 +255,29 @@ static inline int fscrypt_encrypt_symlink(struct inode *inode,
 	return 0;
 }
 
+/* fscrypt_ice.c */
+#ifdef CONFIG_PFK
+extern int fscrypt_using_hardware_encryption(const struct inode *inode);
+extern void fscrypt_set_ice_dun(const struct inode *inode,
+	struct bio *bio, u64 dun);
+extern bool fscrypt_mergeable_bio(struct bio *bio, u64 dun, bool bio_encrypted);
+#else
+static inline int fscrypt_using_hardware_encryption(const struct inode *inode)
+{
+	return 0;
+}
+
+static inline void fscrypt_set_ice_dun(const struct inode *inode,
+	struct bio *bio, u64 dun)
+{
+	return;
+}
+
+static inline bool fscrypt_mergeable_bio(struct bio *bio,
+	u64 dun, bool bio_encrypted)
+{
+	return true;
+}
+#endif
+
 #endif	/* _LINUX_FSCRYPT_H */

--- a/include/linux/fscrypt_notsupp.h
+++ b/include/linux/fscrypt_notsupp.h
@@ -183,23 +183,7 @@ static inline int fscrypt_zeroout_range(const struct inode *inode, pgoff_t lblk,
 	return -EOPNOTSUPP;
 }
 
-/* fscrypt_ice.c */
-static inline int fscrypt_using_hardware_encryption(const struct inode *inode)
-{
-	return 0;
-}
-
-static inline void fscrypt_set_ice_dun(const struct inode *inode,
-		struct bio *bio, u64 dun){}
-
-static inline bool fscrypt_mergeable_bio(struct bio *bio,
-		sector_t iv_block, bool bio_encrypted)
-{
-	return true;
-}
-
 /* hooks.c */
-
 static inline int fscrypt_file_open(struct inode *inode, struct file *filp)
 {
 	if (IS_ENCRYPTED(inode))

--- a/include/linux/fscrypt_supp.h
+++ b/include/linux/fscrypt_supp.h
@@ -196,13 +196,6 @@ extern void fscrypt_pullback_bio_page(struct page **, bool);
 extern int fscrypt_zeroout_range(const struct inode *, pgoff_t, sector_t,
 				 unsigned int);
 
-/* fscrypt_ice.c */
-extern int fscrypt_using_hardware_encryption(const struct inode *inode);
-extern void fscrypt_set_ice_dun(const struct inode *inode,
-		struct bio *bio, u64 dun);
-extern bool fscrypt_mergeable_bio(struct bio *bio, u64 dun, bool bio_encrypted);
-
-
 /* hooks.c */
 extern int fscrypt_file_open(struct inode *inode, struct file *filp);
 extern int __fscrypt_prepare_link(struct inode *inode, struct inode *dir);

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -178,6 +178,7 @@ enum node_stat_item {
 	NR_VMSCAN_IMMEDIATE,	/* Prioritise for reclaim when writeback ends */
 	NR_DIRTIED,		/* page dirtyings since bootup */
 	NR_WRITTEN,		/* page writings since bootup */
+	NR_INDIRECTLY_RECLAIMABLE_BYTES, /* measured in bytes */
 	NR_VM_NODE_STAT_ITEMS
 };
 

--- a/include/linux/pfk.h
+++ b/include/linux/pfk.h
@@ -33,7 +33,8 @@ struct blk_encryption_key {
 };
 
 int pfk_load_key_start(const struct bio *bio,
-		struct ice_crypto_setting *ice_setting, bool *is_pfe, bool);
+		struct ice_crypto_setting *ice_setting,
+		bool *is_pfe, bool async, int ice_rev);
 int pfk_load_key_end(const struct bio *bio, bool *is_pfe);
 int pfk_remove_key(const unsigned char *key, size_t key_size);
 bool pfk_allow_merge_bio(const struct bio *bio1, const struct bio *bio2);
@@ -41,7 +42,8 @@ void pfk_clear_on_reset(void);
 
 #else
 static inline int pfk_load_key_start(const struct bio *bio,
-	struct ice_crypto_setting *ice_setting, bool *is_pfe, bool async)
+	struct ice_crypto_setting *ice_setting, bool *is_pfe,
+	bool async, int ice_rev)
 {
 	return -ENODEV;
 }

--- a/include/linux/usb/msm_hsusb.h
+++ b/include/linux/usb/msm_hsusb.h
@@ -171,6 +171,7 @@ enum usb_id_state {
  * @extcon_id: Used for ID notification registration.
  * @vbus_nb: Notification callback for VBUS event.
  * @id_nb: Notification callback for ID event.
+ * @extcon_registered: indicates if extcon notifier registered or not.
  * @dpdm_desc: Regulator descriptor for D+ and D- voting.
  * @dpdm_rdev: Regulator class device for dpdm regulator.
  * @dbg_idx: Dynamic debug buffer Index.
@@ -297,6 +298,7 @@ struct msm_otg {
 	struct extcon_dev       *extcon_id;
 	struct notifier_block   vbus_nb;
 	struct notifier_block   id_nb;
+	bool			extcon_registered;
 	struct regulator_desc	dpdm_rdesc;
 	struct regulator_dev	*dpdm_rdev;
 /* Maximum debug message length */

--- a/include/uapi/linux/msm_ipa.h
+++ b/include/uapi/linux/msm_ipa.h
@@ -586,6 +586,9 @@ enum ipa_rm_resource_name {
  * @IPA_HW_v3_5: IPA hardware version 3.5
  * @IPA_HW_v3_5_1: IPA hardware version 3.5.1
  * @IPA_HW_v4_0: IPA hardware version 4.0
+ * @IPA_HW_v4_1: IPA hardware version 4.1
+ * @IPA_HW_v4_2: IPA hardware version 4.2
+ * @IPA_HW_v4_5: IPA hardware version 4.5
  */
 enum ipa_hw_type {
 	IPA_HW_None = 0,
@@ -601,10 +604,16 @@ enum ipa_hw_type {
 	IPA_HW_v3_5 = 12,
 	IPA_HW_v3_5_1 = 13,
 	IPA_HW_v4_0 = 14,
+	IPA_HW_v4_1 = 15,
+	IPA_HW_v4_2 = 16,
+	IPA_HW_v4_5 = 17,
 };
-#define IPA_HW_MAX (IPA_HW_v4_0 + 1)
+#define IPA_HW_MAX (IPA_HW_v4_5 + 1)
 
 #define IPA_HW_v4_0 IPA_HW_v4_0
+#define IPA_HW_v4_1 IPA_HW_v4_1
+#define IPA_HW_v4_2 IPA_HW_v4_2
+#define IPA_HW_v4_5 IPA_HW_v4_5
 
 /**
  * struct ipa_rule_attrib - attributes of a routing/filtering

--- a/include/uapi/media/cam_req_mgr.h
+++ b/include/uapi/media/cam_req_mgr.h
@@ -262,6 +262,9 @@ struct cam_req_mgr_link_control {
 	((idx & CAM_MEM_MGR_HDL_IDX_MASK) | \
 	(fd << (CAM_MEM_MGR_HDL_FD_END_POS - CAM_MEM_MGR_HDL_FD_SIZE))) \
 
+#define GET_FD_FROM_HANDLE(hdl) \
+	(hdl >> (CAM_MEM_MGR_HDL_FD_END_POS - CAM_MEM_MGR_HDL_FD_SIZE)) \
+
 #define CAM_MEM_MGR_GET_HDL_IDX(hdl) (hdl & CAM_MEM_MGR_HDL_IDX_MASK)
 
 #define CAM_MEM_MGR_SET_SECURE_HDL(hdl, flag) \

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -617,7 +617,6 @@ static int cpuhp_up_callbacks(unsigned int cpu, struct cpuhp_cpu_state *st,
 		if (ret) {
 			st->target = prev_state;
 			undo_cpu_up(cpu, st);
-			cpu_notify(CPU_UP_CANCELED, cpu);
 			break;
 		}
 	}
@@ -1488,7 +1487,6 @@ static struct cpuhp_step cpuhp_bp_states[] = {
 		.name			= "notify:prepare",
 		.startup.single		= notify_prepare,
 		.teardown.single	= notify_dead,
-		.skip_onerr		= true,
 		.cant_stop		= true,
 	},
 	/*
@@ -1606,7 +1604,6 @@ static struct cpuhp_step cpuhp_ap_states[] = {
 		.name			= "notify:online",
 		.startup.single		= notify_online,
 		.teardown.single	= notify_down_prepare,
-		.skip_onerr		= true,
 	},
 #endif
 	/*

--- a/kernel/trace/trace.c
+++ b/kernel/trace/trace.c
@@ -4689,7 +4689,7 @@ tracing_saved_tgids_read(struct file *file, char __user *ubuf,
 	preempt_disable();
 	arch_spin_lock(&trace_cmdline_lock);
 
-	pids = kmalloc_array(savedcmd->cmdline_num, 2*sizeof(int), GFP_KERNEL);
+	pids = kmalloc_array(savedcmd->cmdline_num, 2*sizeof(int), GFP_ATOMIC);
 	if (!pids) {
 		arch_spin_unlock(&trace_cmdline_lock);
 		preempt_enable();

--- a/mm/cma.c
+++ b/mm/cma.c
@@ -466,7 +466,8 @@ struct page *cma_alloc(struct cma *cma, size_t count, unsigned int align)
 				bitmap_maxno, start, bitmap_count, mask,
 				offset);
 		if (bitmap_no >= bitmap_maxno) {
-			if (retry_after_sleep < max_retries) {
+			if ((retry_after_sleep < max_retries) &&
+						(ret == -EBUSY)) {
 				start = 0;
 				/*
 				 * update max retries if available free regions

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -4310,6 +4310,13 @@ long si_mem_available(void)
 	available += global_page_state(NR_SLAB_RECLAIMABLE) -
 		     min(global_page_state(NR_SLAB_RECLAIMABLE) / 2, wmark_low);
 
+	/*
+	 * Part of the kernel memory, which can be released under memory
+	 * pressure.
+	 */
+	available += global_node_page_state(NR_INDIRECTLY_RECLAIMABLE_BYTES) >>
+		PAGE_SHIFT;
+
 	if (available < 0)
 		available = 0;
 	return available;

--- a/mm/util.c
+++ b/mm/util.c
@@ -576,6 +576,13 @@ int __vm_enough_memory(struct mm_struct *mm, long pages, int cap_sys_admin)
 		free += global_page_state(NR_SLAB_RECLAIMABLE);
 
 		/*
+		 * Part of the kernel memory, which can be released
+		 * under memory pressure.
+		 */
+		free += global_node_page_state(
+			NR_INDIRECTLY_RECLAIMABLE_BYTES) >> PAGE_SHIFT;
+
+		/*
 		 * Leave reserved pages. The pages are not for anonymous pages.
 		 */
 		if (free <= totalreserve_pages)

--- a/mm/vmstat.c
+++ b/mm/vmstat.c
@@ -973,6 +973,7 @@ const char * const vmstat_text[] = {
 	"nr_vmscan_immediate_reclaim",
 	"nr_dirtied",
 	"nr_written",
+	"nr_indirectly_reclaimable",
 
 	/* enum writeback_stat_item counters */
 	"nr_dirty_threshold",

--- a/security/pfe/pfk.c
+++ b/security/pfe/pfk.c
@@ -287,8 +287,8 @@ static int pfk_get_key_for_bio(const struct bio *bio,
 {
 	const struct inode *inode;
 	enum pfe_type which_pfe;
-	const struct blk_encryption_key *key;
 	char *s_type = NULL;
+	const struct blk_encryption_key *key = NULL;
 
 	inode = pfk_bio_get_inode(bio);
 	which_pfe = pfk_get_pfe_type(inode);
@@ -307,7 +307,9 @@ static int pfk_get_key_for_bio(const struct bio *bio,
 	 * bio is not for an encrypted file.  Use ->bi_crypt_key if it was set.
 	 * Otherwise, don't encrypt/decrypt the bio.
 	 */
+#ifdef CONFIG_DM_DEFAULT_KEY
 	key = bio->bi_crypt_key;
+#endif
 	if (!key) {
 		*is_pfe = false;
 		return -EINVAL;
@@ -469,12 +471,17 @@ int pfk_load_key_end(const struct bio *bio, bool *is_pfe)
  */
 bool pfk_allow_merge_bio(const struct bio *bio1, const struct bio *bio2)
 {
-	const struct blk_encryption_key *key1;
-	const struct blk_encryption_key *key2;
+	const struct blk_encryption_key *key1 = NULL;
+	const struct blk_encryption_key *key2 = NULL;
 	const struct inode *inode1;
 	const struct inode *inode2;
 	enum pfe_type which_pfe1;
 	enum pfe_type which_pfe2;
+
+#ifdef CONFIG_DM_DEFAULT_KEY
+	key1 = bio1->bi_crypt_key;
+	key2 = bio2->bi_crypt_key;
+#endif
 
 	if (!pfk_is_ready())
 		return false;

--- a/security/pfe/pfk.c
+++ b/security/pfe/pfk.c
@@ -222,11 +222,7 @@ static struct inode *pfk_bio_get_inode(const struct bio *bio)
 	if (!page_mapping(bio->bi_io_vec->bv_page))
 		return NULL;
 
-	if (!bio->bi_io_vec->bv_page->mapping->host)
-
-		return NULL;
-
-	return bio->bi_io_vec->bv_page->mapping->host;
+	return page_mapping(bio->bi_io_vec->bv_page)->host;
 }
 
 /**

--- a/security/pfe/pfk.c
+++ b/security/pfe/pfk.c
@@ -75,7 +75,9 @@ typedef int (*pfk_parse_inode_type)(const struct bio *bio,
 	const struct inode *inode,
 	struct pfk_key_info *key_info,
 	enum ice_cryto_algo_mode *algo,
-	bool *is_pfe);
+	bool *is_pfe,
+	unsigned int *data_unit,
+	const char *storage_type);
 
 typedef bool (*pfk_allow_merge_bio_type)(const struct bio *bio1,
 	const struct bio *bio2, const struct inode *inode1,
@@ -285,21 +287,24 @@ bool pfe_is_inode_filesystem_type(const struct inode *inode,
 static int pfk_get_key_for_bio(const struct bio *bio,
 		struct pfk_key_info *key_info,
 		enum ice_cryto_algo_mode *algo_mode,
-		bool *is_pfe)
+		bool *is_pfe, unsigned int *data_unit)
 {
 	const struct inode *inode;
 	enum pfe_type which_pfe;
 	const struct blk_encryption_key *key;
+	char *s_type = NULL;
 
 	inode = pfk_bio_get_inode(bio);
 	which_pfe = pfk_get_pfe_type(inode);
+	s_type = (char *)pfk_kc_get_storage_type();
 
 	if (which_pfe != INVALID_PFE) {
 		/* Encrypted file; override ->bi_crypt_key */
 		pr_debug("parsing inode %lu with PFE type %d\n",
 			 inode->i_ino, which_pfe);
 		return (*(pfk_parse_inode_ftable[which_pfe]))
-				(bio, inode, key_info, algo_mode, is_pfe);
+				(bio, inode, key_info, algo_mode, is_pfe,
+					data_unit, (const char *)s_type);
 	}
 
 	/*
@@ -352,6 +357,7 @@ int pfk_load_key_start(const struct bio *bio,
 	struct pfk_key_info key_info = {NULL, NULL, 0, 0};
 	enum ice_cryto_algo_mode algo_mode = ICE_CRYPTO_ALGO_MODE_AES_XTS;
 	enum ice_crpto_key_size key_size_type = 0;
+	unsigned int data_unit = 1 << ICE_CRYPTO_DATA_UNIT_512_B;
 	u32 key_index = 0;
 
 	if (!is_pfe) {
@@ -374,7 +380,8 @@ int pfk_load_key_start(const struct bio *bio,
 		return -EINVAL;
 	}
 
-	ret = pfk_get_key_for_bio(bio, &key_info, &algo_mode, is_pfe);
+	ret = pfk_get_key_for_bio(bio, &key_info, &algo_mode, is_pfe,
+					&data_unit);
 
 	if (ret != 0)
 		return ret;
@@ -384,7 +391,8 @@ int pfk_load_key_start(const struct bio *bio,
 		return ret;
 
 	ret = pfk_kc_load_key_start(key_info.key, key_info.key_size,
-			key_info.salt, key_info.salt_size, &key_index, async);
+			key_info.salt, key_info.salt_size, &key_index, async,
+			data_unit);
 	if (ret) {
 		if (ret != -EBUSY && ret != -EAGAIN)
 			pr_err("start: could not load key into pfk key cache, error %d\n",
@@ -435,7 +443,7 @@ int pfk_load_key_end(const struct bio *bio, bool *is_pfe)
 	if (!pfk_is_ready())
 		return -ENODEV;
 
-	ret = pfk_get_key_for_bio(bio, &key_info, NULL, is_pfe);
+	ret = pfk_get_key_for_bio(bio, &key_info, NULL, is_pfe, NULL);
 	if (ret != 0)
 		return ret;
 

--- a/security/pfe/pfk.c
+++ b/security/pfe/pfk.c
@@ -351,7 +351,7 @@ static int pfk_get_key_for_bio(const struct bio *bio,
  */
 int pfk_load_key_start(const struct bio *bio,
 		struct ice_crypto_setting *ice_setting, bool *is_pfe,
-		bool async)
+		bool async, int ice_rev)
 {
 	int ret = 0;
 	struct pfk_key_info key_info = {NULL, NULL, 0, 0};
@@ -392,7 +392,7 @@ int pfk_load_key_start(const struct bio *bio,
 
 	ret = pfk_kc_load_key_start(key_info.key, key_info.key_size,
 			key_info.salt, key_info.salt_size, &key_index, async,
-			data_unit);
+			data_unit, ice_rev);
 	if (ret) {
 		if (ret != -EBUSY && ret != -EAGAIN)
 			pr_err("start: could not load key into pfk key cache, error %d\n",

--- a/security/pfe/pfk_ext4.c
+++ b/security/pfe/pfk_ext4.c
@@ -142,7 +142,6 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	struct pfk_key_info *key_info,
 	enum ice_cryto_algo_mode *algo,
 	bool *is_pfe,
-	unsigned int *data_unit,
 	const char *storage_type)
 {
 	int ret = 0;
@@ -156,19 +155,6 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	 * otherwise we will consider it PFE
 	 */
 	*is_pfe = true;
-
-	/* Update dun based upon storage type.
-	 * For ext4 FS UFS has 4k dun whereas eMMC
-	 * uses 512Byte dun.
-	 */
-	if (storage_type && data_unit) {
-		if (!memcmp(storage_type, "ufs", strlen("ufs")))
-			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_4_KB;
-		else if (!memcmp(storage_type, "sdcc", strlen("sdcc")))
-			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_512_B;
-		else
-			return -EINVAL;
-	}
 
 	if (!pfk_ext4_is_ready())
 		return -ENODEV;

--- a/security/pfe/pfk_ext4.c
+++ b/security/pfe/pfk_ext4.c
@@ -141,7 +141,9 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	const struct inode *inode,
 	struct pfk_key_info *key_info,
 	enum ice_cryto_algo_mode *algo,
-	bool *is_pfe)
+	bool *is_pfe,
+	unsigned int *data_unit,
+	const char *storage_type)
 {
 	int ret = 0;
 
@@ -154,6 +156,19 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	 * otherwise we will consider it PFE
 	 */
 	*is_pfe = true;
+
+	/* Update dun based upon storage type.
+	 * For ext4 FS UFS has 4k dun whereas eMMC
+	 * uses 512Byte dun.
+	 */
+	if (storage_type && data_unit) {
+		if (!memcmp(storage_type, "ufs", strlen("ufs")))
+			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_4_KB;
+		else if (!memcmp(storage_type, "sdcc", strlen("sdcc")))
+			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_512_B;
+		else
+			return -EINVAL;
+	}
 
 	if (!pfk_ext4_is_ready())
 		return -ENODEV;

--- a/security/pfe/pfk_ext4.h
+++ b/security/pfe/pfk_ext4.h
@@ -25,7 +25,6 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	struct pfk_key_info *key_info,
 	enum ice_cryto_algo_mode *algo,
 	bool *is_pfe,
-	unsigned int *data_unit,
 	const char *storage_type);
 
 bool pfk_ext4_allow_merge_bio(const struct bio *bio1,

--- a/security/pfe/pfk_ext4.h
+++ b/security/pfe/pfk_ext4.h
@@ -24,7 +24,9 @@ int pfk_ext4_parse_inode(const struct bio *bio,
 	const struct inode *inode,
 	struct pfk_key_info *key_info,
 	enum ice_cryto_algo_mode *algo,
-	bool *is_pfe);
+	bool *is_pfe,
+	unsigned int *data_unit,
+	const char *storage_type);
 
 bool pfk_ext4_allow_merge_bio(const struct bio *bio1,
 	const struct bio *bio2, const struct inode *inode1,

--- a/security/pfe/pfk_f2fs.c
+++ b/security/pfe/pfk_f2fs.c
@@ -117,7 +117,6 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 		struct pfk_key_info *key_info,
 		enum ice_cryto_algo_mode *algo,
 		bool *is_pfe,
-		unsigned int *data_unit,
 		const char *storage_type)
 {
 	int ret = 0;
@@ -131,18 +130,6 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 	 * otherwise we will consider it PFE
 	 */
 	*is_pfe = true;
-
-	/* Update the dun based upon storage type.
-	 * Right now both UFS and eMMC storage uses 4KB dun
-	 * for F2FS
-	 */
-	if (storage_type && data_unit) {
-		if (!memcmp(storage_type, "ufs", strlen("ufs")) ||
-			!memcmp(storage_type, "sdcc", strlen("sdcc")))
-			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_4_KB;
-		else
-			return -EINVAL;
-	}
 
 	if (!pfk_f2fs_is_ready())
 		return -ENODEV;

--- a/security/pfe/pfk_f2fs.c
+++ b/security/pfe/pfk_f2fs.c
@@ -116,7 +116,9 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 		const struct inode *inode,
 		struct pfk_key_info *key_info,
 		enum ice_cryto_algo_mode *algo,
-		bool *is_pfe)
+		bool *is_pfe,
+		unsigned int *data_unit,
+		const char *storage_type)
 {
 	int ret = 0;
 
@@ -129,6 +131,18 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 	 * otherwise we will consider it PFE
 	 */
 	*is_pfe = true;
+
+	/* Update the dun based upon storage type.
+	 * Right now both UFS and eMMC storage uses 4KB dun
+	 * for F2FS
+	 */
+	if (storage_type && data_unit) {
+		if (!memcmp(storage_type, "ufs", strlen("ufs")) ||
+			!memcmp(storage_type, "sdcc", strlen("sdcc")))
+			*data_unit = 1 << ICE_CRYPTO_DATA_UNIT_4_KB;
+		else
+			return -EINVAL;
+	}
 
 	if (!pfk_f2fs_is_ready())
 		return -ENODEV;

--- a/security/pfe/pfk_f2fs.h
+++ b/security/pfe/pfk_f2fs.h
@@ -25,7 +25,6 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 		struct pfk_key_info *key_info,
 		enum ice_cryto_algo_mode *algo,
 		bool *is_pfe,
-		unsigned int *data_unit,
 		const char *storage_type);
 
 bool pfk_f2fs_allow_merge_bio(const struct bio *bio1,

--- a/security/pfe/pfk_f2fs.h
+++ b/security/pfe/pfk_f2fs.h
@@ -24,7 +24,9 @@ int pfk_f2fs_parse_inode(const struct bio *bio,
 		const struct inode *inode,
 		struct pfk_key_info *key_info,
 		enum ice_cryto_algo_mode *algo,
-		bool *is_pfe);
+		bool *is_pfe,
+		unsigned int *data_unit,
+		const char *storage_type);
 
 bool pfk_f2fs_allow_merge_bio(const struct bio *bio1,
 	const struct bio *bio2, const struct inode *inode1,

--- a/security/pfe/pfk_ice.c
+++ b/security/pfe/pfk_ice.c
@@ -26,13 +26,19 @@
 #include "pfk_ice.h"
 
 
-#define TZ_ES_CONFIG_SET_ICE_KEY 0x4
-#define TZ_ES_INVALIDATE_ICE_KEY 0x3
+#define TZ_ES_SET_ICE_KEY		0x2
+#define TZ_ES_CONFIG_SET_ICE_KEY	0x4
+#define TZ_ES_INVALIDATE_ICE_KEY	0x3
 
 /* index 0 and 1 is reserved for FDE */
-#define MIN_ICE_KEY_INDEX 2
+#define MIN_ICE_KEY_INDEX	2
 
-#define MAX_ICE_KEY_INDEX 31
+#define MAX_ICE_KEY_INDEX	31
+#define ICE20			2
+
+#define TZ_ES_SET_ICE_KEY_ID \
+	TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, TZ_SVC_ES, \
+		TZ_ES_SET_ICE_KEY)
 
 #define TZ_ES_CONFIG_SET_ICE_KEY_ID \
 	TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, TZ_SVC_ES, \
@@ -41,6 +47,12 @@
 #define TZ_ES_INVALIDATE_ICE_KEY_ID \
 		TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, \
 			TZ_SVC_ES, TZ_ES_INVALIDATE_ICE_KEY)
+
+#define TZ_ES_SET_ICE_KEY_PARAM_ID \
+	TZ_SYSCALL_CREATE_PARAM_ID_5( \
+		TZ_SYSCALL_PARAM_TYPE_VAL, \
+		TZ_SYSCALL_PARAM_TYPE_BUF_RW, TZ_SYSCALL_PARAM_TYPE_VAL, \
+		TZ_SYSCALL_PARAM_TYPE_BUF_RW, TZ_SYSCALL_PARAM_TYPE_VAL)
 
 #define TZ_ES_CONFIG_SET_ICE_KEY_PARAM_ID \
 	TZ_SYSCALL_CREATE_PARAM_ID_5( \
@@ -54,22 +66,16 @@
 
 #define ICE_BUFFER_SIZE 64
 
-enum {
-	TZ_CIPHER_MODE_XTS_128 = 0,
-	TZ_CIPHER_MODE_CBC_128 = 1,
-	TZ_CIPHER_MODE_XTS_256 = 3,
-	TZ_CIPHER_MODE_CBC_256 = 4
-};
-
-static uint8_t ice_buffer[ICE_BUFFER_SIZE];
-
 int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
-			char *storage_type, unsigned int data_unit)
+			char *storage_type, unsigned int data_unit,
+			int ice_rev)
 {
 	struct scm_desc desc = {0};
 	int ret, ret1;
-	char *tzbuf = (char *)ice_buffer;
 	char *s_type = storage_type;
+	char *ice_buffer = NULL;
+	char *tzbuf_salt = NULL;
+	char *tzbuf_key = NULL;
 
 	uint32_t smc_id = 0;
 	u32 size = ICE_BUFFER_SIZE / 2;
@@ -83,31 +89,59 @@ int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
 		return -EINVAL;
 	}
 
-	if (!tzbuf) {
-		pr_err("%s No Memory\n", __func__);
-		return -ENOMEM;
-	}
-
 	if (s_type == NULL) {
 		pr_err("%s Invalid Storage type\n", __func__);
 		return -EINVAL;
 	}
 
-	memset(tzbuf, 0, ICE_BUFFER_SIZE);
+	if (ice_rev > ICE20) {
+		ice_buffer = kzalloc(ICE_BUFFER_SIZE, GFP_KERNEL);
+		if (!ice_buffer)
+			return -ENOMEM;
 
-	memcpy(ice_buffer, key, size);
-	memcpy(ice_buffer + size, salt, size);
+		memset(ice_buffer, 0, ICE_BUFFER_SIZE);
+		memcpy(ice_buffer, key, size);
+		memcpy(ice_buffer + size, salt, size);
 
-	dmac_flush_range(tzbuf, tzbuf + ICE_BUFFER_SIZE);
+		dmac_flush_range(ice_buffer, ice_buffer + ICE_BUFFER_SIZE);
 
-	smc_id = TZ_ES_CONFIG_SET_ICE_KEY_ID;
+		smc_id = TZ_ES_CONFIG_SET_ICE_KEY_ID;
 
-	desc.arginfo = TZ_ES_CONFIG_SET_ICE_KEY_PARAM_ID;
-	desc.args[0] = index;
-	desc.args[1] = virt_to_phys(tzbuf);
-	desc.args[2] = ICE_BUFFER_SIZE;
-	desc.args[3] = TZ_CIPHER_MODE_XTS_256;
-	desc.args[4] = data_unit;
+		desc.arginfo = TZ_ES_CONFIG_SET_ICE_KEY_PARAM_ID;
+		desc.args[0] = index;
+		desc.args[1] = virt_to_phys(ice_buffer);
+		desc.args[2] = ICE_BUFFER_SIZE;
+		desc.args[3] = ICE_CRYPTO_MODE_XTS_256;
+		desc.args[4] = data_unit;
+	} else {
+		tzbuf_key = kzalloc((ICE_BUFFER_SIZE / 2), GFP_KERNEL);
+		if (tzbuf_key) {
+			tzbuf_salt = kzalloc((ICE_BUFFER_SIZE / 2), GFP_KERNEL);
+			if (!tzbuf_salt) {
+				kfree(tzbuf_key);
+				return -ENOMEM;
+			}
+		} else {
+			return -ENOMEM;
+		}
+
+		memset(tzbuf_key, 0, size);
+		memset(tzbuf_salt, 0, size);
+		memcpy(tzbuf_key, key, size);
+		memcpy(tzbuf_salt, salt, size);
+
+		dmac_flush_range(tzbuf_key, tzbuf_key + size);
+		dmac_flush_range(tzbuf_salt, tzbuf_salt + size);
+
+		smc_id = TZ_ES_SET_ICE_KEY_ID;
+
+		desc.arginfo = TZ_ES_SET_ICE_KEY_PARAM_ID;
+		desc.args[0] = index;
+		desc.args[1] = virt_to_phys(tzbuf_key);
+		desc.args[2] = size;
+		desc.args[3] = virt_to_phys(tzbuf_salt);
+		desc.args[4] = size;
+	}
 
 	ret = qcom_ice_setup_ice_hw((const char *)s_type, true);
 
@@ -139,6 +173,13 @@ int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
 		pr_err("%s: Error %d disabling clocks\n", __func__, ret1);
 
 out:
+	if (ice_rev > ICE20) {
+		kfree(ice_buffer);
+	} else {
+		kfree(tzbuf_key);
+		kfree(tzbuf_salt);
+	}
+
 	return ret;
 }
 

--- a/security/pfe/pfk_ice.c
+++ b/security/pfe/pfk_ice.c
@@ -26,11 +26,7 @@
 #include "pfk_ice.h"
 
 
-/**********************************/
-/** global definitions		 **/
-/**********************************/
-
-#define TZ_ES_SET_ICE_KEY 0x2
+#define TZ_ES_CONFIG_SET_ICE_KEY 0x4
 #define TZ_ES_INVALIDATE_ICE_KEY 0x3
 
 /* index 0 and 1 is reserved for FDE */
@@ -38,44 +34,45 @@
 
 #define MAX_ICE_KEY_INDEX 31
 
-
-#define TZ_ES_SET_ICE_KEY_ID \
-	TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, TZ_SVC_ES, TZ_ES_SET_ICE_KEY)
-
+#define TZ_ES_CONFIG_SET_ICE_KEY_ID \
+	TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, TZ_SVC_ES, \
+		TZ_ES_CONFIG_SET_ICE_KEY)
 
 #define TZ_ES_INVALIDATE_ICE_KEY_ID \
 		TZ_SYSCALL_CREATE_SMC_ID(TZ_OWNER_SIP, \
 			TZ_SVC_ES, TZ_ES_INVALIDATE_ICE_KEY)
 
-
-#define TZ_ES_SET_ICE_KEY_PARAM_ID \
+#define TZ_ES_CONFIG_SET_ICE_KEY_PARAM_ID \
 	TZ_SYSCALL_CREATE_PARAM_ID_5( \
 		TZ_SYSCALL_PARAM_TYPE_VAL, \
 		TZ_SYSCALL_PARAM_TYPE_BUF_RW, TZ_SYSCALL_PARAM_TYPE_VAL, \
-		TZ_SYSCALL_PARAM_TYPE_BUF_RW, TZ_SYSCALL_PARAM_TYPE_VAL)
+		TZ_SYSCALL_PARAM_TYPE_VAL, TZ_SYSCALL_PARAM_TYPE_VAL)
 
 #define TZ_ES_INVALIDATE_ICE_KEY_PARAM_ID \
 	TZ_SYSCALL_CREATE_PARAM_ID_1( \
 	TZ_SYSCALL_PARAM_TYPE_VAL)
 
-#define ICE_KEY_SIZE 32
-#define ICE_SALT_SIZE 32
+#define ICE_BUFFER_SIZE 64
 
-static uint8_t ice_key[ICE_KEY_SIZE];
-static uint8_t ice_salt[ICE_KEY_SIZE];
+enum {
+	TZ_CIPHER_MODE_XTS_128 = 0,
+	TZ_CIPHER_MODE_CBC_128 = 1,
+	TZ_CIPHER_MODE_XTS_256 = 3,
+	TZ_CIPHER_MODE_CBC_256 = 4
+};
+
+static uint8_t ice_buffer[ICE_BUFFER_SIZE];
 
 int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
-			char *storage_type)
+			char *storage_type, unsigned int data_unit)
 {
 	struct scm_desc desc = {0};
 	int ret, ret1;
-	char *tzbuf_key = (char *)ice_key;
-	char *tzbuf_salt = (char *)ice_salt;
+	char *tzbuf = (char *)ice_buffer;
 	char *s_type = storage_type;
 
 	uint32_t smc_id = 0;
-	u32 tzbuflen_key = sizeof(ice_key);
-	u32 tzbuflen_salt = sizeof(ice_salt);
+	u32 size = ICE_BUFFER_SIZE / 2;
 
 	if (index < MIN_ICE_KEY_INDEX || index > MAX_ICE_KEY_INDEX) {
 		pr_err("%s Invalid index %d\n", __func__, index);
@@ -86,7 +83,7 @@ int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
 		return -EINVAL;
 	}
 
-	if (!tzbuf_key || !tzbuf_salt) {
+	if (!tzbuf) {
 		pr_err("%s No Memory\n", __func__);
 		return -ENOMEM;
 	}
@@ -96,23 +93,21 @@ int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
 		return -EINVAL;
 	}
 
-	memset(tzbuf_key, 0, tzbuflen_key);
-	memset(tzbuf_salt, 0, tzbuflen_salt);
+	memset(tzbuf, 0, ICE_BUFFER_SIZE);
 
-	memcpy(ice_key, key, tzbuflen_key);
-	memcpy(ice_salt, salt, tzbuflen_salt);
+	memcpy(ice_buffer, key, size);
+	memcpy(ice_buffer + size, salt, size);
 
-	dmac_flush_range(tzbuf_key, tzbuf_key + tzbuflen_key);
-	dmac_flush_range(tzbuf_salt, tzbuf_salt + tzbuflen_salt);
+	dmac_flush_range(tzbuf, tzbuf + ICE_BUFFER_SIZE);
 
-	smc_id = TZ_ES_SET_ICE_KEY_ID;
+	smc_id = TZ_ES_CONFIG_SET_ICE_KEY_ID;
 
-	desc.arginfo = TZ_ES_SET_ICE_KEY_PARAM_ID;
+	desc.arginfo = TZ_ES_CONFIG_SET_ICE_KEY_PARAM_ID;
 	desc.args[0] = index;
-	desc.args[1] = virt_to_phys(tzbuf_key);
-	desc.args[2] = tzbuflen_key;
-	desc.args[3] = virt_to_phys(tzbuf_salt);
-	desc.args[4] = tzbuflen_salt;
+	desc.args[1] = virt_to_phys(tzbuf);
+	desc.args[2] = ICE_BUFFER_SIZE;
+	desc.args[3] = TZ_CIPHER_MODE_XTS_256;
+	desc.args[4] = data_unit;
 
 	ret = qcom_ice_setup_ice_hw((const char *)s_type, true);
 

--- a/security/pfe/pfk_ice.c
+++ b/security/pfe/pfk_ice.c
@@ -133,9 +133,10 @@ int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
 		if (ret1)
 			pr_err("%s: Invalidate Key Error: %d\n", __func__,
 					ret1);
-		goto out;
 	}
-	ret = qcom_ice_setup_ice_hw((const char *)s_type, false);
+	ret1 = qcom_ice_setup_ice_hw((const char *)s_type, false);
+	if (ret1)
+		pr_err("%s: Error %d disabling clocks\n", __func__, ret1);
 
 out:
 	return ret;

--- a/security/pfe/pfk_ice.h
+++ b/security/pfe/pfk_ice.h
@@ -26,7 +26,8 @@ int pfk_ice_init(void);
 int pfk_ice_deinit(void);
 
 int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
-			char *storage_type, unsigned int data_unit);
+			char *storage_type, unsigned int data_unit,
+			int ice_rev);
 int qti_pfk_ice_invalidate_key(uint32_t index, char *storage_type);
 
 

--- a/security/pfe/pfk_ice.h
+++ b/security/pfe/pfk_ice.h
@@ -26,7 +26,7 @@ int pfk_ice_init(void);
 int pfk_ice_deinit(void);
 
 int qti_pfk_ice_set_key(uint32_t index, uint8_t *key, uint8_t *salt,
-			char *storage_type);
+			char *storage_type, unsigned int data_unit);
 int qti_pfk_ice_invalidate_key(uint32_t index, char *storage_type);
 
 

--- a/security/pfe/pfk_kc.c
+++ b/security/pfe/pfk_kc.c
@@ -407,7 +407,7 @@ static void kc_clear_entry(struct kc_entry *entry)
  */
 static int kc_update_entry(struct kc_entry *entry, const unsigned char *key,
 	size_t key_size, const unsigned char *salt, size_t salt_size,
-	unsigned int data_unit)
+	unsigned int data_unit, int ice_rev)
 {
 	int ret;
 
@@ -424,7 +424,7 @@ static int kc_update_entry(struct kc_entry *entry, const unsigned char *key,
 	kc_spin_unlock();
 
 	ret = qti_pfk_ice_set_key(entry->key_index, entry->key,
-			entry->salt, s_type, data_unit);
+			entry->salt, s_type, data_unit, ice_rev);
 
 	kc_spin_lock();
 	return ret;
@@ -490,7 +490,7 @@ int pfk_kc_deinit(void)
  */
 int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size, u32 *key_index,
-		bool async, unsigned int data_unit)
+		bool async, unsigned int data_unit, int ice_rev)
 {
 	int ret = 0;
 	struct kc_entry *entry = NULL;
@@ -556,7 +556,7 @@ int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 		}
 	case (FREE):
 		ret = kc_update_entry(entry, key, key_size, salt, salt_size,
-					data_unit);
+					data_unit, ice_rev);
 		if (ret) {
 			entry->state = SCM_ERROR;
 			entry->scm_error = ret;

--- a/security/pfe/pfk_kc.c
+++ b/security/pfe/pfk_kc.c
@@ -132,6 +132,16 @@ static inline void kc_spin_unlock(void)
 }
 
 /**
+ * pfk_kc_get_storage_type() - return the hardware storage type.
+ *
+ * Return: storage type queried during bootup.
+ */
+const char *pfk_kc_get_storage_type(void)
+{
+	return s_type;
+}
+
+/**
  * kc_entry_is_available() - checks whether the entry is available
  *
  * Return true if it is , false otherwise or if invalid
@@ -389,13 +399,15 @@ static void kc_clear_entry(struct kc_entry *entry)
  * @key_size: key_size
  * @salt: salt
  * @salt_size: salt_size
+ * @data_unit: dun size
  *
  * The previous key is securely released and wiped, the new one is loaded
  * to ICE.
  * Should be invoked under spinlock
  */
 static int kc_update_entry(struct kc_entry *entry, const unsigned char *key,
-	size_t key_size, const unsigned char *salt, size_t salt_size)
+	size_t key_size, const unsigned char *salt, size_t salt_size,
+	unsigned int data_unit)
 {
 	int ret;
 
@@ -412,7 +424,7 @@ static int kc_update_entry(struct kc_entry *entry, const unsigned char *key,
 	kc_spin_unlock();
 
 	ret = qti_pfk_ice_set_key(entry->key_index, entry->key,
-			entry->salt, s_type);
+			entry->salt, s_type, data_unit);
 
 	kc_spin_lock();
 	return ret;
@@ -478,7 +490,7 @@ int pfk_kc_deinit(void)
  */
 int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size, u32 *key_index,
-		bool async)
+		bool async, unsigned int data_unit)
 {
 	int ret = 0;
 	struct kc_entry *entry = NULL;
@@ -543,7 +555,8 @@ int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 			break;
 		}
 	case (FREE):
-		ret = kc_update_entry(entry, key, key_size, salt, salt_size);
+		ret = kc_update_entry(entry, key, key_size, salt, salt_size,
+					data_unit);
 		if (ret) {
 			entry->state = SCM_ERROR;
 			entry->scm_error = ret;

--- a/security/pfe/pfk_kc.h
+++ b/security/pfe/pfk_kc.h
@@ -19,7 +19,7 @@ int pfk_kc_init(void);
 int pfk_kc_deinit(void);
 int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size, u32 *key_index,
-		bool async);
+		bool async, unsigned int data_unit);
 void pfk_kc_load_key_end(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size);
 int pfk_kc_remove_key_with_salt(const unsigned char *key, size_t key_size,
@@ -27,6 +27,7 @@ int pfk_kc_remove_key_with_salt(const unsigned char *key, size_t key_size,
 int pfk_kc_remove_key(const unsigned char *key, size_t key_size);
 int pfk_kc_clear(void);
 void pfk_kc_clear_on_reset(void);
+const char *pfk_kc_get_storage_type(void);
 extern char *saved_command_line;
 
 

--- a/security/pfe/pfk_kc.h
+++ b/security/pfe/pfk_kc.h
@@ -19,7 +19,7 @@ int pfk_kc_init(void);
 int pfk_kc_deinit(void);
 int pfk_kc_load_key_start(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size, u32 *key_index,
-		bool async, unsigned int data_unit);
+		bool async, unsigned int data_unit, int ice_rev);
 void pfk_kc_load_key_end(const unsigned char *key, size_t key_size,
 		const unsigned char *salt, size_t salt_size);
 int pfk_kc_remove_key_with_salt(const unsigned char *key, size_t key_size,

--- a/sound/soc/soc-ops.c
+++ b/sound/soc/soc-ops.c
@@ -379,7 +379,7 @@ int snd_soc_get_volsw_sx(struct snd_kcontrol *kcontrol,
 	unsigned int rshift = mc->rshift;
 	int max = mc->max;
 	int min = mc->min;
-	unsigned int mask = (1 << (fls(min + max) - 1)) - 1;
+	unsigned int mask = (1U << (fls(min + max) - 1)) - 1;
 	unsigned int val;
 	int ret;
 
@@ -424,7 +424,7 @@ int snd_soc_put_volsw_sx(struct snd_kcontrol *kcontrol,
 	unsigned int rshift = mc->rshift;
 	int max = mc->max;
 	int min = mc->min;
-	unsigned int mask = (1 << (fls(min + max) - 1)) - 1;
+	unsigned int mask = (1U << (fls(min + max) - 1)) - 1;
 	int err = 0;
 	unsigned int val, val_mask, val2 = 0;
 


### PR DESCRIPTION
This PR adds some hardening, F2FS support for ICE and updates hardware
encryption to use the right key size on UFS and eMMC (which is different!).

Also adds some memory management improvement and some fixes for
some race conditions.

Tested on SoMC Discovery DSDS (SDE)