### PR TITLE
[2.3.2.r1.4] [URGENT] irqchip: irq-gic: Differentiate init for msm-qgic2 to add set_wake

### DIFF
--- a/drivers/irqchip/irq-gic.c
+++ b/drivers/irqchip/irq-gic.c
@@ -416,6 +416,11 @@ static void gic_handle_cascade_irq(struct irq_desc *desc)
 	chained_irq_exit(chip, desc);
 }
 
+static int msm_qgic2_set_wake(struct irq_data *d, unsigned int on)
+{
+	return 0;
+}
+
 static struct irq_chip gic_chip = {
 	.irq_mask		= gic_mask_irq,
 	.irq_unmask		= gic_unmask_irq,
@@ -1449,6 +1454,21 @@ static void __init gic_of_setup_kvm_info(struct device_node *node)
 }
 
 int __init
+msm_qgic2_of_init(struct device_node *node, struct device_node *parent)
+{
+	/*
+	 * QGIC2 requires MPM set_wake to exist due to the genirq API
+	 * being inflexible about a child interrupt controller calling
+	 * a function that does not exist on the parent.
+	 */
+#ifdef CONFIG_QTI_MPM
+	gic_chip.irq_set_wake = msm_qgic2_set_wake;
+#endif
+
+	return gic_of_init(node, parent);
+}
+
+int __init
 gic_of_init(struct device_node *node, struct device_node *parent)
 {
 	struct gic_chip_data *gic;
@@ -1502,7 +1522,7 @@ IRQCHIP_DECLARE(cortex_a15_gic, "arm,cortex-a15-gic", gic_of_init);
 IRQCHIP_DECLARE(cortex_a9_gic, "arm,cortex-a9-gic", gic_of_init);
 IRQCHIP_DECLARE(cortex_a7_gic, "arm,cortex-a7-gic", gic_of_init);
 IRQCHIP_DECLARE(msm_8660_qgic, "qcom,msm-8660-qgic", gic_of_init);
-IRQCHIP_DECLARE(msm_qgic2, "qcom,msm-qgic2", gic_of_init);
+IRQCHIP_DECLARE(msm_qgic2, "qcom,msm-qgic2", msm_qgic2_of_init);
 IRQCHIP_DECLARE(pl390, "arm,pl390", gic_of_init);
 #else
 int gic_of_init_child(struct device *dev, struct gic_chip_data **gic, int irq)


### PR DESCRIPTION
** URGENT MERGE **

QGIC2 requires MPM set_wake to exist due to the genirq API
being inflexible about a child interrupt controller calling
a function that does not exist on the parent.

For this reason, if qgic2 is compiled with QTI MPM support,
add a dummy irq_set_wake callback.

This fixes SoMC Loire boot issues after PR #1884 