### PR TITLE
[DONOTMERGE] sdm630/msm8998: switch to intc

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-pinctrl.dtsi
@@ -19,7 +19,7 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		interrupt-controller;
-		interrupt-parent = <&wakegpio>;
+		//interrupt-parent = <&wakegpio>;
 		#interrupt-cells = <2>;
 
 

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -26,7 +26,7 @@
 	model = "Qualcomm Technologies, Inc. MSM 8998";
 	compatible = "qcom,msm8998";
 	qcom,msm-id = <292 0x0>;
-	interrupt-parent = <&wakegic>;
+	interrupt-parent = <&intc>;
 
 	aliases {
 		ufshc1 = &ufs1;
@@ -478,7 +478,7 @@
 	wakegpio: wake-gpio {
 		compatible = "qcom,mpm-gpio-msm8998", "qcom,mpm-gpio";
 		interrupt-controller;
-		interrupt-parent = <&intc>;
+		interrupt-parent = <&tlmm>;
 		#interrupt-cells = <2>;
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -24,7 +24,7 @@
 	model = "Qualcomm Technologies, Inc. SDM630";
 	compatible = "qcom,sdm630";
 	qcom,msm-id = <318 0x0>;
-	interrupt-parent = <&wakegic>;
+	interrupt-parent = <&intc>;
 
 	aliases {
 		serial0 = &uartblsp1dm1;
@@ -479,7 +479,7 @@
 	wakegpio: wake-gpio {
 		compatible = "qcom,mpm-gpio-sdm630", "qcom,mpm-gpio";
 		interrupt-controller;
-		interrupt-parent = <&intc>;
+		interrupt-parent = <&tlmm>;
 		#interrupt-cells = <2>;
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-pinctrl.dtsi
@@ -19,7 +19,7 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		interrupt-controller;
-		interrupt-parent = <&wakegpio>;
+		//interrupt-parent = <&wakegpio>;
 		#interrupt-cells = <2>;
 
 		uart_console_active: uart_console_active {


### PR DESCRIPTION
an experimental change that may help with the suspend issue
nile (sdm630) is tested and can boot with this, yoshino (msm8998) has not been tested