### PR TITLE
[DO NOT MERGE] [2.3.2.r1.4] Remove ifdefs to support one kernel for all new devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8056-loire-blanc_windy.dts
+++ b/arch/arm64/boot/dts/qcom/apq8056-loire-blanc_windy.dts
@@ -28,7 +28,7 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "qcom,apq8056";
+	compatible = "somc,blanc-row", "somc,loire", "qcom,apq8056";
 	qcom,board-id = <8 0>;
 	qcom,msm-id = <274 0x0>; /* APQ variant */
 };

--- a/arch/arm64/boot/dts/qcom/apq8056-loire-blanc_windy.dts
+++ b/arch/arm64/boot/dts/qcom/apq8056-loire-blanc_windy.dts
@@ -28,7 +28,7 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "somc,loire", "qcom,apq8056";
+	compatible = "somc,blanc-row", "somc,loire", "somc,somc-platform", "qcom,apq8056";
 	qcom,board-id = <8 0>;
 	qcom,msm-id = <274 0x0>; /* APQ variant */
 };

--- a/arch/arm64/boot/dts/qcom/apq8056-v1.1-loire-blanc_windy.dts
+++ b/arch/arm64/boot/dts/qcom/apq8056-v1.1-loire-blanc_windy.dts
@@ -28,7 +28,7 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "qcom,apq8056";
+	compatible = "somc,blanc-row", "somc,loire", "qcom,apq8056";
 	qcom,board-id = <8 0>;
 	qcom,msm-id = <274 0x10001>; /* APQ variant */
 };

--- a/arch/arm64/boot/dts/qcom/apq8056-v1.1-loire-blanc_windy.dts
+++ b/arch/arm64/boot/dts/qcom/apq8056-v1.1-loire-blanc_windy.dts
@@ -28,7 +28,7 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "somc,loire", "qcom,apq8056";
+	compatible = "somc,blanc-row", "somc,loire", "somc,somc-platform", "qcom,apq8056";
 	qcom,board-id = <8 0>;
 	qcom,msm-id = <274 0x10001>; /* APQ variant */
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-loire-blanc_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-blanc_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "qcom,msm8956";
+	compatible = "somc,blanc-row", "somc,loire", "qcom,msm8956";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-loire-blanc_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-blanc_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "somc,loire", "qcom,msm8956";
+	compatible = "somc,blanc-row", "somc,loire", "somc,somc-platform", "qcom,msm8956";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-blanc_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-blanc_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "qcom,msm8956";
+	compatible = "somc,blanc-row", "somc,loire", "qcom,msm8956";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-blanc_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-blanc_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Blanc-ROW";
-	compatible = "somc,blanc-row", "somc,loire", "qcom,msm8956";
+	compatible = "somc,blanc-row", "somc,loire", "somc,somc-platform", "qcom,msm8956";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-kugo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-kugo_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Kugo-ROW";
-	compatible = "somc,kugo-row", "qcom,msm8956";
+	compatible = "somc,kugo-row", "somc,loire", "qcom,msm8956";
 	qcom,board-id= <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-kugo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-kugo_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Kugo-ROW";
-	compatible = "somc,kugo-row", "somc,loire", "qcom,msm8956";
+	compatible = "somc,kugo-row", "somc,loire", "somc,somc-platform", "qcom,msm8956";
 	qcom,board-id= <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-suzu_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-suzu_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Suzu-ROW";
-	compatible = "somc,suzu-row", "qcom,msm8956";
+	compatible = "somc,suzu-row", "somc,loire", "qcom,msm8956";
 	qcom,board-id= <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-suzu_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8956-v1.1-loire-suzu_generic.dts
@@ -28,6 +28,6 @@
 
 / {
 	model = "SoMC Suzu-ROW";
-	compatible = "somc,suzu-row", "somc,loire", "qcom,msm8956";
+	compatible = "somc,suzu-row", "somc,loire", "somc,somc-platform", "qcom,msm8956";
 	qcom,board-id= <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-dora_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-kagura_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3-pmi8996-tone-keyaki_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-dora_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Dora-ROW";
-	compatible = "somc,dora-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,dora-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-kagura_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Kagura-ROW";
-	compatible = "somc,kagura-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,kagura-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki-sde_generic.dts
@@ -34,6 +34,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8996-v3.0-pmi8996-tone-keyaki_generic.dts
@@ -31,6 +31,6 @@
 
 / {
 	model = "SoMC Keyaki-ROW";
-	compatible = "somc,keyaki-row", "somc,tone", "qcom,msm8996";
+	compatible = "somc,keyaki-row", "somc,tone", "somc,somc-platform", "qcom,msm8996";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac-sde_generic.dts
@@ -32,7 +32,8 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2)";
-	compatible = "somc,lilac-row", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2)";
-	compatible = "somc,lilac-row", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-lilac_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2)";
-	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
@@ -30,7 +30,7 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2)";
-	compatible = "somc,maple-row", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple-sde_generic.dts
@@ -30,7 +30,8 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2)";
-	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2)";
-	compatible = "somc,maple-row", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-maple_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2)";
-	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Poplar-ROW(MSM8998 v2)";
-	compatible = "somc,poplar-row", "qcom,msm8998";
+	compatible = "somc,poplar-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Poplar-ROW(MSM8998 v2)";
-	compatible = "somc,poplar-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,poplar-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
@@ -32,7 +32,7 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2.1)";
-	compatible = "somc,lilac-row", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac-sde_generic.dts
@@ -32,7 +32,8 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2.1)";
-	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2.1)";
-	compatible = "somc,lilac-row", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-lilac_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Lilac-ROW(MSM8998 v2.1)";
-	compatible = "somc,lilac-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,lilac-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
@@ -31,7 +31,7 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2.1)";
-	compatible = "somc,maple-row", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple-sde_generic.dts
@@ -31,7 +31,8 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2.1)";
-	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2.1)";
-	compatible = "somc,maple-row", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-maple_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Maple-ROW(MSM8998 v2.1)";
-	compatible = "somc,maple-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,maple-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "SoMC Poplar-ROW(MSM8998 v2.1)";
-	compatible = "somc,poplar-row", "qcom,msm8998";
+	compatible = "somc,poplar-row", "somc,yoshino", "qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "SoMC Poplar-ROW(MSM8998 v2.1)";
-	compatible = "somc,poplar-row", "somc,yoshino", "qcom,msm8998";
+	compatible = "somc,poplar-row", "somc,yoshino", "somc,somc-platform",
+			"qcom,msm8998";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-discovery-sde.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-discovery-sde.dts
@@ -13,7 +13,7 @@
 / {
 	model = "Qualcomm Technologies, Inc. SDM 630 PM660 + PM660L MTP";
 	compatible = "qcom,sdm630-mtp", "qcom,sdm630", "qcom,mtp",
-			"somc,nile", "somc,discovery";
+			"somc,nile", "somc,somc-platform", "somc,discovery";
 	qcom,board-id = <8 0>;
 	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>,
 			<0x0001001b 0x0201011a 0x0 0x0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-discovery.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-discovery.dts
@@ -24,7 +24,7 @@
 / {
 	model = "Qualcomm Technologies, Inc. SDM 630 PM660 + PM660L MTP";
 	compatible = "qcom,sdm630-mtp", "qcom,sdm630", "qcom,mtp",
-			"somc,nile", "somc,discovery";
+			"somc,nile", "somc,somc-platform", "somc,discovery";
 	qcom,board-id = <8 0>;
 	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>,
 			<0x0001001b 0x0201011a 0x0 0x0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-pioneer-sde.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-pioneer-sde.dts
@@ -13,7 +13,7 @@
 / {
 	model = "Qualcomm Technologies, Inc. SDM 630 PM660 + PM660L MTP";
 	compatible = "qcom,sdm630-mtp", "qcom,sdm630", "qcom,mtp",
-			"somc,nile", "somc,pioneer";
+			"somc,nile", "somc,somc-platform", "somc,pioneer";
 	qcom,board-id = <8 0>;
 	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>,
 			<0x0001001b 0x0201011a 0x0 0x0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-pioneer.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-pioneer.dts
@@ -24,7 +24,7 @@
 / {
 	model = "Qualcomm Technologies, Inc. SDM 630 PM660 + PM660L MTP";
 	compatible = "qcom,sdm630-mtp", "qcom,sdm630", "qcom,mtp",
-			"somc,nile", "somc,pioneer";
+			"somc,nile", "somc,somc-platform", "somc,pioneer";
 	qcom,board-id = <8 0>;
 	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>,
 			<0x0001001b 0x0201011a 0x0 0x0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-voyager.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-voyager.dts
@@ -24,7 +24,7 @@
 / {
 	model = "Qualcomm Technologies, Inc. SDM 630 PM660 + PM660L MTP";
 	compatible = "qcom,sdm630-mtp", "qcom,sdm630", "qcom,mtp",
-			"somc,nile", "somc,voyager";
+			"somc,nile", "somc,somc-platform", "somc,voyager";
 	qcom,board-id = <8 0>;
 	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>,
 			<0x0001001b 0x0201011a 0x0 0x0>;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v1)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v1)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic.dts
@@ -27,7 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v1)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akari_generic.dts
@@ -27,7 +27,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v1)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v1)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v1)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic.dts
@@ -27,7 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v1)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_generic.dts
@@ -27,7 +27,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v1)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v1)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v1)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x10000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic.dts
@@ -27,7 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v1)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-apollo_generic.dts
@@ -27,7 +27,8 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v1)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akari_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-akatsuki_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20000>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic.dts
@@ -27,6 +27,6 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2-tama-apollo_generic.dts
@@ -27,6 +27,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2.1)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2.1)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic.dts
@@ -26,6 +26,6 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2.1)";
-	compatible = "somc,akari-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akari_generic.dts
@@ -26,6 +26,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akari(SDM845 v2.1)";
-	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akari-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2.1)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2.1)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic.dts
@@ -26,6 +26,6 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2.1)";
-	compatible = "somc,akatsuki-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-akatsuki_generic.dts
@@ -26,6 +26,7 @@
 
 / {
 	model = "Sony Mobile Communications. Akatsuki(SDM845 v2.1)";
-	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,akatsuki-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic-overlay.dts
@@ -33,7 +33,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2.1)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic-overlay.dts
@@ -33,7 +33,8 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2.1)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,msm-id = <321 0x20001>;
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic.dts
@@ -26,6 +26,6 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2.1)";
-	compatible = "somc,apollo-row", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.1-tama-apollo_generic.dts
@@ -26,6 +26,7 @@
 
 / {
 	model = "Sony Mobile Communications. Apollo(SDM845 v2.1)";
-	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845", "qcom,mtp";
+	compatible = "somc,apollo-row", "somc,tama", "qcom,sdm845",
+			"somc,somc-platform", "qcom,mtp";
 	qcom,board-id = <8 0>;
 };

--- a/drivers/input/misc/qpnp-power-on.c
+++ b/drivers/input/misc/qpnp-power-on.c
@@ -313,6 +313,41 @@ static const char * const qpnp_poff_reason[] = {
 	[39] = "Triggered from S3_RESET_KPDPWR_ANDOR_RESIN (power key and/or reset line)",
 };
 
+int restart_reason_map_qcom[PON_RESTART_REASON_MAX] = {
+	/* 0 ~ 31 for common defined features */
+	[PON_RESTART_REASON_UNKNOWN]		= 0x00,
+	[PON_RESTART_REASON_RECOVERY]		= 0x01,
+	[PON_RESTART_REASON_BOOTLOADER]		= 0x02,
+	[PON_RESTART_REASON_RTC]		= 0x03,
+	[PON_RESTART_REASON_DMVERITY_CORRUPTED]	= 0x04,
+	[PON_RESTART_REASON_DMVERITY_ENFORCE]	= 0x05,
+	[PON_RESTART_REASON_KEYS_CLEAR]		= 0x06,
+	[PON_RESTART_REASON_REBOOT]		= 0x10,
+
+	/* 32 ~ 63 for OEMs/ODMs secific features */
+	[PON_RESTART_REASON_OEM_MIN]		= 0x20,
+	[PON_RESTART_REASON_OEM_MAX]		= 0x3f,
+};
+
+int restart_reason_map_xboot[PON_RESTART_REASON_MAX] = {
+	[PON_RESTART_REASON_NONE]		= 0x00,
+	[PON_RESTART_REASON_UNKNOWN]		= 0x01,
+	[PON_RESTART_REASON_RECOVERY]		= 0x02,
+	[PON_RESTART_REASON_BOOTLOADER]		= 0x03,
+	[PON_RESTART_REASON_RTC]		= 0x04,
+	[PON_RESTART_REASON_DMVERITY_CORRUPTED]	= 0x05,
+	[PON_RESTART_REASON_DMVERITY_ENFORCE]	= 0x06,
+	[PON_RESTART_REASON_KEYS_CLEAR]		= 0x07,
+	[PON_RESTART_REASON_KERNEL_PANIC]	= 0x40,
+	[PON_RESTART_REASON_UNHANDLED_RESET]	= 0x41,
+	[PON_RESTART_REASON_FOTA_CRASH]		= 0x42,
+	[PON_RESTART_REASON_OEM_MIN]		= 0x50,
+	[PON_RESTART_REASON_OEM_F]		= 0x50,
+	[PON_RESTART_REASON_OEM_P]		= 0x51,
+	[PON_RESTART_REASON_OEM_MAX]		= 0x5f,
+	[PON_RESTART_REASON_XFL]		= 0x60,
+};
+
 static int
 qpnp_pon_masked_write(struct qpnp_pon *pon, u16 addr, u8 mask, u8 val)
 {
@@ -339,7 +374,7 @@ static bool is_pon_gen2(struct qpnp_pon *pon)
 }
 
 /**
- * qpnp_pon_set_restart_reason - Store device restart reason in PMIC register.
+ * __qpnp_pon_set_restart_reason - Store device restart reason in PMIC register.
  *
  * Returns = 0 if PMIC feature is not available or store restart reason
  * successfully.
@@ -349,7 +384,7 @@ static bool is_pon_gen2(struct qpnp_pon *pon)
  * It checks here to see if the restart reason register has been specified.
  * If it hasn't, this function should immediately return 0
  */
-int qpnp_pon_set_restart_reason(enum pon_restart_reason reason)
+int __qpnp_pon_set_restart_reason(int reason)
 {
 	int rc = 0;
 	struct qpnp_pon *pon = sys_reset_dev;
@@ -372,6 +407,20 @@ int qpnp_pon_set_restart_reason(enum pon_restart_reason reason)
 				"Unable to write to addr=%x, rc(%d)\n",
 				QPNP_PON_SOFT_RB_SPARE(pon), rc);
 	return rc;
+}
+
+int qpnp_pon_set_restart_reason(enum pon_restart_reason reason)
+{
+	int real_reason = reason;
+	int loader_tgt = msm_restart_get_bootloader_target();
+
+	if (loader_tgt == LOADER_TARGET_QCOM ||
+	    loader_tgt == LOADER_TARGET_SOMC_S1BOOT)
+		real_reason = restart_reason_map_qcom[reason];
+	else
+		real_reason = restart_reason_map_xboot[reason];
+
+	return __qpnp_pon_set_restart_reason(real_reason);
 }
 EXPORT_SYMBOL(qpnp_pon_set_restart_reason);
 

--- a/drivers/scsi/ufs/ufshcd.c
+++ b/drivers/scsi/ufs/ufshcd.c
@@ -10748,6 +10748,14 @@ int ufshcd_init(struct ufs_hba *hba, void __iomem *mmio_base, unsigned int irq)
 	struct Scsi_Host *host = hba->host;
 	struct device *dev = hba->dev;
 
+#if !defined(CONFIG_ARCH_SONY_YOSHINO) && !defined(CONFIG_ARCH_SONY_TAMA)
+	if (of_machine_is_compatible("somc,yoshino") ||
+	    of_machine_is_compatible("somc,tama")) {
+		panic("Crashing the kernel to prevent erasing your bootloader."
+		    "Build your kernel with ARCH_SONY_YOSHINO/TAMA support!!");
+	}
+#endif
+
 	if (!mmio_base) {
 		dev_err(hba->dev,
 		"Invalid memory reference for mmio_base is NULL\n");

--- a/include/linux/input/qpnp-power-on.h
+++ b/include/linux/input/qpnp-power-on.h
@@ -14,6 +14,7 @@
 #define QPNP_PON_H
 
 #include <linux/errno.h>
+#include <linux/of.h>
 
 /**
  * enum pon_trigger_source: List of PON trigger sources
@@ -50,27 +51,7 @@ enum pon_power_off_type {
 	PON_POWER_OFF_MAX_TYPE		= 0x10,
 };
 
-#if defined(CONFIG_ARCH_SONY_YOSHINO) || defined(CONFIG_ARCH_SONY_NILE) || \
-    defined(CONFIG_ARCH_SONY_TAMA)
-enum pon_restart_reason {
-	PON_RESTART_REASON_NONE			= 0x00,
-	PON_RESTART_REASON_UNKNOWN		= 0x01,
-	PON_RESTART_REASON_RECOVERY		= 0x02,
-	PON_RESTART_REASON_BOOTLOADER		= 0x03,
-	PON_RESTART_REASON_RTC			= 0x04,
-	PON_RESTART_REASON_DMVERITY_CORRUPTED	= 0x05,
-	PON_RESTART_REASON_DMVERITY_ENFORCE	= 0x06,
-	PON_RESTART_REASON_KEYS_CLEAR		= 0x07,
-	PON_RESTART_REASON_KERNEL_PANIC		= 0x40,
-	PON_RESTART_REASON_UNHANDLED_RESET	= 0x41,
-	PON_RESTART_REASON_FOTA_CRASH		= 0x42,
-	PON_RESTART_REASON_OEM_MIN		= 0x50,
-	PON_RESTART_REASON_OEM_F		= 0x50,
-	PON_RESTART_REASON_OEM_P		= 0x51,
-	PON_RESTART_REASON_OEM_MAX		= 0x5f,
-	PON_RESTART_REASON_XFL			= 0x60,
-};
-#else
+/* NOTE: These are NOT the real restart reason values. */
 enum pon_restart_reason {
 	/* 0 ~ 31 for common defined features */
 	PON_RESTART_REASON_UNKNOWN		= 0x00,
@@ -82,11 +63,45 @@ enum pon_restart_reason {
 	PON_RESTART_REASON_KEYS_CLEAR		= 0x06,
 	PON_RESTART_REASON_REBOOT		= 0x10,
 
-	/* 32 ~ 63 for OEMs/ODMs secific features */
-	PON_RESTART_REASON_OEM_MIN		= 0x20,
-	PON_RESTART_REASON_OEM_MAX		= 0x3f,
+	/* QCOM: 32 ~ 63 for OEMs/ODMs secific features */
+	//PON_RESTART_REASON_OEM_MIN		= 0x20,
+	//PON_RESTART_REASON_OEM_MAX		= 0x3f,
+
+	/* SoMC specific */
+	PON_RESTART_REASON_KERNEL_PANIC		= 0x40,
+	PON_RESTART_REASON_UNHANDLED_RESET	= 0x41,
+	PON_RESTART_REASON_FOTA_CRASH		= 0x42,
+	PON_RESTART_REASON_OEM_MIN		= 0x50,
+	PON_RESTART_REASON_OEM_F		= 0x50,
+	PON_RESTART_REASON_OEM_P		= 0x51,
+	PON_RESTART_REASON_OEM_MAX		= 0x5f,
+	PON_RESTART_REASON_XFL			= 0x60,
+
+	PON_RESTART_REASON_NONE			= 0x80,
+	PON_RESTART_REASON_MAX,
 };
-#endif /* CONFIG_ARCH_SONY_YOSHINO */
+
+enum loader_target {
+	LOADER_TARGET_UNKNOWN = 0,
+	LOADER_TARGET_QCOM,
+	LOADER_TARGET_SOMC_S1BOOT = 10,
+	LOADER_TARGET_SOMC_XBOOT,
+	LOADER_TARGET_SOMC_XBOOT_AB,
+	LOADER_TARGET_SOMC_MAX,
+	LOADER_TARGET_MAX
+};
+
+#define IS_ANY_LOADER_TARGET_SOMC(x) \
+	((x >= LOADER_TARGET_SOMC_S1BOOT) && (x < LOADER_TARGET_SOMC_MAX))
+
+#ifdef CONFIG_POWER_RESET_QCOM
+int msm_restart_get_bootloader_target(void);
+#else
+static inline int msm_restart_get_bootloader_target(void)
+{
+	return LOADER_TARGET_QCOM;
+}
+#endif
 
 #ifdef CONFIG_INPUT_QPNP_POWER_ON
 int qpnp_pon_system_pwr_off(enum pon_power_off_type type);

--- a/techpack/audio/asoc/codecs/wcd-mbhc-v2.h
+++ b/techpack/audio/asoc/codecs/wcd-mbhc-v2.h
@@ -23,13 +23,8 @@
 #define WCD_MBHC_DEF_BUTTONS 8
 #define WCD_MBHC_KEYCODE_NUM 8
 #define WCD_MBHC_USLEEP_RANGE_MARGIN_US 100
-#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
- #define WCD_MBHC_THR_HS_MICB_MV	2450
-#elif defined(CONFIG_ARCH_SONY_TAMA)
- #define WCD_MBHC_THR_HS_MICB_MV	2750
-#else
- #define WCD_MBHC_THR_HS_MICB_MV  2700
-#endif
+#define WCD_MBHC_THR_HS_MICB_MV  2700
+
 /* z value defined in Ohms */
 #define WCD_MONO_HS_MIN_THR	2
 #define WCD_MBHC_STRINGIFY(s)  __stringify(s)
@@ -249,9 +244,7 @@ enum wcd_mbhc_plug_type {
 	MBHC_PLUG_TYPE_HIGH_HPH,
 	MBHC_PLUG_TYPE_GND_MIC_SWAP,
 	MBHC_PLUG_TYPE_ANC_HEADPHONE,
-#if defined(CONFIG_ARCH_SONY_LOIRE) || defined(CONFIG_ARCH_SONY_TONE)
 	MBHC_PLUG_TYPE_STEREO_MICROPHONE,
-#endif
 };
 
 enum pa_dac_ack_flags {
@@ -526,12 +519,26 @@ struct wcd_mbhc_fn {
 					  struct work_struct *work);
 };
 
+enum wcd_somc_platform {
+	WCD_SOMC_PLATFORM_UNKNOWN = 1,
+	WCD_SOMC_PLATFORM_LOIRE,
+	WCD_SOMC_PLATFORM_TONE,
+	WCD_SOMC_PLATFORM_NILE,
+	WCD_SOMC_PLATFORM_YOSHINO,
+	WCD_SOMC_PLATFORM_TAMA,
+	WCD_SOMC_PLATFORM_MAX
+};
+
 struct wcd_mbhc {
 	/* Delayed work to report long button press */
 	struct delayed_work mbhc_btn_dwork;
 	int buttons_pressed;
 	struct wcd_mbhc_config *mbhc_cfg;
 	const struct wcd_mbhc_cb *mbhc_cb;
+
+	/* ARCH_SONY */
+	int somc_platform;
+	/* */
 
 	u32 hph_status; /* track headhpone status */
 	u8 hphlocp_cnt; /* headphone left ocp retry */
@@ -557,9 +564,9 @@ struct wcd_mbhc {
 	bool btn_press_intr;
 	bool is_hs_recording;
 	bool is_extn_cable;
-#ifdef CONFIG_ARCH_SONY_TAMA
+	/* ARCH_SONY_TAMA */
 	bool extn_cable_inserted;
-#endif
+	/* */
 	bool skip_imped_detection;
 	bool is_btn_already_regd;
 	bool extn_cable_hph_rem;

--- a/techpack/audio/asoc/codecs/wcd9335.c
+++ b/techpack/audio/asoc/codecs/wcd9335.c
@@ -49,6 +49,8 @@
 #include "wcdcal-hwdep.h"
 #include "wcd-mbhc-v2-api.h"
 
+static unsigned int WCD_MBHC_THR_HS_MICB_MV_VAR = 2700;
+
 #define TASHA_RX_PORT_START_NUMBER  16
 
 #define WCD9335_RATES_MASK (SNDRV_PCM_RATE_8000 | SNDRV_PCM_RATE_16000 |\
@@ -1641,10 +1643,10 @@ static int tasha_mbhc_micb_ctrl_threshold_mic(struct snd_soc_codec *codec,
 	 * voltage needed to detect threshold microphone, then do
 	 * not change the micbias, just return.
 	 */
-	if (pdata->micbias.micb2_mv >= WCD_MBHC_THR_HS_MICB_MV)
+	if (pdata->micbias.micb2_mv >= WCD_MBHC_THR_HS_MICB_MV_VAR)
 		return 0;
 
-	micb_mv = req_en ? WCD_MBHC_THR_HS_MICB_MV : pdata->micbias.micb2_mv;
+	micb_mv = req_en ? WCD_MBHC_THR_HS_MICB_MV_VAR : pdata->micbias.micb2_mv;
 
 	mutex_lock(&tasha->micb_lock);
 	rc = tasha_mbhc_micb_adjust_voltage(codec, micb_mv, MIC_BIAS_2);
@@ -13618,6 +13620,10 @@ static int tasha_codec_probe(struct snd_soc_codec *codec)
 		control->post_reset = tasha_post_reset_cb;
 		control->ssr_priv = (void *)codec;
 	}
+
+	if (of_machine_is_compatible("somc,loire") ||
+	    of_machine_is_compatible("somc,tone"))
+		WCD_MBHC_THR_HS_MICB_MV_VAR = 2450;
 
 	/* Resource Manager post Init */
 	ret = wcd_resmgr_post_init(tasha->resmgr, &tasha_resmgr_cb, codec);

--- a/techpack/audio/asoc/codecs/wcd934x/wcd934x.c
+++ b/techpack/audio/asoc/codecs/wcd934x/wcd934x.c
@@ -144,9 +144,9 @@ static const struct snd_kcontrol_new name##_mux = \
 #define  CF_MIN_3DB_75HZ		0x1
 #define  CF_MIN_3DB_150HZ		0x2
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+/* ARCH_SONY_TAMA */
 #define  SB_OF_UF_MAX_RETRY_CNT		5
-#endif
+/* */
 
 #define CPE_ERR_WDOG_BITE BIT(0)
 #define CPE_FATAL_IRQS CPE_ERR_WDOG_BITE
@@ -632,9 +632,7 @@ struct tavil_priv {
 	struct tavil_dsd_config *dsd_config;
 	struct tavil_idle_detect_config idle_det_cfg;
 
-#ifdef CONFIG_ARCH_SONY_TAMA
 	unsigned short slim_tx_of_uf_cnt[WCD934X_TX_MAX][SB_PORT_ERR_MAX];
-#endif
 
 	int power_active_ref;
 	u8 sidetone_coeff_array[IIR_MAX][BAND_MAX]
@@ -645,6 +643,16 @@ struct tavil_priv {
 		[WCD934X_CHILD_DEVICES_MAX];
 	int child_count;
 };
+
+/* 
+ * QCOM: M1P5_DB=0; 0_DB=1
+ * TAMA: M1P5_DB=0; M0P5_DB=1; 0_DB=2 (set at wcd934x init time)
+ */
+#define ARCH_SONY_TAMA 1
+static unsigned short somc_platform = 0;
+int WCD934X_RX_GAIN_OFFSET_M1P5_DB = 0;
+int WCD934X_RX_GAIN_OFFSET_M0P5_DB = 1; /* ARCH_SONY ARCH_SONY_TAMA */
+int WCD934X_RX_GAIN_OFFSET_0_DB    = 1;
 
 static const struct tavil_reg_mask_val tavil_spkr_default[] = {
 	{WCD934X_CDC_COMPANDER7_CTL3, 0x80, 0x80},
@@ -1860,6 +1868,18 @@ static int tavil_codec_enable_tx_i2c(struct snd_soc_dapm_widget *w,
 	return ret;
 }
 
+static inline void tavil_codec_reset_of_uf_cnt(struct tavil_priv *tavil_p,
+					struct wcd9xxx_codec_dai_data *dai)
+{
+	struct wcd9xxx_ch *ch;
+
+	/* reset overflow and underflow counts */
+	list_for_each_entry(ch, &dai->wcd9xxx_ch_list, list) {
+		tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_OF] = 0;
+		tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_UF] = 0;
+	}
+}
+
 static int tavil_codec_enable_tx(struct snd_soc_dapm_widget *w,
 				 struct snd_kcontrol *kcontrol,
 				 int event)
@@ -1869,9 +1889,6 @@ static int tavil_codec_enable_tx(struct snd_soc_dapm_widget *w,
 	struct wcd9xxx_codec_dai_data *dai;
 	struct wcd9xxx *core;
 	int ret = 0;
-#ifdef CONFIG_ARCH_SONY_TAMA
-	struct wcd9xxx_ch *ch;
-#endif
 
 	dev_dbg(codec->dev,
 		"%s: w->name %s, w->shift = %d, num_dai %d stream name %s\n",
@@ -1907,15 +1924,10 @@ static int tavil_codec_enable_tx(struct snd_soc_dapm_widget *w,
 			dev_dbg(codec->dev, "%s: Disconnect RX port, ret = %d\n",
 				 __func__, ret);
 		}
-#ifdef CONFIG_ARCH_SONY_TAMA
-		/* reset overflow and underflow counts */
-		list_for_each_entry(ch, &dai->wcd9xxx_ch_list, list) {
-			tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_OF]
-									= 0;
-			tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_UF]
-									= 0;
+		if (somc_platform == ARCH_SONY_TAMA) {
+			/* reset overflow and underflow counts */
+			tavil_codec_reset_of_uf_cnt(tavil_p, dai);
 		}
-#endif
 		break;
 	}
 	return ret;
@@ -1930,9 +1942,6 @@ static int tavil_codec_enable_slimvi_feedback(struct snd_soc_dapm_widget *w,
 	struct tavil_priv *tavil_p = NULL;
 	int ret = 0;
 	struct wcd9xxx_codec_dai_data *dai = NULL;
-#ifdef CONFIG_ARCH_SONY_TAMA
-	struct wcd9xxx_ch *ch;
-#endif
 
 	codec = snd_soc_dapm_to_codec(w->dapm);
 	tavil_p = snd_soc_codec_get_drvdata(codec);
@@ -2025,15 +2034,10 @@ static int tavil_codec_enable_slimvi_feedback(struct snd_soc_dapm_widget *w,
 			dev_dbg(codec->dev, "%s: Disconnect TX port, ret = %d\n",
 				__func__, ret);
 		}
-#ifdef CONFIG_ARCH_SONY_TAMA
-		/* reset overflow and underflow counts */
-		list_for_each_entry(ch, &dai->wcd9xxx_ch_list, list) {
-			tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_OF]
-									= 0;
-			tavil_p->slim_tx_of_uf_cnt[ch->port][SB_PORT_ERR_UF]
-									= 0;
+		if (somc_platform == ARCH_SONY_TAMA) {
+			/* reset overflow and underflow counts */
+			tavil_codec_reset_of_uf_cnt(tavil_p, dai);
 		}
-#endif
 		if (test_bit(VI_SENSE_1, &tavil_p->status_mask)) {
 			/* Disable V&I sensing */
 			dev_dbg(codec->dev, "%s: spkr1 disabled\n", __func__);
@@ -3889,23 +3893,18 @@ static int tavil_codec_set_idle_detect_thr(struct snd_soc_codec *codec,
 	return 0;
 }
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+/* ARCH_SONY_TAMA */
 static void tavil_codec_set_offset_val(int *offset_val, int gain_offset,
 				       int mult)
 {
-	switch (gain_offset) {
-	case WCD934X_RX_GAIN_OFFSET_M0P5_DB:
+	if (gain_offset == WCD934X_RX_GAIN_OFFSET_M0P5_DB)
 		*offset_val = 1 * mult;
-		break;
-	case WCD934X_RX_GAIN_OFFSET_M1P5_DB:
+	else if (gain_offset == WCD934X_RX_GAIN_OFFSET_M1P5_DB)
 		*offset_val = 2 * mult;
-		break;
-	default:
+	else
 		pr_err("Improper gain offset\n");
-		break;
-	}
 }
-#endif
+/* */
 
 static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 				       struct snd_kcontrol *kcontrol,
@@ -3941,13 +3940,16 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, mix_reg, 0x20, 0x20);
 		break;
 	case SND_SOC_DAPM_POST_PMU:
-#ifdef CONFIG_ARCH_SONY_TAMA
-		if ((tavil->swr.spkr_gain_offset ==
-		     WCD934X_RX_GAIN_OFFSET_0_DB) &&
-#else
-		if ((tavil->swr.spkr_gain_offset ==
-		     WCD934X_RX_GAIN_OFFSET_M1P5_DB) &&
-#endif
+		if (((
+		      (somc_platform == ARCH_SONY_TAMA) &&
+		      (tavil->swr.spkr_gain_offset ==
+		 	WCD934X_RX_GAIN_OFFSET_0_DB)
+		     ) ||
+		     (
+		      (somc_platform == 0) &&
+		      (tavil->swr.spkr_gain_offset ==
+			 WCD934X_RX_GAIN_OFFSET_M1P5_DB)
+		     )) &&
 		    (tavil->comp_enabled[COMPANDER_7] ||
 		     tavil->comp_enabled[COMPANDER_8]) &&
 		    (gain_reg == WCD934X_CDC_RX7_RX_VOL_MIX_CTL ||
@@ -3962,12 +3964,12 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x01);
-#ifdef CONFIG_ARCH_SONY_TAMA
-			tavil_codec_set_offset_val(&offset_val,
+			if (somc_platform == ARCH_SONY_TAMA) {
+				tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, -1);
-#else
-			offset_val = -2;
-#endif
+			} else {
+				offset_val = -2;
+			}
 		}
 		val = snd_soc_read(codec, gain_reg);
 		val += offset_val;
@@ -3982,13 +3984,16 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 		snd_soc_update_bits(codec, mix_reg, 0x40, 0x40);
 		snd_soc_update_bits(codec, mix_reg, 0x40, 0x00);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
-		if ((tavil->swr.spkr_gain_offset ==
-		     WCD934X_RX_GAIN_OFFSET_0_DB) &&
-#else
-		if ((tavil->swr.spkr_gain_offset ==
-		     WCD934X_RX_GAIN_OFFSET_M1P5_DB) &&
-#endif
+		if (((
+		      (somc_platform == ARCH_SONY_TAMA) &&
+		      (tavil->swr.spkr_gain_offset ==
+		 	WCD934X_RX_GAIN_OFFSET_0_DB)
+		     ) ||
+		     (
+		      (somc_platform == 0) &&
+		      (tavil->swr.spkr_gain_offset ==
+			 WCD934X_RX_GAIN_OFFSET_M1P5_DB)
+		     )) &&
 		    (tavil->comp_enabled[COMPANDER_7] ||
 		     tavil->comp_enabled[COMPANDER_8]) &&
 		    (gain_reg == WCD934X_CDC_RX7_RX_VOL_MIX_CTL ||
@@ -4003,12 +4008,12 @@ static int tavil_codec_enable_mix_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x00);
-#ifdef CONFIG_ARCH_SONY_TAMA
-			tavil_codec_set_offset_val(&offset_val,
+			if (somc_platform == ARCH_SONY_TAMA) {
+				tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, 1);
-#else
-			offset_val = 2;
-#endif
+			} else {
+				offset_val = 2;
+			}
 			val = snd_soc_read(codec, gain_reg);
 			val += offset_val;
 			snd_soc_write(codec, gain_reg, val);
@@ -4077,13 +4082,16 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 		break;
 	case SND_SOC_DAPM_POST_PMU:
 		/* apply gain after int clk is enabled */
-#ifdef CONFIG_ARCH_SONY_TAMA
-		if ((tavil->swr.spkr_gain_offset ==
-		     			WCD934X_RX_GAIN_OFFSET_0_DB) &&
-#else
-		if ((tavil->swr.spkr_gain_offset ==
-					WCD934X_RX_GAIN_OFFSET_M1P5_DB) &&
-#endif
+		if (((
+		      (somc_platform == ARCH_SONY_TAMA) &&
+		      (tavil->swr.spkr_gain_offset ==
+		 	WCD934X_RX_GAIN_OFFSET_0_DB)
+		     ) ||
+		     (
+		      (somc_platform == 0) &&
+		      (tavil->swr.spkr_gain_offset ==
+			 WCD934X_RX_GAIN_OFFSET_M1P5_DB)
+		     )) &&
 		    (tavil->comp_enabled[COMPANDER_7] ||
 		     tavil->comp_enabled[COMPANDER_8]) &&
 		    (gain_reg == WCD934X_CDC_RX7_RX_VOL_CTL ||
@@ -4098,12 +4106,12 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x01);
-#ifdef CONFIG_ARCH_SONY_TAMA
-			tavil_codec_set_offset_val(&offset_val,
+			if (somc_platform == ARCH_SONY_TAMA) {
+				tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, -1);
-#else
-			offset_val = -2;
-#endif
+			} else {
+				offset_val = -2;
+			}
 		}
 		val = snd_soc_read(codec, gain_reg);
 		val += offset_val;
@@ -4113,13 +4121,16 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 	case SND_SOC_DAPM_POST_PMD:
 		tavil_codec_enable_interp_clk(codec, event, w->shift);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
-		if ((tavil->swr.spkr_gain_offset ==
-		     			WCD934X_RX_GAIN_OFFSET_0_DB) &&
-#else
-		if ((tavil->swr.spkr_gain_offset ==
-					WCD934X_RX_GAIN_OFFSET_M1P5_DB) &&
-#endif
+		if (((
+		      (somc_platform == ARCH_SONY_TAMA) &&
+		      (tavil->swr.spkr_gain_offset ==
+		 	WCD934X_RX_GAIN_OFFSET_0_DB)
+		     ) ||
+		     (
+		      (somc_platform == 0) &&
+		      (tavil->swr.spkr_gain_offset ==
+			 WCD934X_RX_GAIN_OFFSET_M1P5_DB)
+		     )) &&
 		    (tavil->comp_enabled[COMPANDER_7] ||
 		     tavil->comp_enabled[COMPANDER_8]) &&
 		    (gain_reg == WCD934X_CDC_RX7_RX_VOL_CTL ||
@@ -4134,12 +4145,12 @@ static int tavil_codec_enable_main_path(struct snd_soc_dapm_widget *w,
 			snd_soc_update_bits(codec,
 					    WCD934X_CDC_RX8_RX_PATH_MIX_SEC0,
 					    0x01, 0x00);
-#ifdef CONFIG_ARCH_SONY_TAMA
-			tavil_codec_set_offset_val(&offset_val,
+			if (somc_platform == ARCH_SONY_TAMA) {
+				tavil_codec_set_offset_val(&offset_val,
 						   tavil->swr.spkr_gain_offset, 1);
-#else
-			offset_val = 2;
-#endif
+			} else {
+				offset_val = 2;
+			}
 			val = snd_soc_read(codec, gain_reg);
 			val += offset_val;
 			snd_soc_write(codec, gain_reg, val);
@@ -9522,9 +9533,10 @@ static const struct tavil_reg_mask_val tavil_codec_reg_init_common_val[] = {
 	{WCD934X_MICB2_TEST_CTL_1, 0xff, 0xfa},
 	{WCD934X_MICB3_TEST_CTL_1, 0xff, 0xfa},
 	{WCD934X_MICB4_TEST_CTL_1, 0xff, 0xfa},
-#ifdef CONFIG_ARCH_SONY_TAMA
+};
+
+static const struct tavil_reg_mask_val tavil_codec_reg_init_tama[] = {
 	{WCD934X_CDC_RX3_RX_PATH_CFG1, 0x64, 0x00}
-#endif
 };
 
 static void tavil_codec_init_reg(struct tavil_priv *priv)
@@ -9537,6 +9549,15 @@ static void tavil_codec_init_reg(struct tavil_priv *priv)
 				    tavil_codec_reg_init_common_val[i].reg,
 				    tavil_codec_reg_init_common_val[i].mask,
 				    tavil_codec_reg_init_common_val[i].val);
+
+	if (somc_platform == ARCH_SONY_TAMA) {
+		for (i = 0; i < ARRAY_SIZE(tavil_codec_reg_init_tama); i++)
+			snd_soc_update_bits(codec,
+				    tavil_codec_reg_init_tama[i].reg,
+				    tavil_codec_reg_init_tama[i].mask,
+				    tavil_codec_reg_init_tama[i].val);
+
+	}
 
 	if (TAVIL_IS_1_1(priv->wcd9xxx)) {
 		for (i = 0; i < ARRAY_SIZE(tavil_codec_reg_init_1_1_val); i++)
@@ -9692,8 +9713,8 @@ static irqreturn_t tavil_slimbus_irq(int irq, void *data)
 		if (val & WCD934X_SLIM_IRQ_UNDERFLOW)
 			dev_err_ratelimited(tavil->dev, "%s: underflow error on %s port %d, value %x\n",
 			   __func__, (tx ? "TX" : "RX"), port_id, val);
-#ifdef CONFIG_ARCH_SONY_TAMA
-		if (tx) {
+
+		if (somc_platform == ARCH_SONY_TAMA && tx) {
 			/* inc count */
 			if (val & WCD934X_SLIM_IRQ_OVERFLOW) {
 				tavil->slim_tx_of_uf_cnt[port_id]
@@ -9713,26 +9734,24 @@ static irqreturn_t tavil_slimbus_irq(int irq, void *data)
 			}
 
 		}
-#endif
+
 		if ((val & WCD934X_SLIM_IRQ_OVERFLOW) ||
 			(val & WCD934X_SLIM_IRQ_UNDERFLOW)) {
 			if (!tx)
 				reg = WCD934X_SLIM_PGD_PORT_INT_RX_EN0 +
 					(port_id / 8);
-#ifdef CONFIG_ARCH_SONY_TAMA
-			else if ((tavil->slim_tx_of_uf_cnt[port_id]
-				[SB_PORT_ERR_OF] > SB_OF_UF_MAX_RETRY_CNT) ||
-				(tavil->slim_tx_of_uf_cnt[port_id]
-				[SB_PORT_ERR_UF] > SB_OF_UF_MAX_RETRY_CNT))
- 				reg = WCD934X_SLIM_PGD_PORT_INT_TX_EN0 +
- 					(port_id / 8);
-			else
-				goto skip_port_disable;
-#else
 			else
 				reg = WCD934X_SLIM_PGD_PORT_INT_TX_EN0 +
 					(port_id / 8);
-#endif
+
+			if (somc_platform == ARCH_SONY_TAMA &&
+			    !((tavil->slim_tx_of_uf_cnt[port_id]
+			       [SB_PORT_ERR_OF] > SB_OF_UF_MAX_RETRY_CNT) ||
+			       (tavil->slim_tx_of_uf_cnt[port_id]
+			       [SB_PORT_ERR_UF] > SB_OF_UF_MAX_RETRY_CNT) )) {
+				goto skip_port_disable;
+			}
+
 			int_val = wcd9xxx_interface_reg_read(
 				tavil->wcd9xxx, reg);
 			if (int_val & (1 << (port_id % 8))) {
@@ -9741,9 +9760,8 @@ static irqreturn_t tavil_slimbus_irq(int irq, void *data)
 					reg, int_val);
 			}
 		}
-#ifdef CONFIG_ARCH_SONY_TAMA
+
 skip_port_disable:
-#endif
 		if (val & WCD934X_SLIM_IRQ_PORT_CLOSED) {
 			/*
 			 * INT SOURCE register starts from RX to TX
@@ -11065,9 +11083,11 @@ static int tavil_probe(struct platform_device *pdev)
 	tavil->swr.plat_data.handle_irq = tavil_swrm_handle_irq;
 	tavil->swr.spkr_gain_offset = WCD934X_RX_GAIN_OFFSET_0_DB;
 
-#ifdef CONFIG_ARCH_SONY_TAMA
-	tavil->swr.spkr_gain_offset = WCD934X_RX_GAIN_OFFSET_M0P5_DB;
-#endif
+	if (of_machine_is_compatible("somc,tama")) {
+		somc_platform = ARCH_SONY_TAMA;
+		WCD934X_RX_GAIN_OFFSET_0_DB = 2;
+		tavil->swr.spkr_gain_offset = WCD934X_RX_GAIN_OFFSET_M0P5_DB;
+	}
 
 	/* Register for Clock */
 	wcd_ext_clk = clk_get(tavil->wcd9xxx->dev, "wcd_clk");

--- a/techpack/audio/asoc/codecs/wcd934x/wcd934x.h
+++ b/techpack/audio/asoc/codecs/wcd934x/wcd934x.h
@@ -95,14 +95,14 @@ enum {
 	INTERP_MAX,
 };
 
-#ifdef CONFIG_ARCH_SONY_TAMA
+/* ARCH_SONY ARCH_SONY_TAMA*/
 /* WCD934X slimbus slave port error status */
 enum {
 	SB_PORT_ERR_OF, /* SB port overflow */
 	SB_PORT_ERR_UF, /* SB port underflow */
 	SB_PORT_ERR_MAX,
 };
-#endif
+/*  */
 
 /*
  * Selects compander and smart boost settings
@@ -116,13 +116,20 @@ enum {
 /*
  * Rx path gain offsets
  */
+#if 0
 enum {
 	WCD934X_RX_GAIN_OFFSET_M1P5_DB,
-#ifdef CONFIG_ARCH_SONY_TAMA
-	WCD934X_RX_GAIN_OFFSET_M0P5_DB,
-#endif
 	WCD934X_RX_GAIN_OFFSET_0_DB,
 };
+#else
+/* 
+ * QCOM: M1P5_DB=0; 0_DB=1
+ * TAMA: M1P5_DB=0; M0P5_DB=1; 0_DB=2 (vars defined in wcd934x.c)
+ */
+extern int WCD934X_RX_GAIN_OFFSET_M1P5_DB;
+extern int WCD934X_RX_GAIN_OFFSET_M0P5_DB; /* ARCH_SONY ARCH_SONY_TAMA */
+extern int WCD934X_RX_GAIN_OFFSET_0_DB;
+#endif
 
 /*
  * Dai data structure holds the

--- a/techpack/audio/asoc/codecs/wcd_cpe_core.c
+++ b/techpack/audio/asoc/codecs/wcd_cpe_core.c
@@ -827,12 +827,14 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 		bool enable)
 {
 	int ret = 0;
-#ifdef CONFIG_ARCH_SONY_TAMA
 	int timeout = 0;
 	int err_cnt = 0;
-#endif
+	bool platform_somc = false;
 
 	if (enable) {
+		if (of_machine_is_compatible("somc,tama"))
+			platform_somc = true;
+
 		/* Reset CPE first */
 		ret = cpe_svc_reset(core->cpe_handle);
 		if (ret < 0) {
@@ -853,24 +855,24 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 		if (ret)
 			goto fail_boot;
 
-		/* Dload data section */
-#ifdef CONFIG_ARCH_SONY_TAMA
-		for (err_cnt = 0; err_cnt < 10; err_cnt++) {
+		if (platform_somc) {
+			for (err_cnt = 0; err_cnt < 10; err_cnt++) {
+				/* Dload data section */
+				ret = wcd_cpe_load_fw(core, ELF_FLAG_RW);
+				if (ret) {
+					pr_err("%s: wcd_cpe_load_fw error"
+							" ret=%d. retry.\n",
+							__func__, ret);
+					msleep(5);
+				} else {
+					break;
+				}
+			}
+		} else {
 			/* Dload data section */
 			ret = wcd_cpe_load_fw(core, ELF_FLAG_RW);
-			if (ret) {
-				pr_err("%s: wcd_cpe_load_fw error ret=%d. retry.\n", __func__, ret);
-				msleep(5);
-			} else {
-				if (err_cnt > 0) {
-					pr_err("%s: wcd_cpe_load_fw error count=%d.\n", __func__, err_cnt);
-				}
-				break;
-			}
 		}
-#else
-		ret = wcd_cpe_load_fw(core, ELF_FLAG_RW);
-#endif
+
 		if (ret) {
 			dev_err(core->dev,
 				"%s: Failed to dload data section, err = %d\n",
@@ -900,18 +902,18 @@ static int wcd_cpe_enable(struct wcd_cpe_core *core,
 			"%s: waiting for CPE bootup\n",
 			__func__);
 
-#ifdef CONFIG_ARCH_SONY_TAMA
-		timeout = wait_for_completion_timeout(&core->online_compl,
-						msecs_to_jiffies(1000));
-		if (!timeout) {
-			dev_err(core->dev,
-				"%s: Timeout boot CPE.\n", __func__);
-			ret = -ETIMEDOUT;
-			goto fail_boot;
+		if (platform_somc) {
+			timeout = wait_for_completion_timeout(
+				  &core->online_compl, msecs_to_jiffies(1000));
+			if (!timeout) {
+				dev_err(core->dev,
+					"%s: Timeout boot CPE.\n", __func__);
+				ret = -ETIMEDOUT;
+				goto fail_boot;
+			}
+		} else {
+			wait_for_completion(&core->online_compl);
 		}
-#else
-		wait_for_completion(&core->online_compl);
-#endif
 
 		dev_dbg(core->dev,
 			"%s: CPE bootup done\n",

--- a/techpack/audio/asoc/sdm845.c
+++ b/techpack/audio/asoc/sdm845.c
@@ -4033,22 +4033,23 @@ static void *def_tavil_mbhc_cal(void)
 	void *tavil_wcd_cal;
 	struct wcd_mbhc_btn_detect_cfg *btn_cfg;
 	u16 *btn_high;
+	unsigned int plat_v_hs_max, plat_btn_h1;
 
 	tavil_wcd_cal = kzalloc(WCD_MBHC_CAL_SIZE(WCD_MBHC_DEF_BUTTONS,
 				WCD9XXX_MBHC_DEF_RLOADS), GFP_KERNEL);
 	if (!tavil_wcd_cal)
 		return NULL;
 
-#ifdef CONFIG_ARCH_SONY_TAMA
- #define VHSMAX 1700
- #define BTN_H1 137
-#else
- #define VHSMAX 1600
- #define BTN_H1 150
-#endif
+	if (of_machine_is_compatible("somc,tama")) {
+		plat_v_hs_max = 1700;
+		plat_btn_h1 = 137;
+	} else {
+		plat_v_hs_max = 1600;
+		plat_btn_h1 = 150;
+	}
 
 #define S(X, Y) ((WCD_MBHC_CAL_PLUG_TYPE_PTR(tavil_wcd_cal)->X) = (Y))
-	S(v_hs_max, VHSMAX);
+	S(v_hs_max, plat_v_hs_max);
 #undef S
 #define S(X, Y) ((WCD_MBHC_CAL_BTN_DET_PTR(tavil_wcd_cal)->X) = (Y))
 	S(num_btn, WCD_MBHC_DEF_BUTTONS);
@@ -4059,7 +4060,7 @@ static void *def_tavil_mbhc_cal(void)
 		(sizeof(btn_cfg->_v_btn_low[0]) * btn_cfg->num_btn);
 
 	btn_high[0] = 75;
-	btn_high[1] = BTN_H1;
+	btn_high[1] = plat_btn_h1;
 	btn_high[2] = 237;
 	btn_high[3] = 500;
 	btn_high[4] = 500;

--- a/techpack/audio/dsp/q6adm.c
+++ b/techpack/audio/dsp/q6adm.c
@@ -2475,10 +2475,11 @@ int adm_open(int port_id, int path, int rate, int channel_mode, int topology,
 	    (topology == VPM_TX_DM_RFECNS_COPP_TOPOLOGY))
 		rate = 16000;
 
-#ifdef CONFIG_ARCH_SONY_NILE
-	if (path == ADM_PATH_PLAYBACK)
+	/* ARCH_SONY */
+	if (of_machine_is_compatible("somc,nile") &&
+	    path == ADM_PATH_PLAYBACK)
 		bit_width = 24;
-#endif
+
 	/*
 	 * Routing driver reuses the same adm for streams with the same
 	 * app_type, sample_rate etc.

--- a/techpack/audio/dsp/q6asm.c
+++ b/techpack/audio/dsp/q6asm.c
@@ -2914,14 +2914,15 @@ static int __q6asm_open_write(struct audio_client *ac, uint32_t format,
 	open.sink_endpointype = ASM_END_POINT_DEVICE_MATRIX;
 	open.bits_per_sample = bits_per_sample;
 
-#ifdef CONFIG_ARCH_SONY_NILE
-	if (ac->perf_mode == LOW_LATENCY_PCM_MODE ||
-	    ac->perf_mode == ULTRA_LOW_LATENCY_PCM_MODE ||
-	    ac->perf_mode == ULL_POST_PROCESSING_PCM_MODE)
-		open.bits_per_sample = bits_per_sample;
-	else
-		open.bits_per_sample = 24;
-#endif
+	/* ARCH_SONY */
+	if (of_machine_is_compatible("somc,nile")) {
+		if (ac->perf_mode == LOW_LATENCY_PCM_MODE ||
+		    ac->perf_mode == ULTRA_LOW_LATENCY_PCM_MODE ||
+		    ac->perf_mode == ULL_POST_PROCESSING_PCM_MODE)
+			open.bits_per_sample = bits_per_sample;
+		else
+			open.bits_per_sample = 24;
+	}
 
 	rc = q6asm_get_asm_topology_apptype(&cal_info);
 	open.postprocopo_id = cal_info.topology_id;


### PR DESCRIPTION
This treewide removes all possible ifdefs to support building one kernel
for all devices supporting DTBO.

This is a sort of bad practice anyway, because the kernel size will be
larger than normal, but it can be a huge commodity for a lot of users.

Please note: the main target for this removal is SoMC Tama, as this is
the only platform that currently supports DTBO! Some ifdefs are still
around for legacy platforms, like Loire, Tone, Nile and even Yoshino.

P.S.: Carefully test this on **ALL PLATFORMS** before merging.
