### PR TITLE
[2.3.2.r1.4] Fixes for SDM630/660

### DIFF
--- a/Documentation/devicetree/bindings/soc/qcom/qcom,cx_ipeak.txt
+++ b/Documentation/devicetree/bindings/soc/qcom/qcom,cx_ipeak.txt
@@ -1,0 +1,22 @@
+* Cx iPeak driver to handle requests from various multimedia clients.
+
+Cx ipeak HW module is used to limit the current drawn by various subsystem
+blocks on Cx power rail. Each client needs to set their
+bit in tcsr register if it is going to cross its own threshold. If all
+clients are going to cross their thresholds then Cx ipeak hw module will raise
+an interrupt to cDSP block to throttle cDSP's fmax.
+
+Required properties:
+
+- compatible : name of the component used for driver matching, should be
+	       "qcom,cx-ipeak-sdm660"
+
+- reg : physical base address and length of the register set(s), SRAM and XPU
+	of the component.
+
+Example:
+
+	cx_ipeak_lm: cx_ipeak@1fe5040 {
+		compatible = "qcom,cx-ipeak-sdm660";
+		reg = <0x01fe5040 0x28>;
+	};

--- a/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
@@ -95,6 +95,7 @@
 #define VBIF_XIN_HALT_TIMEOUT		0x4000
 
 #define DEFAULT_PIXEL_RAM_SIZE		(50 * 1024)
+#define SDM630_PIXEL_RAM_SIZE		(40 * 1024)
 
 /* access property value based on prop_type and hardware index */
 #define PROP_VALUE_ACCESS(p, i, j)		((p + i)->value[j])
@@ -1123,7 +1124,7 @@ static void _sde_sspp_setup_dma(struct sde_mdss_cfg *sde_cfg,
 }
 
 static int sde_sspp_parse_dt(struct device_node *np,
-	struct sde_mdss_cfg *sde_cfg)
+	struct sde_mdss_cfg *sde_cfg, uint32_t hw_rev)
 {
 	int rc, prop_count[SSPP_PROP_MAX], off_count, i, j;
 	int vig_prop_count[VIG_PROP_MAX], rgb_prop_count[RGB_PROP_MAX];
@@ -1263,7 +1264,12 @@ static int sde_sspp_parse_dt(struct device_node *np,
 		sblk->maxvdeciexp = MAX_VERT_DECIMATION;
 
 		sspp->xin_id = PROP_VALUE_ACCESS(prop_value, SSPP_XIN, i);
-		sblk->pixel_ram_size = DEFAULT_PIXEL_RAM_SIZE;
+
+		if (IS_SDM630_TARGET(hw_rev)) {
+			sblk->pixel_ram_size = SDM630_PIXEL_RAM_SIZE;
+		} else {
+			sblk->pixel_ram_size = DEFAULT_PIXEL_RAM_SIZE;
+		}
 		sblk->src_blk.len = PROP_VALUE_ACCESS(prop_value, SSPP_SIZE, 0);
 
 		if (PROP_VALUE_ACCESS(prop_value, SSPP_EXCL_RECT, i) == 1)
@@ -3415,7 +3421,7 @@ struct sde_mdss_cfg *sde_hw_catalog_init(struct drm_device *dev, u32 hw_rev)
 	if (rc)
 		goto end;
 
-	rc = sde_sspp_parse_dt(np, sde_cfg);
+	rc = sde_sspp_parse_dt(np, sde_cfg, hw_rev);
 	if (rc)
 		goto end;
 

--- a/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_catalog.c
@@ -3147,7 +3147,7 @@ static int sde_hardware_format_caps(struct sde_mdss_cfg *sde_cfg,
 	uint32_t index = 0;
 
 	if (IS_MSM8996_TARGET(hw_rev) || IS_MSM8998_TARGET(hw_rev) ||
-	    IS_SDM630_TARGET(hw_rev)) {
+	    IS_SDM630_TARGET(hw_rev) || IS_SDM660_TARGET(hw_rev)) {
 		cursor_list_size = ARRAY_SIZE(cursor_formats);
 		sde_cfg->cursor_formats = kcalloc(cursor_list_size,
 			sizeof(struct sde_format_extended), GFP_KERNEL);
@@ -3252,13 +3252,14 @@ static int _sde_hardware_pre_caps(struct sde_mdss_cfg *sde_cfg, uint32_t hw_rev)
 		/* update msm8996 target here */
 		sde_cfg->has_wb_ubwc = true;
 		sde_cfg->perf.min_prefill_lines = 21;
-	} else if (IS_MSM8998_TARGET(hw_rev) || IS_SDM630_TARGET(hw_rev)) {
+	} else if (IS_MSM8998_TARGET(hw_rev) || IS_SDM630_TARGET(hw_rev) ||
+		   IS_SDM660_TARGET(hw_rev)) {
 		/* update msm8998/sdm630 target here */
 		sde_cfg->has_wb_ubwc = true;
 		sde_cfg->has_cwb_support = true;
 		sde_cfg->perf.min_prefill_lines = 25;
 		sde_cfg->vbif_qos_nlvl = 4;
-		if (IS_SDM630_TARGET(hw_rev))
+		if (IS_SDM630_TARGET(hw_rev) || IS_SDM660_TARGET(hw_rev))
 			sde_cfg->ts_prefill_rev = 1;
 		else
 			sde_cfg->ts_prefill_rev = 2;

--- a/drivers/gpu/drm/msm/sde/sde_hw_catalog.h
+++ b/drivers/gpu/drm/msm/sde/sde_hw_catalog.h
@@ -44,6 +44,7 @@
 #define SDE_HW_VER_172	SDE_HW_VER(1, 7, 2) /* 8996 v3.0 */
 #define SDE_HW_VER_300	SDE_HW_VER(3, 0, 0) /* 8998 v1.0 */
 #define SDE_HW_VER_301	SDE_HW_VER(3, 0, 1) /* 8998 v1.1 */
+#define SDE_HW_VER_320  SDE_HW_VER(3, 2, 0) /* sdm660 v1.0 */
 #define SDE_HW_VER_330	SDE_HW_VER(3, 3, 0) /* sdm630 v1.0 */
 #define SDE_HW_VER_400	SDE_HW_VER(4, 0, 0) /* sdm845 v1.0 */
 #define SDE_HW_VER_401	SDE_HW_VER(4, 0, 1) /* sdm845 v2.0 */
@@ -55,6 +56,7 @@
 #define IS_MSM8998_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_300) || \
 			       IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_301)
 #define IS_SDM630_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_330)
+#define IS_SDM660_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_320)
 #define IS_SDM845_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_400)
 #define IS_SDM670_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_410)
 

--- a/drivers/gpu/drm/msm/sde_power_handle.c
+++ b/drivers/gpu/drm/msm/sde_power_handle.c
@@ -758,6 +758,12 @@ int sde_power_resource_init(struct platform_device *pdev,
 		}
 	}
 
+	if (of_find_property(pdev->dev.of_node, "qcom,dss-cx-ipeak", NULL))
+		phandle->dss_cx_ipeak = cx_ipeak_register(pdev->dev.of_node,
+						"qcom,dss-cx-ipeak");
+	else
+		pr_debug("cx ipeak client parse failed\n");
+
 	INIT_LIST_HEAD(&phandle->power_client_clist);
 	INIT_LIST_HEAD(&phandle->event_list);
 
@@ -821,6 +827,9 @@ void sde_power_resource_deinit(struct platform_device *pdev,
 		list_del(&curr_event->list);
 	}
 	mutex_unlock(&phandle->phandle_lock);
+
+	if (phandle->dss_cx_ipeak)
+		cx_ipeak_unregister(phandle->dss_cx_ipeak);
 
 	for (i = 0; i < SDE_POWER_HANDLE_DBUS_ID_MAX; i++)
 		sde_power_data_bus_unregister(&phandle->data_bus_handle[i]);
@@ -1068,11 +1077,47 @@ int sde_power_resource_is_enabled(struct sde_power_handle *phandle)
 	return phandle->current_usecase_ndx != VOTE_INDEX_DISABLE;
 }
 
+int sde_cx_ipeak_vote(struct sde_power_handle *phandle, struct dss_clk *clock,
+		u64 requested_clk_rate, u64 prev_clk_rate, bool enable_vote)
+{
+	int ret = 0;
+	u64 curr_core_clk_rate, max_core_clk_rate, prev_core_clk_rate;
+
+	if (phandle->dss_cx_ipeak) {
+		pr_debug("%pS->%s: Invalid input\n",
+				__builtin_return_address(0), __func__);
+		return -EINVAL;
+	}
+
+	if (strcmp("core_clk", clock->clk_name)) {
+		pr_debug("Not a core clk , cx_ipeak vote not needed\n");
+		return -EINVAL;
+	}
+
+	curr_core_clk_rate = clock->rate;
+	max_core_clk_rate = clock->max_rate;
+	prev_core_clk_rate = prev_clk_rate;
+
+	if (enable_vote && requested_clk_rate == max_core_clk_rate &&
+				curr_core_clk_rate != requested_clk_rate)
+		ret = cx_ipeak_update(phandle->dss_cx_ipeak, true);
+	else if (!enable_vote && requested_clk_rate != max_core_clk_rate &&
+				prev_core_clk_rate == max_core_clk_rate)
+		ret = cx_ipeak_update(phandle->dss_cx_ipeak, false);
+
+	if (ret)
+		SDE_EVT32(ret, enable_vote, requested_clk_rate,
+					curr_core_clk_rate, prev_core_clk_rate);
+
+	return ret;
+}
+
 int sde_power_clk_set_rate(struct sde_power_handle *phandle, char *clock_name,
 	u64 rate)
 {
 	int i, rc = -EINVAL;
 	struct dss_module_power *mp;
+	u64 prev_clk_rate, requested_clk_rate;
 
 	if (!phandle) {
 		pr_err("invalid input power handle\n");
@@ -1086,8 +1131,15 @@ int sde_power_clk_set_rate(struct sde_power_handle *phandle, char *clock_name,
 					(rate > mp->clk_config[i].max_rate))
 				rate = mp->clk_config[i].max_rate;
 
+			prev_clk_rate = mp->clk_config[i].rate;
+			requested_clk_rate = rate;
+			sde_cx_ipeak_vote(phandle, &mp->clk_config[i],
+				requested_clk_rate, prev_clk_rate, true);
 			mp->clk_config[i].rate = rate;
 			rc = msm_dss_clk_set_rate(mp->clk_config, mp->num_clk);
+			if (!rc)
+				sde_cx_ipeak_vote(phandle, &mp->clk_config[i],
+				   requested_clk_rate, prev_clk_rate, false);
 			break;
 		}
 	}

--- a/drivers/gpu/drm/msm/sde_power_handle.h
+++ b/drivers/gpu/drm/msm/sde_power_handle.h
@@ -26,6 +26,7 @@
 #define SDE_POWER_HANDLE_CONT_SPLASH_BUS_AB_QUOTA	1800000000
 
 #include <linux/sde_io_util.h>
+#include <soc/qcom/cx_ipeak.h>
 
 /* event will be triggered before power handler disable */
 #define SDE_POWER_EVENT_PRE_DISABLE	0x1
@@ -165,6 +166,7 @@ struct sde_power_event {
  * @event_list: current power handle event list
  * @rsc_client: sde rsc client pointer
  * @rsc_client_init: boolean to control rsc client create
+ * @dss_cx_ipeak: client pointer for cx ipeak driver
  */
 struct sde_power_handle {
 	struct dss_module_power mp;
@@ -178,6 +180,7 @@ struct sde_power_handle {
 	struct list_head event_list;
 	struct sde_rsc_client *rsc_client;
 	bool rsc_client_init;
+	struct cx_ipeak_client *dss_cx_ipeak;
 };
 
 /**

--- a/drivers/soc/qcom/Kconfig
+++ b/drivers/soc/qcom/Kconfig
@@ -728,6 +728,15 @@ config MSM_CDSP_LOADER
 	  for platforms that have compute DSP.
 	  Say M if you want to enable this module.
 
+config QCOM_CX_IPEAK
+	bool "Common driver to handle Cx iPeak limitation"
+	help
+	  Cx ipeak HW module is used to limit the current drawn by various subsystem
+	  blocks on Cx power rail. Each client needs to set their
+	  bit in tcsr register if it is going to cross its own threshold. If all
+	  clients are going to cross their thresholds then Cx ipeak hw module will raise
+	  an interrupt to cDSP block to throttle cDSP fmax.
+
 config QCOM_SMCINVOKE
 	bool "Secure QSEE Support"
 	help
@@ -968,3 +977,4 @@ config BIG_CLUSTER_MIN_FREQ_ADJUST
 	  This driver is used to set the floor of the min frequency of big cluster
 	  to the user specified value when the cluster is not power collapsed. When
 	  the cluster is power collpsed it resets the value to physical limits.
+

--- a/drivers/soc/qcom/Makefile
+++ b/drivers/soc/qcom/Makefile
@@ -103,6 +103,7 @@ endif
 ifdef CONFIG_QTI_RPMH_API
 	obj-$(CONFIG_QTI_RPM_STATS_LOG) += rpmh_master_stat.o
 endif
+obj-$(CONFIG_QCOM_CX_IPEAK) += cx_ipeak.o
 obj-$(CONFIG_QCOM_SMCINVOKE) += smcinvoke.o
 obj-$(CONFIG_QMP_DEBUGFS_CLIENT) += qmp-debugfs-client.o
 obj-$(CONFIG_MSM_REMOTEQDSS) += remoteqdss.o

--- a/drivers/soc/qcom/cx_ipeak.c
+++ b/drivers/soc/qcom/cx_ipeak.c
@@ -1,0 +1,202 @@
+/* Copyright (c) 2018, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include <linux/module.h>
+#include <linux/io.h>
+#include <linux/iopoll.h>
+#include <linux/printk.h>
+#include <linux/spinlock.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/slab.h>
+#include <linux/err.h>
+
+#include <soc/qcom/cx_ipeak.h>
+
+#define TCSR_CXIP_LM_VOTE_BYPASS_OFFSET                 0x4
+#define TCSR_CXIP_LM_VOTE_CLEAR_OFFSET                  0x8
+#define TCSR_CXIP_LM_VOTE_SET_OFFSET                    0xC
+#define TCSR_CXIP_LM_VOTE_FEATURE_ENABLE_OFFSET         0x10
+#define TCSR_CXIP_LM_TRS_OFFSET                         0x24
+
+#define CXIP_POLL_TIMEOUT_US (50 * 1000)
+
+static struct cx_ipeak_device {
+	spinlock_t vote_lock;
+	void __iomem *tcsr_vptr;
+} device_ipeak;
+
+struct cx_ipeak_client {
+	int vote_count;
+	unsigned int vote_mask;
+	struct cx_ipeak_device *dev;
+};
+
+/**
+ * cx_ipeak_register() - allocate client structure and fill device private and
+ *			bit details.
+ * @dev_node: device node of the client
+ * @client_name: property name of the client
+ *
+ * Allocate client memory and fill the structure with device private and bit
+ *
+ */
+struct cx_ipeak_client *cx_ipeak_register(struct device_node *dev_node,
+		const char *client_name)
+{
+	struct of_phandle_args cx_spec;
+	struct cx_ipeak_client *client;
+	unsigned int reg_enable, reg_bypass;
+	int ret;
+
+	ret = of_parse_phandle_with_fixed_args(dev_node, client_name,
+			1, 0, &cx_spec);
+	if (ret)
+		return ERR_PTR(-EINVAL);
+
+	if (!of_device_is_available(cx_spec.np))
+		return NULL;
+
+	if (device_ipeak.tcsr_vptr == NULL)
+		return ERR_PTR(-EPROBE_DEFER);
+
+	if (cx_spec.args[0] > 31)
+		return ERR_PTR(-EINVAL);
+
+	reg_enable = readl_relaxed(device_ipeak.tcsr_vptr +
+			TCSR_CXIP_LM_VOTE_FEATURE_ENABLE_OFFSET);
+	reg_bypass = readl_relaxed(device_ipeak.tcsr_vptr +
+			TCSR_CXIP_LM_VOTE_BYPASS_OFFSET) &
+			BIT(cx_spec.args[0]);
+
+	if (!reg_enable || reg_bypass)
+		return NULL;
+
+	client = kzalloc(sizeof(struct cx_ipeak_client), GFP_KERNEL);
+	if (!client)
+		return ERR_PTR(-ENOMEM);
+
+	client->vote_mask = BIT(cx_spec.args[0]);
+	client->dev = &device_ipeak;
+
+	return client;
+}
+EXPORT_SYMBOL(cx_ipeak_register);
+
+/**
+ * cx_ipeak_unregister() - unregister client
+ * @client: client address to free
+ *
+ * Free the client memory
+ */
+void cx_ipeak_unregister(struct cx_ipeak_client *client)
+{
+	kfree(client);
+}
+EXPORT_SYMBOL(cx_ipeak_unregister);
+
+/*
+ * cx_ipeak_update() - Set/Clear client vote for Cx iPeak limit
+ * manager to throttle cDSP.
+ * @client: client handle.
+ * @vote: True to set the vote and False for reset.
+ *
+ * Receives vote from each client and decides whether to throttle cDSP or not.
+ * This function is NOP for the targets which does not support TCSR Cx iPeak.
+ */
+int cx_ipeak_update(struct cx_ipeak_client *client, bool vote)
+{
+	unsigned int reg_val;
+	int ret = 0;
+
+	/* Check for client and device availability and proceed */
+	if (client == NULL || client->dev->tcsr_vptr == NULL)
+		return ret;
+
+	spin_lock(&client->dev->vote_lock);
+
+	if (vote) {
+		if (client->vote_count == 0) {
+			writel_relaxed(client->vote_mask,
+				client->dev->tcsr_vptr +
+				TCSR_CXIP_LM_VOTE_SET_OFFSET);
+
+			/*
+			 * Do a dummy read to give enough time for TRS register
+			 * to become 1 when the last client votes.
+			 */
+			readl_relaxed(client->dev->tcsr_vptr +
+				TCSR_CXIP_LM_TRS_OFFSET);
+
+			ret = readl_poll_timeout(client->dev->tcsr_vptr +
+				TCSR_CXIP_LM_TRS_OFFSET, reg_val, !reg_val,
+				0, CXIP_POLL_TIMEOUT_US);
+			if (ret) {
+				writel_relaxed(client->vote_mask,
+					client->dev->tcsr_vptr +
+					TCSR_CXIP_LM_VOTE_CLEAR_OFFSET);
+				goto done;
+			}
+		}
+		client->vote_count++;
+	} else {
+		if (client->vote_count > 0) {
+			client->vote_count--;
+			if (client->vote_count == 0) {
+				writel_relaxed(client->vote_mask,
+					client->dev->tcsr_vptr +
+					TCSR_CXIP_LM_VOTE_CLEAR_OFFSET);
+			}
+		} else
+			ret = -EINVAL;
+	}
+
+done:
+	spin_unlock(&client->dev->vote_lock);
+	return ret;
+}
+EXPORT_SYMBOL(cx_ipeak_update);
+
+static int cx_ipeak_probe(struct platform_device *pdev)
+{
+	struct resource *res;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	device_ipeak.tcsr_vptr = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(device_ipeak.tcsr_vptr))
+		return PTR_ERR(device_ipeak.tcsr_vptr);
+
+	spin_lock_init(&device_ipeak.vote_lock);
+	return 0;
+}
+
+static const struct of_device_id cx_ipeak_match_table[] = {
+	{ .compatible = "qcom,cx-ipeak-sdm660"},
+	{}
+};
+
+static struct platform_driver cx_ipeak_platform_driver = {
+	.probe = cx_ipeak_probe,
+	.driver = {
+		.name  = "cx_ipeak",
+		.of_match_table = cx_ipeak_match_table,
+		.suppress_bind_attrs = true,
+	}
+};
+
+static int __init cx_ipeak_init(void)
+{
+	return platform_driver_register(&cx_ipeak_platform_driver);
+}
+
+arch_initcall(cx_ipeak_init);


### PR DESCRIPTION
This patchset adds support for the Cx IPeak driver, needed for SDM660 and variants to request the right votes for the cDSP vddcx.

Also adds support for the SDM660 MDP revision 3.2 on SDE and fixes a bug on the SSPP block on SDM630 and variants where a pixel ram overflow would produce unpredictable behavior on the display.