### PR TITLE
[2.3.2.r1.4] Sanitation and KGSL fixup

### DIFF
--- a/arch/arm64/include/asm/io.h
+++ b/arch/arm64/include/asm/io.h
@@ -41,22 +41,22 @@
  */
 static inline void __raw_writeb_no_log(u8 val, volatile void __iomem *addr)
 {
-	asm volatile("strb %w0, [%1]" : : "r" (val), "r" (addr));
+	asm volatile("strb %w0, [%1]" : : "rZ" (val), "r" (addr));
 }
 
 static inline void __raw_writew_no_log(u16 val, volatile void __iomem *addr)
 {
-	asm volatile("strh %w0, [%1]" : : "r" (val), "r" (addr));
+	asm volatile("strh %w0, [%1]" : : "rZ" (val), "r" (addr));
 }
 
 static inline void __raw_writel_no_log(u32 val, volatile void __iomem *addr)
 {
-	asm volatile("str %w0, [%1]" : : "r" (val), "r" (addr));
+	asm volatile("str %w0, [%1]" : : "rZ" (val), "r" (addr));
 }
 
 static inline void __raw_writeq_no_log(u64 val, volatile void __iomem *addr)
 {
-	asm volatile("str %0, [%1]" : : "r" (val), "r" (addr));
+	asm volatile("str %x0, [%1]" : : "rZ" (val), "r" (addr));
 }
 
 static inline u8 __raw_readb_no_log(const volatile void __iomem *addr)

--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -4138,6 +4138,7 @@ retry:
 			binder_inner_proc_unlock(proc);
 			if (put_user(e->cmd, (uint32_t __user *)ptr))
 				return -EFAULT;
+			cmd = e->cmd;
 			e->cmd = BR_OK;
 			ptr += sizeof(uint32_t);
 

--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -4965,7 +4965,9 @@ static int binder_mmap(struct file *filp, struct vm_area_struct *vma)
 		failure_string = "bad vm_flags";
 		goto err_bad_arg;
 	}
-	vma->vm_flags = (vma->vm_flags | VM_DONTCOPY) & ~VM_MAYWRITE;
+	vma->vm_flags |= VM_DONTCOPY | VM_MIXEDMAP;
+	vma->vm_flags &= ~VM_MAYWRITE;
+
 	vma->vm_ops = &binder_vm_ops;
 	vma->vm_private_data = proc;
 

--- a/drivers/android/binder_alloc.c
+++ b/drivers/android/binder_alloc.c
@@ -217,7 +217,7 @@ static int binder_update_page_range(struct binder_alloc *alloc, int allocate,
 		mm = alloc->vma_vm_mm;
 
 	if (mm) {
-		down_write(&mm->mmap_sem);
+		down_read(&mm->mmap_sem);
 		vma = alloc->vma;
 	}
 
@@ -286,7 +286,7 @@ static int binder_update_page_range(struct binder_alloc *alloc, int allocate,
 		/* vm_insert_page does not seem to increment the refcount */
 	}
 	if (mm) {
-		up_write(&mm->mmap_sem);
+		up_read(&mm->mmap_sem);
 		mmput(mm);
 	}
 	return 0;
@@ -319,7 +319,7 @@ err_page_ptr_cleared:
 	}
 err_no_vma:
 	if (mm) {
-		up_write(&mm->mmap_sem);
+		up_read(&mm->mmap_sem);
 		mmput(mm);
 	}
 	return vma ? -ENOMEM : -ESRCH;

--- a/drivers/gpu/msm/adreno-gpulist.h
+++ b/drivers/gpu/msm/adreno-gpulist.h
@@ -20,7 +20,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 0,
 		.minor = 6,
 		.patchid = 0x00,
-		.features = ADRENO_SOFT_FAULT_DETECT,
+		.features = ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a300_pm4.fw",
 		.pfpfw_name = "a300_pfp.fw",
 		.gpudev = &adreno_a3xx_gpudev,
@@ -33,7 +34,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 0,
 		.minor = 6,
 		.patchid = 0x20,
-		.features = ADRENO_SOFT_FAULT_DETECT,
+		.features = ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a300_pm4.fw",
 		.pfpfw_name = "a300_pfp.fw",
 		.gpudev = &adreno_a3xx_gpudev,
@@ -46,7 +48,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 0,
 		.minor = 4,
 		.patchid = 0x00,
-		.features = ADRENO_SOFT_FAULT_DETECT,
+		.features = ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a300_pm4.fw",
 		.pfpfw_name = "a300_pfp.fw",
 		.gpudev = &adreno_a3xx_gpudev,
@@ -59,7 +62,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 0,
 		.minor = 5,
 		.patchid = ANY_ID,
-		.features = ADRENO_SOFT_FAULT_DETECT,
+		.features = ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a420_pm4.fw",
 		.pfpfw_name = "a420_pfp.fw",
 		.gpudev = &adreno_a4xx_gpudev,
@@ -73,7 +77,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 0,
 		.patchid = ANY_ID,
 		.features = ADRENO_USES_OCMEM | ADRENO_WARM_START |
-			ADRENO_USE_BOOTSTRAP | ADRENO_SOFT_FAULT_DETECT,
+			ADRENO_USE_BOOTSTRAP | ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a420_pm4.fw",
 		.pfpfw_name = "a420_pfp.fw",
 		.gpudev = &adreno_a4xx_gpudev,
@@ -96,7 +101,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.features = ADRENO_USES_OCMEM  | ADRENO_WARM_START |
 			ADRENO_USE_BOOTSTRAP | ADRENO_SPTP_PC | ADRENO_PPD |
 			ADRENO_CONTENT_PROTECTION | ADRENO_PREEMPTION |
-			ADRENO_SOFT_FAULT_DETECT,
+			ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a420_pm4.fw",
 		.pfpfw_name = "a420_pfp.fw",
 		.gpudev = &adreno_a4xx_gpudev,
@@ -121,7 +127,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.patchid = ANY_ID,
 		.features = ADRENO_USES_OCMEM  | ADRENO_WARM_START |
 			ADRENO_USE_BOOTSTRAP | ADRENO_SPTP_PC |
-			ADRENO_SOFT_FAULT_DETECT,
+			ADRENO_SOFT_FAULT_DETECT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a420_pm4.fw",
 		.pfpfw_name = "a420_pfp.fw",
 		.gpudev = &adreno_a4xx_gpudev,
@@ -144,6 +151,7 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 3,
 		.minor = 0,
 		.patchid = 0,
+		.features = ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530v1_pm4.fw",
 		.pfpfw_name = "a530v1_pfp.fw",
 		.gpudev = &adreno_a5xx_gpudev,
@@ -159,7 +167,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.patchid = 1,
 		.features = ADRENO_GPMU | ADRENO_SPTP_PC | ADRENO_LM |
 			ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION,
+			ADRENO_CONTENT_PROTECTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a530_zap",
@@ -184,7 +193,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.patchid = ANY_ID,
 		.features = ADRENO_GPMU | ADRENO_SPTP_PC | ADRENO_LM |
 			ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION,
+			ADRENO_CONTENT_PROTECTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a530_zap",
@@ -208,7 +218,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 4,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a506_zap",
@@ -224,7 +235,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 5,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a506_zap",
@@ -240,7 +252,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 6,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a506_zap",
@@ -255,7 +268,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.major = 1,
 		.minor = 0,
 		.patchid = ANY_ID,
-		.features = ADRENO_PREEMPTION | ADRENO_64BIT,
+		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.gpudev = &adreno_a5xx_gpudev,
@@ -271,7 +285,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.patchid = 0,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
 			ADRENO_CONTENT_PROTECTION |
-			ADRENO_GPMU | ADRENO_SPTP_PC,
+			ADRENO_GPMU | ADRENO_SPTP_PC |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a540_zap",
@@ -293,7 +308,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
 			ADRENO_CONTENT_PROTECTION |
-			ADRENO_GPMU | ADRENO_SPTP_PC,
+			ADRENO_GPMU | ADRENO_SPTP_PC |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a540_zap",
@@ -314,7 +330,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 2,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a512_zap",
@@ -330,7 +347,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 9,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a512_zap",
@@ -346,7 +364,8 @@ static const struct adreno_gpu_core adreno_gpulist[] = {
 		.minor = 8,
 		.patchid = ANY_ID,
 		.features = ADRENO_PREEMPTION | ADRENO_64BIT |
-			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION,
+			ADRENO_CONTENT_PROTECTION | ADRENO_CPZ_RETENTION |
+			ADRENO_MMU_GLOBAL_MEMSZ_8M,
 		.pm4fw_name = "a530_pm4.fw",
 		.pfpfw_name = "a530_pfp.fw",
 		.zap_name = "a508_zap",

--- a/drivers/gpu/msm/adreno.c
+++ b/drivers/gpu/msm/adreno.c
@@ -1398,6 +1398,9 @@ static int adreno_probe(struct platform_device *pdev)
 	if (ADRENO_FEATURE(adreno_dev, ADRENO_IOCOHERENT))
 		device->mmu.features |= KGSL_MMU_IO_COHERENT;
 
+	if (ADRENO_FEATURE(adreno_dev, ADRENO_MMU_GLOBAL_MEMSZ_8M))
+		device->mmu.features |= KGSL_MMU_GLOBAL_MEMSZ_8M;
+
 	status = adreno_ringbuffer_probe(adreno_dev, nopreempt);
 	if (status)
 		goto out;

--- a/drivers/gpu/msm/adreno.h
+++ b/drivers/gpu/msm/adreno.h
@@ -124,6 +124,9 @@
 /* The core supports IO-coherent memory */
 #define ADRENO_IOCOHERENT BIT(16)
 
+/* The MMU carveout size is limited to 8MB */
+#define ADRENO_MMU_GLOBAL_MEMSZ_8M BIT(30)
+
 /*
  * Adreno GPU quirks - control bits for various workarounds
  */

--- a/drivers/gpu/msm/kgsl_iommu.c
+++ b/drivers/gpu/msm/kgsl_iommu.c
@@ -42,7 +42,7 @@
 #define ADDR_IN_GLOBAL(_mmu, _a) \
 	(((_a) >= KGSL_IOMMU_GLOBAL_MEM_BASE(_mmu)) && \
 	 ((_a) < (KGSL_IOMMU_GLOBAL_MEM_BASE(_mmu) + \
-	 KGSL_IOMMU_GLOBAL_MEM_SIZE)))
+	 KGSL_IOMMU_GLOBAL_MEM_SIZE(_mmu))))
 
 /*
  * Flag to set SMMU memory attributes required to
@@ -228,7 +228,7 @@ static void kgsl_iommu_add_global(struct kgsl_mmu *mmu,
 	/*Check that we can fit the global allocations */
 	if (WARN_ON(global_pt_count >= GLOBAL_PT_ENTRIES) ||
 		WARN_ON((global_pt_alloc + memdesc->size) >=
-			KGSL_IOMMU_GLOBAL_MEM_SIZE))
+			KGSL_IOMMU_GLOBAL_MEM_SIZE(mmu)))
 		return;
 
 	memdesc->gpuaddr = KGSL_IOMMU_GLOBAL_MEM_BASE(mmu) + global_pt_alloc;

--- a/drivers/gpu/msm/kgsl_iommu.h
+++ b/drivers/gpu/msm/kgsl_iommu.h
@@ -23,9 +23,15 @@
  * These defines control the address range for allocations that
  * are mapped into all pagetables.
  */
-#define KGSL_IOMMU_GLOBAL_MEM_SIZE	(20 * SZ_1M)
+#define KGSL_IOMMU_GLOBAL_MEM_SIZE_NG	(20 * SZ_1M)
+#define KGSL_IOMMU_GLOBAL_MEM_SIZE_A5XX	(8 * SZ_1M)
 #define KGSL_IOMMU_GLOBAL_MEM_BASE32	0xf8000000
 #define KGSL_IOMMU_GLOBAL_MEM_BASE64	0xfc000000
+
+#define KGSL_IOMMU_GLOBAL_MEM_SIZE(__mmu)	\
+	(MMU_FEATURE(__mmu, KGSL_MMU_GLOBAL_MEMSZ_8M) ?	\
+		KGSL_IOMMU_GLOBAL_MEM_SIZE_A5XX : \
+		KGSL_IOMMU_GLOBAL_MEM_SIZE_NG)
 
 #define KGSL_IOMMU_GLOBAL_MEM_BASE(__mmu)	\
 	(MMU_FEATURE(__mmu, KGSL_MMU_64BIT) ? \

--- a/drivers/gpu/msm/kgsl_iommu.h
+++ b/drivers/gpu/msm/kgsl_iommu.h
@@ -23,7 +23,7 @@
  * These defines control the address range for allocations that
  * are mapped into all pagetables.
  */
-#define KGSL_IOMMU_GLOBAL_MEM_SIZE	SZ_8M
+#define KGSL_IOMMU_GLOBAL_MEM_SIZE	(20 * SZ_1M)
 #define KGSL_IOMMU_GLOBAL_MEM_BASE32	0xf8000000
 #define KGSL_IOMMU_GLOBAL_MEM_BASE64	0xfc000000
 

--- a/drivers/gpu/msm/kgsl_mmu.h
+++ b/drivers/gpu/msm/kgsl_mmu.h
@@ -143,6 +143,9 @@ struct kgsl_mmu_pt_ops {
 /* The device supports IO coherency */
 #define KGSL_MMU_IO_COHERENT BIT(10)
 
+/* The MMU carveout size is limited to 8MB */
+#define KGSL_MMU_GLOBAL_MEMSZ_8M BIT(20)
+
 /**
  * struct kgsl_mmu - Master definition for KGSL MMU devices
  * @flags: MMU device flags

--- a/drivers/iommu/arm-smmu.c
+++ b/drivers/iommu/arm-smmu.c
@@ -1192,7 +1192,7 @@ static void __arm_smmu_tlb_sync(struct arm_smmu_device *smmu)
 	int count = 0;
 	void __iomem *gr0_base = ARM_SMMU_GR0(smmu);
 
-	writel_relaxed(0, gr0_base + ARM_SMMU_GR0_sTLBGSYNC);
+	writel_relaxed(0xdeadbeef, gr0_base + ARM_SMMU_GR0_sTLBGSYNC);
 	while (readl_relaxed(gr0_base + ARM_SMMU_GR0_sTLBGSTATUS)
 	       & sTLBGSTATUS_GSACTIVE) {
 		cpu_relax();
@@ -3916,8 +3916,8 @@ static void arm_smmu_device_reset(struct arm_smmu_device *smmu)
 	}
 
 	/* Invalidate the TLB, just in case */
-	writel_relaxed(0, gr0_base + ARM_SMMU_GR0_TLBIALLH);
-	writel_relaxed(0, gr0_base + ARM_SMMU_GR0_TLBIALLNSNH);
+	writel_relaxed(reg, gr0_base + ARM_SMMU_GR0_TLBIALLH);
+	writel_relaxed(reg, gr0_base + ARM_SMMU_GR0_TLBIALLNSNH);
 
 	reg = readl_relaxed(ARM_SMMU_GR0_NS(smmu) + ARM_SMMU_GR0_sCR0);
 

--- a/drivers/pinctrl/qcom/pinctrl-spmi-gpio.c
+++ b/drivers/pinctrl/qcom/pinctrl-spmi-gpio.c
@@ -664,7 +664,7 @@ static void pmic_gpio_config_dbg_show(struct pinctrl_dev *pctldev,
 		"push-pull", "open-drain", "open-source"
 	};
 	static const char *const strengths[] = {
-		"no", "high", "medium", "low"
+		"no", "low", "medium", "high"
 	};
 
 	pad = pctldev->desc->pins[pin].drv_data;


### PR DESCRIPTION
This patchset contains some sanitation for Android Binder driver, SPMI-GPIO and
changes the previous arm64/io revert for a proper solution for the IOMMU hypervisor
that came up after a discussion on LKML.

Also, fix the previous KGSL fix attempt properly, by runtime detecting the Adreno chip
that requires different MMU carveouts.