### PR TITLE
arm64: DT: Nile: Reconfigure LEDs PWM parameters

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -576,39 +576,36 @@
 &red_led {
 	linux,name = "led:rgb_red";
 	qcom,start-idx = <0>;
-	qcom,idx-len = <2>;
-	qcom,duty-pcts =
-		[00 0E 1C 2A 38 46 54 64];
-	qcom,lut-flags = <25>;
+	qcom,lut-flags = <31>;
 	qcom,pause-lo = <500>;
 	qcom,pause-hi = <500>;
-	qcom,ramp-step-ms = <100>;
+	qcom,ramp-step-ms = <50>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
 	qcom,use-blink;
 };
 
 &green_led {
 	linux,name = "led:rgb_green";
 	qcom,start-idx = <0>;
-	qcom,idx-len = <2>;
-	qcom,duty-pcts =
-		[00 0E 1C 2A 38 46 54 64];
-	qcom,lut-flags = <25>;
+	qcom,lut-flags = <31>;
 	qcom,pause-lo = <500>;
 	qcom,pause-hi = <500>;
-	qcom,ramp-step-ms = <100>;
+	qcom,ramp-step-ms = <50>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
 	qcom,use-blink;
 };
 
 &blue_led {
 	linux,name = "led:rgb_blue";
 	qcom,start-idx = <0>;
-	qcom,idx-len = <2>;
-	qcom,duty-pcts =
-		[00 0E 1C 2A 38 46 54 64];
-	qcom,lut-flags = <25>;
+	qcom,lut-flags = <31>;
 	qcom,pause-lo = <500>;
 	qcom,pause-hi = <500>;
-	qcom,ramp-step-ms = <100>;
+	qcom,ramp-step-ms = <50>;
+	qcom,duty-pcts =
+		[00 0E 1C 2A 38 46 54 64];
 	qcom,use-blink;
 };
 


### PR DESCRIPTION
From https://github.com/sonyxperiadev/kernel/pull/1876
Nile needs the same lut flags to show a breathing effect. The old flags result in a ramp-down only, just like on Tama.

Change the rest of the parameters to be consistent with the configuration for Tama and Yoshino.