### PR TITLE
[2.3.2.r1.4] Fix all Clang warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,7 +507,11 @@ endif
 
 ifeq ($(cc-name),clang)
 ifneq ($(CROSS_COMPILE),)
-CLANG_FLAGS	:= --target=$(notdir $(CROSS_COMPILE:%-=%))
+CLANG_TRIPLE	?= $(CROSS_COMPILE)
+CLANG_FLAGS	:= --target=$(notdir $(CLANG_TRIPLE:%-=%))
+ifeq ($(shell $(srctree)/scripts/clang-android.sh $(CC) $(CLANG_FLAGS)), y)
+$(error "Clang with Android --target detected. Did you specify CLANG_TRIPLE?")
+endif
 GCC_TOOLCHAIN_DIR := $(dir $(shell which $(LD)))
 CLANG_FLAGS	+= --prefix=$(GCC_TOOLCHAIN_DIR)
 GCC_TOOLCHAIN	:= $(realpath $(GCC_TOOLCHAIN_DIR)/..)

--- a/Makefile
+++ b/Makefile
@@ -784,8 +784,7 @@ KBUILD_CFLAGS += $(stackp-flag)
 
 ifeq ($(cc-name),clang)
 ifneq ($(CROSS_COMPILE),)
-CLANG_TRIPLE    ?= $(CROSS_COMPILE)
-CLANG_TARGET	:= -target $(notdir $(CLANG_TRIPLE:%-=%))
+CLANG_TARGET	:= -target $(notdir $(CROSS_COMPILE:%-=%))
 GCC_TOOLCHAIN	:= $(realpath $(dir $(shell which $(LD)))/..)
 endif
 ifneq ($(GCC_TOOLCHAIN),)

--- a/Makefile
+++ b/Makefile
@@ -507,8 +507,7 @@ endif
 
 ifeq ($(cc-name),clang)
 ifneq ($(CROSS_COMPILE),)
-CLANG_TRIPLE    ?= $(CROSS_COMPILE)
-CLANG_FLAGS	:= --target=$(notdir $(CLANG_TRIPLE:%-=%))
+CLANG_FLAGS	:= --target=$(notdir $(CROSS_COMPILE:%-=%))
 GCC_TOOLCHAIN_DIR := $(dir $(shell which $(LD)))
 CLANG_FLAGS	+= --prefix=$(GCC_TOOLCHAIN_DIR)
 GCC_TOOLCHAIN	:= $(realpath $(GCC_TOOLCHAIN_DIR)/..)

--- a/Makefile
+++ b/Makefile
@@ -783,15 +783,6 @@ endif
 KBUILD_CFLAGS += $(stackp-flag)
 
 ifeq ($(cc-name),clang)
-ifneq ($(CROSS_COMPILE),)
-CLANG_TARGET	:= -target $(notdir $(CROSS_COMPILE:%-=%))
-GCC_TOOLCHAIN	:= $(realpath $(dir $(shell which $(LD)))/..)
-endif
-ifneq ($(GCC_TOOLCHAIN),)
-CLANG_GCC_TC	:= -gcc-toolchain $(GCC_TOOLCHAIN)
-endif
-KBUILD_CFLAGS += $(CLANG_TARGET) $(CLANG_GCC_TC)
-KBUILD_AFLAGS += $(CLANG_TARGET) $(CLANG_GCC_TC)
 KBUILD_CPPFLAGS += $(call cc-option,-Qunused-arguments,)
 KBUILD_CFLAGS += $(call cc-disable-warning, format-invalid-specifier)
 KBUILD_CFLAGS += $(call cc-disable-warning, gnu)

--- a/Makefile
+++ b/Makefile
@@ -804,8 +804,6 @@ KBUILD_CFLAGS += $(call cc-disable-warning, tautological-compare)
 # See modpost pattern 2
 KBUILD_CFLAGS += $(call cc-option, -mno-global-merge,)
 KBUILD_CFLAGS += $(call cc-option, -fcatch-undefined-behavior)
-KBUILD_CFLAGS += $(call cc-option, -no-integrated-as)
-KBUILD_AFLAGS += $(call cc-option, -no-integrated-as)
 else
 
 # These warnings generated too much noise in a regular build.

--- a/drivers/char/diag/diagfwd_cntl.c
+++ b/drivers/char/diag/diagfwd_cntl.c
@@ -846,7 +846,7 @@ int diag_add_diag_id_to_list(uint8_t diag_id, char *process_name,
 	new_item->diag_id = diag_id;
 	new_item->pd_val = pd_val;
 	new_item->peripheral = peripheral;
-	strlcpy(new_item->process_name, process_name, strlen(process_name) + 1);
+	strscpy(new_item->process_name, process_name, sizeof(new_item->process_name));
 	INIT_LIST_HEAD(&new_item->link);
 	mutex_lock(&driver->diag_id_mutex);
 	list_add_tail(&new_item->link, &driver->diag_id_list);
@@ -947,8 +947,8 @@ static void process_diagid(uint8_t *buf, uint32_t len,
 
 	ctrl_pkt.pkt_id = DIAG_CTRL_MSG_DIAGID;
 	ctrl_pkt.version = 1;
-	strlcpy((char *)&ctrl_pkt.process_name, process_name,
-		strlen(process_name) + 1);
+	strscpy((char *)&ctrl_pkt.process_name, process_name,
+		sizeof((char *)&ctrl_pkt.process_name));
 	ctrl_pkt.len = sizeof(ctrl_pkt.diag_id) + sizeof(ctrl_pkt.version) +
 			strlen(process_name) + 1;
 	err = diagfwd_write(peripheral, TYPE_CNTL, &ctrl_pkt, ctrl_pkt.len +

--- a/drivers/clk/qcom/clk-cpu-8976.c
+++ b/drivers/clk/qcom/clk-cpu-8976.c
@@ -1624,11 +1624,11 @@ static void __init cpu_clock_early_sel(u32 alias)
 
 	/* Wait for update to take effect */
 	for (count = 500; count > 0; count--) {
-		if (!(readl_relaxed(base)) & BIT(0))
+		if (!(readl_relaxed(base) & BIT(0)))
 			break;
 		udelay(1);
 	}
-	if (!(readl_relaxed(base)) & BIT(0))
+	if (!(readl_relaxed(base) & BIT(0)))
 		panic("RCG configuration didn't update!\n");
 
 	/* Enable the branch */

--- a/drivers/clk/qcom/mdss/mdss-pll.h
+++ b/drivers/clk/qcom/mdss/mdss-pll.h
@@ -27,11 +27,12 @@
 #include "../clk-regmap-divider.h"
 #include "../clk-regmap-mux.h"
 
-#define LEGACY_GDSC_TARGET \
-	defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8953) || \
-	defined(CONFIG_ARCH_MSM8937) || defined(CONFIG_ARCH_MSM8917) || \
-	defined(CONFIG_ARCH_MSM8996) || defined(CONFIG_ARCH_MSM8998) || \
-	defined(CONFIG_ARCH_SDM630) || defined(CONFIG_ARCH_SDM660)
+#if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8953) || \
+    defined(CONFIG_ARCH_MSM8937) || defined(CONFIG_ARCH_MSM8917) || \
+    defined(CONFIG_ARCH_MSM8996) || defined(CONFIG_ARCH_MSM8998) || \
+    defined(CONFIG_ARCH_SDM630) || defined(CONFIG_ARCH_SDM660)
+#define LEGACY_GDSC_TARGET
+#endif
 
 
 #define MDSS_PLL_REG_W(base, offset, data)	\
@@ -215,7 +216,7 @@ static inline bool is_gdsc_disabled(struct mdss_pll_resources *pll_res)
 		WARN(1, "gdsc_base register is not defined\n");
 		return true;
 	}
-#if LEGACY_GDSC_TARGET
+#ifdef LEGACY_GDSC_TARGET
 	return ((readl_relaxed(pll_res->gdsc_base + 0x4) & BIT(31)) &&
 		(!(readl_relaxed(pll_res->gdsc_base) & BIT(0)))) ? false : true;
 #else

--- a/drivers/crypto/msm/Makefile
+++ b/drivers/crypto/msm/Makefile
@@ -4,3 +4,5 @@ obj-$(CONFIG_CRYPTO_DEV_QCEDEV) += qcedev_smmu.o
 obj-$(CONFIG_CRYPTO_DEV_QCRYPTO) += qcrypto.o
 obj-$(CONFIG_CRYPTO_DEV_OTA_CRYPTO) += ota_crypto.o
 obj-$(CONFIG_CRYPTO_DEV_QCOM_ICE) += ice.o
+
+CFLAGS_qcedev.o := $(call cc-option,-Wframe-larger-than=5120)

--- a/drivers/gpu/drm/msm/dp/dp_display.c
+++ b/drivers/gpu/drm/msm/dp/dp_display.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -262,8 +262,7 @@ static void dp_display_deinitialize_hdcp(struct dp_display_private *dp)
 
 	sde_dp_hdcp2p2_deinit(dp->hdcp.data);
 	dp_display_destroy_hdcp_workqueue(dp);
-	if (&dp->hdcp_mutex)
-		mutex_destroy(&dp->hdcp_mutex);
+	mutex_destroy(&dp->hdcp_mutex);
 }
 
 static int dp_display_initialize_hdcp(struct dp_display_private *dp)

--- a/drivers/gpu/drm/msm/sde/sde_hw_interrupts.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_interrupts.c
@@ -18,11 +18,12 @@
 #include "sde_hw_util.h"
 #include "sde_hw_mdss.h"
 
-#define BUILD_FOR_AD4_TARGET \
-	!defined(CONFIG_ARCH_MSM8916) && !defined(CONFIG_ARCH_MSM8953) && \
-	!defined(CONFIG_ARCH_MSM8937) && !defined(CONFIG_ARCH_MSM8917) && \
-	!defined(CONFIG_ARCH_MSM8996) && !defined(CONFIG_ARCH_MSM8998) && \
-	!defined(CONFIG_ARCH_SDM630) && !defined(CONFIG_ARCH_SDM660)
+#if !defined(CONFIG_ARCH_MSM8916) && !defined(CONFIG_ARCH_MSM8953) && \
+    !defined(CONFIG_ARCH_MSM8937) && !defined(CONFIG_ARCH_MSM8917) && \
+    !defined(CONFIG_ARCH_MSM8996) && !defined(CONFIG_ARCH_MSM8998) && \
+    !!defined(CONFIG_ARCH_SDM630) && !defined(CONFIG_ARCH_SDM660)
+#define BUILD_FOR_AD4_TARGET
+#endif
 
 /**
  * Register offsets in MDSS register file for the interrupt registers
@@ -252,7 +253,7 @@ static const struct sde_intr_reg sde_intr_set[] = {
 		MDP_INTF_4_OFF+INTF_INTR_EN,
 		MDP_INTF_4_OFF+INTF_INTR_STATUS
 	},
-#if BUILD_FOR_AD4_TARGET
+#ifdef BUILD_FOR_AD4_TARGET
 	{
 		MDP_AD4_0_OFF + MDP_AD4_INTR_CLEAR_OFF,
 		MDP_AD4_0_OFF + MDP_AD4_INTR_EN_OFF,

--- a/drivers/gpu/drm/msm/sde/sde_plane.c
+++ b/drivers/gpu/drm/msm/sde/sde_plane.c
@@ -4276,7 +4276,7 @@ static void _sde_plane_install_properties(struct drm_plane *plane,
 	psde->catalog = catalog;
 
 	if (sde_is_custom_client()) {
-		if (catalog->mixer_count && catalog->mixer &&
+		if (catalog->mixer_count &&
 				catalog->mixer[0].sblk->maxblendstages) {
 			zpos_max = catalog->mixer[0].sblk->maxblendstages - 1;
 			if (zpos_max > SDE_STAGE_MAX - SDE_STAGE_0 - 1)

--- a/drivers/hwmon/qpnp-adc-common.c
+++ b/drivers/hwmon/qpnp-adc-common.c
@@ -1982,7 +1982,7 @@ int32_t qpnp_adc_scale_default(struct qpnp_vadc_chip *vadc,
 	} else {
 		qpnp_adc_scale_with_calib_param(adc_code, adc_properties,
 					chan_properties, &scale_voltage);
-		if (!chan_properties->calib_type == CALIB_ABSOLUTE)
+		if (chan_properties->calib_type)
 			scale_voltage *= 1000;
 	}
 

--- a/drivers/input/misc/adux1050.c
+++ b/drivers/input/misc/adux1050.c
@@ -3434,7 +3434,7 @@ static ssize_t store_proxy_time(struct device *dev,
 	} else if (ret == -ERANGE) {
 		dev_err(adux1050->dev, "[ADUX1050]: Values not in RANGE\n");
 		goto error;
-	} else if ((ret == -EINVAL)) {
+	} else if (ret == -EINVAL) {
 		dev_err(adux1050->dev, "[ADUX1050]: Invalid COMD/ARG\n");
 		goto error;
 	} else {

--- a/drivers/iommu/arm-smmu.c
+++ b/drivers/iommu/arm-smmu.c
@@ -639,7 +639,7 @@ static void parse_driver_options(struct arm_smmu_device *smmu)
 	} while (arm_smmu_options[++i].opt);
 
 	if (arm_smmu_opt_hibernation(smmu) &&
-	    smmu->options && ARM_SMMU_OPT_SKIP_INIT) {
+	    smmu->options & ARM_SMMU_OPT_SKIP_INIT) {
 		dev_info(smmu->dev,
 			 "Disabling incompatible option: skip-init\n");
 		smmu->options &= ~ARM_SMMU_OPT_SKIP_INIT;

--- a/drivers/irqchip/irq-gic.c
+++ b/drivers/irqchip/irq-gic.c
@@ -416,10 +416,12 @@ static void gic_handle_cascade_irq(struct irq_desc *desc)
 	chained_irq_exit(chip, desc);
 }
 
+#ifdef CONFIG_QTI_MPM
 static int msm_qgic2_set_wake(struct irq_data *d, unsigned int on)
 {
 	return 0;
 }
+#endif
 
 static struct irq_chip gic_chip = {
 	.irq_mask		= gic_mask_irq,

--- a/drivers/media/platform/msm/camera/cam_cdm/cam_cdm_intf.c
+++ b/drivers/media/platform/msm/camera/cam_cdm/cam_cdm_intf.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -166,8 +166,7 @@ int cam_cdm_acquire(struct cam_cdm_acquire_data *data)
 	struct cam_hw_intf *hw;
 	uint32_t hw_index = 0;
 
-	if ((!data) || (!data->identifier) || (!data->base_array) ||
-		(!data->base_array_cnt))
+	if (!data || !data->base_array_cnt)
 		return -EINVAL;
 
 	if (get_cdm_mgr_refcount()) {

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -713,7 +713,8 @@ static int cam_ife_hw_mgr_acquire_res_ife_out_rdi(
 	ife_out_res->hw_res[0] = vfe_acquire.vfe_out.rsrc_node;
 	ife_out_res->is_dual_vfe = 0;
 	ife_out_res->res_id = vfe_out_res_id;
-	ife_out_res->res_type = CAM_ISP_RESOURCE_VFE_OUT;
+	ife_out_res->res_type = (enum cam_ife_hw_mgr_res_type)
+		CAM_ISP_RESOURCE_VFE_OUT;
 	ife_src_res->child[ife_src_res->num_children++] = ife_out_res;
 
 	return 0;
@@ -803,7 +804,8 @@ static int cam_ife_hw_mgr_acquire_res_ife_out_pixel(
 				ife_out_res->hw_res[j]->res_id);
 
 		}
-		ife_out_res->res_type = CAM_ISP_RESOURCE_VFE_OUT;
+		ife_out_res->res_type = (enum cam_ife_hw_mgr_res_type)
+			CAM_ISP_RESOURCE_VFE_OUT;
 		ife_out_res->res_id = out_port->res_type;
 		ife_out_res->parent = ife_src_res;
 		ife_src_res->child[ife_src_res->num_children++] = ife_out_res;
@@ -916,7 +918,8 @@ static int cam_ife_hw_mgr_acquire_res_ife_src(
 			CAM_ERR(CAM_ISP, "Wrong IFE CSID Resource Node");
 			goto err;
 		}
-		ife_src_res->res_type = vfe_acquire.rsrc_type;
+		ife_src_res->res_type = (enum cam_ife_hw_mgr_res_type)
+			vfe_acquire.rsrc_type;
 		ife_src_res->res_id = vfe_acquire.vfe_in.res_id;
 		ife_src_res->is_dual_vfe = csid_res->is_dual_vfe;
 
@@ -1148,7 +1151,8 @@ static int cam_ife_hw_mgr_acquire_res_ife_csid_ipp(
 		goto end;
 	}
 
-	csid_res->res_type = CAM_ISP_RESOURCE_PIX_PATH;
+	csid_res->res_type = (enum cam_ife_hw_mgr_res_type)
+		CAM_ISP_RESOURCE_PIX_PATH;
 	csid_res->res_id = CAM_IFE_PIX_PATH_RES_IPP;
 
 	if (in_port->usage_type)

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_flash/cam_flash_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_flash/cam_flash_core.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -184,7 +184,7 @@ static int cam_flash_ops(struct cam_flash_ctrl *flash_ctrl,
 	if (flash_ctrl->switch_trigger)
 		cam_res_mgr_led_trigger_event(
 			flash_ctrl->switch_trigger,
-			LED_SWITCH_ON);
+			(enum led_brightness)LED_SWITCH_ON);
 
 	return 0;
 }
@@ -198,7 +198,7 @@ int cam_flash_off(struct cam_flash_ctrl *flash_ctrl)
 
 	if (flash_ctrl->switch_trigger)
 		cam_res_mgr_led_trigger_event(flash_ctrl->switch_trigger,
-			LED_SWITCH_OFF);
+			(enum led_brightness)LED_SWITCH_OFF);
 
 	flash_ctrl->flash_state = CAM_FLASH_STATE_START;
 	return 0;

--- a/drivers/media/platform/msm/camera/cam_smmu/cam_smmu_api.c
+++ b/drivers/media/platform/msm/camera/cam_smmu/cam_smmu_api.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -3005,7 +3005,7 @@ int cam_smmu_destroy_handle(int handle)
 		cam_smmu_clean_kernel_buffer_list(idx);
 	}
 
-	if (&iommu_cb_set.cb_info[idx].is_secure) {
+	if (iommu_cb_set.cb_info[idx].is_secure) {
 		if (iommu_cb_set.cb_info[idx].secure_count == 0) {
 			mutex_unlock(&iommu_cb_set.cb_info[idx].lock);
 			return -EPERM;

--- a/drivers/media/platform/msm/camera_v2/common/cam_soc_api.c
+++ b/drivers/media/platform/msm/camera_v2/common/cam_soc_api.c
@@ -208,7 +208,7 @@ int msm_camera_get_clk_info(struct platform_device *pdev,
 {
 	int rc = 0;
 
-	if (!pdev || !&pdev->dev || !clk_info || !clk_ptr || !num_clk)
+	if (!pdev || !clk_info || !clk_ptr || !num_clk)
 		return -EINVAL;
 
 	rc = msm_camera_get_clk_info_internal(&pdev->dev,
@@ -513,7 +513,7 @@ int msm_camera_put_clk_info(struct platform_device *pdev,
 {
 	int rc = 0;
 
-	if (!pdev || !&pdev->dev || !clk_info || !clk_ptr)
+	if (!pdev || !clk_info || !clk_ptr)
 		return -EINVAL;
 
 	rc = msm_camera_put_clk_info_internal(&pdev->dev,

--- a/drivers/media/platform/msm/camera_v2/msm.c
+++ b/drivers/media/platform/msm/camera_v2/msm.c
@@ -607,9 +607,6 @@ static inline int __msm_remove_session_cmd_ack_q(void *d1, void *d2)
 {
 	struct msm_command_ack *cmd_ack = d1;
 
-	if (!(&cmd_ack->command_q))
-		return 0;
-
 	msm_queue_drain(&cmd_ack->command_q, struct msm_command, list);
 
 	return 0;
@@ -617,7 +614,7 @@ static inline int __msm_remove_session_cmd_ack_q(void *d1, void *d2)
 
 static void msm_remove_session_cmd_ack_q(struct msm_session *session)
 {
-	if ((!session) || !(&session->command_ack_q))
+	if (!session)
 		return;
 
 	mutex_lock(&session->lock);

--- a/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/flash/msm_flash.c
@@ -512,13 +512,6 @@ static int32_t msm_flash_i2c_release(
 {
 	int32_t rc = 0;
 
-	if (!(&flash_ctrl->power_info) || !(&flash_ctrl->flash_i2c_client)) {
-		pr_err("%s:%d failed: %pK %pK\n",
-			__func__, __LINE__, &flash_ctrl->power_info,
-			&flash_ctrl->flash_i2c_client);
-		return -EINVAL;
-	}
-
 	rc = msm_camera_power_down(&flash_ctrl->power_info,
 		flash_ctrl->flash_device_type,
 		&flash_ctrl->flash_i2c_client);

--- a/drivers/media/platform/msm/camera_v2/sensor/io/msm_camera_dt_util.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/io/msm_camera_dt_util.c
@@ -1349,7 +1349,7 @@ static int msm_cam_sensor_handle_reg_gpio(int seq_val,
 	CDBG("%s: %d GPIO offset: %d, seq_val: %d\n", __func__, __LINE__,
 		gpio_offset, seq_val);
 
-	if ((gconf->gpio_num_info->valid[gpio_offset] == 1)) {
+	if (gconf->gpio_num_info->valid[gpio_offset] == 1) {
 		gpio_set_value_cansleep(
 			gconf->gpio_num_info->gpio_num
 			[gpio_offset], val);

--- a/drivers/media/platform/msm/vidc/hfi_response_handler.c
+++ b/drivers/media/platform/msm/vidc/hfi_response_handler.c
@@ -1683,13 +1683,9 @@ static int hfi_process_session_rel_buf_done(u32 device_id,
 	cmd_done.size = sizeof(struct msm_vidc_cb_cmd_done);
 	cmd_done.session_id = (void *)(uintptr_t)pkt->session_id;
 	cmd_done.status = hfi_map_err_status(pkt->error_type);
-	if (pkt->rg_buffer_info) {
-		cmd_done.data.buffer_info =
+	cmd_done.data.buffer_info =
 			*(struct hal_buffer_info *)pkt->rg_buffer_info;
-		cmd_done.size = sizeof(struct hal_buffer_info);
-	} else {
-		dprintk(VIDC_ERR, "invalid payload in rel_buff_done\n");
-	}
+	cmd_done.size = sizeof(struct hal_buffer_info);
 
 	info->response_type = HAL_SESSION_RELEASE_BUFFER_DONE;
 	info->response.cmd = cmd_done;

--- a/drivers/media/platform/msm/vidc_3x/hfi_response_handler.c
+++ b/drivers/media/platform/msm/vidc_3x/hfi_response_handler.c
@@ -1679,13 +1679,9 @@ static int hfi_process_session_rel_buf_done(u32 device_id,
 	cmd_done.size = sizeof(struct msm_vidc_cb_cmd_done);
 	cmd_done.session_id = (void *)(uintptr_t)pkt->session_id;
 	cmd_done.status = hfi_map_err_status(pkt->error_type);
-	if (pkt->rg_buffer_info) {
-		cmd_done.data.buffer_info =
+	cmd_done.data.buffer_info =
 			*(struct hal_buffer_info *)pkt->rg_buffer_info;
-		cmd_done.size = sizeof(struct hal_buffer_info);
-	} else {
-		dprintk(VIDC_ERR, "invalid payload in rel_buff_done\n");
-	}
+	cmd_done.size = sizeof(struct hal_buffer_info);
 
 	*info = (struct msm_vidc_cb_info) {
 		.response_type =  HAL_SESSION_RELEASE_BUFFER_DONE,

--- a/drivers/mmc/core/sdio_cis.c
+++ b/drivers/mmc/core/sdio_cis.c
@@ -55,7 +55,7 @@ static int cistpl_vers_1(struct mmc_card *card, struct sdio_func *func,
 
 	for (i = 0; i < nr_strings; i++) {
 		buffer[i] = string;
-		strlcpy(string, buf, strlen(buf) + 1);
+		memcpy(string, buf, strlen(buf) + 1);
 		string += strlen(string) + 1;
 		buf += strlen(buf) + 1;
 	}

--- a/drivers/pci/host/pci-msm.c
+++ b/drivers/pci/host/pci-msm.c
@@ -5622,7 +5622,7 @@ static void msm_pcie_config_link_pm_rc(struct msm_pcie_dev_t *dev,
 {
 	bool child_l0s_enable = 0, child_l1_enable = 0, child_l1ss_enable = 0;
 
-	if (!pdev->subordinate || !(&pdev->subordinate->devices)) {
+	if (!pdev->subordinate) {
 		PCIE_DBG(dev,
 			"PCIe: RC%d: no device connected to root complex\n",
 			dev->rc_idx);

--- a/drivers/phy/phy-qcom-qmp.c
+++ b/drivers/phy/phy-qcom-qmp.c
@@ -1453,7 +1453,7 @@ static int qcom_qmp_phy_probe(struct platform_device *pdev)
 	dev_set_drvdata(dev, qmp);
 
 	/* Get the specific init parameters of QMP phy */
-	qmp->cfg = of_device_get_match_data(dev);
+	qmp->cfg = (struct qmp_phy_cfg *)of_device_get_match_data(dev);
 	if (!qmp->cfg)
 		return -EINVAL;
 

--- a/drivers/platform/msm/ipa/ipa_v2/rmnet_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v2/rmnet_ipa.c
@@ -691,7 +691,7 @@ static int wwan_add_ul_flt_rule_to_ipa(void)
 	/* send ipa_fltr_installed_notif_req_msg_v01 to Q6*/
 	req->source_pipe_index =
 		ipa2_get_ep_mapping(IPA_CLIENT_APPS_LAN_WAN_PROD);
-	req->install_status = QMI_RESULT_SUCCESS_V01;
+	req->install_status = IPA_QMI_RESULT_SUCCESS_V01;
 	req->filter_index_list_len = num_q6_rule;
 	mutex_lock(&ipa_qmi_lock);
 	for (i = 0; i < num_q6_rule; i++) {

--- a/drivers/platform/msm/ipa/ipa_v3/ipa_rt.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_rt.c
@@ -1242,7 +1242,7 @@ int ipa3_add_rt_rule_after(struct ipa_ioc_add_rt_rule_after *rules)
 	tbl = __ipa3_find_rt_tbl(rules->ip, rules->rt_tbl_name);
 	if (tbl == NULL || (tbl->cookie != IPA_RT_TBL_COOKIE)) {
 		IPAERR_RL("failed finding rt tbl name = %s\n",
-			rules->rt_tbl_name ? rules->rt_tbl_name : "");
+			(rules->rt_tbl_name != NULL) ? rules->rt_tbl_name : "");
 		ret = -EINVAL;
 		goto bail;
 	}

--- a/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2014-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -728,7 +728,8 @@ static int ipa3_wwan_add_ul_flt_rule_to_ipa(void)
 		retval = -EFAULT;
 	}
 
-	req->install_status = QMI_RESULT_SUCCESS_V01;
+	req->install_status = (enum ipa_qmi_result_type_v01)
+							QMI_RESULT_SUCCESS_V01;
 	req->rule_id_valid = 1;
 	req->rule_id_len = rmnet_ipa3_ctx->num_q6_rules;
 	for (i = 0; i < rmnet_ipa3_ctx->num_q6_rules; i++) {

--- a/drivers/platform/msm/usb_bam.c
+++ b/drivers/platform/msm/usb_bam.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1478,7 +1478,7 @@ void usb_bam_finish_suspend_(struct work_struct *w)
 
 	info_ptr = container_of(w, struct usb_bam_ipa_handshake_info,
 			finish_suspend_work);
-	cur_bam = info_ptr->cur_bam_mode;
+	cur_bam = info_ptr->bam_type;
 
 	log_event_dbg("%s: Finishing suspend sequence(BAM=%s)\n", __func__,
 			bam_enable_strings[cur_bam]);

--- a/drivers/regulator/qpnp-lcdb-regulator.c
+++ b/drivers/regulator/qpnp-lcdb-regulator.c
@@ -1873,8 +1873,7 @@ static int qpnp_lcdb_init_bst(struct qpnp_lcdb *lcdb)
 
 		if (lcdb->bst.ps != -EINVAL) {
 			rc = qpnp_lcdb_masked_write(lcdb, lcdb->base +
-					LCDB_PS_CTL_REG, EN_PS_BIT,
-					&lcdb->bst.ps ? EN_PS_BIT : 0);
+					LCDB_PS_CTL_REG, EN_PS_BIT, EN_PS_BIT);
 			if (rc < 0) {
 				pr_err("Failed to disable BST PS rc=%d", rc);
 				return rc;

--- a/drivers/soc/qcom/glink_debugfs.c
+++ b/drivers/soc/qcom/glink_debugfs.c
@@ -567,10 +567,10 @@ void glink_dfs_update_list(struct dentry *curr_dent, struct dentry *parent,
 			spin_lock_init(&dbgfs_dent_s->file_list_lock_lhb0);
 			dbgfs_dent_s->parent = parent;
 			dbgfs_dent_s->self = curr_dent;
-			strlcpy(dbgfs_dent_s->self_name,
-				curr, strlen(curr) + 1);
-			strlcpy(dbgfs_dent_s->par_name, par_dir,
-					strlen(par_dir) + 1);
+			strscpy(dbgfs_dent_s->self_name,
+				curr, sizeof(dbgfs_dent_s->self_name));
+			strscpy(dbgfs_dent_s->par_name, par_dir,
+					sizeof(dbgfs_dent_s->par_name));
 			INIT_WORK(&dbgfs_dent_s->rm_work,
 				  glink_dfs_dent_rm_worker);
 			mutex_lock(&dent_list_lock_lha0);

--- a/drivers/soc/qcom/msm-spm.c
+++ b/drivers/soc/qcom/msm-spm.c
@@ -151,7 +151,7 @@ static uint32_t num_pmic_data;
 static void msm_spm_drv_flush_shadow(struct msm_spm_driver_data *dev,
 		unsigned int reg_index)
 {
-	if (!dev || !dev->reg_shadow)
+	if (!dev)
 		return;
 
 	__raw_writel(dev->reg_shadow[reg_index],

--- a/drivers/soc/qcom/msm_bus/msm_bus_dbg.c
+++ b/drivers/soc/qcom/msm_bus/msm_bus_dbg.c
@@ -577,7 +577,6 @@ static ssize_t  msm_bus_dbg_update_request_write(struct file *file,
 	list_for_each_entry(cldata, &cl_list, list) {
 		if (strnstr(chid, cldata->pdata->name, cnt)) {
 			found = 1;
-			cldata = cldata;
 			strsep(&chid, " ");
 			if (chid) {
 				ret = kstrtoul(chid, 10, &index);

--- a/drivers/soc/qcom/rpm_master_stat.c
+++ b/drivers/soc/qcom/rpm_master_stat.c
@@ -415,8 +415,8 @@ static struct msm_rpm_master_stats_platform_data
 				strlen(master_name) + 1, GFP_KERNEL);
 		if (!pdata->masters[i])
 			goto err;
-		strlcpy(pdata->masters[i], master_name,
-					strlen(master_name) + 1);
+		strscpy(pdata->masters[i], master_name,
+					sizeof(pdata->masters[i]));
 	}
 	return pdata;
 err:

--- a/drivers/soc/qcom/sysmon-qmi.c
+++ b/drivers/soc/qcom/sysmon-qmi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2014-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -480,7 +480,7 @@ int sysmon_send_shutdown(struct subsys_desc *dest_desc)
 	shutdown_ack_ret = wait_for_shutdown_ack(dest_desc);
 	if (shutdown_ack_ret < 0) {
 		pr_err("shutdown_ack SMP2P bit for %s not set\n", data->name);
-		if (!&data->ind_recv.done) {
+		if (!completion_done(&data->ind_recv)) {
 			pr_err("QMI shutdown indication not received\n");
 			ret = shutdown_ack_ret;
 		}

--- a/drivers/soc/qcom/system_stats.c
+++ b/drivers/soc/qcom/system_stats.c
@@ -377,8 +377,8 @@ static int msm_rpmstats_probe(struct platform_device *pdev)
 			pr_err("%s:Failed to get memory\n", __func__);
 			return -ENOMEM;
 		}
-		strlcpy(ss.master[i], master_name,
-					strlen(master_name) + 1);
+		strscpy(ss.master[i], master_name,
+					sizeof(ss.master[i]));
 	}
 
 	dent = debugfs_create_file("system_stats", S_IRUGO, NULL,

--- a/drivers/staging/android/ion/ion_carveout_heap.c
+++ b/drivers/staging/android/ion/ion_carveout_heap.c
@@ -428,7 +428,7 @@ struct ion_heap *ion_secure_carveout_heap_create(
 	}
 
 	manager->heap.ops = &ion_sc_heap_ops;
-	manager->heap.type = ION_HEAP_TYPE_SECURE_CARVEOUT;
+	manager->heap.type = (enum ion_heap_type)ION_HEAP_TYPE_SECURE_CARVEOUT;
 	return &manager->heap;
 
 err:

--- a/drivers/staging/android/ion/ion_cma_heap.c
+++ b/drivers/staging/android/ion/ion_cma_heap.c
@@ -4,7 +4,7 @@
  * Copyright (C) Linaro 2012
  * Author: <benjamin.gaignard@linaro.org> for ST-Ericsson.
  *
- * Copyright (c) 2016-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2016-2019, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -254,7 +254,7 @@ struct ion_heap *ion_cma_heap_create(struct ion_platform_heap *data)
 	 * used to make the link with reserved CMA memory
 	 */
 	heap->priv = data->priv;
-	heap->type = ION_HEAP_TYPE_DMA;
+	heap->type = (enum ion_heap_type)ION_HEAP_TYPE_DMA;
 	cma_heap_has_outer_cache = data->has_outer_cache;
 	return heap;
 }
@@ -436,7 +436,7 @@ struct ion_heap *ion_cma_secure_heap_create(struct ion_platform_heap *data)
 	 * used to make the link with reserved CMA memory
 	 */
 	heap->priv = data->priv;
-	heap->type = ION_HEAP_TYPE_HYP_CMA;
+	heap->type = (enum ion_heap_type)ION_HEAP_TYPE_HYP_CMA;
 	cma_heap_has_outer_cache = data->has_outer_cache;
 	return heap;
 }

--- a/drivers/staging/android/ion/ion_cma_secure_heap.c
+++ b/drivers/staging/android/ion/ion_cma_secure_heap.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) Linaro 2012
  * Author: <benjamin.gaignard@linaro.org> for ST-Ericsson.
- * Copyright (c) 2013-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2019, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -867,7 +867,7 @@ struct ion_heap *ion_secure_cma_heap_create(struct ion_platform_heap *data)
 	mutex_init(&sheap->chunk_lock);
 	mutex_init(&sheap->alloc_lock);
 	sheap->heap.ops = &ion_secure_cma_ops;
-	sheap->heap.type = ION_HEAP_TYPE_SECURE_DMA;
+	sheap->heap.type = (enum ion_heap_type)ION_HEAP_TYPE_SECURE_DMA;
 	sheap->npages = data->size >> PAGE_SHIFT;
 	sheap->base = data->base;
 	sheap->heap_size = data->size;

--- a/drivers/staging/android/ion/ion_system_secure_heap.c
+++ b/drivers/staging/android/ion/ion_system_secure_heap.c
@@ -49,10 +49,10 @@ struct prefetch_info {
 
 static bool is_cp_flag_present(unsigned long flags)
 {
-	return flags && (ION_FLAG_CP_TOUCH ||
-			ION_FLAG_CP_BITSTREAM ||
-			ION_FLAG_CP_PIXEL ||
-			ION_FLAG_CP_NON_PIXEL ||
+	return flags & (ION_FLAG_CP_TOUCH |
+			ION_FLAG_CP_BITSTREAM |
+			ION_FLAG_CP_PIXEL |
+			ION_FLAG_CP_NON_PIXEL |
 			ION_FLAG_CP_CAMERA);
 }
 

--- a/drivers/staging/android/ion/ion_system_secure_heap.c
+++ b/drivers/staging/android/ion/ion_system_secure_heap.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2014-2016,2018 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2014-2016, 2018-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -118,7 +118,7 @@ static int ion_system_secure_heap_allocate(
 						heap);
 
 	if (!ion_heap_is_system_secure_heap_type(secure_heap->heap.type) ||
-	    !is_cp_flag_present(flags)) {
+	    !(is_cp_flag_present(flags) || (flags & ION_FLAG_SECURE))) {
 		pr_info("%s: Incorrect heap type or incorrect flags\n",
 			__func__);
 		return -EINVAL;
@@ -393,7 +393,7 @@ struct ion_heap *ion_system_secure_heap_create(struct ion_platform_heap *unused)
 	if (!heap)
 		return ERR_PTR(-ENOMEM);
 	heap->heap.ops = &system_secure_heap_ops;
-	heap->heap.type = ION_HEAP_TYPE_SYSTEM_SECURE;
+	heap->heap.type = (enum ion_heap_type)ION_HEAP_TYPE_SYSTEM_SECURE;
 	heap->sys_heap = get_ion_heap(ION_SYSTEM_HEAP_ID);
 
 	heap->destroy_heap = false;

--- a/drivers/staging/android/ion/msm/msm_ion.c
+++ b/drivers/staging/android/ion/msm/msm_ion.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -840,13 +840,15 @@ long msm_ion_custom_ioctl(struct ion_client *client,
 		int ret;
 
 		ret = ion_walk_heaps(client, data.prefetch_data.heap_id,
-			ION_HEAP_TYPE_SECURE_DMA,
-			(void *)data.prefetch_data.len,
-			ion_secure_cma_prefetch);
+				     (enum ion_heap_type)
+				     ION_HEAP_TYPE_SECURE_DMA,
+				     (void *)data.prefetch_data.len,
+				     ion_secure_cma_prefetch);
 		if (ret)
 			return ret;
 
 		ret = ion_walk_heaps(client, data.prefetch_data.heap_id,
+				     (enum ion_heap_type)
 				     ION_HEAP_TYPE_SYSTEM_SECURE,
 				     (void *)&data.prefetch_data,
 				     ion_system_secure_heap_prefetch);
@@ -858,6 +860,7 @@ long msm_ion_custom_ioctl(struct ion_client *client,
 	{
 		int ret;
 		ret = ion_walk_heaps(client, data.prefetch_data.heap_id,
+				     (enum ion_heap_type)
 				     ION_HEAP_TYPE_SECURE_DMA,
 				     (void *)data.prefetch_data.len,
 				     ion_secure_cma_drain_pool);
@@ -866,6 +869,7 @@ long msm_ion_custom_ioctl(struct ion_client *client,
 			return ret;
 
 		ret = ion_walk_heaps(client, data.prefetch_data.heap_id,
+				     (enum ion_heap_type)
 				     ION_HEAP_TYPE_SYSTEM_SECURE,
 				     (void *)&data.prefetch_data,
 				     ion_system_secure_heap_drain);

--- a/drivers/thermal/qpnp-temp-alarm.c
+++ b/drivers/thermal/qpnp-temp-alarm.c
@@ -403,7 +403,7 @@ static int qpnp_tm_probe(struct platform_device *pdev)
 	int rc = 0;
 	u8 raw_type[2], type, subtype;
 
-	if (!pdev || !(&pdev->dev) || !pdev->dev.of_node) {
+	if (!pdev || !pdev->dev.of_node) {
 		dev_err(&pdev->dev, "%s: device tree node not found\n",
 			__func__);
 		return -EINVAL;

--- a/drivers/thermal/tsens.h
+++ b/drivers/thermal/tsens.h
@@ -69,9 +69,9 @@ struct tsens_dbg_context {
 };
 
 struct tsens_context {
-	enum thermal_device_mode	high_th_state;
-	enum thermal_device_mode	low_th_state;
-	enum thermal_device_mode	crit_th_state;
+	int				high_th_state;
+	int				low_th_state;
+	int				crit_th_state;
 	int				high_temp;
 	int				low_temp;
 	int				crit_temp;

--- a/drivers/tty/serial/msm_smd_tty.c
+++ b/drivers/tty/serial/msm_smd_tty.c
@@ -370,9 +370,6 @@ static int smd_tty_dummy_probe(struct platform_device *pdev)
 	int n;
 
 	for (n = 0; n < MAX_SMD_TTYS; ++n) {
-		if (!smd_tty[n].dev_name)
-			continue;
-
 		if (pdev->id == smd_tty[n].edge &&
 			!strcmp(pdev->name, smd_tty[n].dev_name)) {
 			complete_all(&smd_tty[n].ch_allocated);
@@ -504,7 +501,7 @@ static int smd_tty_port_activate(struct tty_port *tport,
 	struct smd_tty_info *info;
 	const char *peripheral = NULL;
 
-	if (n >= MAX_SMD_TTYS || !smd_tty[n].ch_name)
+	if (n >= MAX_SMD_TTYS)
 		return -ENODEV;
 
 	info = smd_tty + n;

--- a/drivers/usb/gadget/function/f_gsi.h
+++ b/drivers/usb/gadget/function/f_gsi.h
@@ -261,7 +261,7 @@ struct gsi_data_port {
 
 struct f_gsi {
 	struct usb_function function;
-	enum usb_prot_id prot_id;
+	int prot_id;
 	int ctrl_id;
 	int data_id;
 	u32 vendorID;

--- a/drivers/usb/gadget/function/f_qc_rndis.c
+++ b/drivers/usb/gadget/function/f_qc_rndis.c
@@ -331,33 +331,14 @@ static struct usb_endpoint_descriptor rndis_qc_ss_notify_desc = {
 	.bInterval =		RNDIS_QC_LOG2_STATUS_INTERVAL_MSEC + 4,
 };
 
-static struct usb_ss_ep_comp_descriptor ss_intr_comp_desc = {
-	.bLength =		sizeof(ss_intr_comp_desc),
-	.bDescriptorType =	USB_DT_SS_ENDPOINT_COMP,
-
-	/* the following 3 values can be tweaked if necessary */
-	/* .bMaxBurst =		0, */
-	/* .bmAttributes =	0, */
-	.wBytesPerInterval =	cpu_to_le16(RNDIS_QC_STATUS_BYTECOUNT),
-};
-
 static struct usb_ss_ep_comp_descriptor rndis_qc_ss_intr_comp_desc = {
-	.bLength =		sizeof(ss_intr_comp_desc),
+	.bLength =		sizeof(rndis_qc_ss_intr_comp_desc),
 	.bDescriptorType =	USB_DT_SS_ENDPOINT_COMP,
 
 	/* the following 3 values can be tweaked if necessary */
 	/* .bMaxBurst =		0, */
 	/* .bmAttributes =	0, */
 	.wBytesPerInterval =	cpu_to_le16(RNDIS_QC_STATUS_BYTECOUNT),
-};
-
-static struct usb_ss_ep_comp_descriptor ss_bulk_comp_desc = {
-	.bLength =		sizeof(ss_bulk_comp_desc),
-	.bDescriptorType =	USB_DT_SS_ENDPOINT_COMP,
-
-	/* the following 2 values can be tweaked if necessary */
-	/* .bMaxBurst =		0, */
-	/* .bmAttributes =	0, */
 };
 
 static struct usb_endpoint_descriptor rndis_qc_ss_in_desc = {
@@ -379,7 +360,7 @@ static struct usb_endpoint_descriptor rndis_qc_ss_out_desc = {
 };
 
 static struct usb_ss_ep_comp_descriptor rndis_qc_ss_bulk_comp_desc = {
-	.bLength =		sizeof(ss_bulk_comp_desc),
+	.bLength =		sizeof(rndis_qc_ss_bulk_comp_desc),
 	.bDescriptorType =	USB_DT_SS_ENDPOINT_COMP,
 
 	/* the following 2 values can be tweaked if necessary */

--- a/drivers/usb/misc/fusb301.c
+++ b/drivers/usb/misc/fusb301.c
@@ -2245,6 +2245,7 @@ static int fusb301_probe(struct i2c_client *client,
 	struct power_supply_config type_c_psy_cfg = {};
 	struct dual_role_phy_desc *desc;
 	struct dual_role_phy_instance *dual_role;
+	struct fusb301_data *data;
 	int ret = 0;
 
 #ifndef FUSB301_NOT_USE_USB_PSY
@@ -2279,25 +2280,19 @@ static int fusb301_probe(struct i2c_client *client,
 		goto err1;
 	}
 
-	if (&client->dev.of_node) {
-		struct fusb301_data *data = devm_kzalloc(cdev,
-				sizeof(struct fusb301_data), GFP_KERNEL);
+	data = devm_kzalloc(cdev, sizeof(struct fusb301_data), GFP_KERNEL);
+	if (!data) {
+		dev_err(cdev, "can't alloc fusb301_data\n");
+		ret = -ENOMEM;
+		goto err1;
+	}
 
-		if (!data) {
-			dev_err(cdev, "can't alloc fusb301_data\n");
-			ret = -ENOMEM;
-			goto err1;
-		}
+	chip->pdata = data;
 
-		chip->pdata = data;
-
-		ret = fusb301_parse_dt(chip);
-		if (ret) {
-			dev_err(cdev, "can't parse dt\n");
-			goto err2;
-		}
-	} else {
-		chip->pdata = client->dev.platform_data;
+	ret = fusb301_parse_dt(chip);
+	if (ret) {
+		dev_err(cdev, "can't parse dt\n");
+		goto err2;
 	}
 
 	ret = fusb301_init_gpio(chip);
@@ -2466,8 +2461,7 @@ err3:
 	wakeup_source_trash(&chip->wlock);
 	fusb301_free_gpio(chip);
 err2:
-	if (&client->dev.of_node)
-		devm_kfree(cdev, chip->pdata);
+	devm_kfree(cdev, chip->pdata);
 err1:
 	i2c_set_clientdata(client, NULL);
 	devm_kfree(cdev, chip);
@@ -2506,8 +2500,7 @@ static int fusb301_remove(struct i2c_client *client)
 	wakeup_source_trash(&chip->wlock);
 	fusb301_free_gpio(chip);
 
-	if (&client->dev.of_node)
-		devm_kfree(cdev, chip->pdata);
+	devm_kfree(cdev, chip->pdata);
 
 	i2c_set_clientdata(client, NULL);
 	devm_kfree(cdev, chip);

--- a/drivers/video/fbdev/msm/dsi_status_6g.c
+++ b/drivers/video/fbdev/msm/dsi_status_6g.c
@@ -168,7 +168,7 @@ void mdss_check_dsi_ctrl_status(struct work_struct *work, uint32_t interval)
 	if ((mipi->mode == DSI_CMD_MODE) && !ctrl_pdata->burst_mode_enabled)
 		mutex_unlock(&mdp5_data->ov_lock);
 
-	if ((pstatus_data->mfd->panel_power_state == MDSS_PANEL_POWER_ON)) {
+	if (pstatus_data->mfd->panel_power_state == MDSS_PANEL_POWER_ON) {
 		if (ret > 0)
 			schedule_delayed_work(&pstatus_data->check_status,
 				msecs_to_jiffies(interval));

--- a/drivers/video/fbdev/msm/mdss_mdp_pp.c
+++ b/drivers/video/fbdev/msm/mdss_mdp_pp.c
@@ -3372,8 +3372,7 @@ static int pp_ad_calc_bl(struct msm_fb_data_type *mfd, int bl_in, int *bl_out,
 		return -EPERM;
 	}
 
-	if (!ad->bl_mfd || !ad->bl_mfd->panel_info ||
-		!ad->bl_att_lut) {
+	if (!ad->bl_mfd || !ad->bl_mfd->panel_info) {
 		pr_err("Invalid ad info: bl_mfd = 0x%pK, ad->bl_mfd->panel_info = 0x%pK, bl_att_lut = 0x%pK\n",
 			ad->bl_mfd,
 			(!ad->bl_mfd) ? NULL : ad->bl_mfd->panel_info,

--- a/drivers/video/fbdev/msm/mdss_mdp_pp.c
+++ b/drivers/video/fbdev/msm/mdss_mdp_pp.c
@@ -6924,7 +6924,7 @@ static int is_valid_calib_dspp_addr(char __iomem *ptr)
 			ret = MDP_PP_OPS_READ | MDP_PP_OPS_WRITE;
 			break;
 		/* Dither enable/disable */
-		} else if ((ptr == base + MDSS_MDP_REG_DSPP_DITHER_DEPTH)) {
+		} else if (ptr == base + MDSS_MDP_REG_DSPP_DITHER_DEPTH) {
 			ret = MDP_PP_OPS_READ | MDP_PP_OPS_WRITE;
 			break;
 		/* Six zone and mem color */

--- a/drivers/video/fbdev/msm/somc_panel/panel_debugfs.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_debugfs.c
@@ -880,11 +880,6 @@ void mipi_dsi_panel_create_debugfs(struct msm_fb_data_type *mfd)
 
 	dev = &pdev->dev;
 
-	if (!&dev->kobj) {
-		pr_err("%s: no &dev->kobj\n", __func__);
-		return;
-	}
-
 	mdss_dsi_buf_alloc(dev, &debug_tx_buf, ALIGN(DSI_BUF_SIZE, SZ_4K));
 	mdss_dsi_buf_alloc(dev, &debug_rx_buf, ALIGN(DSI_BUF_SIZE, SZ_4K));
 

--- a/drivers/video/fbdev/msm/somc_panel/panel_driver.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_driver.c
@@ -362,9 +362,7 @@ static int mdss_dsi_panel_reset_seq(struct mdss_panel_data *pdata, int enable)
 
 #ifdef CONFIG_FBDEV_SOMC_PANEL_INCELL
 	if (incell_panel_is_seq_for_ewu() && enable)
-		pw_seq = &ctrl_pdata->spec_pdata->ewu_seq ?
-				&ctrl_pdata->spec_pdata->ewu_seq :
-				&ctrl_pdata->spec_pdata->on_seq;
+		pw_seq = &ctrl_pdata->spec_pdata->ewu_seq;
 #endif
 
 	if (pw_seq->rst_b_seq)

--- a/drivers/video/fbdev/msm/somc_panel/panel_incell.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_incell.c
@@ -997,7 +997,7 @@ static int incell_dsi_panel_power_on_ex(struct mdss_panel_data *pdata)
 	struct mdss_panel_specific_pdata *spec_pdata = NULL;
 	struct mdss_panel_power_seq *pw_seq = NULL;
 	struct incell_ctrl *incell = incell_get_info();
-	incell_state state = INCELL_STATE_NONE;
+	incell_state state = INCELL_STATE_SLE000_P0;
 	int ret = 0;
 	int wait;
 

--- a/drivers/video/fbdev/msm/somc_panel/panel_incell.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_incell.c
@@ -1753,7 +1753,7 @@ void incell_ewu_mode_ctrl(incell_ewu_mode ewu)
 
 	pr_debug("%s: status:%d --->\n", __func__, ((int)(incell->state)));
 
-	if ((ewu == INCELL_DISPLAY_EWU_ENABLE))
+	if (ewu == INCELL_DISPLAY_EWU_ENABLE)
 		incell_ewu_mode_state_on(&(incell->state));
 	else
 		incell_ewu_mode_state_off(&(incell->state));

--- a/drivers/video/fbdev/msm/somc_panel/panel_incell.c
+++ b/drivers/video/fbdev/msm/somc_panel/panel_incell.c
@@ -194,12 +194,9 @@ static int somc_panel_calc_gpio_sleep(
 	int wait = 0;
 
 	if (incell_panel_is_seq_for_ewu() &&
-		(gpio == spec_pdata->touch_reset_gpio) &&
-		!enable) {
-		if (&spec_pdata->ewu_seq)
-			pw_seq = &spec_pdata->ewu_seq;
-		else
-			pw_seq = &spec_pdata->on_seq;
+	    gpio == spec_pdata->touch_reset_gpio &&
+	    !enable) {
+		pw_seq = &spec_pdata->ewu_seq;
 	} else {
 		if (enable)
 			pw_seq = &spec_pdata->on_seq;

--- a/include/linux/qpnp/qpnp-adc.h
+++ b/include/linux/qpnp/qpnp-adc.h
@@ -1307,7 +1307,7 @@ struct qpnp_adc_amux_properties {
 	uint32_t				fast_avg_setup;
 	enum qpnp_vadc_trigger			trigger_channel;
 	enum qpnp_adc_calib_type		calib_type;
-	enum qpnp_adc_cal_val			cal_val;
+	uint32_t				cal_val;
 	struct qpnp_vadc_chan_properties	chan_prop[0];
 };
 

--- a/include/soc/qcom/qseecomi.h
+++ b/include/soc/qcom/qseecomi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -105,82 +105,82 @@ enum qseecom_qsee_reentrancy_phase {
 	QSEE_REENTRANCY_PHASE_MAX = 0xFF
 };
 
-__packed  struct qsee_apps_region_info_ireq {
+struct qsee_apps_region_info_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t addr;
 	uint32_t size;
-};
+} __attribute__((__packed__));
 
-__packed  struct qsee_apps_region_info_64bit_ireq {
+struct qsee_apps_region_info_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint64_t addr;
 	uint32_t size;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_check_app_ireq {
+struct qseecom_check_app_ireq {
 	uint32_t qsee_cmd_id;
 	char     app_name[MAX_APP_NAME_SIZE];
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_load_app_ireq {
+struct qseecom_load_app_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t mdt_len;		/* Length of the mdt file */
 	uint32_t img_len;		/* Length of .bxx and .mdt files */
 	uint32_t phy_addr;		/* phy addr of the start of image */
 	char     app_name[MAX_APP_NAME_SIZE];	/* application name*/
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_load_app_64bit_ireq {
+struct qseecom_load_app_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t mdt_len;
 	uint32_t img_len;
 	uint64_t phy_addr;
 	char     app_name[MAX_APP_NAME_SIZE];
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_unload_app_ireq {
+struct qseecom_unload_app_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t  app_id;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_load_lib_image_ireq {
+struct qseecom_load_lib_image_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t mdt_len;
 	uint32_t img_len;
 	uint32_t phy_addr;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_load_lib_image_64bit_ireq {
+struct qseecom_load_lib_image_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t mdt_len;
 	uint32_t img_len;
 	uint64_t phy_addr;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_unload_lib_image_ireq {
+struct qseecom_unload_lib_image_ireq {
 	uint32_t qsee_cmd_id;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_register_listener_ireq {
+struct qseecom_register_listener_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t listener_id;
 	uint32_t sb_ptr;
 	uint32_t sb_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_register_listener_64bit_ireq {
+struct qseecom_register_listener_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t listener_id;
 	uint64_t sb_ptr;
 	uint32_t sb_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_unregister_listener_ireq {
+struct qseecom_unregister_listener_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t  listener_id;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_client_send_data_ireq {
+struct qseecom_client_send_data_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t app_id;
 	uint32_t req_ptr;
@@ -189,9 +189,9 @@ __packed struct qseecom_client_send_data_ireq {
 	uint32_t rsp_len;
 	uint32_t sglistinfo_ptr;
 	uint32_t sglistinfo_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_client_send_data_64bit_ireq {
+struct qseecom_client_send_data_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t app_id;
 	uint64_t req_ptr;
@@ -200,36 +200,36 @@ __packed struct qseecom_client_send_data_64bit_ireq {
 	uint32_t rsp_len;
 	uint64_t sglistinfo_ptr;
 	uint32_t sglistinfo_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_reg_log_buf_ireq {
+struct qseecom_reg_log_buf_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t phy_addr;
 	uint32_t len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_reg_log_buf_64bit_ireq {
+struct qseecom_reg_log_buf_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint64_t phy_addr;
 	uint32_t len;
-};
+} __attribute__((__packed__));
 
 /* send_data resp */
-__packed struct qseecom_client_listener_data_irsp {
+struct qseecom_client_listener_data_irsp {
 	uint32_t qsee_cmd_id;
 	uint32_t listener_id;
 	uint32_t status;
 	uint32_t sglistinfo_ptr;
 	uint32_t sglistinfo_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_client_listener_data_64bit_irsp {
+struct qseecom_client_listener_data_64bit_irsp {
 	uint32_t qsee_cmd_id;
 	uint32_t listener_id;
 	uint32_t status;
 	uint64_t sglistinfo_ptr;
 	uint32_t sglistinfo_len;
-};
+} __attribute__((__packed__));
 
 /*
  * struct qseecom_command_scm_resp - qseecom response buffer
@@ -238,40 +238,40 @@ __packed struct qseecom_client_listener_data_64bit_irsp {
  *                buffer
  * @sb_in_rsp_len: length of command response
  */
-__packed struct qseecom_command_scm_resp {
+struct qseecom_command_scm_resp {
 	uint32_t result;
 	enum qseecom_command_scm_resp_type resp_type;
 	unsigned int data;
-};
+} __attribute__((__packed__));
 
 struct qseecom_rpmb_provision_key {
 	uint32_t key_type;
 };
 
-__packed struct qseecom_client_send_service_ireq {
+struct qseecom_client_send_service_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t key_type; /* in */
 	unsigned int req_len; /* in */
 	uint32_t rsp_ptr; /* in/out */
 	unsigned int rsp_len; /* in/out */
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_client_send_service_64bit_ireq {
+struct qseecom_client_send_service_64bit_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t key_type;
 	unsigned int req_len;
 	uint64_t rsp_ptr;
 	unsigned int rsp_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_generate_ireq {
+struct qseecom_key_generate_ireq {
 	uint32_t qsee_command_id;
 	uint32_t flags;
 	uint8_t key_id[QSEECOM_KEY_ID_SIZE];
 	uint8_t hash32[QSEECOM_HASH_SIZE];
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_select_ireq {
+struct qseecom_key_select_ireq {
 	uint32_t qsee_command_id;
 	uint32_t ce;
 	uint32_t pipe;
@@ -279,33 +279,33 @@ __packed struct qseecom_key_select_ireq {
 	uint32_t flags;
 	uint8_t key_id[QSEECOM_KEY_ID_SIZE];
 	uint8_t hash32[QSEECOM_HASH_SIZE];
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_delete_ireq {
+struct qseecom_key_delete_ireq {
 	uint32_t qsee_command_id;
 	uint32_t flags;
 	uint8_t key_id[QSEECOM_KEY_ID_SIZE];
 	uint8_t hash32[QSEECOM_HASH_SIZE];
 
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_userinfo_update_ireq {
+struct qseecom_key_userinfo_update_ireq {
 	uint32_t qsee_command_id;
 	uint32_t flags;
 	uint8_t key_id[QSEECOM_KEY_ID_SIZE];
 	uint8_t current_hash32[QSEECOM_HASH_SIZE];
 	uint8_t new_hash32[QSEECOM_HASH_SIZE];
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_max_count_query_ireq {
+struct qseecom_key_max_count_query_ireq {
 	uint32_t flags;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_key_max_count_query_irsp {
+struct qseecom_key_max_count_query_irsp {
 	uint32_t max_key_count;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_qteec_ireq {
+struct qseecom_qteec_ireq {
 	uint32_t    qsee_cmd_id;
 	uint32_t    app_id;
 	uint32_t    req_ptr;
@@ -314,9 +314,9 @@ __packed struct qseecom_qteec_ireq {
 	uint32_t    resp_len;
 	uint32_t    sglistinfo_ptr;
 	uint32_t    sglistinfo_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_qteec_64bit_ireq {
+struct qseecom_qteec_64bit_ireq {
 	uint32_t    qsee_cmd_id;
 	uint32_t    app_id;
 	uint64_t    req_ptr;
@@ -325,21 +325,20 @@ __packed struct qseecom_qteec_64bit_ireq {
 	uint32_t    resp_len;
 	uint64_t    sglistinfo_ptr;
 	uint32_t    sglistinfo_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_client_send_fsm_key_req {
+struct qseecom_client_send_fsm_key_req {
 	uint32_t qsee_cmd_id;
 	uint32_t req_ptr;
 	uint32_t req_len;
 	uint32_t rsp_ptr;
 	uint32_t rsp_len;
-};
+} __attribute__((__packed__));
 
-__packed struct qseecom_continue_blocked_request_ireq {
+struct qseecom_continue_blocked_request_ireq {
 	uint32_t qsee_cmd_id;
 	uint32_t app_or_session_id; /*legacy: app_id; smcinvoke: session_id*/
-};
-
+} __attribute__((__packed__));
 
 /**********      ARMV8 SMC INTERFACE TZ MACRO     *******************/
 

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -2151,7 +2151,7 @@ static bool inactive_list_is_low(struct lruvec *lruvec, bool file,
 				struct scan_control *sc, bool actual_reclaim)
 {
 	enum lru_list active_lru = file * LRU_FILE + LRU_ACTIVE;
-	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
+	struct pglist_data *pgdat __maybe_unused = lruvec_pgdat(lruvec);
 	enum lru_list inactive_lru = file * LRU_FILE;
 	unsigned long inactive, active;
 	unsigned long inactive_ratio;

--- a/scripts/clang-android.sh
+++ b/scripts/clang-android.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+
+$* -dM -E - </dev/null 2>&1 | grep -q __ANDROID__ && echo "y"

--- a/scripts/mod/file2alias.c
+++ b/scripts/mod/file2alias.c
@@ -50,46 +50,6 @@ struct devtable {
 	void *function;
 };
 
-#define ___cat(a,b) a ## b
-#define __cat(a,b) ___cat(a,b)
-
-/* we need some special handling for this host tool running eventually on
- * Darwin. The Mach-O section handling is a bit different than ELF section
- * handling. The differnces in detail are:
- *  a) we have segments which have sections
- *  b) we need a API call to get the respective section symbols */
-#if defined(__MACH__)
-#include <mach-o/getsect.h>
-
-#define INIT_SECTION(name)  do {					\
-		unsigned long name ## _len;				\
-		char *__cat(pstart_,name) = getsectdata("__TEXT",	\
-			#name, &__cat(name,_len));			\
-		char *__cat(pstop_,name) = __cat(pstart_,name) +	\
-			__cat(name, _len);				\
-		__cat(__start_,name) = (void *)__cat(pstart_,name);	\
-		__cat(__stop_,name) = (void *)__cat(pstop_,name);	\
-	} while (0)
-#define SECTION(name)   __attribute__((section("__TEXT, " #name)))
-
-struct devtable **__start___devtable, **__stop___devtable;
-#else
-#define INIT_SECTION(name) /* no-op for ELF */
-#define SECTION(name)   __attribute__((section(#name)))
-
-/* We construct a table of pointers in an ELF section (pointers generally
- * go unpadded by gcc).  ld creates boundary syms for us. */
-extern struct devtable *__start___devtable[], *__stop___devtable[];
-#endif /* __MACH__ */
-
-#if !defined(__used)
-# if __GNUC__ == 3 && __GNUC_MINOR__ < 3
-#  define __used			__attribute__((__unused__))
-# else
-#  define __used			__attribute__((__used__))
-# endif
-#endif
-
 /* Define a variable f that holds the value of field f of struct devid
  * based at address m.
  */
@@ -101,16 +61,6 @@ extern struct devtable *__start___devtable[], *__stop___devtable[];
  */
 #define DEF_FIELD_ADDR(m, devid, f) \
 	typeof(((struct devid *)0)->f) *f = ((m) + OFF_##devid##_##f)
-
-/* Add a table entry.  We test function type matches while we're here. */
-#define ADD_TO_DEVTABLE(device_id, type, function) \
-	static struct devtable __cat(devtable,__LINE__) = {	\
-		device_id + 0*sizeof((function)((const char *)NULL,	\
-						(void *)NULL,		\
-						(char *)NULL)),		\
-		SIZE_##type, (function) };				\
-	static struct devtable *SECTION(__devtable) __used \
-		__cat(devtable_ptr,__LINE__) = &__cat(devtable,__LINE__)
 
 #define ADD(str, sep, cond, field)                              \
 do {                                                            \
@@ -431,7 +381,6 @@ static int do_hid_entry(const char *filename,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("hid", hid_device_id, do_hid_entry);
 
 /* Looks like: ieee1394:venNmoNspNverN */
 static int do_ieee1394_entry(const char *filename,
@@ -456,7 +405,6 @@ static int do_ieee1394_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("ieee1394", ieee1394_device_id, do_ieee1394_entry);
 
 /* Looks like: pci:vNdNsvNsdNbcNscNiN. */
 static int do_pci_entry(const char *filename,
@@ -500,7 +448,6 @@ static int do_pci_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("pci", pci_device_id, do_pci_entry);
 
 /* looks like: "ccw:tNmNdtNdmN" */
 static int do_ccw_entry(const char *filename,
@@ -524,7 +471,6 @@ static int do_ccw_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("ccw", ccw_device_id, do_ccw_entry);
 
 /* looks like: "ap:tN" */
 static int do_ap_entry(const char *filename,
@@ -535,7 +481,6 @@ static int do_ap_entry(const char *filename,
 	sprintf(alias, "ap:t%02X*", dev_type);
 	return 1;
 }
-ADD_TO_DEVTABLE("ap", ap_device_id, do_ap_entry);
 
 /* looks like: "css:tN" */
 static int do_css_entry(const char *filename,
@@ -546,7 +491,6 @@ static int do_css_entry(const char *filename,
 	sprintf(alias, "css:t%01X", type);
 	return 1;
 }
-ADD_TO_DEVTABLE("css", css_device_id, do_css_entry);
 
 /* Looks like: "serio:tyNprNidNexN" */
 static int do_serio_entry(const char *filename,
@@ -566,7 +510,6 @@ static int do_serio_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("serio", serio_device_id, do_serio_entry);
 
 /* looks like: "acpi:ACPI0003" or "acpi:PNP0C0B" or "acpi:LNXVIDEO" or
  *             "acpi:bbsspp" (bb=base-class, ss=sub-class, pp=prog-if)
@@ -604,7 +547,6 @@ static int do_acpi_entry(const char *filename,
 	}
 	return 1;
 }
-ADD_TO_DEVTABLE("acpi", acpi_device_id, do_acpi_entry);
 
 /* looks like: "pnp:dD" */
 static void do_pnp_device_entry(void *symval, unsigned long size,
@@ -725,7 +667,6 @@ static int do_pcmcia_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("pcmcia", pcmcia_device_id, do_pcmcia_entry);
 
 static int do_vio_entry(const char *filename, void *symval,
 		char *alias)
@@ -745,7 +686,6 @@ static int do_vio_entry(const char *filename, void *symval,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("vio", vio_device_id, do_vio_entry);
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
@@ -818,7 +758,6 @@ static int do_input_entry(const char *filename, void *symval,
 		do_input(alias, *swbit, 0, INPUT_DEVICE_ID_SW_MAX);
 	return 1;
 }
-ADD_TO_DEVTABLE("input", input_device_id, do_input_entry);
 
 static int do_eisa_entry(const char *filename, void *symval,
 		char *alias)
@@ -830,7 +769,6 @@ static int do_eisa_entry(const char *filename, void *symval,
 		strcat(alias, "*");
 	return 1;
 }
-ADD_TO_DEVTABLE("eisa", eisa_device_id, do_eisa_entry);
 
 /* Looks like: parisc:tNhvNrevNsvN */
 static int do_parisc_entry(const char *filename, void *symval,
@@ -850,7 +788,6 @@ static int do_parisc_entry(const char *filename, void *symval,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("parisc", parisc_device_id, do_parisc_entry);
 
 /* Looks like: sdio:cNvNdN. */
 static int do_sdio_entry(const char *filename,
@@ -867,7 +804,6 @@ static int do_sdio_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("sdio", sdio_device_id, do_sdio_entry);
 
 /* Looks like: ssb:vNidNrevN. */
 static int do_ssb_entry(const char *filename,
@@ -884,7 +820,6 @@ static int do_ssb_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("ssb", ssb_device_id, do_ssb_entry);
 
 /* Looks like: bcma:mNidNrevNclN. */
 static int do_bcma_entry(const char *filename,
@@ -903,7 +838,6 @@ static int do_bcma_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("bcma", bcma_device_id, do_bcma_entry);
 
 /* Looks like: virtio:dNvN */
 static int do_virtio_entry(const char *filename, void *symval,
@@ -919,7 +853,6 @@ static int do_virtio_entry(const char *filename, void *symval,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("virtio", virtio_device_id, do_virtio_entry);
 
 /*
  * Looks like: vmbus:guid
@@ -942,7 +875,6 @@ static int do_vmbus_entry(const char *filename, void *symval,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("vmbus", hv_vmbus_device_id, do_vmbus_entry);
 
 /* Looks like: i2c:S */
 static int do_i2c_entry(const char *filename, void *symval,
@@ -953,7 +885,6 @@ static int do_i2c_entry(const char *filename, void *symval,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("i2c", i2c_device_id, do_i2c_entry);
 
 /* Looks like: spi:S */
 static int do_spi_entry(const char *filename, void *symval,
@@ -964,7 +895,6 @@ static int do_spi_entry(const char *filename, void *symval,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("spi", spi_device_id, do_spi_entry);
 
 static const struct dmifield {
 	const char *prefix;
@@ -1019,7 +949,6 @@ static int do_dmi_entry(const char *filename, void *symval,
 	strcat(alias, ":");
 	return 1;
 }
-ADD_TO_DEVTABLE("dmi", dmi_system_id, do_dmi_entry);
 
 static int do_platform_entry(const char *filename,
 			     void *symval, char *alias)
@@ -1028,7 +957,6 @@ static int do_platform_entry(const char *filename,
 	sprintf(alias, PLATFORM_MODULE_PREFIX "%s", *name);
 	return 1;
 }
-ADD_TO_DEVTABLE("platform", platform_device_id, do_platform_entry);
 
 static int do_mdio_entry(const char *filename,
 			 void *symval, char *alias)
@@ -1053,7 +981,6 @@ static int do_mdio_entry(const char *filename,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("mdio", mdio_device_id, do_mdio_entry);
 
 /* Looks like: zorro:iN. */
 static int do_zorro_entry(const char *filename, void *symval,
@@ -1064,7 +991,6 @@ static int do_zorro_entry(const char *filename, void *symval,
 	ADD(alias, "i", id != ZORRO_WILDCARD, id);
 	return 1;
 }
-ADD_TO_DEVTABLE("zorro", zorro_device_id, do_zorro_entry);
 
 /* looks like: "pnp:dD" */
 static int do_isapnp_entry(const char *filename,
@@ -1080,7 +1006,6 @@ static int do_isapnp_entry(const char *filename,
 		(function >> 12) & 0x0f, (function >> 8) & 0x0f);
 	return 1;
 }
-ADD_TO_DEVTABLE("isapnp", isapnp_device_id, do_isapnp_entry);
 
 /* Looks like: "ipack:fNvNdN". */
 static int do_ipack_entry(const char *filename,
@@ -1096,7 +1021,6 @@ static int do_ipack_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("ipack", ipack_device_id, do_ipack_entry);
 
 /*
  * Append a match expression for a single masked hex digit.
@@ -1167,7 +1091,6 @@ static int do_amba_entry(const char *filename,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("amba", amba_id, do_amba_entry);
 
 /*
  * looks like: "mipscdmm:tN"
@@ -1183,7 +1106,6 @@ static int do_mips_cdmm_entry(const char *filename,
 	sprintf(alias, "mipscdmm:t%02X*", type);
 	return 1;
 }
-ADD_TO_DEVTABLE("mipscdmm", mips_cdmm_device_id, do_mips_cdmm_entry);
 
 /* LOOKS like cpu:type:x86,venVVVVfamFFFFmodMMMM:feature:*,FEAT,*
  * All fields are numbers. It would be nicer to use strings for vendor
@@ -1208,7 +1130,6 @@ static int do_x86cpu_entry(const char *filename, void *symval,
 		sprintf(alias + strlen(alias), "%04X*", feature);
 	return 1;
 }
-ADD_TO_DEVTABLE("x86cpu", x86_cpu_id, do_x86cpu_entry);
 
 /* LOOKS like cpu:type:*:feature:*FEAT* */
 static int do_cpu_entry(const char *filename, void *symval, char *alias)
@@ -1218,7 +1139,6 @@ static int do_cpu_entry(const char *filename, void *symval, char *alias)
 	sprintf(alias, "cpu:type:*:feature:*%04X*", feature);
 	return 1;
 }
-ADD_TO_DEVTABLE("cpu", cpu_feature, do_cpu_entry);
 
 /* Looks like: mei:S:uuid:N:* */
 static int do_mei_entry(const char *filename, void *symval,
@@ -1237,7 +1157,6 @@ static int do_mei_entry(const char *filename, void *symval,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("mei", mei_cl_device_id, do_mei_entry);
 
 /* Looks like: rapidio:vNdNavNadN */
 static int do_rio_entry(const char *filename,
@@ -1257,7 +1176,6 @@ static int do_rio_entry(const char *filename,
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("rapidio", rio_device_id, do_rio_entry);
 
 /* Looks like: ulpi:vNpN */
 static int do_ulpi_entry(const char *filename, void *symval,
@@ -1270,7 +1188,6 @@ static int do_ulpi_entry(const char *filename, void *symval,
 
 	return 1;
 }
-ADD_TO_DEVTABLE("ulpi", ulpi_device_id, do_ulpi_entry);
 
 /* Looks like: hdaudio:vNrNaN */
 static int do_hda_entry(const char *filename, void *symval, char *alias)
@@ -1287,7 +1204,6 @@ static int do_hda_entry(const char *filename, void *symval, char *alias)
 	add_wildcard(alias);
 	return 1;
 }
-ADD_TO_DEVTABLE("hdaudio", hda_device_id, do_hda_entry);
 
 /* Looks like: fsl-mc:vNdN */
 static int do_fsl_mc_entry(const char *filename, void *symval,
@@ -1299,7 +1215,6 @@ static int do_fsl_mc_entry(const char *filename, void *symval,
 	sprintf(alias, "fsl-mc:v%08Xd%s", vendor, *obj_type);
 	return 1;
 }
-ADD_TO_DEVTABLE("fslmc", fsl_mc_device_id, do_fsl_mc_entry);
 
 /* Does namelen bytes of name exactly match the symbol? */
 static bool sym_is(const char *name, unsigned namelen, const char *symbol)
@@ -1331,6 +1246,44 @@ static void do_table(void *symval, unsigned long size,
 		}
 	}
 }
+
+static const struct devtable devtable[] = {
+	{"hid", SIZE_hid_device_id, do_hid_entry},
+	{"ieee1394", SIZE_ieee1394_device_id, do_ieee1394_entry},
+	{"pci", SIZE_pci_device_id, do_pci_entry},
+	{"ccw", SIZE_ccw_device_id, do_ccw_entry},
+	{"ap", SIZE_ap_device_id, do_ap_entry},
+	{"css", SIZE_css_device_id, do_css_entry},
+	{"serio", SIZE_serio_device_id, do_serio_entry},
+	{"acpi", SIZE_acpi_device_id, do_acpi_entry},
+	{"pcmcia", SIZE_pcmcia_device_id, do_pcmcia_entry},
+	{"vio", SIZE_vio_device_id, do_vio_entry},
+	{"input", SIZE_input_device_id, do_input_entry},
+	{"eisa", SIZE_eisa_device_id, do_eisa_entry},
+	{"parisc", SIZE_parisc_device_id, do_parisc_entry},
+	{"sdio", SIZE_sdio_device_id, do_sdio_entry},
+	{"ssb", SIZE_ssb_device_id, do_ssb_entry},
+	{"bcma", SIZE_bcma_device_id, do_bcma_entry},
+	{"virtio", SIZE_virtio_device_id, do_virtio_entry},
+	{"vmbus", SIZE_hv_vmbus_device_id, do_vmbus_entry},
+	{"i2c", SIZE_i2c_device_id, do_i2c_entry},
+	{"spi", SIZE_spi_device_id, do_spi_entry},
+	{"dmi", SIZE_dmi_system_id, do_dmi_entry},
+	{"platform", SIZE_platform_device_id, do_platform_entry},
+	{"mdio", SIZE_mdio_device_id, do_mdio_entry},
+	{"zorro", SIZE_zorro_device_id, do_zorro_entry},
+	{"isapnp", SIZE_isapnp_device_id, do_isapnp_entry},
+	{"ipack", SIZE_ipack_device_id, do_ipack_entry},
+	{"amba", SIZE_amba_id, do_amba_entry},
+	{"mipscdmm", SIZE_mips_cdmm_device_id, do_mips_cdmm_entry},
+	{"x86cpu", SIZE_x86_cpu_id, do_x86cpu_entry},
+	{"cpu", SIZE_cpu_feature, do_cpu_entry},
+	{"mei", SIZE_mei_cl_device_id, do_mei_entry},
+	{"rapidio", SIZE_rio_device_id, do_rio_entry},
+	{"ulpi", SIZE_ulpi_device_id, do_ulpi_entry},
+	{"hdaudio", SIZE_hda_device_id, do_hda_entry},
+	{"fslmc", SIZE_fsl_mc_device_id, do_fsl_mc_entry},
+};
 
 /* Create MODULE_ALIAS() statements.
  * At this time, we cannot write the actual output C source yet,
@@ -1386,13 +1339,14 @@ void handle_moddevtable(struct module *mod, struct elf_info *info,
 	else if (sym_is(name, namelen, "pnp_card"))
 		do_pnp_card_entries(symval, sym->st_size, mod);
 	else {
-		struct devtable **p;
-		INIT_SECTION(__devtable);
+		int i;
 
-		for (p = __start___devtable; p < __stop___devtable; p++) {
-			if (sym_is(name, namelen, (*p)->device_id)) {
-				do_table(symval, sym->st_size, (*p)->id_size,
-					 (*p)->device_id, (*p)->function, mod);
+		for (i = 0; i < ARRAY_SIZE(devtable); i++) {
+			const struct devtable *p = &devtable[i];
+
+			if (sym_is(name, namelen, p->device_id)) {
+				do_table(symval, sym->st_size, p->id_size,
+					 p->device_id, p->function, mod);
 				break;
 			}
 		}

--- a/scripts/mod/file2alias.c
+++ b/scripts/mod/file2alias.c
@@ -47,7 +47,7 @@ typedef struct {
 struct devtable {
 	const char *device_id; /* name of table, __mod_<name>__*_device_table. */
 	unsigned long id_size;
-	void *function;
+	int (*do_entry)(const char *filename, void *symval, char *alias);
 };
 
 /* Define a variable f that holds the value of field f of struct devid
@@ -1228,12 +1228,11 @@ static bool sym_is(const char *name, unsigned namelen, const char *symbol)
 static void do_table(void *symval, unsigned long size,
 		     unsigned long id_size,
 		     const char *device_id,
-		     void *function,
+		     int (*do_entry)(const char *filename, void *symval, char *alias),
 		     struct module *mod)
 {
 	unsigned int i;
 	char alias[500];
-	int (*do_entry)(const char *, void *entry, char *alias) = function;
 
 	device_id_check(mod->name, device_id, size, id_size, symval);
 	/* Leave last one: it's the terminator. */
@@ -1346,7 +1345,7 @@ void handle_moddevtable(struct module *mod, struct elf_info *info,
 
 			if (sym_is(name, namelen, p->device_id)) {
 				do_table(symval, sym->st_size, p->id_size,
-					 p->device_id, p->function, mod);
+					 p->device_id, p->do_entry, mod);
 				break;
 			}
 		}

--- a/techpack/audio/asoc/codecs/wcd_cpe_services.c
+++ b/techpack/audio/asoc/codecs/wcd_cpe_services.c
@@ -654,7 +654,7 @@ static void cpe_notify_cmi_client(struct cpe_info *t_info, u8 *payload,
 	hdr = CMI_GET_HEADER(payload);
 	service = CMI_HDR_GET_SERVICE(hdr);
 
-	notif.event = CPE_SVC_CMI_MSG;
+	notif.event = CMI_API_MSG;
 	notif.result = result;
 	notif.message = payload;
 
@@ -1170,7 +1170,7 @@ static enum cpe_process_result cpe_boot_complete(
 	}
 
 	pr_debug("%s: boot complete\n", __func__);
-	return CPE_SVC_SUCCESS;
+	return CPE_PROC_SUCCESS;
 }
 
 static enum cpe_process_result cpe_process_send_msg(

--- a/techpack/audio/asoc/msm-audio-pinctrl.c
+++ b/techpack/audio/asoc/msm-audio-pinctrl.c
@@ -123,8 +123,9 @@ int msm_gpioset_initialize(enum pinctrl_client client,
 			ret = -ENOMEM;
 			goto err;
 		}
-		strlcpy(gpioset_info[client].gpiosets[i],
-				gpioset_names_str, strlen(gpioset_names_str)+1);
+		strscpy(gpioset_info[client].gpiosets[i],
+				gpioset_names_str,
+				sizeof(gpioset_info[client].gpiosets[i]));
 		gpioset_names_str = NULL;
 	}
 	num_strings = 0;
@@ -167,9 +168,9 @@ int msm_gpioset_initialize(enum pinctrl_client client,
 			goto err;
 		}
 
-		strlcpy(gpioset_info[client].gpiosets_comb_names[i],
-					gpioset_comb_str,
-					strlen(gpioset_comb_str)+1);
+		strscpy(gpioset_info[client].gpiosets_comb_names[i],
+			gpioset_comb_str,
+			sizeof(gpioset_info[client].gpiosets_comb_names[i]));
 		pr_debug("%s: GPIO configuration %s\n",
 				__func__,
 				gpioset_info[client].gpiosets_comb_names[i]);

--- a/techpack/audio/dsp/q6lsm.c
+++ b/techpack/audio/dsp/q6lsm.c
@@ -268,7 +268,7 @@ static void q6lsm_session_free(struct lsm_client *client)
 
 	pr_debug("%s: Freeing session ID %d\n", __func__, client->session);
 	spin_lock_irqsave(&lsm_session_lock, flags);
-	lsm_session[client->session] = LSM_INVALID_SESSION_ID;
+	lsm_session[client->session] = NULL;
 	spin_unlock_irqrestore(&lsm_session_lock, flags);
 	client->session = LSM_INVALID_SESSION_ID;
 }


### PR DESCRIPTION
All of the commits should be self explanatory. This is purely build tested so run time issues are obviously possible but the vast majority of these commits are just cleaning up dead code. Please let me know if there are any issues or concern, I'll be happy to address them :)

I used the latest Clang version from AOSP (9.0.3) to ensure I've caught all warnings.

```
for CONFIG in arch/arm64/configs/aosp_*; do
    git clean -fxdq
    make -j$(nproc) ARCH=arm64 CC=clang HOSTCC=clang CROSS_COMPILE=aarch64-linux-android- CLANG_TRIPLE=aarch64-linux-gnu- O=out ${CONFIG##*/} Image.gz-dtb
done
```