### PR TITLE
net: rmnet_data: Add support to configure custom device name

### DIFF
--- a/include/uapi/linux/rmnet_data.h
+++ b/include/uapi/linux/rmnet_data.h
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2015, 2017 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -223,8 +223,19 @@ enum rmnet_netlink_message_types_e {
 	 *       uint32_t MAP Flow Handle
 	 * Returns: status code
 	 */
-	RMNET_NETLINK_DEL_VND_TC_FLOW
+	RMNET_NETLINK_DEL_VND_TC_FLOW,
+
+	/*
+	 * RMNET_NETLINK_NEW_VND_WITH_NAME - Creates a new virtual network
+	 *                                   device node with the specified
+	 *                                   device name
+	 * Args: int32_t node number
+	 *       char[] vnd_name - Use as name
+	 * Returns: status code
+	 */
+	RMNET_NETLINK_NEW_VND_WITH_NAME
 };
+#define RMNET_NETLINK_NEW_VND_WITH_NAME RMNET_NETLINK_NEW_VND_WITH_NAME
 
 enum rmnet_config_endpoint_modes_e {
 	/* Pass the frame up the stack with no modifications to skb->dev      */

--- a/net/rmnet_data/rmnet_data_config.c
+++ b/net/rmnet_data/rmnet_data_config.c
@@ -629,6 +629,13 @@ void rmnet_config_netlink_msg_handler(struct sk_buff *skb)
 						rmnet_header->vnd.vnd_name);
 		break;
 
+	case RMNET_NETLINK_NEW_VND_WITH_NAME:
+		resp_rmnet->crd = RMNET_NETLINK_MSG_RETURNCODE;
+		resp_rmnet->return_code = rmnet_create_vnd_name(
+						rmnet_header->vnd.id,
+						rmnet_header->vnd.vnd_name);
+		break;
+
 	case RMNET_NETLINK_FREE_VND:
 		resp_rmnet->crd = RMNET_NETLINK_MSG_RETURNCODE;
 		/* Please check rmnet_vnd_free_dev documentation regarding
@@ -1071,11 +1078,11 @@ int rmnet_create_vnd(int id)
 	struct net_device *dev;
 	ASSERT_RTNL();
 	LOGL("(%d);", id);
-	return rmnet_vnd_create_dev(id, &dev, NULL);
+	return rmnet_vnd_create_dev(id, &dev, NULL, 0);
 }
 
 /**
- * rmnet_create_vnd() - Create virtual network device node
+ * rmnet_create_vnd_prefix() - Create virtual network device node
  * @id:       RmNet virtual device node id
  * @prefix:   String prefix for device name
  *
@@ -1087,7 +1094,24 @@ int rmnet_create_vnd_prefix(int id, const char *prefix)
 	struct net_device *dev;
 	ASSERT_RTNL();
 	LOGL("(%d, \"%s\");", id, prefix);
-	return rmnet_vnd_create_dev(id, &dev, prefix);
+	return rmnet_vnd_create_dev(id, &dev, prefix, 0);
+}
+
+/**
+ * rmnet_create_vnd_name() - Create virtual network device node
+ * @id:       RmNet virtual device node id
+ * @prefix:   String prefix for device name
+ *
+ * Return:
+ *      - result of rmnet_vnd_create_dev()
+ */
+int rmnet_create_vnd_name(int id, const char *name)
+{
+	struct net_device *dev;
+
+	ASSERT_RTNL();
+	LOGL("(%d, \"%s\");", id, name);
+	return rmnet_vnd_create_dev(id, &dev, name, 1);
 }
 
 /**

--- a/net/rmnet_data/rmnet_data_config.h
+++ b/net/rmnet_data/rmnet_data_config.h
@@ -120,6 +120,7 @@ int rmnet_config_notify_cb(struct notifier_block *nb,
 				  unsigned long event, void *data);
 int rmnet_create_vnd(int id);
 int rmnet_create_vnd_prefix(int id, const char *name);
+int rmnet_create_vnd_name(int id, const char *name);
 int rmnet_free_vnd(int id);
 
 #endif /* _RMNET_DATA_CONFIG_H_ */

--- a/net/rmnet_data/rmnet_data_vnd.c
+++ b/net/rmnet_data/rmnet_data_vnd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2017, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -553,7 +553,7 @@ int rmnet_vnd_init(void)
  *      - RMNET_CONFIG_UNKNOWN_ERROR if register_netdevice() fails
  */
 int rmnet_vnd_create_dev(int id, struct net_device **new_device,
-			 const char *prefix)
+			 const char *prefix, int use_name)
 {
 	struct net_device *dev;
 	char dev_prefix[IFNAMSIZ];
@@ -569,12 +569,15 @@ int rmnet_vnd_create_dev(int id, struct net_device **new_device,
 		return RMNET_CONFIG_DEVICE_IN_USE;
 	}
 
-	if (!prefix)
+	if (!prefix && !use_name)
 		p = scnprintf(dev_prefix, IFNAMSIZ, "%s%%d",
 			  RMNET_DATA_DEV_NAME_STR);
+	else if (prefix && use_name)
+		p = scnprintf(dev_prefix, IFNAMSIZ, "%s", prefix);
+	else if (prefix && !use_name)
+		p = scnprintf(dev_prefix, IFNAMSIZ, "%s%%d", prefix);
 	else
-		p = scnprintf(dev_prefix, IFNAMSIZ, "%s%%d",
-			  prefix);
+		return RMNET_CONFIG_BAD_ARGUMENTS;
 	if (p >= (IFNAMSIZ-1)) {
 		LOGE("Specified prefix longer than IFNAMSIZ");
 		return RMNET_CONFIG_BAD_ARGUMENTS;

--- a/net/rmnet_data/rmnet_data_vnd.h
+++ b/net/rmnet_data/rmnet_data_vnd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2017, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -27,7 +27,7 @@ int rmnet_vnd_do_flow_control(struct net_device *dev,
 struct rmnet_logical_ep_conf_s *rmnet_vnd_get_le_config(struct net_device *dev);
 int rmnet_vnd_get_name(int id, char *name, int name_len);
 int rmnet_vnd_create_dev(int id, struct net_device **new_device,
-			 const char *prefix);
+			 const char *prefix, int use_name);
 int rmnet_vnd_free_dev(int id);
 int rmnet_vnd_rx_fixup(struct sk_buff *skb, struct net_device *dev);
 int rmnet_vnd_tx_fixup(struct sk_buff *skb, struct net_device *dev);


### PR DESCRIPTION
rmnet_data assigns device name by the order they are created.
This causes problems which multiple processes are trying to
create devices and leads to random device names.

Assign device name as specified by user.

[mikeioannina]: Backport to 3.10

CRs-Fixed: 2018785
Change-Id: Iab8e053c6ccacbeedaa7763e760d0c12e756b5d0
Signed-off-by: Subash Abhinov Kasiviswanathan <subashab@codeaurora.org>