### PR TITLE
[2.3.2.r1.4] [TESTME!] arm64: DT: Yoshino: Add SoMC Poplar SDE configuration

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-base-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-base-sde.dtsi
@@ -1,0 +1,554 @@
+/* Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2016 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#include "dsi-panel-somc-poplar-id6_pcc.dtsi"
+#include "dsi-panel-somc-poplar-id9_pcc.dtsi"
+
+&sde_kms {
+	/* JDI ID6 */
+	sde_dsi_6: somc,sde_6_panel {
+		qcom,mdss-dsi-panel-name = "6";
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-pulse-width = <8>;
+		qcom,mdss-dsi-v-front-porch = <227>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,mdss-dsi-on-command = [
+				29 01 00 00 00 00 02 B0 00
+				29 01 00 00 00 00 02 D6 01
+				29 01 00 00 00 00 08 C2 01 07 80 04 00 04 F0
+				29 01 00 00 00 00 03 C4 70 22
+				29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+				29 01 00 00 00 00 02 B0 03
+				39 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 02 36 00
+				39 01 00 00 00 00 02 3A 77
+				39 01 00 00 00 00 05 2A 00 00 04 37
+				39 01 00 00 00 00 05 2B 00 00 07 7F
+				39 01 00 00 00 00 03 44 00 00
+				39 01 00 00 78 00 01 11];
+		qcom,mdss-dsi-post-panel-on-command = [
+				39 01 00 00 00 00 01 29];
+		qcom,mdss-dsi-off-command = [
+				39 01 00 00 14 00 01 28
+				29 01 00 00 00 00 02 B0 00
+				29 01 00 00 00 00 02 D6 01
+				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+				29 01 00 00 00 00 02 B0 03
+				39 01 00 00 78 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+		qcom,mdss-dsi-t-clk-post = <0x07>;
+		qcom,mdss-dsi-t-clk-pre = <0x29>;
+
+		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_hybrid_incell>;
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+
+		qcom,mdss-dsi-panel-hdr-enabled;
+		qcom,mdss-dsi-panel-hdr-color-primaries = <14940 15790 33800 15700 10950 33800 7450 2300>;
+		qcom,mdss-dsi-panel-peak-brightness = <7000000>;
+		qcom,mdss-dsi-panel-blackness-level = <4646>;
+
+		somc,lcd-id = <0>;
+		somc,lcd-id-adc = <565000 653000>;
+		somc,mdss-dsi-master;
+		somc,pw-on-rst-seq = <0 15>, <1 16>, <0 15>, <1 20>;
+		somc,pw-off-rst-b-seq = <0 11>;
+		somc,pw-wait-after-on-vdd = <0>;
+		somc,pw-wait-after-on-vddio = <1>;
+		somc,pw-wait-after-on-vsp = <1>;
+		somc,pw-wait-after-on-vsn = <0>;
+		somc,pw-wait-after-off-vdd = <0>;
+		somc,pw-wait-after-off-vddio = <1>;
+		somc,pw-wait-after-off-vsp = <8>;
+		somc,pw-wait-after-off-vsn = <8>;
+		somc,pw-wait-after-on-touch-avdd = <1>;
+		somc,pw-wait-after-on-touch-vddio = <0>;
+		somc,pw-wait-after-on-touch-reset = <0>;
+		somc,pw-wait-after-on-touch-int-n = <10>;
+		somc,pw-wait-after-off-touch-avdd = <0>;
+		somc,pw-wait-after-off-touch-vddio = <0>;
+		somc,pw-wait-after-off-touch-reset = <11>;
+		somc,pw-wait-after-off-touch-int-n = <0>;
+		somc,pw-down-period = <300>;
+
+		somc,lab-output-voltage = <5600000>;
+		somc,ibb-output-voltage = <5600000>;
+		somc,qpnp-lab-limit-maximum-current = <200>;
+		somc,qpnp-ibb-limit-maximum-current = <800>;
+		somc,qpnp-lab-max-precharge-time = <500>;
+		somc,qpnp-lab-soft-start = <800>;
+		somc,qpnp-ibb-discharge-resistor = <300>;
+		somc,qpnp-lab-pull-down-enable;
+		somc,qpnp-lab-full-pull-down;
+		somc,qpnp-ibb-pull-down-enable;
+		somc,qpnp-ibb-full-pull-down;
+
+		somc,ewu-wait-after-touch-reset = <40>;
+
+		somc,change-fps-enable;
+		somc,change-fps-panel-type = "hybrid_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
+		somc,change-fps-command =
+				[29 01 00 00 00 00 02 B0 04
+				 29 01 00 00 00 00 02 D6 01
+				 29 01 00 00 00 00 08 C2 01 07 80 04 00 04 F0];
+		somc,driver-ic-rtn = <83>;
+		somc,driver-ic-vdisp = <1920>;
+		somc,driver-ic-vtouch = <6818000>;
+		somc,driver-ic-mclk = <61539>;
+		somc,change-fps-send-pos = <2 4>;
+		somc,change-fps-send-byte = <4>;
+		somc,change-fps-porch-mask-pos = <3>;
+		somc,change-fps-porch-mask = <0xF0>;
+		somc,change-fps-porch-range = <4 511>;
+
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-pan-physical-width-dimension = <64>;
+				qcom,mdss-pan-physical-height-dimension = <114>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-h-sync-skew = <0>;
+				qcom,mdss-dsi-h-left-border = <0>;
+				qcom,mdss-dsi-h-right-border = <0>;
+				qcom,mdss-dsi-v-top-border = <0>;
+				qcom,mdss-dsi-v-bottom-border = <0>;
+				qcom,mdss-dsi-h-sync-pulse = <1>;
+				qcom,mdss-dsi-panel-phy-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 08 C2 01 07 80 04 00 04 F0
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
+			};
+		};
+	};
+
+	/* Sharp ID9 */
+	sde_dsi_9: somc,sde_9_panel {
+		qcom,mdss-dsi-panel-name = "9";
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-pulse-width = <8>;
+		qcom,mdss-dsi-v-front-porch = <227>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,mdss-dsi-on-command = [
+				39 01 00 00 00 00 02 35 00
+				05 01 00 00 00 00 01 29
+				];
+		qcom,mdss-dsi-post-panel-on-command = [
+				05 01 00 00 00 00 01 11
+				];
+		qcom,mdss-dsi-off-command = [
+				05 01 00 00 00 00 01 28
+				05 01 00 00 78 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+		qcom,mdss-dsi-t-clk-post = <0x07>;
+		qcom,mdss-dsi-t-clk-pre = <0x29>;
+
+		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_full_incell>;
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+
+		qcom,mdss-dsi-panel-hdr-enabled;
+		qcom,mdss-dsi-panel-hdr-color-primaries = <14940 15790 33800 15700 10950 33800 7450 2300>;
+		qcom,mdss-dsi-panel-peak-brightness = <7000000>;
+		qcom,mdss-dsi-panel-blackness-level = <4646>;
+
+		somc,lcd-id = <0>;
+		somc,lcd-id-adc = <0 57000>;
+		somc,mdss-dsi-master;
+		somc,pw-on-rst-seq = <0 15>, <1 20>;
+		somc,pw-off-rst-b-seq = <0 11>;
+		somc,pw-wait-after-on-vdd = <0>;
+		somc,pw-wait-after-on-vddio = <10>;
+		somc,pw-wait-after-on-vsp = <10>;
+		somc,pw-wait-after-on-vsn = <0>;
+		somc,pw-wait-after-off-vdd = <0>;
+		somc,pw-wait-after-off-vddio = <0>;
+		somc,pw-wait-after-off-vsp = <8>;
+		somc,pw-wait-after-off-vsn = <8>;
+		somc,pw-wait-after-on-touch-vddio = <0>;
+		somc,pw-wait-after-on-touch-reset = <0>;
+		somc,pw-wait-after-on-touch-int-n = <10>;
+		somc,pw-wait-after-off-touch-vddio = <0>;
+		somc,pw-wait-after-off-touch-reset = <11>;
+		somc,pw-wait-after-off-touch-int-n = <0>;
+		somc,pw-down-period = <300>;
+
+		somc,lab-output-voltage = <5600000>;
+		somc,ibb-output-voltage = <5600000>;
+		somc,qpnp-lab-limit-maximum-current = <200>;
+		somc,qpnp-ibb-limit-maximum-current = <800>;
+		somc,qpnp-lab-max-precharge-time = <500>;
+		somc,qpnp-lab-soft-start = <800>;
+		somc,qpnp-ibb-discharge-resistor = <300>;
+		somc,qpnp-lab-pull-down-enable;
+		somc,qpnp-lab-full-pull-down;
+		somc,qpnp-ibb-pull-down-enable;
+		somc,qpnp-ibb-full-pull-down;
+
+		somc,ewu-rst-seq = <0 2>, <1 5>;
+		somc,ewu-wait-after-touch-reset = <0>;
+
+		somc,change-fps-enable;
+		somc,change-fps-panel-type = "full_incell_type";
+		somc,change-fps-panel-mode = "dynamic_mode";
+		somc,change-fps-command =
+				[29 01 00 00 00 00 02 B0 04
+				 29 01 00 00 00 00 02 D6 01
+				 29 01 00 00 00 00 02 C6 59];
+		somc,driver-ic-total-porch = <11>;
+		somc,driver-ic-vdisp = <1920>;
+		somc,driver-ic-rclk = <14000000>;
+		somc,driver-ic-vtp = <682>;
+		somc,change-fps-rtn-pos = <2 1>;
+
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-pan-physical-width-dimension = <64>;
+				qcom,mdss-pan-physical-height-dimension = <114>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-h-sync-skew = <0>;
+				qcom,mdss-dsi-h-left-border = <0>;
+				qcom,mdss-dsi-h-right-border = <0>;
+				qcom,mdss-dsi-v-top-border = <0>;
+				qcom,mdss-dsi-v-bottom-border = <0>;
+				qcom,mdss-dsi-h-sync-pulse = <1>;
+				qcom,mdss-dsi-panel-phy-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+				qcom,mdss-dsi-on-command = [
+						39 01 00 00 00 00 02 35 00
+						05 01 00 00 00 00 01 29
+						39 01 00 00 78 00 01 11];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						39 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
+			};
+		};
+	};
+
+	/* Default */
+	sde_dsi_default_panel: somc,sde_default_cmd_panel {
+		qcom,mdss-dsi-panel-name = "default";
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
+		qcom,mdss-dsi-panel-destination = "display_1";
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-h-back-porch = <8>;
+		qcom,mdss-dsi-h-pulse-width = <8>;
+		qcom,mdss-dsi-h-front-porch = <56>;
+		qcom,mdss-dsi-v-back-porch = <8>;
+		qcom,mdss-dsi-v-pulse-width = <8>;
+		qcom,mdss-dsi-v-front-porch = <227>;
+		qcom,mdss-pan-physical-width-dimension = <64>;
+		qcom,mdss-pan-physical-height-dimension = <114>;
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-border-color = <0>;
+		qcom,mdss-dsi-h-sync-pulse = <1>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,mdss-dsi-on-command = [
+				29 01 00 00 00 00 02 B0 00
+				29 01 00 00 00 00 02 D6 01
+				29 01 00 00 00 00 08 C2 01 07 80 04 00 04 F0
+				29 01 00 00 00 00 03 C4 70 22
+				29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+				29 01 00 00 00 00 02 B0 03
+				39 01 00 00 00 00 02 35 00
+				39 01 00 00 00 00 02 36 00
+				39 01 00 00 00 00 02 3A 77
+				39 01 00 00 00 00 05 2A 00 00 04 37
+				39 01 00 00 00 00 05 2B 00 00 07 7F
+				39 01 00 00 00 00 03 44 00 00
+				39 01 00 00 78 00 01 11];
+		qcom,mdss-dsi-post-panel-on-command = [
+				39 01 00 00 00 00 01 29];
+		qcom,mdss-dsi-off-command = [
+				39 01 00 00 14 00 01 28
+				29 01 00 00 00 00 02 B0 00
+				29 01 00 00 00 00 02 D6 01
+				29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+				29 01 00 00 00 00 02 B0 03
+				39 01 00 00 78 00 01 10];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+		qcom,mdss-dsi-t-clk-post = <0x07>;
+		qcom,mdss-dsi-t-clk-pre = <0x29>;
+
+		qcom,panel-supply-entries = <&dsi_panel_pwr_supply_hybrid_incell>;
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-bl-min-level = <1>;
+		qcom,mdss-dsi-bl-max-level = <4095>;
+		qcom,mdss-brightness-max-level = <4095>;
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
+
+		qcom,mdss-dsi-panel-hdr-enabled;
+		qcom,mdss-dsi-panel-hdr-color-primaries = <14940 15790 33800 15700 10950 33800 7450 2300>;
+		qcom,mdss-dsi-panel-peak-brightness = <7000000>;
+		qcom,mdss-dsi-panel-blackness-level = <4646>;
+
+		qcom,mdss-dsi-panel-clockrate = <899000000>;
+
+		somc,lcd-id = <0>;
+		somc,lcd-id-adc = <0 0x7fffffff>;
+		somc,mdss-dsi-master;
+		somc,pw-on-rst-seq = <0 15>, <1 16>, <0 15>, <1 20>;
+		somc,pw-off-rst-b-seq = <0 11>;
+		somc,pw-wait-after-on-vdd = <0>;
+		somc,pw-wait-after-on-vddio = <1>;
+		somc,pw-wait-after-on-vsp = <1>;
+		somc,pw-wait-after-on-vsn = <0>;
+		somc,pw-wait-after-off-vdd = <0>;
+		somc,pw-wait-after-off-vddio = <1>;
+		somc,pw-wait-after-off-vsp = <8>;
+		somc,pw-wait-after-off-vsn = <8>;
+		somc,pw-wait-after-on-touch-avdd = <1>;
+		somc,pw-wait-after-on-touch-vddio = <0>;
+		somc,pw-wait-after-on-touch-reset = <0>;
+		somc,pw-wait-after-on-touch-int-n = <10>;
+		somc,pw-wait-after-off-touch-avdd = <0>;
+		somc,pw-wait-after-off-touch-vddio = <0>;
+		somc,pw-wait-after-off-touch-reset = <11>;
+		somc,pw-wait-after-off-touch-int-n = <0>;
+		somc,pw-down-period = <300>;
+
+		somc,lab-output-voltage = <5600000>;
+		somc,ibb-output-voltage = <5600000>;
+		somc,qpnp-lab-limit-maximum-current = <200>;
+		somc,qpnp-ibb-limit-maximum-current = <800>;
+		somc,qpnp-lab-max-precharge-time = <500>;
+		somc,qpnp-lab-soft-start = <800>;
+		somc,qpnp-ibb-discharge-resistor = <300>;
+		somc,qpnp-lab-pull-down-enable;
+		somc,qpnp-lab-full-pull-down;
+		somc,qpnp-ibb-pull-down-enable;
+		somc,qpnp-ibb-full-pull-down;
+
+		somc,ewu-wait-after-touch-reset = <40>;
+
+		somc,mdss-dsi-disp-on-in-hs = <0>;
+		somc,mdss-dsi-wait-time-before-post-on-cmd = <0>;
+		qcom,mdss-dsi-display-timings {
+			1080p60 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <1920>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <56>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <227>;
+				qcom,mdss-pan-physical-width-dimension = <64>;
+				qcom,mdss-pan-physical-height-dimension = <114>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-h-sync-skew = <0>;
+				qcom,mdss-dsi-h-left-border = <0>;
+				qcom,mdss-dsi-h-right-border = <0>;
+				qcom,mdss-dsi-v-top-border = <0>;
+				qcom,mdss-dsi-v-bottom-border = <0>;
+				qcom,mdss-dsi-h-sync-pulse = <1>;
+				qcom,mdss-dsi-panel-phy-timings = [00 1B 06 06 0B 11 05 07 05 03 04 00];
+				qcom,mdss-dsi-on-command = [
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 08 C2 01 07 80 04 00 04 F0
+						29 01 00 00 00 00 03 C4 70 22
+						29 01 00 00 00 00 15 C6 53 2E 2E 05 45 00 00 00 00 00 00 42 0F 00 00 00 00 04 10 06
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B B5
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 00 00 02 35 00
+						39 01 00 00 00 00 02 36 00
+						39 01 00 00 00 00 02 3A 77
+						39 01 00 00 00 00 05 2A 00 00 04 37
+						39 01 00 00 00 00 05 2B 00 00 07 7F
+						39 01 00 00 00 00 03 44 00 00
+						39 01 00 00 78 00 01 11
+						39 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-off-command = [
+						39 01 00 00 14 00 01 28
+						29 01 00 00 00 00 02 B0 00
+						29 01 00 00 00 00 02 D6 01
+						29 01 00 00 00 00 0E EC 64 DC EC 3B 52 00 0B 0B 13 15 68 0B 95
+						29 01 00 00 00 00 02 B0 03
+						39 01 00 00 78 00 01 10];
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-dsi-panel-clockrate = <899000000>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-sde.dtsi
@@ -1,0 +1,68 @@
+/* Copyright (c) 2018, AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+&sde_dsi_6 {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	somc,disp-dcdc-en-gpio = <&pmi8998_gpios 10 0>;
+	qcom,mdss-dsi-reset-sequence = <0 15>, <1 16>, <0 15>, <1 20>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 5>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p60 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&sde_dsi_9 {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	qcom,mdss-dsi-reset-sequence = <0 15>, <1 20>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 5>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p60 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
+&sde_dsi_default_panel {
+	qcom,platform-te-gpio = <&tlmm 10 0>;
+	qcom,platform-reset-gpio = <&tlmm 94 0>;
+	qcom,platform-touch-vddio-en-gpio = <&tlmm 133 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 89 0>;
+	qcom,mdss-dsi-reset-sequence = <0 10>, <1 16>, <0 7>, <1 16>;
+	qcom,mdss-dsi-touch-reset-sequence = <1 5>;
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
+	somc,pw-on-rst-seq = "after_power_on";
+	qcom,mdss-dsi-display-timings {
+		1080p60 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2-yoshino-poplar-sde_generic.dts
@@ -1,0 +1,48 @@
+/* Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2017 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+
+/dts-v1/;
+
+#include "msm8998-v2.dtsi"
+#include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
+#include "msm8998-yoshino-common-sde-overlay.dtsi"
+#include "msm8998-yoshino-poplar_common.dtsi"
+#include "dsi-panel-somc-poplar-base-sde.dtsi"
+#include "dsi-panel-somc-poplar-sde.dtsi"
+
+/ {
+	model = "SoMC Poplar-ROW(MSM8998 v2)";
+	compatible = "somc,poplar-row", "qcom,msm8998";
+	qcom,board-id = <8 0>;
+};
+
+/* Disable MDSS rotator node to use SDE rotator. */
+&mdss_rotator {
+	status = "disabled";
+};
+
+&sde_rotator {
+	status = "ok";
+};
+
+&dsi_panel_cmd_display {
+	qcom,dsi-panel = <&sde_dsi_9>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar-sde_generic.dts
+++ b/arch/arm64/boot/dts/qcom/msm8998-v2.1-yoshino-poplar-sde_generic.dts
@@ -1,0 +1,49 @@
+/* Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2017 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+
+/dts-v1/;
+
+#include "msm8998-v2.1.dtsi"
+#include "msm8998-mtp.dtsi"
+#include "msm8998-yoshino-common.dtsi"
+#include "msm8998-yoshino-common-sde-overlay.dtsi"
+#include "msm8998-yoshino-poplar_common.dtsi"
+#include "dsi-panel-somc-poplar-base-sde.dtsi"
+#include "dsi-panel-somc-poplar-sde.dtsi"
+
+/ {
+	model = "SoMC Poplar-ROW(MSM8998 v2.1)";
+	compatible = "somc,poplar-row", "qcom,msm8998";
+	qcom,board-id = <8 0>;
+};
+
+/* Disable MDSS rotator node to use SDE rotator. */
+&mdss_rotator {
+	status = "disabled";
+};
+
+&sde_rotator {
+	status = "ok";
+};
+
+&dsi_panel_cmd_display {
+	qcom,dsi-panel = <&sde_dsi_9>;
+};
+	


### PR DESCRIPTION
The last missing piece for full Yoshino SDE migration was Poplar.
Add the DTs for it.