### PR TITLE
[2.3.2.r1.4] [URGENT] arm64: DT: sdm845-sde: Explicitly declare unsecured SMMU context

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
@@ -250,6 +250,12 @@
 			};
 		};
 
+		smmu_sde_unsec: qcom,smmu_sde_unsec_cb {
+			compatible = "qcom,smmu_sde_unsec";
+			iommus = <&apps_smmu 0x880 0x8>,
+				<&apps_smmu 0xc80 0x8>;
+		};
+
 		smmu_sde_sec: qcom,smmu_sde_sec_cb {
 			compatible = "qcom,smmu_sde_sec";
 			iommus = <&apps_smmu 0x881 0x8>,


### PR DESCRIPTION
Latest (custom) updates to the code require everyone to actually
explicitly declare also the unsecured context for the SDE.