### PR TITLE
input: misc: fpc1145: Remove unused variable and log hardware string.

### DIFF
--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -508,9 +508,9 @@ static int et51x_probe(struct platform_device *pdev)
 		dev_info(dev, "Egistec sensor not found, bailing out\n");
 		rc = -ENODEV;
 		goto exit_powerdown;
-	} else {
-		dev_info(dev, "Detected Egistec sensor\n");
 	}
+
+	dev_info(dev, "Detected Egistec sensor\n");
 #endif
 
 	rc = et51x_request_named_gpio(et51x, "et51x,gpio_irq",

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -560,10 +560,10 @@ static int fpc1145_probe(struct platform_device *pdev)
 	int rc = 0;
 	size_t i;
 	int irqf;
+	struct device_node *np = dev->of_node;
 #ifdef CONFIG_ARCH_SONY_NILE
 	int hw_type;
 #endif
-	struct device_node *np = dev->of_node;
 
 	struct fpc1145_data *fpc1145 =
 		devm_kzalloc(dev, sizeof(*fpc1145), GFP_KERNEL);
@@ -598,14 +598,16 @@ static int fpc1145_probe(struct platform_device *pdev)
 		goto exit;
 
 	hw_type = cei_fp_module_detect();
-	dev_info(dev, "Detected hw type %d\n", hw_type);
 
 	(void)vreg_setup(fpc1145, VDD_ANA, false);
 
 	if (hw_type != FP_HW_TYPE_FPC) {
+		dev_info(dev, "FPC sensor not found, bailing out\n");
 		rc = -ENODEV;
 		goto exit;
 	}
+
+	dev_info(dev, "Detected FPC sensor\n");
 #endif
 
 	rc = fpc1145_request_named_gpio(fpc1145, "fpc,gpio_irq",


### PR DESCRIPTION
Remainder of the fixes in https://github.com/sonyxperiadev/kernel/pull/1906/commits/8cd62e7f37a4311e6b70ca46659038c4ed23d96a and https://github.com/sonyxperiadev/kernel/pull/1906/commits/6a08052ea80a71fb9908f1cfee3c4c4274e3a07b. These were supposed to go with more useful commits, but those never happened.
The warning has already been addressed, this fixes an earlier request for _useful_ logging.