### PR TITLE
arm64: DT: Tama: Define notification led parameters for blinking.

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -647,6 +647,14 @@
 		46 511 511
 		47 511 511
 		48 511 511>;
+	qcom,start-idx = <0>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
+	qcom,lut-flags = <25>;
+	qcom,pause-lo = <500>;
+	qcom,pause-hi = <500>;
+	qcom,ramp-step-ms = <100>;
+	qcom,use-blink;
 };
 
 &green_led {
@@ -659,6 +667,14 @@
 		46 511 511
 		47 511 511
 		48 511 511>;
+	qcom,start-idx = <0>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
+	qcom,lut-flags = <25>;
+	qcom,pause-lo = <500>;
+	qcom,pause-hi = <500>;
+	qcom,ramp-step-ms = <100>;
+	qcom,use-blink;
 };
 
 &blue_led {
@@ -671,6 +687,14 @@
 		46 511 511
 		47 511 511
 		48 511 511>;
+	qcom,start-idx = <0>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
+	qcom,lut-flags = <25>;
+	qcom,pause-lo = <500>;
+	qcom,pause-hi = <500>;
+	qcom,ramp-step-ms = <100>;
+	qcom,use-blink;
 };
 
 &flash_led {


### PR DESCRIPTION
This configuration is necessary in order to export rgb blinking
attributes to sysfs, which are used by our HAL to blink the led when
notifications are received.
The parameters are copied from sdm630-nile-common.dtsi.

There is still odd/undefined behaviour with regards to the duty cycle values: They are processed inversely (meaning that a `"0,20,40,60,80,100"` cycle starts at full brightness and rams down). Inverting this works, except for the blue led which causes it to alternate between yellow and white :thinking: 

We might also consider decreasing the brightness of the LED, since it seems way too distracting at the moment (though I have not checked it in a bright/sunny environment yet). And I'm just too used to Suzu's way dimmer LED.