### PR TITLE
[2.3.2.r1.4] [URGENT] WALL OF SHAME: Fix definition of BRANCH_WARNONLY

### DIFF
--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -40,8 +40,8 @@ struct clk_branch {
 	u8	halt_check;
 	bool	aggr_sibling_rates;
 	unsigned long rate;
+#define BRANCH_WARNONLY			BIT(6) /* No error on halt check fail*/
 #define BRANCH_VOTED			BIT(7) /* Delay on disable */
-#define BRANCH_WARNONLY			BIT(8) /* No error on halt check fail*/
 #define BRANCH_HALT			0 /* pol: 1 = halt */
 #define BRANCH_HALT_VOTED		(BRANCH_HALT | BRANCH_VOTED)
 #define BRANCH_HALT_WARNONLY		(BRANCH_HALT | BRANCH_WARNONLY)


### PR DESCRIPTION
The halt_check variable is 8 bits long and now that I went through
elementary school again I am finally able to count on my fingers.
Of course, BIT(8) overflows the u8 variable, nullifying the check
in clk-branch.c: for this reason, define BRANCH_WARNONLY as BIT(6).
