### PR TITLE
[2.3.2.r1.4] Global bugfixes and improvements

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-mermaid.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-mermaid.dtsi
@@ -21,6 +21,11 @@
 	qcom,mdss-dsi-reset-sequence = <1 10>;
 	qcom,mdss-dsi-post-init-delay = <1>;
 
+	qcom,mdss-dsi-panel-hdr-enabled;
+	qcom,mdss-dsi-panel-hdr-color-primaries = <14940 15790 33800 15700 10950 33800 7450 2300>;
+	qcom,mdss-dsi-panel-peak-brightness = <7000000>;
+	qcom,mdss-dsi-panel-blackness-level = <4646>;
+
 	somc,lcd-id-adc = <801000 917000>;
 	somc,mdss-dsi-master;
 	somc,pw-on-rst-seq = <1 10>, <0 10>, <1 10>;

--- a/drivers/clk/qcom/dispcc-sdm845.c
+++ b/drivers/clk/qcom/dispcc-sdm845.c
@@ -1131,7 +1131,7 @@ static int disp_cc_sdm845_probe(struct platform_device *pdev)
 	clk_fabia_pll_configure(&disp_cc_pll0, regmap, &disp_cc_pll0_config);
 
 	/* Enable clock gating for DSI and MDP clocks */
-	regmap_update_bits(regmap, DISP_CC_MISC_CMD, 0x7f0, 0x7f0);
+	regmap_update_bits(regmap, DISP_CC_MISC_CMD, 0x10, 0x10);
 
 	ret = disp_cc_sdm845_fixup(pdev, regmap);
 	if (ret)

--- a/drivers/clk/qcom/mdss/mdss-dsi-pll-14nm-util.c
+++ b/drivers/clk/qcom/mdss/mdss-dsi-pll-14nm-util.c
@@ -290,20 +290,20 @@ static bool pll_is_pll_locked_14nm(struct mdss_pll_resources *pll)
 
 	/* poll for PLL ready status */
 	if (readl_poll_timeout_atomic((pll->pll_base +
-		DSIPHY_PLL_RESET_SM_READY_STATUS),
-		status,
-		((status & BIT(5)) > 0),
-		DSI_PLL_POLL_MAX_READS,
-		DSI_PLL_POLL_TIMEOUT_US)) {
+			DSIPHY_PLL_RESET_SM_READY_STATUS),
+			status,
+			((status & BIT(5)) > 0),
+			DSI_PLL_POLL_MAX_READS,
+			DSI_PLL_POLL_TIMEOUT_US)) {
 		pr_err("DSI PLL ndx=%d status=%x failed to Lock\n",
 				pll->index, status);
 		pll_locked = false;
 	} else if (readl_poll_timeout_atomic((pll->pll_base +
-		DSIPHY_PLL_RESET_SM_READY_STATUS),
-		status,
-		((status & BIT(0)) > 0),
-		DSI_PLL_POLL_MAX_READS,
-		DSI_PLL_POLL_TIMEOUT_US)) {
+				DSIPHY_PLL_RESET_SM_READY_STATUS),
+				status,
+				((status & BIT(0)) > 0),
+				DSI_PLL_POLL_MAX_READS,
+				DSI_PLL_POLL_TIMEOUT_US)) {
 		pr_err("DSI PLL ndx=%d status=%x PLl not ready\n",
 				pll->index, status);
 		pll_locked = false;
@@ -316,7 +316,7 @@ static bool pll_is_pll_locked_14nm(struct mdss_pll_resources *pll)
 
 static void dsi_pll_start_14nm(void __iomem *pll_base)
 {
-	pr_debug("start PLL at base=%p\n", pll_base);
+	pr_debug("start PLL at base=%pK\n", pll_base);
 
 	MDSS_PLL_REG_W(pll_base, DSIPHY_PLL_VREF_CFG1, 0x10);
 	MDSS_PLL_REG_W(pll_base, DSIPHY_CMN_PLL_CNTRL, 1);
@@ -324,7 +324,7 @@ static void dsi_pll_start_14nm(void __iomem *pll_base)
 
 static void dsi_pll_stop_14nm(void __iomem *pll_base)
 {
-	pr_debug("stop PLL at base=%p\n", pll_base);
+	pr_debug("stop PLL at base=%pK\n", pll_base);
 
 	MDSS_PLL_REG_W(pll_base, DSIPHY_CMN_PLL_CNTRL, 0);
 }
@@ -491,8 +491,8 @@ static void pll_14nm_dec_frac_calc(struct mdss_pll_resources *pll,
 {
 	struct dsi_pll_input *pin = &pdb->in;
 	struct dsi_pll_output *pout = &pdb->out;
-	s64 multiplier = BIT(20);
-	s64 dec_start_multiple, dec_start, pll_comp_val;
+	u64 multiplier = BIT(20);
+	u64 dec_start_multiple, dec_start, pll_comp_val;
 	s32 duration, div_frac_start;
 	s64 vco_clk_rate = pll->vco_current_rate;
 	s64 fref = pll->vco_ref_clk_rate;
@@ -518,7 +518,7 @@ static void pll_14nm_dec_frac_calc(struct mdss_pll_resources *pll,
 		duration = 32;
 
 	pll_comp_val =  duration * dec_start_multiple;
-	pll_comp_val =  div_s64(pll_comp_val, multiplier);
+	pll_comp_val =  div_u64(pll_comp_val, multiplier);
 	do_div(pll_comp_val, 10);
 
 	pout->plllock_cmp = (u32)pll_comp_val;
@@ -549,7 +549,7 @@ static void pll_14nm_calc_vco_count(struct dsi_pll_db *pdb,
 {
 	struct dsi_pll_input *pin = &pdb->in;
 	struct dsi_pll_output *pout = &pdb->out;
-	s64 data;
+	u64 data;
 	u32 cnt;
 
 	data = fref * pin->vco_measure_time;
@@ -571,7 +571,7 @@ static void pll_14nm_calc_vco_count(struct dsi_pll_db *pdb,
 
 	cnt = pll_14nm_kvco_slop(vco_clk_rate);
 	cnt *= 2;
-	do_div(cnt, 100);
+	cnt /= 100;
 	cnt *= pin->kvco_measure_time;
 	pout->pll_kvco_count = cnt;
 
@@ -920,7 +920,7 @@ int pll_vco_set_rate_14nm(struct clk_hw *hw, unsigned long rate,
 
 	pll_source_setup(pll);
 
-	pr_debug("%s: ndx=%d base=%p rate=%lu slave=%p\n", __func__,
+	pr_debug("%s: ndx=%d base=%pK rate=%lu slave=%pK\n", __func__,
 				pll->index, pll->pll_base, rate, pll->slave);
 
 	pll->vco_current_rate = rate;
@@ -1041,7 +1041,7 @@ int shadow_pll_vco_set_rate_14nm(struct clk_hw *hw, unsigned long rate,
 		return rc;
 	}
 
-	pr_debug("%s: ndx=%d base=%p rate=%lu\n", __func__,
+	pr_debug("%s: ndx=%d base=%pK rate=%lu\n", __func__,
 			pll->index, pll->pll_base, rate);
 
 	pll->vco_current_rate = rate;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
@@ -87,6 +87,7 @@ static void dsi_catalog_cmn_init(struct dsi_ctrl_hw *ctrl,
 		ctrl->ops.schedule_dma_cmd = NULL;
 		ctrl->ops.get_cont_splash_status = dsi_ctrl_hw_14_get_cont_splash_status;
 		ctrl->ops.kickoff_command_non_embedded_mode = NULL;
+		ctrl->ops.config_clk_gating = NULL;
 		break;
 	case DSI_CTRL_VERSION_2_0:
 		ctrl->ops.setup_lane_map = dsi_ctrl_hw_20_setup_lane_map;
@@ -102,9 +103,11 @@ static void dsi_catalog_cmn_init(struct dsi_ctrl_hw *ctrl,
 		ctrl->ops.schedule_dma_cmd = NULL;
 		ctrl->ops.get_cont_splash_status = dsi_ctrl_hw_14_get_cont_splash_status;
 		ctrl->ops.kickoff_command_non_embedded_mode = NULL;
+		ctrl->ops.config_clk_gating = NULL;
 		break;
 	case DSI_CTRL_VERSION_2_2:
 		ctrl->ops.phy_reset_config = dsi_ctrl_hw_22_phy_reset_config;
+		ctrl->ops.config_clk_gating = dsi_ctrl_hw_22_config_clk_gating;
 		ctrl->ops.get_cont_splash_status =
 			dsi_ctrl_hw_22_get_cont_splash_status;
 		ctrl->ops.setup_lane_map = dsi_ctrl_hw_20_setup_lane_map;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.c
@@ -74,12 +74,12 @@ static void dsi_catalog_cmn_init(struct dsi_ctrl_hw *ctrl,
 	switch (version) {
 	case DSI_CTRL_VERSION_1_4:
 		ctrl->ops.setup_lane_map = dsi_ctrl_hw_14_setup_lane_map;
-		ctrl->ops.ulps_ops.ulps_request = dsi_ctrl_hw_14_ulps_request;
-		ctrl->ops.ulps_ops.ulps_exit = dsi_ctrl_hw_14_ulps_exit;
+		ctrl->ops.ulps_ops.ulps_request = dsi_ctrl_hw_cmn_ulps_request;
+		ctrl->ops.ulps_ops.ulps_exit = dsi_ctrl_hw_cmn_ulps_exit;
 		ctrl->ops.wait_for_lane_idle =
 			dsi_ctrl_hw_14_wait_for_lane_idle;
 		ctrl->ops.ulps_ops.get_lanes_in_ulps =
-			dsi_ctrl_hw_14_get_lanes_in_ulps;
+			dsi_ctrl_hw_cmn_get_lanes_in_ulps;
 		ctrl->ops.clamp_enable = dsi_ctrl_hw_14_clamp_enable;
 		ctrl->ops.clamp_disable = dsi_ctrl_hw_14_clamp_disable;
 		ctrl->ops.reg_dump_to_buffer =
@@ -112,9 +112,10 @@ static void dsi_catalog_cmn_init(struct dsi_ctrl_hw *ctrl,
 			dsi_ctrl_hw_20_wait_for_lane_idle;
 		ctrl->ops.reg_dump_to_buffer =
 			dsi_ctrl_hw_20_reg_dump_to_buffer;
-		ctrl->ops.ulps_ops.ulps_request = NULL;
-		ctrl->ops.ulps_ops.ulps_exit = NULL;
-		ctrl->ops.ulps_ops.get_lanes_in_ulps = NULL;
+		ctrl->ops.ulps_ops.ulps_request = dsi_ctrl_hw_cmn_ulps_request;
+		ctrl->ops.ulps_ops.ulps_exit = dsi_ctrl_hw_cmn_ulps_exit;
+		ctrl->ops.ulps_ops.get_lanes_in_ulps =
+			dsi_ctrl_hw_cmn_get_lanes_in_ulps;
 		ctrl->ops.clamp_enable = NULL;
 		ctrl->ops.clamp_disable = NULL;
 		ctrl->ops.schedule_dma_cmd = dsi_ctrl_hw_22_schedule_dma_cmd;
@@ -191,6 +192,7 @@ static void dsi_catalog_phy_2_0_init(struct dsi_phy_hw *phy)
 	phy->ops.calculate_timing_params =
 		dsi_phy_hw_calculate_timing_params;
 	phy->ops.phy_timing_val = dsi_phy_hw_timing_val_v2_0;
+	phy->ops.clamp_ctrl = dsi_phy_hw_v2_0_clamp_ctrl;
 }
 
 /**

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.h
@@ -86,6 +86,7 @@ void dsi_phy_hw_v2_0_idle_on(struct dsi_phy_hw *phy, struct dsi_phy_cfg *cfg);
 void dsi_phy_hw_v2_0_idle_off(struct dsi_phy_hw *phy);
 int dsi_phy_hw_timing_val_v2_0(struct dsi_phy_per_lane_cfgs *timing_cfg,
 		u32 *timing_val, u32 size);
+void dsi_phy_hw_v2_0_clamp_ctrl(struct dsi_phy_hw *phy, bool enable);
 
 /* Definitions for 10nm PHY hardware driver */
 void dsi_phy_hw_v3_0_regulator_enable(struct dsi_phy_hw *phy,
@@ -196,9 +197,9 @@ bool dsi_ctrl_hw_14_get_cont_splash_status(struct dsi_ctrl_hw *ctrl);
 int dsi_ctrl_hw_14_wait_for_lane_idle(struct dsi_ctrl_hw *ctrl, u32 lanes);
 void dsi_ctrl_hw_14_setup_lane_map(struct dsi_ctrl_hw *ctrl,
 		       struct dsi_lane_map *lane_map);
-void dsi_ctrl_hw_14_ulps_request(struct dsi_ctrl_hw *ctrl, u32 lanes);
-void dsi_ctrl_hw_14_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes);
-u32 dsi_ctrl_hw_14_get_lanes_in_ulps(struct dsi_ctrl_hw *ctrl);
+void dsi_ctrl_hw_cmn_ulps_request(struct dsi_ctrl_hw *ctrl, u32 lanes);
+void dsi_ctrl_hw_cmn_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes);
+u32 dsi_ctrl_hw_cmn_get_lanes_in_ulps(struct dsi_ctrl_hw *ctrl);
 
 void dsi_ctrl_hw_14_clamp_enable(struct dsi_ctrl_hw *ctrl,
 				 u32 lanes,

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_catalog.h
@@ -225,6 +225,8 @@ void dsi_ctrl_hw_kickoff_non_embedded_mode(struct dsi_ctrl_hw *ctrl,
 
 /* Definitions specific to 2.2 DSI controller hardware */
 bool dsi_ctrl_hw_22_get_cont_splash_status(struct dsi_ctrl_hw *ctrl);
+void dsi_ctrl_hw_22_config_clk_gating(struct dsi_ctrl_hw *ctrl, bool enable,
+		enum dsi_clk_gate_type clk_selection);
 
 void dsi_ctrl_hw_cmn_set_continuous_clk(struct dsi_ctrl_hw *ctrl, bool enable);
 

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
@@ -2177,6 +2177,29 @@ int dsi_ctrl_set_roi(struct dsi_ctrl *dsi_ctrl, struct dsi_rect *roi,
 }
 
 /**
+ * dsi_ctrl_config_clk_gating() - Enable/disable DSI PHY clk gating.
+ * @dsi_ctrl:                     DSI controller handle.
+ * @enable:                       Enable/disable DSI PHY clk gating
+ * @clk_selection:                clock to enable/disable clock gating
+ *
+ * Return: error code.
+ */
+int dsi_ctrl_config_clk_gating(struct dsi_ctrl *dsi_ctrl, bool enable,
+			enum dsi_clk_gate_type clk_selection)
+{
+	if (!dsi_ctrl) {
+		pr_err("Invalid params\n");
+		return -EINVAL;
+	}
+
+	if (dsi_ctrl->hw.ops.config_clk_gating)
+		dsi_ctrl->hw.ops.config_clk_gating(&dsi_ctrl->hw, enable,
+				clk_selection);
+
+	return 0;
+}
+
+/**
  * dsi_ctrl_phy_reset_config() - Mask/unmask propagation of ahb reset signal
  *	to DSI PHY hardware.
  * @dsi_ctrl:        DSI controller handle.

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.h
@@ -404,6 +404,17 @@ int dsi_ctrl_phy_sw_reset(struct dsi_ctrl *dsi_ctrl);
 int dsi_ctrl_phy_reset_config(struct dsi_ctrl *dsi_ctrl, bool enable);
 
 /**
+ * dsi_ctrl_config_clk_gating() - Enable/Disable DSI PHY clk gating
+ * @dsi_ctrl:        DSI controller handle.
+ * @enable:          Enable/disable DSI PHY clk gating
+ * @clk_selection:   clock selection for gating
+ *
+ * Return: error code.
+ */
+int dsi_ctrl_config_clk_gating(struct dsi_ctrl *dsi_ctrl, bool enable,
+		 enum dsi_clk_gate_type clk_selection);
+
+/**
  * dsi_ctrl_soft_reset() - perform a soft reset on DSI controller
  * @dsi_ctrl:         DSI controller handle.
  *

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw.h
@@ -451,6 +451,15 @@ struct dsi_ctrl_hw_ops {
 	void (*phy_sw_reset)(struct dsi_ctrl_hw *ctrl);
 
 	/**
+	 * config_clk_gating() - enable/disable DSI PHY clk gating
+	 * @ctrl:          Pointer to the controller host hardware.
+	 * @enable:        enable/disable DSI PHY clock gating.
+	 * @clk_selection:        clock to enable/disable clock gating.
+	 */
+	void (*config_clk_gating)(struct dsi_ctrl_hw *ctrl, bool enable,
+			enum dsi_clk_gate_type clk_selection);
+
+	/**
 	 * debug_bus() - get dsi debug bus status.
 	 * @ctrl:        Pointer to the controller host hardware.
 	 * @entries:     Array of dsi debug bus control values.

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw_1_4.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl_hw_1_4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2015-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -120,12 +120,14 @@ error:
  * Caller should check if lanes are in ULPS mode by calling
  * get_lanes_in_ulps() operation.
  */
-void dsi_ctrl_hw_14_ulps_request(struct dsi_ctrl_hw *ctrl, u32 lanes)
+void dsi_ctrl_hw_cmn_ulps_request(struct dsi_ctrl_hw *ctrl, u32 lanes)
 {
 	u32 reg = 0;
 
+	reg = DSI_R32(ctrl, DSI_LANE_CTRL);
+
 	if (lanes & DSI_CLOCK_LANE)
-		reg = BIT(4);
+		reg |= BIT(4);
 	if (lanes & DSI_DATA_LANE_0)
 		reg |= BIT(0);
 	if (lanes & DSI_DATA_LANE_1)
@@ -155,12 +157,16 @@ void dsi_ctrl_hw_14_ulps_request(struct dsi_ctrl_hw *ctrl, u32 lanes)
  * Caller should check if lanes are in active mode by calling
  * get_lanes_in_ulps() operation.
  */
-void dsi_ctrl_hw_14_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes)
+void dsi_ctrl_hw_cmn_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes)
 {
 	u32 reg = 0;
+	u32 prev_reg = 0;
+
+	prev_reg = DSI_R32(ctrl, DSI_LANE_CTRL);
+	prev_reg &= BIT(24);
 
 	if (lanes & DSI_CLOCK_LANE)
-		reg = BIT(12);
+		reg |= BIT(12);
 	if (lanes & DSI_DATA_LANE_0)
 		reg |= BIT(8);
 	if (lanes & DSI_DATA_LANE_1)
@@ -174,7 +180,7 @@ void dsi_ctrl_hw_14_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes)
 	 * ULPS Exit Request
 	 * Hardware requirement is to wait for at least 1ms
 	 */
-	DSI_W32(ctrl, DSI_LANE_CTRL, reg);
+	DSI_W32(ctrl, DSI_LANE_CTRL, reg | prev_reg);
 	usleep_range(1000, 1010);
 	/*
 	 * Sometimes when exiting ULPS, it is possible that some DSI
@@ -182,8 +188,10 @@ void dsi_ctrl_hw_14_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes)
 	 * commands not going through. To avoid this, force the lanes
 	 * to be in stop state.
 	 */
-	DSI_W32(ctrl, DSI_LANE_CTRL, reg << 8);
-	DSI_W32(ctrl, DSI_LANE_CTRL, 0x0);
+	DSI_W32(ctrl, DSI_LANE_CTRL, (reg << 8) | prev_reg);
+	wmb(); /* ensure lanes are put to stop state */
+	DSI_W32(ctrl, DSI_LANE_CTRL, 0x0 | prev_reg);
+	wmb(); /* ensure lanes are put to stop state */
 
 	pr_debug("[DSI_%d] ULPS exit request for lanes=0x%x\n",
 		 ctrl->index, lanes);
@@ -198,7 +206,7 @@ void dsi_ctrl_hw_14_ulps_exit(struct dsi_ctrl_hw *ctrl, u32 lanes)
  *
  * Return: List of lanes in ULPS state.
  */
-u32 dsi_ctrl_hw_14_get_lanes_in_ulps(struct dsi_ctrl_hw *ctrl)
+u32 dsi_ctrl_hw_cmn_get_lanes_in_ulps(struct dsi_ctrl_hw *ctrl)
 {
 	u32 reg = 0;
 	u32 lanes = 0;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_defs.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_defs.h
@@ -310,6 +310,18 @@ enum dsi_cmd_set_state {
 };
 
 /**
+ * enum dsi_clk_gate_type - Type of clock to be gated.
+ * @PIXEL_CLK:  DSI pixel clock.
+ * @BYTE_CLK:   DSI byte clock.
+ * @DSI_PHY:    DSI PHY.
+ */
+enum dsi_clk_gate_type {
+	PIXEL_CLK = 1,
+	BYTE_CLK = 2,
+	DSI_PHY = 4,
+};
+
+/**
  * enum dsi_phy_type - DSI phy types
  * @DSI_PHY_TYPE_DPHY:
  * @DSI_PHY_TYPE_CPHY:

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -3239,7 +3239,7 @@ int dsi_pre_clkoff_cb(void *priv,
 	struct dsi_display *display = priv;
 
 	if ((clk & DSI_LINK_CLK) && (new_state == DSI_CLK_OFF) &&
-		(l_type && DSI_LINK_LP_CLK)) {
+		(l_type & DSI_LINK_LP_CLK)) {
 		/*
 		 * If continuous clock is enabled then disable it
 		 * before entering into ULPS Mode.
@@ -3262,6 +3262,20 @@ int dsi_pre_clkoff_cb(void *priv,
 			       __func__, rc);
 	}
 
+	if ((clk & DSI_LINK_CLK) && (new_state == DSI_CLK_OFF) &&
+		(l_type & DSI_LINK_HS_CLK)) {
+		/*
+		 * PHY clock gating should be disabled before the PLL and the
+		 * branch clocks are turned off. Otherwise, it is possible that
+		 * the clock RCGs may not be turned off correctly resulting
+		 * in clock warnings.
+		 */
+		rc = dsi_display_config_clk_gating(display, false);
+		if (rc)
+			pr_err("[%s] failed to disable clk gating, rc=%d\n",
+					display->name, rc);
+	}
+
 	if ((clk & DSI_CORE_CLK) && (new_state == DSI_CLK_OFF)) {
 		/*
 		 * Enable DSI clamps only if entering idle power collapse or
@@ -3274,10 +3288,6 @@ int dsi_pre_clkoff_cb(void *priv,
 			if (rc)
 				pr_err("%s: Failed to enable dsi clamps. rc=%d\n",
 					__func__, rc);
-			rc = dsi_display_config_clk_gating(display, false);
-			if (rc)
-				pr_err("[%s] failed to disable clk gating, rc=%d\n",
-						display->name, rc);
 
 			rc = dsi_display_phy_reset_config(display, false);
 			if (rc)
@@ -3348,13 +3358,6 @@ int dsi_post_clkon_cb(void *priv,
 			}
 		}
 
-		rc = dsi_display_config_clk_gating(display, true);
-		if (rc) {
-			pr_err("[%s] failed to enable clk gating %d\n",
-					display->name, rc);
-			goto error;
-		}
-
 		rc = dsi_display_phy_reset_config(display, true);
 		if (rc) {
 			pr_err("%s: Failed to reset phy, rc=%d\n",
@@ -3391,6 +3394,13 @@ int dsi_post_clkon_cb(void *priv,
 
 		if (display->panel->host_config.force_hs_clk_lane)
 			_dsi_display_continuous_clk_ctrl(display, true);
+
+		rc = dsi_display_config_clk_gating(display, true);
+		if (rc) {
+			pr_err("[%s] failed to enable clk gating %d\n",
+					display->name, rc);
+			goto error;
+		}
 	}
 
 	/* enable dsi to serve irqs */

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -1324,7 +1324,7 @@ static ssize_t debugfs_alter_esd_check_mode(struct file *file,
 	if (ZERO_OR_NULL_PTR(buf))
 		return -ENOMEM;
 
-	if (copy_from_user(buf, user_buf, user_len)) {
+	if (copy_from_user(buf, user_buf, len)) {
 		rc = -EINVAL;
 		goto error;
 	}

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -370,6 +370,7 @@ static irqreturn_t dsi_display_panel_te_irq_handler(int irq, void *data)
 	if (!display)
 		return IRQ_HANDLED;
 
+	SDE_EVT32(SDE_EVTLOG_FUNC_CASE1);
 	complete_all(&display->esd_te_gate);
 	return IRQ_HANDLED;
 }
@@ -1246,6 +1247,13 @@ static ssize_t debugfs_esd_trigger_check(struct file *file,
 
 	if (user_len > sizeof(u32))
 		return -EINVAL;
+
+	if (!user_len || !user_buf)
+		return -EINVAL;
+
+	if (!display->panel ||
+		atomic_read(&display->panel->esd_recovery_pending))
+		return user_len;
 
 	buf = kzalloc(user_len, GFP_KERNEL);
 	if (!buf)

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -1574,7 +1574,6 @@ static int dsi_display_is_ulps_req_valid(struct dsi_display *display,
 		bool enable)
 {
 	/* TODO: make checks based on cont. splash */
-	int splash_enabled = false;
 
 	pr_debug("checking ulps req validity\n");
 
@@ -1603,7 +1602,7 @@ static int dsi_display_is_ulps_req_valid(struct dsi_display *display,
 	 * boot animation since it is expected that the clocks would be turned
 	 * right back on.
 	 */
-	if (enable && splash_enabled)
+	if (enable && display->is_cont_splash_enabled)
 		return false;
 
 	return true;
@@ -1639,39 +1638,57 @@ static int dsi_display_set_ulps(struct dsi_display *display, bool enable)
 
 	m_ctrl = &display->ctrl[display->cmd_master_idx];
 
-	rc = dsi_ctrl_set_ulps(m_ctrl->ctrl, enable);
-	if (rc) {
-		pr_err("Ulps controller state change(%d) failed\n", enable);
-		return rc;
-	}
+	/*
+	 * ULPS entry-exit can be either through the DSI controller or
+	 * the DSI PHY depending on hardware variation. For some chipsets,
+	 * both controller version and phy version ulps entry-exit ops can
+	 * be present. To handle such cases, send ulps request through PHY,
+	 * if ulps request is handled in PHY, then no need to send request
+	 * through controller.
+	 */
 
 	rc = dsi_phy_set_ulps(m_ctrl->phy, &display->config, enable,
 				display->clamp_enabled);
-	if (rc) {
+			display->clamp_enabled);
+
+	if (rc == DSI_PHY_ULPS_ERROR) {
 		pr_err("Ulps PHY state change(%d) failed\n", enable);
-		return rc;
-	}
+		return -EINVAL;
+	} else if (rc == DSI_PHY_ULPS_HANDLED) {
+		for (i = 0; i < display->ctrl_count; i++) {
+			ctrl = &display->ctrl[i];
+			if (!ctrl->ctrl || (ctrl == m_ctrl))
+				continue;
 
-	for (i = 0; i < display->ctrl_count; i++) {
-		ctrl = &display->ctrl[i];
-		if (!ctrl->ctrl || (ctrl == m_ctrl))
-			continue;
-
-		rc = dsi_ctrl_set_ulps(ctrl->ctrl, enable);
+			rc = dsi_phy_set_ulps(ctrl->phy, &display->config,
+					enable, display->clamp_enabled);
+			if (rc == DSI_PHY_ULPS_ERROR) {
+				pr_err("Ulps PHY state change(%d) failed\n",
+						enable);
+				return -EINVAL;
+			}
+		}
+	} else if (rc == DSI_PHY_ULPS_NOT_HANDLED) {
+		rc = dsi_ctrl_set_ulps(m_ctrl->ctrl, enable);
 		if (rc) {
 			pr_err("Ulps controller state change(%d) failed\n",
-				enable);
+					enable);
 			return rc;
 		}
+		for (i = 0; i < display->ctrl_count; i++) {
+			ctrl = &display->ctrl[i];
+			if (!ctrl->ctrl || (ctrl == m_ctrl))
+				continue;
 
-		rc = dsi_phy_set_ulps(ctrl->phy, &display->config, enable,
-					display->clamp_enabled);
-		if (rc) {
-			pr_err("Ulps PHY state change(%d) failed\n", enable);
-			return rc;
+			rc = dsi_ctrl_set_ulps(ctrl->ctrl, enable);
+			if (rc) {
+				pr_err("Ulps controller state change(%d) failed\n",
+						enable);
+				return rc;
+			}
 		}
-
 	}
+
 	display->ulps_enabled = enable;
 	return 0;
 }

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -92,6 +92,52 @@ static void dsi_display_mask_ctrl_error_interrupts(struct dsi_display *display,
 	}
 }
 
+static int dsi_display_config_clk_gating(struct dsi_display *display,
+					bool enable)
+{
+	int rc = 0, i = 0;
+	struct dsi_display_ctrl *mctrl, *ctrl;
+
+	if (!display) {
+		pr_err("Invalid params\n");
+		return -EINVAL;
+	}
+
+	mctrl = &display->ctrl[display->clk_master_idx];
+	if (!mctrl) {
+		pr_err("Invalid controller\n");
+		return -EINVAL;
+	}
+
+	rc = dsi_ctrl_config_clk_gating(mctrl->ctrl, enable, PIXEL_CLK |
+							DSI_PHY);
+	if (rc) {
+		pr_err("[%s] failed to %s clk gating, rc=%d\n",
+				display->name, enable ? "enable" : "disable",
+				rc);
+		return rc;
+	}
+
+	for (i = 0; i < display->ctrl_count; i++) {
+		ctrl = &display->ctrl[i];
+		if (!ctrl->ctrl || (ctrl == mctrl))
+			continue;
+		/**
+		 * In Split DSI usecase we should not enable clock gating on
+		 * DSI PHY1 to ensure no display atrifacts are seen.
+		 */
+		rc = dsi_ctrl_config_clk_gating(ctrl->ctrl, enable, PIXEL_CLK);
+		if (rc) {
+			pr_err("[%s] failed to %s pixel clk gating, rc=%d\n",
+				display->name, enable ? "enable" : "disable",
+				rc);
+			return rc;
+		}
+	}
+
+	return 0;
+}
+
 static void dsi_display_set_ctrl_esd_check_flag(struct dsi_display *display,
 			bool enable)
 {
@@ -3228,6 +3274,10 @@ int dsi_pre_clkoff_cb(void *priv,
 			if (rc)
 				pr_err("%s: Failed to enable dsi clamps. rc=%d\n",
 					__func__, rc);
+			rc = dsi_display_config_clk_gating(display, false);
+			if (rc)
+				pr_err("[%s] failed to disable clk gating, rc=%d\n",
+						display->name, rc);
 
 			rc = dsi_display_phy_reset_config(display, false);
 			if (rc)
@@ -3296,6 +3346,13 @@ int dsi_post_clkon_cb(void *priv,
 					__func__, rc);
 				goto error;
 			}
+		}
+
+		rc = dsi_display_config_clk_gating(display, true);
+		if (rc) {
+			pr_err("[%s] failed to enable clk gating %d\n",
+					display->name, rc);
+			goto error;
 		}
 
 		rc = dsi_display_phy_reset_config(display, true);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -6077,6 +6077,9 @@ int dsi_display_prepare(struct dsi_display *display)
 
 	dsi_display_set_ctrl_esd_check_flag(display, false);
 
+	/* Set up ctrl isr before enabling core clk */
+	dsi_display_ctrl_isr_configure(display, true);
+
 	if (mode->dsi_mode_flags & DSI_MODE_FLAG_DMS) {
 		if (display->is_cont_splash_enabled) {
 			pr_err("DMS is not supposed to be set on first frame\n");
@@ -6103,9 +6106,6 @@ int dsi_display_prepare(struct dsi_display *display)
 			goto error;
 		}
 	}
-
-	/* Set up ctrl isr before enabling core clk */
-	dsi_display_ctrl_isr_configure(display, true);
 
 	rc = dsi_display_clk_ctrl(display->dsi_clk_handle,
 			DSI_CORE_CLK, DSI_CLK_ON);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -1719,7 +1719,6 @@ static int dsi_display_set_ulps(struct dsi_display *display, bool enable)
 
 	rc = dsi_phy_set_ulps(m_ctrl->phy, &display->config, enable,
 				display->clamp_enabled);
-			display->clamp_enabled);
 
 	if (rc == DSI_PHY_ULPS_ERROR) {
 		pr_err("Ulps PHY state change(%d) failed\n", enable);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -444,6 +444,7 @@ static void dsi_display_register_te_irq(struct dsi_display *display)
 	int rc = 0;
 	struct platform_device *pdev;
 	struct device *dev;
+	unsigned int te_irq;
 
 	pdev = display->pdev;
 	if (!pdev) {
@@ -463,16 +464,21 @@ static void dsi_display_register_te_irq(struct dsi_display *display)
 	}
 
 	init_completion(&display->esd_te_gate);
+	te_irq = gpio_to_irq(display->disp_te_gpio);
 
-	rc = devm_request_irq(dev, gpio_to_irq(display->disp_te_gpio),
-			dsi_display_panel_te_irq_handler, IRQF_TRIGGER_FALLING,
-			"TE_GPIO", display);
+	/* Avoid deferred spurious irqs with disable_irq() */
+	irq_set_status_flags(te_irq, IRQ_DISABLE_UNLAZY);
+
+	rc = devm_request_irq(dev, te_irq, dsi_display_panel_te_irq_handler,
+			      IRQF_TRIGGER_FALLING | IRQF_ONESHOT,
+			      "TE_GPIO", display);
 	if (rc) {
 		pr_err("TE request_irq failed for ESD rc:%d\n", rc);
+		irq_clear_status_flags(te_irq, IRQ_DISABLE_UNLAZY);
 		goto error;
 	}
 
-	disable_irq(gpio_to_irq(display->disp_te_gpio));
+	disable_irq(te_irq);
 	display->is_te_irq_enabled = false;
 
 	return;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -3982,7 +3982,7 @@ static int dsi_display_get_dfps_timing(struct dsi_display *display,
 		rc = dsi_display_dfps_calc_front_porch(
 				curr_refresh_rate,
 				timing->refresh_rate,
-				DSI_H_TOTAL(timing),
+				DSI_H_TOTAL_DSC(timing),
 				DSI_V_TOTAL(timing),
 				timing->v_front_porch,
 				&adj_mode->timing.v_front_porch);
@@ -3993,7 +3993,7 @@ static int dsi_display_get_dfps_timing(struct dsi_display *display,
 				curr_refresh_rate,
 				timing->refresh_rate,
 				DSI_V_TOTAL(timing),
-				DSI_H_TOTAL(timing),
+				DSI_H_TOTAL_DSC(timing),
 				timing->h_front_porch,
 				&adj_mode->timing.h_front_porch);
 		if (!rc)
@@ -5403,7 +5403,7 @@ int dsi_display_get_modes(struct dsi_display *display,
 					sub_mode, curr_refresh_rate);
 
 				sub_mode->pixel_clk_khz =
-					(DSI_H_TOTAL(&sub_mode->timing) *
+					(DSI_H_TOTAL_DSC(&sub_mode->timing) *
 					DSI_V_TOTAL(&sub_mode->timing) *
 					sub_mode->timing.refresh_rate) / 1000;
 			}
@@ -5579,8 +5579,8 @@ int dsi_display_validate_mode_vrr(struct dsi_display *display,
 			break;
 
 		case DSI_DFPS_IMMEDIATE_HFP:
-			if (abs(DSI_H_TOTAL(&cur_mode.timing) -
-				DSI_H_TOTAL(&adj_mode.timing)) > 5)
+			if (abs(DSI_H_TOTAL_DSC(&cur_mode.timing) -
+				DSI_H_TOTAL_DSC(&adj_mode.timing)) > 5)
 				pr_err("Mismatch hfp fps:%d new:%d given:%d\n",
 				adj_mode.timing.refresh_rate,
 				cur_mode.timing.h_front_porch,

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -1642,6 +1642,11 @@ static int dsi_display_is_ulps_req_valid(struct dsi_display *display,
 
 	pr_debug("checking ulps req validity\n");
 
+	if (atomic_read(&display->panel->esd_recovery_pending)) {
+		pr_debug("%s: ESD recovery sequence underway\n", __func__);
+		return false;
+	}
+
 	if (!dsi_panel_ulps_feature_enabled(display->panel) &&
 			!display->panel->ulps_suspend_enabled) {
 		pr_debug("%s: ULPS feature is not enabled\n", __func__);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -889,6 +889,17 @@ int dsi_display_cmd_transfer(void *display, const char *cmd_buf,
 
 	mutex_lock(&dsi_display->display_lock);
 	rc = dsi_display_ctrl_get_host_init_state(dsi_display, &state);
+
+	/**
+	 * Handle scenario where a command transfer is initiated through
+	 * sysfs interface when device is in suepnd state.
+	 */
+	if (!rc && !state) {
+		pr_warn_ratelimited("Command xfer attempted while device is in suspend state\n"
+				);
+		rc = -EPERM;
+		goto end;
+	}
 	if (rc || !state) {
 		pr_err("[DSI] Invalid host state %d rc %d\n",
 				state, rc);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_drm.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_drm.c
@@ -53,6 +53,11 @@ static void convert_to_dsi_mode(const struct drm_display_mode *drm_mode,
 	dsi_mode->priv_info =
 		(struct dsi_display_mode_priv_info *)drm_mode->private;
 
+	if (dsi_mode->priv_info) {
+		dsi_mode->timing.dsc_enabled = dsi_mode->priv_info->dsc_enabled;
+		dsi_mode->timing.dsc = &dsi_mode->priv_info->dsc;
+	}
+
 	if (msm_is_mode_seamless(drm_mode))
 		dsi_mode->dsi_mode_flags |= DSI_MODE_FLAG_SEAMLESS;
 	if (msm_is_mode_dynamic_fps(drm_mode))
@@ -323,6 +328,8 @@ static bool dsi_bridge_mode_fixup(struct drm_bridge *bridge,
 		 */
 		dsi_mode.priv_info = panel_dsi_mode->priv_info;
 		dsi_mode.dsi_mode_flags = panel_dsi_mode->dsi_mode_flags;
+		dsi_mode.timing.dsc_enabled = dsi_mode.priv_info->dsc_enabled;
+		dsi_mode.timing.dsc = &dsi_mode.priv_info->dsc;
 	}
 
 	rc = dsi_display_validate_mode(c_bridge->display, &dsi_mode,
@@ -337,6 +344,9 @@ static bool dsi_bridge_mode_fixup(struct drm_bridge *bridge,
 
 		convert_to_dsi_mode(&crtc_state->crtc->state->mode,
 							&cur_dsi_mode);
+		cur_dsi_mode.timing.dsc_enabled =
+				dsi_mode.priv_info->dsc_enabled;
+		cur_dsi_mode.timing.dsc = &dsi_mode.priv_info->dsc;
 		rc = dsi_display_validate_mode_vrr(c_bridge->display,
 					&cur_dsi_mode, &dsi_mode);
 		if (rc)

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_hw.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_hw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2016-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -33,6 +33,14 @@
 		writel_relaxed((val), (dsi_hw)->mmss_misc_base + (off)); \
 	} while (0)
 
+#define DSI_MISC_R32(dsi_hw, off) \
+	readl_relaxed((dsi_hw)->phy_clamp_base + (off))
+#define DSI_MISC_W32(dsi_hw, off, val) \
+	do {\
+		pr_debug("[DSI_%d][%s] - [0x%08x]\n", \
+			(dsi_hw)->index, #off, val); \
+		writel_relaxed((val), (dsi_hw)->phy_clamp_base + (off)); \
+	} while (0)
 #define DSI_DISP_CC_R32(dsi_hw, off) \
 	readl_relaxed((dsi_hw)->disp_cc_base + (off))
 #define DSI_DISP_CC_W32(dsi_hw, off, val) \

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -2450,7 +2450,7 @@ static int dsi_panel_parse_phy_timing(struct dsi_display_mode *mode,
 		priv_info->phy_timing_len = len;
 	};
 
-	mode->pixel_clk_khz = (mode->timing.h_active *
+	mode->pixel_clk_khz = (DSI_H_TOTAL_DSC(&mode->timing) *
 			DSI_V_TOTAL(&mode->timing) *
 			mode->timing.refresh_rate) / 1000;
 	return rc;
@@ -2567,6 +2567,9 @@ static int dsi_panel_parse_dsc_params(struct dsi_display_mode *mode,
 
 	dsi_dsc_populate_static_param(&priv_info->dsc);
 	dsi_dsc_pclk_param_calc(&priv_info->dsc, intf_width);
+
+	mode->timing.dsc_enabled = true;
+	mode->timing.dsc = &priv_info->dsc;
 
 error:
 	return rc;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
@@ -49,6 +49,17 @@ enum phy_engine_state {
 	DSI_PHY_ENGINE_MAX,
 };
 
+/**
+ * enum phy_ulps_return_type - define set_ulps return type for dsi phy.
+ * @DSI_PHY_ULPS_HANDLED:      ulps is handled in phy.
+ * @DSI_PHY_ULPS_NOT_HANDLED:  ulps is not handled in phy.
+ * @DSI_PHY_ULPS_ERROR:        ulps request failed in phy.
+ */
+enum phy_ulps_return_type {
+	DSI_PHY_ULPS_HANDLED = 0,
+	DSI_PHY_ULPS_NOT_HANDLED,
+	DSI_PHY_ULPS_ERROR,
+};
 
 /**
  * struct msm_dsi_phy - DSI PHY object

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw.h
@@ -265,6 +265,7 @@ struct dsi_phy_hw_ops {
  * @length:                Length of the DSI PHY register base map.
  * @index:                 Instance ID of the controller.
  * @version:               DSI PHY version.
+ * @phy_clamp_base:        Base address of phy clamp register map.
  * @feature_map:           Features supported by DSI PHY.
  * @ops:                   Function pointer to PHY operations.
  */
@@ -274,6 +275,7 @@ struct dsi_phy_hw {
 	u32 index;
 
 	enum dsi_phy_version version;
+	void __iomem *phy_clamp_base;
 
 	DECLARE_BITMAP(feature_map, DSI_PHY_MAX_FEATURES);
 	struct dsi_phy_hw_ops ops;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v2_0.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v2_0.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2015-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -40,6 +40,7 @@
 
 #define DSIPHY_CMN_REGULATOR_CAL_STATUS0          0x0064
 #define DSIPHY_CMN_REGULATOR_CAL_STATUS1          0x0068
+#define DSI_MDP_ULPS_CLAMP_ENABLE_OFF             0x0054
 
 /* n = 0..3 for data lanes and n = 4 for clock lane */
 #define DSIPHY_DLNX_CFG0(n)                     (0x100 + ((n) * 0x80))
@@ -249,4 +250,26 @@ int dsi_phy_hw_timing_val_v2_0(struct dsi_phy_per_lane_cfgs *timing_cfg,
 		}
 	}
 	return 0;
+}
+
+void dsi_phy_hw_v2_0_clamp_ctrl(struct dsi_phy_hw *phy, bool enable)
+{
+	u32 clamp_reg = 0;
+
+	if (!phy->phy_clamp_base) {
+		pr_debug("phy_clamp_base NULL\n");
+		return;
+	}
+
+	if (enable) {
+		clamp_reg |= BIT(0);
+		DSI_MISC_W32(phy, DSI_MDP_ULPS_CLAMP_ENABLE_OFF,
+				clamp_reg);
+		pr_debug("clamp enabled\n");
+	} else {
+		clamp_reg &= ~BIT(0);
+		DSI_MISC_W32(phy, DSI_MDP_ULPS_CLAMP_ENABLE_OFF,
+				clamp_reg);
+		pr_debug("clamp disabled\n");
+	}
 }

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_timing_calc.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_timing_calc.c
@@ -541,7 +541,7 @@ int dsi_phy_hw_calculate_timing_params(struct dsi_phy_hw *phy,
 	struct phy_timing_ops *ops = phy->ops.timing_ops;
 
 	memset(&desc, 0x0, sizeof(desc));
-	h_total = DSI_H_TOTAL(mode);
+	h_total = DSI_H_TOTAL_DSC(mode);
 	v_total = DSI_V_TOTAL(mode);
 
 	bpp = bits_per_pixel[host->dst_format];

--- a/drivers/gpu/drm/msm/sde/sde_crtc.c
+++ b/drivers/gpu/drm/msm/sde/sde_crtc.c
@@ -6360,13 +6360,32 @@ static int sde_crtc_idle_interrupt_handler(struct drm_crtc *crtc_drm,
 }
 
 /**
- * sde_crtc_update_cont_splash_mixer_settings - update mixer settings
- *	during device bootup for cont_splash use case
+ * sde_crtc_update_cont_splash_settings - update mixer settings
+ *	and initial clk during device bootup for cont_splash use case
  * @crtc: Pointer to drm crtc structure
  */
-void sde_crtc_update_cont_splash_mixer_settings(
-		struct drm_crtc *crtc)
+void sde_crtc_update_cont_splash_settings(struct drm_crtc *crtc)
 {
+	struct sde_kms *kms = NULL;
+	struct msm_drm_private *priv;
+	struct sde_crtc *sde_crtc;
+
+	if (!crtc || !crtc->state || !crtc->dev || !crtc->dev->dev_private) {
+		SDE_ERROR("invalid crtc\n");
+		return;
+	}
+
+	priv = crtc->dev->dev_private;
+	kms = to_sde_kms(priv->kms);
+	if (!kms || !kms->catalog) {
+		SDE_ERROR("invalid parameters\n");
+		return;
+	}
+
 	_sde_crtc_setup_mixers(crtc);
 	crtc->enabled = true;
+
+	/* update core clk value for initial state with cont-splash */
+	sde_crtc = to_sde_crtc(crtc);
+	sde_crtc->cur_perf.core_clk_rate = kms->perf.max_core_clk_rate;
 }

--- a/drivers/gpu/drm/msm/sde/sde_crtc.c
+++ b/drivers/gpu/drm/msm/sde/sde_crtc.c
@@ -25,6 +25,7 @@
 #include <drm/drm_crtc.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_flip_work.h>
+#include <linux/clk/qcom.h>
 
 #include "sde_kms.h"
 #include "sde_hw_lm.h"
@@ -4192,6 +4193,12 @@ static void sde_crtc_disable(struct drm_crtc *crtc)
 	msm_mode_object_event_notify(&crtc->base, crtc->dev, &event,
 			(u8 *)&power_on);
 
+	/* disable mdp LUT memory retention */
+	ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
+				CLKFLAG_NORETAIN_MEM);
+	if (ret)
+		SDE_ERROR("failed to disable LUT memory retention %d\n", ret);
+
 	/* destination scaler if enabled should be reconfigured on resume */
 	if (cstate->num_ds_enabled)
 		sde_crtc->ds_reconfig = true;
@@ -4344,6 +4351,12 @@ static void sde_crtc_enable(struct drm_crtc *crtc)
 	power_on = 1;
 	msm_mode_object_event_notify(&crtc->base, crtc->dev, &event,
 			(u8 *)&power_on);
+
+	/* enable mdp LUT memory retention */
+	ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
+					CLKFLAG_RETAIN_MEM);
+	if (ret)
+		SDE_ERROR("failed to enable LUT memory retention %d\n", ret);
 
 	mutex_unlock(&sde_crtc->crtc_lock);
 

--- a/drivers/gpu/drm/msm/sde/sde_crtc.c
+++ b/drivers/gpu/drm/msm/sde/sde_crtc.c
@@ -2281,7 +2281,7 @@ void sde_crtc_prepare_commit(struct drm_crtc *crtc,
 }
 
 /**
- *  _sde_crtc_complete_flip - signal pending page_flip events
+ *  sde_crtc_complete_flip - signal pending page_flip events
  * Any pending vblank events are added to the vblank_event_list
  * so that the next vblank interrupt shall signal them.
  * However PAGE_FLIP events are not handled through the vblank_event_list.
@@ -2291,7 +2291,7 @@ void sde_crtc_prepare_commit(struct drm_crtc *crtc,
  * @crtc: Pointer to drm crtc structure
  * @file: Pointer to drm file
  */
-static void _sde_crtc_complete_flip(struct drm_crtc *crtc,
+void sde_crtc_complete_flip(struct drm_crtc *crtc,
 		struct drm_file *file)
 {
 	struct sde_crtc *sde_crtc = to_sde_crtc(crtc);
@@ -2301,19 +2301,23 @@ static void _sde_crtc_complete_flip(struct drm_crtc *crtc,
 
 	spin_lock_irqsave(&dev->event_lock, flags);
 	event = sde_crtc->event;
-	if (event) {
-		/* if regular vblank case (!file) or if cancel-flip from
-		 * preclose on file that requested flip, then send the
-		 * event:
-		 */
-		if (!file || (event->base.file_priv == file)) {
-			sde_crtc->event = NULL;
-			DRM_DEBUG_VBL("%s: send event: %pK\n",
-						sde_crtc->name, event);
-			SDE_EVT32_VERBOSE(DRMID(crtc));
-			drm_crtc_send_vblank_event(crtc, event);
-		}
+	if (!event)
+		goto end;
+
+	/*
+	 * if regular vblank case (!file) or if cancel-flip from
+	 * preclose on file that requested flip, then send the
+	 * event:
+	 */
+	if (!file || (event->base.file_priv == file)) {
+		sde_crtc->event = NULL;
+		DRM_DEBUG_VBL("%s: send event: %pK\n",
+					sde_crtc->name, event);
+		SDE_EVT32_VERBOSE(DRMID(crtc));
+		drm_crtc_send_vblank_event(crtc, event);
 	}
+
+end:
 	spin_unlock_irqrestore(&dev->event_lock, flags);
 }
 
@@ -2354,7 +2358,6 @@ static void sde_crtc_vblank_cb(void *data)
 	sde_crtc->vblank_last_cb_time = ktime_get();
 	sysfs_notify_dirent(sde_crtc->vsync_event_sf);
 
-	_sde_crtc_complete_flip(crtc, NULL);
 	drm_crtc_handle_vblank(crtc);
 	DRM_DEBUG_VBL("crtc%d\n", crtc->base.id);
 	SDE_EVT32_VERBOSE(DRMID(crtc));
@@ -3102,7 +3105,6 @@ static void sde_crtc_atomic_begin(struct drm_crtc *crtc,
 	struct sde_crtc *sde_crtc;
 	struct drm_encoder *encoder;
 	struct drm_device *dev;
-	unsigned long flags;
 	struct sde_kms *sde_kms;
 
 	if (!crtc) {
@@ -3134,14 +3136,6 @@ static void sde_crtc_atomic_begin(struct drm_crtc *crtc,
 		_sde_crtc_setup_mixers(crtc);
 		_sde_crtc_setup_is_ppsplit(crtc->state);
 		_sde_crtc_setup_lm_bounds(crtc, crtc->state);
-	}
-
-	if (sde_crtc->event) {
-		WARN_ON(sde_crtc->event);
-	} else {
-		spin_lock_irqsave(&dev->event_lock, flags);
-		sde_crtc->event = crtc->state->event;
-		spin_unlock_irqrestore(&dev->event_lock, flags);
 	}
 
 	list_for_each_entry(encoder, &dev->mode_config.encoder_list, head) {
@@ -3196,7 +3190,6 @@ static void sde_crtc_atomic_flush(struct drm_crtc *crtc,
 	struct drm_plane *plane;
 	struct msm_drm_private *priv;
 	struct msm_drm_thread *event_thread;
-	unsigned long flags;
 	struct sde_crtc_state *cstate;
 	struct sde_kms *sde_kms;
 	int idle_time = 0;
@@ -3237,14 +3230,6 @@ static void sde_crtc_atomic_flush(struct drm_crtc *crtc,
 
 	event_thread = &priv->event_thread[crtc->index];
 	idle_time = sde_crtc_get_property(cstate, CRTC_PROP_IDLE_TIMEOUT);
-
-	if (sde_crtc->event) {
-		SDE_DEBUG("already received sde_crtc->event\n");
-	} else {
-		spin_lock_irqsave(&dev->event_lock, flags);
-		sde_crtc->event = crtc->state->event;
-		spin_unlock_irqrestore(&dev->event_lock, flags);
-	}
 
 	/*
 	 * If no mixers has been allocated in sde_crtc_atomic_check(),
@@ -3691,6 +3676,7 @@ void sde_crtc_commit_kickoff(struct drm_crtc *crtc,
 	struct sde_crtc_state *cstate;
 	bool is_error, reset_req;
 	enum sde_crtc_idle_pc_state idle_pc_state;
+	unsigned long flags;
 
 	if (!crtc) {
 		SDE_ERROR("invalid argument\n");
@@ -3795,6 +3781,15 @@ void sde_crtc_commit_kickoff(struct drm_crtc *crtc,
 			continue;
 
 		sde_encoder_kickoff(encoder, false);
+	}
+
+	/* store the event after frame trigger */
+	if (sde_crtc->event) {
+		WARN_ON(sde_crtc->event);
+	} else {
+		spin_lock_irqsave(&dev->event_lock, flags);
+		sde_crtc->event = crtc->state->event;
+		spin_unlock_irqrestore(&dev->event_lock, flags);
 	}
 
 	SDE_ATRACE_END("crtc_commit");
@@ -4919,14 +4914,6 @@ int sde_crtc_vblank(struct drm_crtc *crtc, bool en)
 	mutex_unlock(&sde_crtc->crtc_lock);
 
 	return 0;
-}
-
-void sde_crtc_cancel_pending_flip(struct drm_crtc *crtc, struct drm_file *file)
-{
-	struct sde_crtc *sde_crtc = to_sde_crtc(crtc);
-
-	SDE_DEBUG("%s: cancel: %pK\n", sde_crtc->name, file);
-	_sde_crtc_complete_flip(crtc, file);
 }
 
 int sde_crtc_helper_reset_custom_properties(struct drm_crtc *crtc,

--- a/drivers/gpu/drm/msm/sde/sde_crtc.h
+++ b/drivers/gpu/drm/msm/sde/sde_crtc.h
@@ -567,11 +567,11 @@ struct drm_crtc *sde_crtc_init(struct drm_device *dev, struct drm_plane *plane);
 int sde_crtc_post_init(struct drm_device *dev, struct drm_crtc *crtc);
 
 /**
- * sde_crtc_cancel_pending_flip - complete flip for clients on lastclose
+ * sde_crtc_complete_flip - complete flip for clients
  * @crtc: Pointer to drm crtc object
  * @file: client to cancel's file handle
  */
-void sde_crtc_cancel_pending_flip(struct drm_crtc *crtc, struct drm_file *file);
+void sde_crtc_complete_flip(struct drm_crtc *crtc, struct drm_file *file);
 
 /**
  * sde_crtc_register_custom_event - api for enabling/disabling crtc event

--- a/drivers/gpu/drm/msm/sde/sde_crtc.h
+++ b/drivers/gpu/drm/msm/sde/sde_crtc.h
@@ -786,11 +786,11 @@ int sde_crtc_helper_reset_custom_properties(struct drm_crtc *crtc,
 void sde_crtc_timeline_status(struct drm_crtc *crtc);
 
 /**
- * sde_crtc_update_cont_splash_mixer_settings - update mixer settings
+ * sde_crtc_update_cont_splash_settings - update mixer settings
  *	during device bootup for cont_splash use case
  * @crtc: Pointer to drm crtc structure
  */
-void sde_crtc_update_cont_splash_mixer_settings(
+void sde_crtc_update_cont_splash_settings(
 		struct drm_crtc *crtc);
 
 /**

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -3374,6 +3374,32 @@ static int sde_kms_hw_init(struct msm_kms *kms)
 
 	sde_kms->splash_data.resource_handoff_pending = true;
 
+	/* initialize power domain if defined */
+	if (of_find_property(dev->dev->of_node, "#power-domain-cells", NULL)) {
+		sde_kms->genpd.name = dev->unique;
+		sde_kms->genpd.power_off = sde_kms_pd_disable;
+		sde_kms->genpd.power_on = sde_kms_pd_enable;
+
+		rc = pm_genpd_init(&sde_kms->genpd, NULL, true);
+		if (rc < 0) {
+			SDE_ERROR("failed to init genpd provider %s: %d\n",
+					sde_kms->genpd.name, rc);
+			goto genpd_err;
+		}
+
+		rc = of_genpd_add_provider_simple(dev->dev->of_node,
+				&sde_kms->genpd);
+		if (rc < 0) {
+			SDE_ERROR("failed to add genpd provider %s: %d\n",
+					sde_kms->genpd.name, rc);
+			pm_genpd_remove(&sde_kms->genpd);
+			goto genpd_err;
+		}
+
+		sde_kms->genpd_init = true;
+		SDE_DEBUG("added genpd provider %s\n", sde_kms->genpd.name);
+	}
+
 	rc = _sde_kms_mmu_init(sde_kms);
 	if (rc) {
 		SDE_ERROR("sde_kms_mmu_init failed: %d\n", rc);
@@ -3489,32 +3515,6 @@ static int sde_kms_hw_init(struct msm_kms *kms)
 			SDE_POWER_EVENT_POST_ENABLE |
 			SDE_POWER_EVENT_PRE_DISABLE,
 			sde_kms_handle_power_event, sde_kms, "kms");
-
-	/* initialize power domain if defined */
-	if (of_find_property(dev->dev->of_node, "#power-domain-cells", NULL)) {
-		sde_kms->genpd.name = dev->unique;
-		sde_kms->genpd.power_off = sde_kms_pd_disable;
-		sde_kms->genpd.power_on = sde_kms_pd_enable;
-
-		rc = pm_genpd_init(&sde_kms->genpd, NULL, true);
-		if (rc < 0) {
-			SDE_ERROR("failed to init genpd provider %s: %d\n",
-					sde_kms->genpd.name, rc);
-			goto genpd_err;
-		}
-
-		rc = of_genpd_add_provider_simple(dev->dev->of_node,
-				&sde_kms->genpd);
-		if (rc < 0) {
-			SDE_ERROR("failed to add genpd provider %s: %d\n",
-					sde_kms->genpd.name, rc);
-			pm_genpd_remove(&sde_kms->genpd);
-			goto genpd_err;
-		}
-
-		sde_kms->genpd_init = true;
-		SDE_DEBUG("added genpd provider %s\n", sde_kms->genpd.name);
-	}
 
 	if (sde_kms->splash_data.cont_splash_en) {
 		SDE_DEBUG("Skipping MDP Resources disable\n");

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -2796,7 +2796,7 @@ static int sde_kms_cont_splash_config(struct msm_kms *kms)
 	/* Update encoder structure */
 	sde_encoder_update_caps_for_cont_splash(encoder);
 
-	sde_crtc_update_cont_splash_mixer_settings(crtc);
+	sde_crtc_update_cont_splash_settings(crtc);
 
 	sde_conn = to_sde_connector(connector);
 	if (sde_conn && sde_conn->ops.cont_splash_config)

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -1111,6 +1111,11 @@ static void sde_kms_wait_for_commit_done(struct msm_kms *kms,
 		return;
 	}
 
+	if (!sde_kms_power_resource_is_enabled(crtc->dev)) {
+		SDE_ERROR("power resource is not enabled\n");
+		return;
+	}
+
 	list_for_each_entry(encoder, &dev->mode_config.encoder_list, head) {
 		if (encoder->crtc != crtc)
 			continue;

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -1130,6 +1130,8 @@ static void sde_kms_wait_for_commit_done(struct msm_kms *kms,
 			SDE_ERROR("wait for commit done returned %d\n", ret);
 			break;
 		}
+
+		sde_crtc_complete_flip(crtc, NULL);
 	}
 }
 
@@ -2348,8 +2350,9 @@ static void sde_kms_preclose(struct msm_kms *kms, struct drm_file *file)
 	struct drm_atomic_state *state = NULL;
 	int ret = 0;
 
+	/* cancel pending flip event */
 	for (i = 0; i < priv->num_crtcs; i++)
-		sde_crtc_cancel_pending_flip(priv->crtcs[i], file);
+		sde_crtc_complete_flip(priv->crtcs[i], file);
 
 	drm_modeset_lock_all(dev);
 	state = drm_atomic_state_alloc(dev);

--- a/drivers/gpu/drm/msm/sde/sde_plane.c
+++ b/drivers/gpu/drm/msm/sde/sde_plane.c
@@ -3767,6 +3767,11 @@ static int sde_plane_sspp_atomic_update(struct drm_plane *plane,
 		return -EINVAL;
 	}
 
+	if (!sde_kms_power_resource_is_enabled(plane->dev)) {
+		SDE_ERROR("power resource is not enabled\n");
+		return -EINVAL;
+	}
+
 	psde = to_sde_plane(plane);
 	state = plane->state;
 

--- a/drivers/gpu/drm/msm/sde_io_util.c
+++ b/drivers/gpu/drm/msm/sde_io_util.c
@@ -366,27 +366,41 @@ error:
 } /* msm_dss_get_clk */
 EXPORT_SYMBOL(msm_dss_get_clk);
 
+int msm_dss_single_clk_set_rate(struct dss_clk *clk)
+{
+	int rc = 0;
+
+	if (!clk) {
+		DEV_ERR("invalid clk struct\n");
+		return -EINVAL;
+	}
+
+	DEV_DBG("%pS->%s: set_rate '%s'\n",
+			__builtin_return_address(0), __func__,
+			clk->clk_name);
+
+	if (clk->type != DSS_CLK_AHB) {
+		rc = clk_set_rate(clk->clk, clk->rate);
+		if (rc)
+			DEV_ERR("%pS->%s: %s failed. rc=%d\n",
+					__builtin_return_address(0),
+					__func__,
+					clk->clk_name, rc);
+	}
+
+	return rc;
+} /* msm_dss_single_clk_set_rate */
+EXPORT_SYMBOL(msm_dss_single_clk_set_rate);
+
 int msm_dss_clk_set_rate(struct dss_clk *clk_arry, int num_clk)
 {
 	int i, rc = 0;
 
 	for (i = 0; i < num_clk; i++) {
 		if (clk_arry[i].clk) {
-			if (clk_arry[i].type != DSS_CLK_AHB) {
-				DEV_DBG("%pS->%s: '%s' rate %ld\n",
-					__builtin_return_address(0), __func__,
-					clk_arry[i].clk_name,
-					clk_arry[i].rate);
-				rc = clk_set_rate(clk_arry[i].clk,
-					clk_arry[i].rate);
-				if (rc) {
-					DEV_ERR("%pS->%s: %s failed. rc=%d\n",
-						__builtin_return_address(0),
-						__func__,
-						clk_arry[i].clk_name, rc);
-					break;
-				}
-			}
+			rc = msm_dss_single_clk_set_rate(&clk_arry[i]);
+			if (rc)
+				break;
 		} else {
 			DEV_ERR("%pS->%s: '%s' is not available\n",
 				__builtin_return_address(0), __func__,

--- a/drivers/gpu/drm/msm/sde_power_handle.c
+++ b/drivers/gpu/drm/msm/sde_power_handle.c
@@ -1215,6 +1215,30 @@ struct clk *sde_power_clk_get_clk(struct sde_power_handle *phandle,
 	return clk;
 }
 
+int sde_power_clk_set_flags(struct sde_power_handle *phandle,
+		char *clock_name, unsigned long flags)
+{
+	struct clk *clk;
+
+	if (!phandle) {
+		pr_err("invalid input power handle\n");
+		return -EINVAL;
+	}
+
+	if (!clock_name) {
+		pr_err("invalid input clock name\n");
+		return -EINVAL;
+	}
+
+	clk = sde_power_clk_get_clk(phandle, clock_name);
+	if (!clk) {
+		pr_err("get_clk failed for clk: %s\n", clock_name);
+		return -EINVAL;
+	}
+
+	return clk_set_flags(clk, flags);
+}
+
 struct sde_power_event *sde_power_handle_register_event(
 		struct sde_power_handle *phandle,
 		u32 event_type, void (*cb_fnc)(u32 event_type, void *usr),

--- a/drivers/gpu/drm/msm/sde_power_handle.c
+++ b/drivers/gpu/drm/msm/sde_power_handle.c
@@ -1083,15 +1083,15 @@ int sde_cx_ipeak_vote(struct sde_power_handle *phandle, struct dss_clk *clock,
 	int ret = 0;
 	u64 curr_core_clk_rate, max_core_clk_rate, prev_core_clk_rate;
 
-	if (phandle->dss_cx_ipeak) {
+	if (!phandle->dss_cx_ipeak) {
 		pr_debug("%pS->%s: Invalid input\n",
 				__builtin_return_address(0), __func__);
-		return -EINVAL;
+		return -EOPNOTSUPP;
 	}
 
 	if (strcmp("core_clk", clock->clk_name)) {
 		pr_debug("Not a core clk , cx_ipeak vote not needed\n");
-		return -EINVAL;
+		return -EOPNOTSUPP;
 	}
 
 	curr_core_clk_rate = clock->rate;

--- a/drivers/gpu/drm/msm/sde_power_handle.c
+++ b/drivers/gpu/drm/msm/sde_power_handle.c
@@ -1136,7 +1136,7 @@ int sde_power_clk_set_rate(struct sde_power_handle *phandle, char *clock_name,
 			sde_cx_ipeak_vote(phandle, &mp->clk_config[i],
 				requested_clk_rate, prev_clk_rate, true);
 			mp->clk_config[i].rate = rate;
-			rc = msm_dss_clk_set_rate(mp->clk_config, mp->num_clk);
+			rc = msm_dss_single_clk_set_rate(&mp->clk_config[i]);
 			if (!rc)
 				sde_cx_ipeak_vote(phandle, &mp->clk_config[i],
 				   requested_clk_rate, prev_clk_rate, false);

--- a/drivers/gpu/drm/msm/sde_power_handle.h
+++ b/drivers/gpu/drm/msm/sde_power_handle.h
@@ -306,6 +306,17 @@ struct clk *sde_power_clk_get_clk(struct sde_power_handle *phandle,
 		char *clock_name);
 
 /**
+ * sde_power_clk_set_flags() - set the clock flags
+ * @pdata:  power handle containing the resources
+ * @clock_name: clock name to get the clk pointer.
+ * @flags: flags to set
+ *
+ * Return: error code.
+ */
+int sde_power_clk_set_flags(struct sde_power_handle *pdata,
+		char *clock_name, unsigned long flags);
+
+/**
  * sde_power_data_bus_set_quota() - set data bus quota for power client
  * @phandle:  power handle containing the resources
  * @client: client information to set quota

--- a/drivers/gpu/msm/adreno_a6xx.c
+++ b/drivers/gpu/msm/adreno_a6xx.c
@@ -994,6 +994,7 @@ static void _set_ordinals(struct adreno_device *adreno_dev,
 static int a6xx_send_cp_init(struct adreno_device *adreno_dev,
 			 struct adreno_ringbuffer *rb)
 {
+	struct kgsl_device *device = KGSL_DEVICE(adreno_dev);
 	unsigned int *cmds;
 	int ret;
 
@@ -1006,9 +1007,16 @@ static int a6xx_send_cp_init(struct adreno_device *adreno_dev,
 	_set_ordinals(adreno_dev, cmds, 11);
 
 	ret = adreno_ringbuffer_submit_spin(rb, NULL, 2000);
-	if (ret)
+	if (ret) {
 		adreno_spin_idle_debug(adreno_dev,
 				"CP initialization failed to idle\n");
+
+		if (!adreno_is_a3xx(adreno_dev))
+			kgsl_sharedmem_writel(device, &device->scratch,
+					SCRATCH_RPTR_OFFSET(rb->id), 0);
+		rb->wptr = 0;
+		rb->_wptr = 0;
+	}
 
 	return ret;
 }

--- a/drivers/input/touchscreen/nt36672a/nt36xxx.h
+++ b/drivers/input/touchscreen/nt36672a/nt36xxx.h
@@ -21,11 +21,6 @@
 #include <linux/i2c.h>
 #include <linux/input.h>
 #include "smx3_touch_log.h"
-
-#ifdef CONFIG_HAS_EARLYSUSPEND
-#include <linux/earlysuspend.h>
-#endif
-
 #include "nt36xxx_mem_map.h"
 
 #define NVT_DEBUG 0
@@ -122,8 +117,6 @@ struct nvt_ts_data {
 	int8_t phys[32];
 #if defined(CONFIG_FB)
 	struct notifier_block fb_notif;
-#elif defined(CONFIG_HAS_EARLYSUSPEND)
-	struct early_suspend early_suspend;
 #endif
 	uint8_t fw_ver;
 	uint8_t x_num;

--- a/drivers/iommu/arm-smmu-legacy.c
+++ b/drivers/iommu/arm-smmu-legacy.c
@@ -2541,6 +2541,10 @@ static void arm_smmu_power_off(struct arm_smmu_device *smmu)
 		return;
 	writel_relaxed(sCR0_CLIENTPD,
 		ARM_SMMU_GR0_NS(smmu) + ARM_SMMU_GR0_sCR0);
+
+	/* Wait for writes to complete before off */
+	wmb();
+
 	arm_smmu_disable_clocks(smmu);
 	if (!(smmu->options & ARM_SMMU_OPT_REGISTER_SAVE))
 		arm_smmu_disable_regulators(smmu);

--- a/include/linux/sde_io_util.h
+++ b/include/linux/sde_io_util.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012, 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012, 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -103,6 +103,7 @@ int msm_dss_enable_vreg(struct dss_vreg *in_vreg, int num_vreg,	int enable);
 int msm_dss_get_clk(struct device *dev, struct dss_clk *clk_arry, int num_clk);
 void msm_dss_put_clk(struct dss_clk *clk_arry, int num_clk);
 int msm_dss_clk_set_rate(struct dss_clk *clk_arry, int num_clk);
+int msm_dss_single_clk_set_rate(struct dss_clk *clk);
 int msm_dss_enable_clk(struct dss_clk *clk_arry, int num_clk, int enable);
 
 int sde_i2c_byte_read(struct i2c_client *client, uint8_t slave_addr,

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -26,6 +26,7 @@
 #include <linux/relay.h>
 #include <linux/slab.h>
 #include <linux/highmem.h>
+#include <linux/cpuset.h>
 
 #include <trace/events/power.h>
 #define CREATE_TRACE_POINTS
@@ -1086,6 +1087,18 @@ static int do_cpu_down(unsigned int cpu, enum cpuhp_state target)
 {
 	int err;
 
+	/*
+	 * When cpusets are enabled, the rebuilding of the scheduling
+	 * domains is deferred to a workqueue context. Make sure
+	 * that the work is completed before proceeding to the next
+	 * hotplug. Otherwise scheduler observes an inconsistent
+	 * view of online and offline CPUs in the root domain. If
+	 * the online CPUs are still stuck in the offline (default)
+	 * domain, those CPUs would not be visible when scheduling
+	 * happens on from other CPUs in the root domain.
+	 */
+	cpuset_wait_for_hotplug();
+
 	cpu_maps_update_begin();
 	err = cpu_down_maps_locked(cpu, target);
 	cpu_maps_update_done();
@@ -1239,6 +1252,8 @@ static int do_cpu_up(unsigned int cpu, enum cpuhp_state target)
 #endif
 		return -EINVAL;
 	}
+
+	cpuset_wait_for_hotplug();
 
 	switch_err = switch_to_rt_policy();
 	if (switch_err < 0)


### PR DESCRIPTION
This patchset introduces bugfixes for:
- IOMMU shutdown (stabilization)
- Hotplug (scheduler issue: solves unexpected battery drain and performance drops)
- KGSL (Adreno 6xx corner case: stabilization)
- 14nm 8996/630/636/660 DSI PLL (stabilization)
- SDE  (stabilization for legacy and new gen)

And improvements for:
- NT36672A (DRM support, further cleanup)
- Mermaid panel (HDR parameters)
- SDE (Selective clock gating for SDM845, ULPS support)

Tested on SoMC Tama Akari RoW and SoMC Tama Akari RoW HEADLESS
Partially tested on SoMC Ganges Mermaid DSDS