### PR TITLE
LA.UM.6.4.r1: Fix BACKPORT: seccomp: remove 2-phase API

### DIFF
--- a/kernel/seccomp.c
+++ b/kernel/seccomp.c
@@ -689,7 +689,7 @@ int __secure_computing(const struct seccomp_data *sd)
 
 	if (config_enabled(CONFIG_CHECKPOINT_RESTORE) &&
 	    unlikely(current->ptrace & PT_SUSPEND_SECCOMP))
-		return SECCOMP_PHASE1_OK;
+		return 0;
 
 	switch (mode) {
 	case SECCOMP_MODE_STRICT:


### PR DESCRIPTION
Remove last usage of SECCOMP_PHASE1_OK

Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>