### PR TITLE
[2.3.2.r1.4] arm64: DT: Lilac: Fix VL53L0 configuration

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
@@ -49,9 +49,8 @@
 			ams,rgbcir-gpio-vdd = <0>;
 			ams,rgbcir-vio-supply = <1>;
 		};
-		tof_sensor@52 {
+		tof_sensor@29 {
 			tof_avdd-supply = <&pm8998_l22>;
-			sony,tof-avdd-supply = <1>;
 		};
 	};
 


### PR DESCRIPTION
The tof_sensor node address was wrong: fix it to get the
Lilac specific ToF AVDD probed for the device to get working.