### PR TITLE
[2.3.2.r1.4] arm64: DT: Ganges: Fix actuator-type and move haptics to common

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
@@ -260,6 +260,13 @@
 			qcom,rgb_sync = <1>;
 		};
 	};
+
+	qcom,pm660@1 {
+		pm660_haptics: qcom,haptic@c000 {
+			qcom,actuator-type = <1>;
+			qcom,vmax-mv = <3000>;
+		};
+	};
 };
 
 &red_led {

--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin.dtsi
@@ -137,15 +137,6 @@
 &tlmm {
 };
 
-&spmi_bus {
-	qcom,pm660@1 {
-		pm660_haptics: qcom,haptic@c000 {
-			qcom,actuator-type = "erm";
-			qcom,vmax-mv = <3000>;
-		};
-	};
-};
-
 &pm660_vadc {
 	chan@50 {
 		label = "pa_therm1";

--- a/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid.dtsi
@@ -141,15 +141,6 @@
 &tlmm {
 };
 
-&spmi_bus {
-	qcom,pm660@1 {
-		pm660_haptics: qcom,haptic@c000 {
-			qcom,actuator-type = "erm";
-			qcom,vmax-mv = <3000>;
-		};
-	};
-};
-
 &sdhc_2 {
 	cd-gpios = <&tlmm 54 0x0>;
 };


### PR DESCRIPTION
On k4.9, the qcom,actuator-type is an integer, where "1" stands
for ERM actuator.

Also, since Kirin and Mermaid have got the very same DT config
for this node, move it to ganges-common.