### PR TITLE
[2.3.2.r1] arm64: DT: Loire: Enable DPDM regulator of qpnp-smbcharger

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-common.dtsi
@@ -982,6 +982,7 @@
 	qcom,charging-timeout-mins = <768>;
 	qcom,bmd-pin-src = "bpd_none";
 	qcom,force-aicl-rerun;
+	dpdm-supply = <&usb_otg>;
 	id_poll_enable;
 	id_poll_up_interval = <2000>;
 	id_poll_up_period = <50000>;


### PR DESCRIPTION
The dpdm-supply regulator is required to keep the USB D+/-
lines floating. Hence, enable it.

It fixes charging with QC3.0.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>