### PR TITLE
[2.3.2.r1.4] dts: tone: Set sound gpio to low by default

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -761,14 +761,8 @@
 
 /* GPIO_13: EAR_EN */
 &pm8994_gpio_13 {
-	/* Inherited from MTP */
-/*
+	/* Overwrite MTP */
 	output-low;
-	drive-push-pull;
-	bias-disable;
-	qcom,drive-strength = <PMIC_GPIO_STRENGTH_LOW>;
-	power-source = <PM8994_VPP_1P8>;
-*/
 };
 
 /* GPIO_14: NC */


### PR DESCRIPTION
The `output-high` setting in [pm8994_gpio_13: hph0_enable in msm8996-mtp.dtsi](https://github.com/sonyxperiadev/kernel/blob/aosp/LE.UM.2.3.2.r1.4/arch/arm64/boot/dts/qcom/msm8996-mtp.dtsi#L877) needs to be overwritten since the GPIO should be disabled by default and only switched on for call sounds.

This commit fixes the bug that the top speaker was only initialized after switching to call audio had force-toggled the GPIO.