### PR TITLE
[2.3.2.r1.4] [URGENT] clk: qcom: gpucc-8998: Fix vdd levels for GPU MX and GPU corner

### DIFF
--- a/drivers/clk/qcom/gpucc-msm8998.c
+++ b/drivers/clk/qcom/gpucc-msm8998.c
@@ -66,8 +66,8 @@ static int vdd_gpucc_corner[] = {
 };
 
 static DEFINE_VDD_REGULATORS(vdd_dig, VDD_DIG_NUM, 1, vdd_corner);
-static DEFINE_VDD_REGULATORS(vdd_gpucc, VDD_DIG_NUM, 1, vdd_gpucc_corner);
-static DEFINE_VDD_REGULATORS(vdd_gpucc_mx, VDD_DIG_NUM, 1, vdd_corner);
+static DEFINE_VDD_REGULATORS(vdd_gpucc, VDD_GFX_MAX, 1, vdd_gpucc_corner);
+static DEFINE_VDD_REGULATORS(vdd_gpucc_mx, VDD_MX_NUM, 1, vdd_corner);
 
 enum {
 	P_GPU_XO,

--- a/drivers/clk/qcom/vdd-level-8998.h
+++ b/drivers/clk/qcom/vdd-level-8998.h
@@ -97,17 +97,17 @@
 
 #define VDD_GPU_MX_FMAX_MAP1(l1, f1)  \
 	.vdd_class = &vdd_gpucc_mx,		\
-	.rate_max = (unsigned long[VDD_DIG_NUM]) {	\
-		[VDD_DIG_##l1] = (f1),		\
+	.rate_max = (unsigned long[VDD_MX_NUM]) {	\
+		[VDD_MX_##l1] = (f1),		\
 	},					\
 	.num_rate_max = VDD_MX_NUM
 
 #define VDD_GPU_MX_FMAX_MAP3(l1, f1, l2, f2, l3, f3)  \
 	.vdd_class = &vdd_gpucc_mx,			\
-	.rate_max = (unsigned long[VDD_DIG_NUM]) {		\
-		[VDD_DIG_##l1] = (f1),			\
-		[VDD_DIG_##l2] = (f2),			\
-		[VDD_DIG_##l3] = (f3),			\
+	.rate_max = (unsigned long[VDD_MX_NUM]) {		\
+		[VDD_MX_##l1] = (f1),			\
+		[VDD_MX_##l2] = (f2),			\
+		[VDD_MX_##l3] = (f3),			\
 	},						\
 	.num_rate_max = VDD_MX_NUM
 


### PR DESCRIPTION
The vdd levels were bad due to wrong assignment of enum values
to the vdd classes.

This commit is CRITICAL.
All Yoshino users shall update ASAP.