### PR TITLE
[2.3.2.r1.4] Support displayless devices on Android

### DIFF
--- a/drivers/gpu/drm/msm/Kconfig
+++ b/drivers/gpu/drm/msm/Kconfig
@@ -149,5 +149,18 @@ config DRM_SDE_RSC
           avoids the display core power collapse. A client can also register
           for display core power collapse events on rsc.
 
+config DRM_MSM_EMU_HEADLESS
+	bool "Enable headless display simulation"
+	depends on DRM_MSM
+	help
+	  Enable simulating a display connected on the DSI while using a
+	  display-less system.
+	  This configuration option is useful when using Android userspace
+	  on a system that has no physically connected display and no
+	  possible or not connected external display.
+	  This way, the Android system will initialize the display system
+	  just fine and it will be possible to interact with the UI by
+	  using screen mirroring via the Android Debug Bridge (ADB).
+
 source "drivers/gpu/drm/msm/dsi-staging/somc_panel/Kconfig"
 

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -4085,6 +4085,7 @@ int dsi_panel_disable(struct dsi_panel *panel)
 	if (panel->type == EXT_BRIDGE)
 		return 0;
 
+#ifndef CONFIG_DRM_MSM_EMU_HEADLESS
 	mutex_lock(&panel->panel_lock);
 
 	/* Avoid sending panel off commands when ESD recovery is underway */
@@ -4104,6 +4105,7 @@ int dsi_panel_disable(struct dsi_panel *panel)
 
 error:
 	mutex_unlock(&panel->panel_lock);
+#endif /* CONFIG_DRM_MSM_EMU_HEADLESS */
 	return rc;
 }
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -517,7 +517,22 @@ static int somc_panel_update_merged_pcc_cache(
 	struct dsi_pcc_data *pcc_data = NULL;
 	int table_idx;
 
+	if (unlikely(!sys_cal || !target)) {
+		pr_debug("Calibrations not (yet?) initialized.\n");
+		return -EINVAL;
+	}
+
 	pcc_data = &color_mgr->standard_pcc_data;
+	if (unlikely(!pcc_data)) {
+		pr_debug("No PCC data (yet?)\n");
+		return -EINVAL;
+	}
+
+	if (unlikely(!pcc_data->color_tbl)) {
+		pr_debug("There is no color table.\n");
+		return -EINVAL;
+	}
+
 	table_idx = pcc_data->tbl_idx + color_mgr->pcc_profile;
 
 	pr_debug("%s (%d): Selecting table %d with offset %d\n",

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -1256,6 +1256,42 @@ static void _sde_kms_release_displays(struct sde_kms *sde_kms)
 	sde_kms->dsi_display_count = 0;
 }
 
+#ifdef CONFIG_DRM_MSM_EMU_HEADLESS
+int kms_emu_headless_disp_check_status(void *display, bool te_check_override)
+{
+	struct dsi_display *dsi_display = display;
+	struct dsi_panel *panel;
+	struct dsi_display_ctrl *ctrl;
+	int i, rc = 0x1;
+	u32 mask;
+
+	if (!dsi_display || !dsi_display->panel)
+		return -EINVAL;
+
+	panel = dsi_display->panel;
+
+	dsi_panel_acquire_panel_lock(panel);
+
+	if (!panel->panel_initialized) {
+		pr_debug("Panel not initialized\n");
+		dsi_panel_release_panel_lock(panel);
+		return rc;
+	}
+
+	/* Prevent another ESD check,when ESD recovery is underway */
+	if (atomic_read(&panel->esd_recovery_pending)) {
+		dsi_panel_release_panel_lock(panel);
+		return rc;
+	}
+
+	panel->esd_config.esd_enabled = false;
+
+	dsi_panel_release_panel_lock(panel);
+
+	return rc;
+}
+#endif
+
 /**
  * _sde_kms_setup_displays - create encoders, bridges and connectors
  *                           for underlying displays
@@ -1287,7 +1323,11 @@ static int _sde_kms_setup_displays(struct drm_device *dev,
 		.get_mode_info = dsi_conn_get_mode_info,
 		.get_dst_format = dsi_display_get_dst_format,
 		.post_kickoff = dsi_conn_post_kickoff,
+#ifdef CONFIG_DRM_MSM_EMU_HEADLESS
+		.check_status = kms_emu_headless_disp_check_status,
+#else
 		.check_status = dsi_display_check_status,
+#endif
 		.enable_event = dsi_conn_enable_event,
 		.cmd_transfer = dsi_display_cmd_transfer,
 		.cont_splash_config = dsi_display_cont_splash_config,

--- a/mm/ksm.c
+++ b/mm/ksm.c
@@ -240,7 +240,7 @@ static int ksm_nr_node_ids = 1;
 #define KSM_RUN_MERGE	1
 #define KSM_RUN_UNMERGE	2
 #define KSM_RUN_OFFLINE	4
-static unsigned long ksm_run = KSM_RUN_MERGE;
+static unsigned long ksm_run = KSM_RUN_STOP;
 static void wait_while_offlining(void);
 
 static DECLARE_WAIT_QUEUE_HEAD(ksm_thread_wait);


### PR DESCRIPTION
This introduces CONFIG_DRM_MSM_EMU_HEADLESS:

Enable simulating a display connected on the DSI while using a
display-less system.

This configuration option is useful when using Android userspace
on a system that has no physically connected display and no
possible or not connected external display.

This way, the Android system will initialize the display system
just fine and it will be possible to interact with the UI by
using screen mirroring via the Android Debug Bridge (ADB).

Tested on SoMC Tama Akari DSDS (display physically not present).