### PR TITLE
[2.3.2.r1.4] [CRITICAL] Yoshino: Fix virtual-thermal and case-therm mitigations

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
@@ -667,26 +667,26 @@
 							(THERMAL_MAX_LIMIT-24)>;
 			};
 
-			/* Throttle C1 only from FMAX to 2361.6MHz */
+			/* Throttle C1 only from FMAX to 2342.4MHz */
 			skin6_cpu4 {
 				trip = <&cpu_ct_trip6>;
 				cooling-device = <&CPU4 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-31)>;
+							(THERMAL_MAX_LIMIT-30)>;
 			};
 			skin6_cpu5 {
 				trip = <&cpu_ct_trip6>;
 				cooling-device = <&CPU5 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-31)>;
+							(THERMAL_MAX_LIMIT-30)>;
 			};
 			skin6_cpu6 {
 				trip = <&cpu_ct_trip6>;
 				cooling-device = <&CPU6 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-31)>;
+							(THERMAL_MAX_LIMIT-30)>;
 			};
 			skin6_cpu7 {
 				trip = <&cpu_ct_trip6>;
 				cooling-device = <&CPU7 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-31)>;
+							(THERMAL_MAX_LIMIT-30)>;
 			};
 
 			/* Throttle from FMAX to 257MHz */

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
@@ -388,11 +388,6 @@
 				hysteresis = <1200>;
 				type = "passive";
 			};
-			cpu_ct_trip7: cpu-ct-trip7 {
-				temperature = <47700>;
-				hysteresis = <2700>;
-				type = "passive";
-			};
 
 			charger_trip0: cpu-ct-trip8 {
 				temperature = <45000>;
@@ -694,28 +689,6 @@
 							(THERMAL_MAX_LIMIT-31)>;
 			};
 
-			/* Throttle C1 only from FMAX to 2476.8MHz */
-			skin7_cpu4 {
-				trip = <&cpu_ct_trip7>;
-				cooling-device = <&CPU4 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-34)>;
-			};
-			skin7_cpu5 {
-				trip = <&cpu_ct_trip7>;
-				cooling-device = <&CPU5 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-34)>;
-			};
-			skin7_cpu6 {
-				trip = <&cpu_ct_trip7>;
-				cooling-device = <&CPU6 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-34)>;
-			};
-			skin7_cpu7 {
-				trip = <&cpu_ct_trip7>;
-				cooling-device = <&CPU7 THERMAL_NO_LIMIT
-							(THERMAL_MAX_LIMIT-34)>;
-			};
-
 			/* Throttle from FMAX to 257MHz */
 			skin0_gpu {
 				trip = <&cpu_ct_trip1>;
@@ -751,10 +724,6 @@
 			charger_lvl7 {
 				trip = <&cpu_ct_trip6>;
 				cooling-device = <&pmi8998_charger 5 5>;
-			};
-			charger_lvl8 {
-				trip = <&cpu_ct_trip7>;
-				cooling-device = <&pmi8998_charger 2 2>;
 			};
 
 			/* Modem PA power limit */

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-thermal.dtsi
@@ -34,8 +34,8 @@
 	};
 	avg-cpu-big {
 		virt-zone-name = "avg-cpu-c1";
-		thermal-sensors = "cpu4-gold-usr", "cpu5-gold-usr",
-				  "cpu6-gold-usr", "cpu7-gold-usr",
+		thermal-sensors = "cpu0-gold-usr", "cpu1-gold-usr",
+				  "cpu2-gold-usr", "cpu3-gold-usr",
 				  "kryo-l3-1-usr";
 		aggregation-logic = <0>; /* WEIGHTED_AVG */
 	};

--- a/drivers/platform/msm/qpnp-revid.c
+++ b/drivers/platform/msm/qpnp-revid.c
@@ -76,6 +76,9 @@ struct revid_chip {
 static LIST_HEAD(revid_chips);
 static DEFINE_MUTEX(revid_chips_lock);
 
+#define DRIVER_READY 1
+static int driver_status;
+
 static const struct of_device_id qpnp_revid_match_table[] = {
 	{ .compatible = QPNP_REVID_DEV_NAME },
 	{}
@@ -107,6 +110,9 @@ static u8 qpnp_read_byte(struct regmap *regmap, u16 addr)
 struct pmic_revid_data *get_revid_data(struct device_node *dev_node)
 {
 	struct revid_chip *revid_chip;
+
+	if (driver_status == 0)
+		return ERR_PTR(-EPROBE_DEFER);
 
 	if (!dev_node)
 		return ERR_PTR(-EINVAL);
@@ -250,6 +256,9 @@ static int qpnp_revid_probe(struct platform_device *pdev)
 	build_pmic_string(pmic_string, PMIC_STRING_MAXLENGTH,
 			  to_spmi_device(pdev->dev.parent)->usid,
 			pmic_subtype, rev1, rev2, rev3, rev4);
+
+	driver_status = DRIVER_READY;
+
 	pr_info("%s options: %d, %d, %d, %d\n",
 			pmic_string, option1, option2, option3, option4);
 	return 0;


### PR DESCRIPTION
The virtual-thermal averaging driver obviously wants the
right thermal zone names.
In the MSM8998 thermal DT, the GOLD CPUs are not named as 4-7,
but as 0-3: this was making the C1 averaging thermal node to
fail probe and the system was doing thermal mitigations based
only on the readings from the little cluster cores and cache.

Also fix badnesses with case-therm.


Tested on SoMC Yoshino Maple RoW