### PR TITLE
[2.3.2.r1.4] msm-jpegdma: Add V4L2_CAP_DEVICE_CAPS to caps

### DIFF
--- a/drivers/media/platform/msm/camera_v2/jpeg_dma/msm_jpeg_dma_dev.c
+++ b/drivers/media/platform/msm/camera_v2/jpeg_dma/msm_jpeg_dma_dev.c
@@ -637,8 +637,9 @@ static int msm_jpegdma_querycap(struct file *file,
 	cap->bus_info[0] = 0;
 	strlcpy(cap->driver, MSM_JPEGDMA_DRV_NAME, sizeof(cap->driver));
 	strlcpy(cap->card, MSM_JPEGDMA_DRV_NAME, sizeof(cap->card));
-	cap->capabilities = V4L2_CAP_STREAMING |
-		V4L2_CAP_VIDEO_OUTPUT | V4L2_CAP_VIDEO_CAPTURE;
+	cap->device_caps = V4L2_CAP_STREAMING |
+			V4L2_CAP_VIDEO_OUTPUT | V4L2_CAP_VIDEO_CAPTURE;
+	cap->capabilities = cap->device_caps | V4L2_CAP_DEVICE_CAPS;
 
 	return 0;
 }


### PR DESCRIPTION
See `v4l_querycap()` in `v4l2-ioctl.c`
Otherwise the query fails with a crash:
```
[...]
Bad caps for driver msm_jpegdma, 4200003 0
------------[ cut here ]------------
WARNING: CPU: 1 PID: 23782 at v4l_querycap+0x90/0xd4
Modules linked in:
CPU: 1 PID: 23782 Comm: ExtCamHotPlug Tainted: G W 4.9.154-gb61c5e1840de-dirty #23
Hardware name: SoMC Kagura-ROW (DT)
task  ffffffc037b85e80 task.stack: ffffffc0b7188000
PC is at v4l_querycap+0x90/0xd4
LR is at v4l_querycap+0x90/0xd4
[...]
```