### PR TITLE
[URGENT] char: adsprpc_legacy: Fix missing mutex initialization and destroy

### DIFF
--- a/drivers/char/adsprpc_legacy.c
+++ b/drivers/char/adsprpc_legacy.c
@@ -2485,6 +2485,7 @@ static int fastrpc_device_release(struct inode *inode, struct file *file)
 	if (fl) {
 		if (fl->debugfs_file != NULL)
 			debugfs_remove(fl->debugfs_file);
+		mutex_destroy(&fl->fl_map_mutex);
 		mutex_destroy(&fl->map_mutex);
 		fastrpc_file_free(fl);
 		file->private_data = NULL;
@@ -2819,6 +2820,7 @@ static int fastrpc_device_open(struct inode *inode, struct file *filp)
 	memset(&fl->perf, 0, sizeof(fl->perf));
 	filp->private_data = fl;
 	mutex_init(&fl->map_mutex);
+	mutex_init(&fl->fl_map_mutex);
 	spin_lock(&me->hlock);
 	hlist_add_head(&fl->hn, &me->drivers);
 	spin_unlock(&me->hlock);


### PR DESCRIPTION
Recent updates added usage of a new mutex, but no initialization
of it: that can lead to very unpredictable results.

Correctly initialize the mutex at adsprpc device open time and
destroy it at device release time.

Solves kernel panic on phone calls.
Tested on SoMC Loire Suzu