### PR TITLE
[2.3.2.r1.4] arm64: DT: Ganges: Move common nodes from kirin and mermaid to ganges

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
@@ -121,8 +121,8 @@
 
 	int_codec: sound {
 		qcom,msm-micbias1-ext-cap;
-		qcom,msm-micbias2-ext-cap = "false";
-		qcom,msm-hs-micbias-type = "internal";
+		qcom,msm-micbias2-ext-cap;
+		qcom,msm-hs-micbias-type = "external";
 		qcom,audio-routing =
 			"RX_BIAS", "INT_MCLK0",
 			"SPK_RX_BIAS", "INT_MCLK0",
@@ -130,10 +130,10 @@
 			"RX_I2S_CLK", "INT_MCLK0",
 			"TX_I2S_CLK", "INT_MCLK0",
 			"MIC BIAS External", "Handset Mic",
-			"MIC BIAS Internal2", "Headset Mic",
+			"MIC BIAS External2", "Headset Mic",
 			"MIC BIAS External", "Secondary Mic",
 			"AMIC1", "MIC BIAS External",
-			"AMIC2", "MIC BIAS Internal2",
+			"AMIC2", "MIC BIAS External2",
 			"AMIC3", "MIC BIAS External",
 			"DMIC1", "MIC BIAS External",
 			"MIC BIAS External", "Digital Mic1",
@@ -213,6 +213,32 @@
 			0x9f 0x1c
 			0x00 0x18>;
 	};
+    
+	s5712 {
+		compatible = "s5712-switch";
+		interrupt-parent = <&tlmm>;
+		interrupts = <75 0x3>;
+		//vddio-supply = <&pm660l_l14>;
+		linux,gpio-int = <&tlmm 75 0x1>;
+		linux,wakeup;
+		linux,min-uv = <1700000>;
+		linux,max-uv = <1900000>;
+	};
+
+	qusb_phy0: qusb@c012000 {
+		qcom,tune2-efuse-num-bits = <0>;
+		qcom,tune2-efuse-correction = <0>;
+		qcom,qusb-phy-init-seq = <0xa7 0x80
+			0x22 0x84
+			0x83 0x88
+			0xc7 0x8c
+			0x30 0x08
+			0x79 0x0c
+			0x21 0x10
+			0x14 0x9c
+			0x9f 0x1c
+			0x00 0x18>;
+	};    
 };
 
 &pm660l_wled {
@@ -515,3 +541,8 @@
 	};
 };
 
+&usb3 {
+	dwc3@a800000 {
+		maximum-speed = "high-speed";
+	};
+};

--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin.dtsi
@@ -27,55 +27,6 @@
 		pinctrl-2 = <>;
 	};
 
-	s5712 {
-		compatible = "s5712-switch";
-		interrupt-parent = <&tlmm>;
-		interrupts = <75 0x3>;
-		//vddio-supply = <&pm660l_l14>;
-		linux,gpio-int = <&tlmm 75 0x1>;
-		linux,wakeup;
-		linux,min-uv = <1700000>;
-		linux,max-uv = <1900000>;
-	};
-
-	int_codec: sound {
-		qcom,msm-micbias1-ext-cap;
-		qcom,msm-micbias2-ext-cap;
-		qcom,msm-hs-micbias-type = "external";
-		qcom,audio-routing =
-			"RX_BIAS", "INT_MCLK0",
-			"SPK_RX_BIAS", "INT_MCLK0",
-			"INT_LDO_H", "INT_MCLK0",
-			"RX_I2S_CLK", "INT_MCLK0",
-			"TX_I2S_CLK", "INT_MCLK0",
-			"MIC BIAS External", "Handset Mic",
-			"MIC BIAS External2", "Headset Mic",
-			"MIC BIAS External", "Secondary Mic",
-			"AMIC1", "MIC BIAS External",
-			"AMIC2", "MIC BIAS External2",
-			"AMIC3", "MIC BIAS External",
-			"DMIC1", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic1",
-			"DMIC2", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic2",
-			"DMIC3", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic3",
-			"DMIC4", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic4",
-			"SpkrLeft IN", "SPK1 OUT",
-			"SpkrRight IN", "SPK2 OUT",
-			"PDM_IN_RX1", "PDM_OUT_RX1",
-			"PDM_IN_RX2", "PDM_OUT_RX2",
-			"PDM_IN_RX3", "PDM_OUT_RX3",
-			"ADC1_IN", "ADC1_OUT",
-			"ADC2_IN", "ADC2_OUT",
-			"ADC3_IN", "ADC3_OUT";
-
-		qcom,wsa-max-devs = <1>;
-		qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrLeft",
-					  "SpkrLeft", "SpkrLeft";
-	};
-
 	qcom,sensor-information {
 		sensor_information13: qcom,sensor-information-13 { /* msm_therm */
 			qcom,scaling-factor = <1000>;
@@ -106,32 +57,6 @@
 		};
 	};
 
-	qusb_phy0: qusb@c012000 {
-		qcom,tune2-efuse-num-bits = <0>;
-		qcom,tune2-efuse-correction = <0>;
-		qcom,qusb-phy-init-seq = <0xa7 0x80
-			0x22 0x84
-			0x83 0x88
-			0xc7 0x8c
-			0x30 0x08
-			0x79 0x0c
-			0x21 0x10
-			0x14 0x9c
-			0x9f 0x1c
-			0x00 0x18>;
-	};
-};
-
-&usb3 {
-	dwc3@a800000 {
-		maximum-speed = "high-speed";
-	};
-};
-
-&usb3 {
-	dwc3@a800000 {
-		maximum-speed = "high-speed";
-	};
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid.dtsi
@@ -37,55 +37,6 @@
 		pinctrl-1 = <>;
 	};
 
-	s5712 {
-		compatible = "s5712-switch";
-		interrupt-parent = <&tlmm>;
-		interrupts = <75 0x3>;
-		//vddio-supply = <&pm660l_l14>;
-		linux,gpio-int = <&tlmm 75 0x1>;
-		linux,wakeup;
-		linux,min-uv = <1700000>;
-		linux,max-uv = <1900000>;
-	};
-
-	int_codec: sound {
-		qcom,msm-micbias1-ext-cap;
-		qcom,msm-micbias2-ext-cap;
-		qcom,msm-hs-micbias-type = "external";
-		qcom,audio-routing =
-			"RX_BIAS", "INT_MCLK0",
-			"SPK_RX_BIAS", "INT_MCLK0",
-			"INT_LDO_H", "INT_MCLK0",
-			"RX_I2S_CLK", "INT_MCLK0",
-			"TX_I2S_CLK", "INT_MCLK0",
-			"MIC BIAS External", "Handset Mic",
-			"MIC BIAS External2", "Headset Mic",
-			"MIC BIAS External", "Secondary Mic",
-			"AMIC1", "MIC BIAS External",
-			"AMIC2", "MIC BIAS External2",
-			"AMIC3", "MIC BIAS External",
-			"DMIC1", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic1",
-			"DMIC2", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic2",
-			"DMIC3", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic3",
-			"DMIC4", "MIC BIAS External",
-			"MIC BIAS External", "Digital Mic4",
-			"SpkrLeft IN", "SPK1 OUT",
-			"SpkrRight IN", "SPK2 OUT",
-			"PDM_IN_RX1", "PDM_OUT_RX1",
-			"PDM_IN_RX2", "PDM_OUT_RX2",
-			"PDM_IN_RX3", "PDM_OUT_RX3",
-			"ADC1_IN", "ADC1_OUT",
-			"ADC2_IN", "ADC2_OUT",
-			"ADC3_IN", "ADC3_OUT";
-
-		qcom,wsa-max-devs = <1>;
-		qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrLeft",
-					  "SpkrLeft", "SpkrLeft";
-	};
-
 	qcom,sensor-information {
 		sensor_information15: qcom,sensor-information-15 { /* msm_therm */
 			qcom,scaling-factor = <1000>;
@@ -114,27 +65,6 @@
 			qcom,alias-name = "batt_therm";
 			qcom,scaling-factor = <1000>;
 		};
-	};
-
-	qusb_phy0: qusb@c012000 {
-		qcom,tune2-efuse-num-bits = <0>;
-		qcom,tune2-efuse-correction = <0>;
-		qcom,qusb-phy-init-seq = <0xa7 0x80
-			0x22 0x84
-			0x83 0x88
-			0xc7 0x8c
-			0x30 0x08
-			0x79 0x0c
-			0x21 0x10
-			0x14 0x9c
-			0x9f 0x1c
-			0x00 0x18>;
-	};
-};
-
-&usb3 {
-	dwc3@a800000 {
-		maximum-speed = "high-speed";
 	};
 };
 


### PR DESCRIPTION
These nodes are same for both devices, and therefore
they should be in the ganges dt instead.

It compiles, and shouldn't break anything, yet I wouldn't mind if someone tested it on a physical device.