### PR TITLE
DT: Tone/Yoshino/Nile: Drop unused virtual framebuffer debugging bootarg

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common-sde-overlay.dtsi
@@ -20,7 +20,6 @@
 "fpsimd.fpsimd_settings=1 app_setting.use_app_setting=1 \
 app_setting.use_32bit_app_setting=1 sched_enable_hmp=1 \
 rcupdate.rcu_expedited=1 \
-video=vfb:640x400,bpp=32,memsize=3072000 \
 msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
 
 	};

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -18,7 +18,6 @@
 
 		bootargs = \
 "rcupdate.rcu_expedited=1 \
-video=vfb:640x400,bpp=32,memsize=3072000 \
 msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
 
 	};

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common-sde-overlay.dtsi
@@ -4,8 +4,7 @@
 	/* Bad indentation is required. Sorry. */
 	chosen {
 		bootargs = \
-"video=vfb:640x400,bpp=32,memsize=3072000 \
-msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
+"msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
 
 	};
 };


### PR DESCRIPTION
With https://github.com/sonyxperiadev/kernel-defconfig/pull/27

Virtual framebuffers are used to debug the fbdev system, and should not be used on production devices. It only wastes memory.

Tested on SoMC Akatsuki DSDS (with removal in `tama` repo) and SoMC Discovery SDE.