### PR TITLE
drm: somc_panel: Apply color calibration when selecting pcc profile.

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -547,7 +547,7 @@ static int somc_panel_colormgr_pcc_select(struct dsi_display *display,
 
 	color_mgr->pcc_profile = profile_number;
 	somc_panel_colormgr_reset(display->panel);
-	somc_panel_pcc_setup(display);
+	(void)somc_panel_colormgr_apply_calibrations();
 
 	return ret;
 }


### PR DESCRIPTION
Calling setup only prepares the profiles, but does not apply them to the
display, meaning that writing to the pcc_profile sysfs attribute has no
effect.
Change the call to a function applies the pcc instead (which calls setup
as well to make sure the profiles are available).