### PR TITLE
[2.3.2.r1.4] RQBalance-ISOL: Provide even more robustness

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -1026,7 +1026,9 @@ static int rqbalance_get_package_info(void)
 
 	/* TODO: Check if we are effectively using HMP!!! This is NOT OK!!! */
 	soc_is_hmp = (available_clusters > 1) ? true : false;
-	pr_info("rqbalance: running as %s\n", soc_is_hmp ? "hmp" : "smp");
+	pr_info("rqbalance: running as %s in %s mode\n",
+		soc_is_hmp ? "hmp" : "smp",
+		rqbalance_governor.use_isolation ? "isolation" : "hotplug");
 
 	return 0;
 }

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -2307,6 +2307,7 @@ void __init boot_cpu_init(void)
 	set_cpu_active(cpu, true);
 	set_cpu_present(cpu, true);
 	set_cpu_possible(cpu, true);
+	set_cpu_isolated(cpu, false);
 }
 
 /*

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -8341,6 +8341,7 @@ void __init sched_init(void)
 		rq->avg_idle = 2*sysctl_sched_migration_cost;
 		rq->max_idle_balance_cost = sysctl_sched_migration_cost;
 		rq->push_task = NULL;
+		set_cpu_isolated(i, false);
 		walt_sched_init(rq);
 
 		INIT_LIST_HEAD(&rq->cfs_tasks);


### PR DESCRIPTION
First of all, it's nice to have an informative message saying what actually is
rqbalance going to do with your processors.

Then, a little bit of premise:
The RQBalance-ISOL has been implemented on top of the changes that
are required for EAS and is meant to be a lighter and more controllable
EAS-like performance manager, hence it uses the "cpu isolation" framework
that the EAS implementors wrote.

This framework works all around a newly introduced cpumask that explicates
isolated CPUs and got extended by myself to give the UNisolated ones for both
commodity purposes and sake of keeping APIs in line with each other: the
hotplugging mechanism, for example, works with masks of "active" CPUs and
not with "inactive" CPUs. This basically implies the concept of "usable" CPUs.

Getting to our RQBalance-ISOL point:
Relying on a compiler to do its job is utterly stupid. It's unsafe at best.
So, it's mentally sane to give to the CPU isolation "system" some decent
robustness, by **actually initializing** the cpu masks used by it, which was
apparently missed in at least the version of it that is integrated in this kernel.

P.S.: Tested on SoMC Maple RoW