### PR TITLE
[2.3.2.r1.4] RQBalance-ISOL: Robust switching

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -578,7 +578,7 @@ static void rqbalance_work_func(struct work_struct *work)
 		switch (balance) {
 		/* cpu speed is up and balanced - one more on-line */
 		case CPU_UPCORE:
-			cpu = cpumask_next_zero(0, cpu_online_mask);
+			cpu = cpumask_next_zero(0, avail_cpus_mask);
 			if (cpu < nr_cpu_ids)
 				up = true;
 			break;


### PR DESCRIPTION
The implementation was pretty fragile and it didn't take a lot to actually
break it (both in "destructive" and "not too harmful" ways): make it robust.