### PR TITLE
msm: mdss: share MDP smmu device mappings with other mdss clients

### DIFF
--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
@@ -254,7 +254,9 @@ struct sde_rot_data_type {
 
 	int iommu_attached;
 	int iommu_ref_cnt;
-
+	int (*iommu_ctrl)(int enable);
+	int (*secure_session_ctrl)(int enable);
+	int (*wait_for_transition)(int state, int request);
 	struct sde_rot_vbif_debug_bus *nrt_vbif_dbg_bus;
 	u32 nrt_vbif_dbg_bus_size;
 	struct sde_rot_debug_bus *rot_dbg_bus;
@@ -270,7 +272,7 @@ struct sde_rot_data_type {
 
 	struct sde_rot_lut_cfg lut_cfg[SDE_ROT_OP_MAX];
 	struct sde_rot_lut_cfg inline_lut_cfg[SDE_ROT_OP_MAX];
-
+	bool callback_request;
 	struct ion_client *iclient;
 
 	bool clk_always_on;

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_core.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_core.c
@@ -581,7 +581,7 @@ static int sde_rotator_import_buffer(struct sde_layer_buffer *buffer,
 	return ret;
 }
 
-static int sde_rotator_secure_session_ctrl(bool enable)
+static int _sde_rotator_secure_session_ctrl(bool enable)
 {
 	struct sde_rot_data_type *mdata = sde_rot_get_mdata();
 	uint32_t sid_info;
@@ -661,6 +661,39 @@ static int sde_rotator_secure_session_ctrl(bool enable)
 	return resp;
 }
 
+static int sde_rotator_secure_session_ctrl(bool enable)
+{
+	struct sde_rot_data_type *mdata = sde_rot_get_mdata();
+	int ret = -EINVAL;
+
+	/**
+	  * wait_for_transition and secure_session_control are filled by client
+	  * callback.
+	  */
+	if (mdata->wait_for_transition && mdata->secure_session_ctrl &&
+		mdata->callback_request) {
+		ret = mdata->wait_for_transition(mdata->sec_cam_en, enable);
+		if (ret) {
+			SDEROT_ERR("failed Secure wait for transition %d\n",
+				   ret);
+		} else {
+			if (mdata->sec_cam_en ^ enable) {
+				mdata->sec_cam_en = enable;
+				ret = mdata->secure_session_ctrl(enable);
+				if (ret)
+					mdata->sec_cam_en = 0;
+		    }
+		}
+	} else if (!mdata->callback_request) {
+		ret = _sde_rotator_secure_session_ctrl(enable);
+	}
+
+	if (ret)
+		SDEROT_ERR("failed %d sde_rotator_secure_session %d\n",
+			   ret, mdata->callback_request);
+
+	return ret;
+}
 
 static int sde_rotator_map_and_check_data(struct sde_rot_entry *entry)
 {

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_smmu.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_smmu.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -17,6 +17,7 @@
 #include <linux/types.h>
 #include <linux/device.h>
 #include <linux/dma-buf.h>
+#include <linux/mdss_smmu_ext.h>
 
 #include "sde_rotator_io_util.h"
 
@@ -27,11 +28,6 @@ enum sde_iommu_domain_type {
 };
 
 int sde_smmu_init(struct device *dev);
-
-static inline int sde_smmu_dma_data_direction(int dir)
-{
-	return dir;
-}
 
 int sde_smmu_ctrl(int enable);
 
@@ -47,4 +43,5 @@ void sde_smmu_unmap_dma_buf(struct sg_table *table, int domain,
 
 int sde_smmu_secure_ctrl(int enable);
 
+int sde_smmu_dma_direction(int dir);
 #endif /* SDE_ROTATOR_SMMU_H */

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_util.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_util.c
@@ -800,7 +800,8 @@ static int sde_mdp_put_img(struct sde_mdp_img_data *data, bool rotator,
 		}
 		if (!data->skip_detach) {
 			dma_buf_unmap_attachment(data->srcp_attachment,
-				data->srcp_table, dir);
+				data->srcp_table,
+				sde_smmu_dma_direction(dir));
 			dma_buf_detach(data->srcp_dma_buf,
 					data->srcp_attachment);
 			if (!(data->flags & SDE_ROT_EXT_DMA_BUF)) {
@@ -867,7 +868,8 @@ static int sde_mdp_get_img(struct sde_fb_data *img,
 
 		SDEROT_DBG("%d attach=%p\n", __LINE__, data->srcp_attachment);
 		data->srcp_table =
-			dma_buf_map_attachment(data->srcp_attachment, dir);
+			dma_buf_map_attachment(data->srcp_attachment,
+			sde_smmu_dma_direction(dir));
 		if (IS_ERR(data->srcp_table)) {
 			SDEROT_ERR("%d Failed to map attachment\n", __LINE__);
 			ret = PTR_ERR(data->srcp_table);
@@ -1000,7 +1002,8 @@ static int sde_mdp_map_buffer(struct sde_mdp_img_data *data, bool rotator,
 	return ret;
 
 err_unmap:
-	dma_buf_unmap_attachment(data->srcp_attachment, data->srcp_table, dir);
+	dma_buf_unmap_attachment(data->srcp_attachment, data->srcp_table,
+		sde_smmu_dma_direction(dir));
 	dma_buf_detach(data->srcp_dma_buf, data->srcp_attachment);
 	if (!(data->flags & SDE_ROT_EXT_DMA_BUF)) {
 		dma_buf_put(data->srcp_dma_buf);


### PR DESCRIPTION
Rotator and MDP share same stream ID on sdm600 target,
hence share the smmu device with rotator device to map/unmap
its buffers.

The change will also handle different secure usecase concurrencies
like, mdp running in secure and rotator in non-secure and vice versa.

Change-Id: I3ff118baed3984d63e9a9fe94289d99523c7b3e9
Signed-off-by: Kalyan Thota <kalyant@codeaurora.org>