### PR TITLE
[2.3.2.r1.4] [Ganges] Add QSEECom TA heap

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
@@ -27,6 +27,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@27 { /* QSEECOM HEAP */
 			reg = <27>;
 			memory-region = <&qseecom_mem>;

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -387,6 +387,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;

--- a/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
@@ -27,6 +27,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@27 { /* QSEECOM HEAP */
 			reg = <27>;
 			memory-region = <&qseecom_mem>;

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -385,6 +385,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;


### PR DESCRIPTION
Sony Open Devices blobs for Ganges (which are different/newer than
stock) use a separate heap for TAs. For example, loading the Egistec
fingerprint tzapp results in the following error:
E QSEECOMAPI: Error::Error while trying to allocate data from heap 19
E QSEECOMAPI: Error::ION_memalloc failed
E QSEECOMAPI: Error::Loading image failed with ret = -12
because the heap was missing.
This is a copy of the sdm845 QSEECOM TA heap definition.