### PR TITLE
drm: somc_panel: Recalculate PCC cache after initializing profiles.

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -801,7 +801,7 @@ static int somc_panel_pcc_setup_data(struct somc_panel_color_mgr *color_mgr,
 	return 0;
 }
 
-int somc_panel_pcc_setup(struct dsi_display *display)
+static int somc_panel_pcc_setup(struct dsi_display *display)
 {
 	int ret;
 	struct dsi_panel *panel = display->panel;
@@ -818,6 +818,11 @@ int somc_panel_pcc_setup(struct dsi_display *display)
 		pr_notice("%s (%d): PCC already applied\n", __func__, __LINE__);
 		goto exit;
 	}
+
+	/* Ensure the cached pcc is updated by invalidating
+	 * the current profile
+	 */
+	color_mgr->pcc_profile = -1;
 
 	if (display->tx_cmd_buf == NULL) {
 		ret = dsi_host_alloc_cmd_tx_buffer(display);
@@ -1351,10 +1356,6 @@ int somc_panel_color_manager_init(struct dsi_display *display)
 		pr_err("%s: Color Manager is NULL!!!\n", __func__);
 		return -EINVAL;
 	}
-
-	/* Be sure of initialization to default profile */
-	color_mgr->pcc_profile = 0;
-	(void)somc_panel_update_merged_pcc_cache(color_mgr);
 
 	return 0;
 }

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -385,7 +385,6 @@ int somc_panel_vregs_parse_dt(struct dsi_panel *panel,
 #define somc_panel_vregs_parse_dt(x, y) 0
 #endif
 
-int somc_panel_pcc_setup(struct dsi_display *display);
 int somc_panel_parse_dt_colormgr_config(struct dsi_panel *panel,
 			struct device_node *np);
 int somc_panel_colormgr_register_attr(struct device *dev);


### PR DESCRIPTION
The default value of pcc_profile is initialized to zero, which is a
valid profile. Under some circumstances the initial setup through
manager_init bails out early, meaning that the cache and PCC blocks are
left in an unknown state. Future transitions to the "current" state 0
have no effect, leaving the PCC hardware block in an uninitialized state
until changing the profile or receiving a transform from the system.