### PR TITLE
[2.3.2.r1.4] Fixes for SDM630/636/660 audio, cam, gpu, rot etc

### DIFF
--- a/Documentation/devicetree/bindings/gpu/adreno.txt
+++ b/Documentation/devicetree/bindings/gpu/adreno.txt
@@ -117,6 +117,17 @@ Optional Properties:
 - qcom,l2pc-cpu-mask-latency:
 				The CPU mask latency in microseconds to avoid L2PC
 				on masked CPUs.
+
+- qcom,gpu-cx-ipeak:
+				To handle Cx peak current limit.
+				<phandle bit>
+				phandle - phandle of cx ipeak device node
+				bit     - bit number of client in relevant register
+- qcom,gpu-cx-ipeak-clk:
+				GPU clock threshold for Cx Ipeak voting. KGSL votes
+				to Cx Ipeak driver when GPU clock crosses this threshold.
+				Cx Ipeak can limit peak current based on voting from other clients.
+
 - qcom,force-32bit:
 				Force the GPU to use 32 bit data sizes even if
 				it is capable of doing 64 bit.

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -169,6 +169,7 @@ static struct clk_init_data gpu_clks_init[] = {
  *  | 266000000 | 532000000    |    1        |    2    |
  *  | 370000000 | 740000000    |    1        |    2    |
  *  | 465000000 | 930000000    |    1        |    2    |
+ *  | 585000000 | 1170000000   |    1        |    2    |
  *  | 588000000 | 1176000000   |    1        |    2    |
  *  | 647000000 | 1294000000   |    1        |    2    |
  *  | 700000000 | 1400000000   |    1        |    2    |
@@ -182,6 +183,7 @@ static const struct freq_tbl ftbl_gfx3d_clk_src[] = {
 	F(370000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	F(430000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	F(465000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
+	F(585000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	F(588000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	F(647000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),
 	F(700000000, P_GPU_PLL0_PLL_OUT_MAIN,  2, 0, 0),

--- a/drivers/gpu/drm/msm/sde/sde_hw_top.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_top.c
@@ -302,6 +302,7 @@ static void sde_hw_setup_vsync_source(struct sde_hw_mdp *mdp,
 			    of_machine_is_compatible("qcom,msm8996") ||
 			    of_machine_is_compatible("qcom,msm8998") ||
 			    of_machine_is_compatible("qcom,sdm630")  ||
+			    of_machine_is_compatible("qcom,sdm636")  ||
 			    of_machine_is_compatible("qcom,sdm660"))
 				SDE_REG_WRITE(c, wd_load_value,
 						CALCULATE_WD_LOAD_VALUE_LEGACY(

--- a/drivers/gpu/msm/kgsl_pwrctrl.c
+++ b/drivers/gpu/msm/kgsl_pwrctrl.c
@@ -447,6 +447,26 @@ void kgsl_pwrctrl_pwrlevel_change(struct kgsl_device *device,
 		!test_bit(GMU_DCVS_REPLAY, &device->gmu.flags))
 		return;
 
+	if (pwr->gpu_cx_ipeak) {
+		unsigned int old_freq = pwr->pwrlevels[old_level].gpu_freq;
+		unsigned int new_freq = pwr->pwrlevels[new_level].gpu_freq;
+
+		/*
+		 * Set Cx ipeak vote for GPU if it tries to cross
+		 * threshold frequency.
+		 */
+		if (old_freq < pwr->gpu_cx_ipeak_clk &&
+			new_freq >= pwr->gpu_cx_ipeak_clk) {
+			int ret = cx_ipeak_update(pwr->gpu_cx_ipeak, true);
+
+			if (ret) {
+				KGSL_PWR_ERR(device,
+					"cx_ipeak_update failed %d\n", ret);
+				return;
+			}
+		}
+	}
+
 	kgsl_pwrscale_update_stats(device);
 
 	/*
@@ -511,6 +531,24 @@ void kgsl_pwrctrl_pwrlevel_change(struct kgsl_device *device,
 
 	/* Timestamp the frequency change */
 	device->pwrscale.freq_change_time = ktime_to_ms(ktime_get());
+
+	if (pwr->gpu_cx_ipeak) {
+		unsigned int old_freq = pwr->pwrlevels[old_level].gpu_freq;
+		unsigned int new_freq = pwr->pwrlevels[new_level].gpu_freq;
+
+		/*
+		 * Reset Cx ipeak vote for GPU if it goes below
+		 * threshold frequency.
+		 */
+		if (old_freq >= pwr->gpu_cx_ipeak_clk &&
+			new_freq < pwr->gpu_cx_ipeak_clk) {
+			int ret = cx_ipeak_update(pwr->gpu_cx_ipeak, false);
+
+			if (ret)
+				KGSL_PWR_ERR(device,
+					"cx_ipeak_update failed %d\n", ret);
+		}
+	}
 }
 EXPORT_SYMBOL(kgsl_pwrctrl_pwrlevel_change);
 
@@ -2425,8 +2463,37 @@ int kgsl_pwrctrl_init(struct kgsl_device *device)
 	of_property_read_string(pdev->dev.of_node, "qcom,tzone-name",
 		&pwr->tzone_name);
 
+	/* Cx ipeak client support */
+	if (of_find_property(pdev->dev.of_node, "qcom,gpu-cx-ipeak", NULL)) {
+		if (!of_property_read_u32(pdev->dev.of_node,
+			"qcom,gpu-cx-ipeak-clk", &pwr->gpu_cx_ipeak_clk)) {
+			pwr->gpu_cx_ipeak = cx_ipeak_register(pdev->dev.of_node,
+						"qcom,gpu-cx-ipeak");
+		} else {
+			KGSL_PWR_ERR(device, "failed to get gpu cxip clk\n");
+			result = -EINVAL;
+			goto error_cleanup_pwr_limit;
+		}
+
+		if (IS_ERR(pwr->gpu_cx_ipeak)) {
+			result = PTR_ERR(pwr->gpu_cx_ipeak);
+			KGSL_PWR_ERR(device,
+				"Failed to register Cx ipeak client %d\n",
+				result);
+			goto error_cleanup_pwr_limit;
+		}
+	}
 	return result;
 
+error_cleanup_pwr_limit:
+	pwr->power_flags = 0;
+
+	if (!IS_ERR_OR_NULL(pwr->sysfs_pwr_limit)) {
+		list_del(&pwr->sysfs_pwr_limit->node);
+		kfree(pwr->sysfs_pwr_limit);
+		pwr->sysfs_pwr_limit = NULL;
+	}
+	kfree(pwr->bus_ib);
 error_cleanup_pcl:
 	_close_pcl(pwr);
 error_cleanup_ocmem_pcl:
@@ -2445,6 +2512,8 @@ void kgsl_pwrctrl_close(struct kgsl_device *device)
 	struct kgsl_pwrctrl *pwr = &device->pwrctrl;
 
 	KGSL_PWR_INFO(device, "close device %d\n", device->id);
+
+	cx_ipeak_unregister(pwr->gpu_cx_ipeak);
 
 	pwr->power_flags = 0;
 

--- a/drivers/gpu/msm/kgsl_pwrctrl.h
+++ b/drivers/gpu/msm/kgsl_pwrctrl.h
@@ -14,6 +14,7 @@
 #define __KGSL_PWRCTRL_H
 
 #include <linux/pm_qos.h>
+#include <soc/qcom/cx_ipeak.h>
 
 /*****************************************************************************
  * power flags
@@ -172,6 +173,8 @@ struct kgsl_regulator {
  * isense_clk_indx - index of isense clock, 0 if no isense
  * isense_clk_on_level - isense clock rate is XO rate below this level.
  * tzone_name - pointer to thermal zone name of GPU temperature sensor
+ * gpu_cx_ipeak - pointer to cx ipeak client used by GPU
+ * gpu_cx_ipeak_clk - GPU threshold frequency to call cx ipeak driver API
  */
 
 struct kgsl_pwrctrl {
@@ -230,6 +233,8 @@ struct kgsl_pwrctrl {
 	unsigned int gpu_bimc_int_clk_freq;
 	bool gpu_bimc_interface_enabled;
 	const char *tzone_name;
+	struct cx_ipeak_client *gpu_cx_ipeak;
+	unsigned int gpu_cx_ipeak_clk;
 };
 
 int kgsl_pwrctrl_init(struct kgsl_device *device);

--- a/drivers/media/platform/msm/camera_v2/sensor/csiphy/msm_csiphy.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/csiphy/msm_csiphy.c
@@ -2362,8 +2362,12 @@ static int csiphy_probe(struct platform_device *pdev)
 		"qcom,csiphy-v3.5")) {
 		if (of_machine_is_compatible("qcom,sdm630") ||
 		    of_machine_is_compatible("qcom,sdm636") ||
-		    of_machine_is_compatible("qcom,sdm660"))
+		    of_machine_is_compatible("qcom,sdm660")) {
+			csiphy_v3_5_3ph.mipi_csiphy_3ph_lnn_ctrl23.data = 0x23;
+			csiphy_v3_5_3ph.mipi_csiphy_3ph_lnn_ctrl25.data = 0x50;
 			csiphy_v3_5_3ph.mipi_csiphy_3ph_lnn_ctrl26.data = 0x70;
+		}
+
 		new_csiphy_dev->ctrl_reg->csiphy_3ph_reg = csiphy_v3_5_3ph;
 		new_csiphy_dev->ctrl_reg->csiphy_reg = csiphy_v3_5;
 		new_csiphy_dev->hw_dts_version = CSIPHY_VERSION_V35;

--- a/drivers/media/platform/msm/camera_v2/sensor/csiphy/msm_csiphy.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/csiphy/msm_csiphy.c
@@ -2360,6 +2360,10 @@ static int csiphy_probe(struct platform_device *pdev)
 		new_csiphy_dev->csiphy_3phase = CSI_3PHASE_HW;
 	} else if (of_device_is_compatible(new_csiphy_dev->pdev->dev.of_node,
 		"qcom,csiphy-v3.5")) {
+		if (of_machine_is_compatible("qcom,sdm630") ||
+		    of_machine_is_compatible("qcom,sdm636") ||
+		    of_machine_is_compatible("qcom,sdm660"))
+			csiphy_v3_5_3ph.mipi_csiphy_3ph_lnn_ctrl26.data = 0x70;
 		new_csiphy_dev->ctrl_reg->csiphy_3ph_reg = csiphy_v3_5_3ph;
 		new_csiphy_dev->ctrl_reg->csiphy_reg = csiphy_v3_5;
 		new_csiphy_dev->hw_dts_version = CSIPHY_VERSION_V35;

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_r3.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_r3.c
@@ -2861,6 +2861,11 @@ static int sde_hw_rotator_config(struct sde_rot_hw_resource *hw,
 		SDE_ROTREG_WRITE(rot->mdss_base, ROT_SSPP_CREQ_LUT, qos_lut);
 	}
 
+	if (!test_bit(SDE_QOS_CDP, mdata->sde_qos_map)) {
+		SDE_ROTREG_WRITE(rot->mdss_base, ROT_SSPP_CDP_CNTL, 0x0);
+		SDE_ROTREG_WRITE(rot->mdss_base, ROT_WB_CDP_CNTL, 0x0);
+	}
+
 	/* VBIF QoS and other settings */
 	if (!ctx->sbuf_mode)
 		sde_hw_rotator_vbif_setting(rot);

--- a/drivers/platform/msm/ipa/ipa_v2/ipa_utils.c
+++ b/drivers/platform/msm/ipa/ipa_v2/ipa_utils.c
@@ -828,6 +828,7 @@ int ipa_init_hw(void)
 
 	/* enable IPA Bit:0, enable 2x fast clock Bit:4 */
 	if (of_machine_is_compatible("qcom,sdm630") ||
+	    of_machine_is_compatible("qcom,sdm636") ||
 	    of_machine_is_compatible("qcom,sdm660"))
 		ena_bit = 0x11;
 

--- a/techpack/audio/asoc/msm-dai-fe.c
+++ b/techpack/audio/asoc/msm-dai-fe.c
@@ -2879,6 +2879,7 @@ static void msm_fe_dais_fixup_legacy(void)
 	    !of_machine_is_compatible("qcom,msm8996") &&
 	    !of_machine_is_compatible("qcom,msm8998") &&
 	    !of_machine_is_compatible("qcom,sdm630")  &&
+	    !of_machine_is_compatible("qcom,sdm636")  &&
 	    !of_machine_is_compatible("qcom,sdm660"))
 		return;
 

--- a/techpack/audio/dsp/q6asm.c
+++ b/techpack/audio/dsp/q6asm.c
@@ -2910,7 +2910,7 @@ static int __q6asm_open_write(struct audio_client *ac, uint32_t format,
 	open.sink_endpointype = ASM_END_POINT_DEVICE_MATRIX;
 	open.bits_per_sample = bits_per_sample;
 
-#ifdef CONFIG_ARCH_SONY_NILE
+#if defined(CONFIG_ARCH_SONY_NILE) || defined(CONFIG_ARCH_SONY_GANGES)
 	if (ac->perf_mode == LOW_LATENCY_PCM_MODE ||
 	    ac->perf_mode == ULTRA_LOW_LATENCY_PCM_MODE ||
 	    ac->perf_mode == ULL_POST_PROCESSING_PCM_MODE)

--- a/techpack/audio/dsp/q6voice.c
+++ b/techpack/audio/dsp/q6voice.c
@@ -4305,6 +4305,7 @@ static int voice_get_avcs_version_per_service(uint32_t service_id)
 	    of_machine_is_compatible("qcom,msm8996") ||
 	    of_machine_is_compatible("qcom,msm8998") ||
 	    of_machine_is_compatible("qcom,sdm630")  ||
+	    of_machine_is_compatible("qcom,sdm636")  ||
 	    of_machine_is_compatible("qcom,sdm660"))
 		return CVP_VERSION_1;
 

--- a/techpack/audio/soc/pinctrl-lpi.c
+++ b/techpack/audio/soc/pinctrl-lpi.c
@@ -597,6 +597,7 @@ static int lpi_pinctrl_probe(struct platform_device *pdev)
 	pctrldesc->npins = npins;
 
 	if (of_machine_is_compatible("qcom,sdm630") ||
+	    of_machine_is_compatible("qcom,sdm636") ||
 	    of_machine_is_compatible("qcom,sdm660")) {
 		lpi_sz = 0xC000; /* Address size on SDM630/660 */
 		pad_offsets = lpi_offset_660;


### PR DESCRIPTION
This patchset includes fixes for mainly SDM636, but also SDM630 and 660.

This is mainly fixing issues with IPA, rotator and camera. Also fixes some issues
with SDE and with the GPU, as when the load is too high it may crash.