### PR TITLE
LA.UM.6.4.r1: Revert "msm:ipa:Prevent rt rule deletion if rt rule id is invalid"

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v2/ipa_rt.c
+++ b/drivers/platform/msm/ipa/ipa_v2/ipa_rt.c
@@ -1324,8 +1324,6 @@ int ipa2_reset_rt(enum ipa_ip_type ip)
 	struct ipa_rt_entry *rule_next;
 	struct ipa_rt_tbl_set *rset;
 	u32 apps_start_idx;
-	struct ipa_hdr_entry *hdr_entry;
-	struct ipa_hdr_proc_ctx_entry *hdr_proc_entry;
 	int id;
 
 	if (ip >= IPA_IP_MAX) {
@@ -1370,25 +1368,6 @@ int ipa2_reset_rt(enum ipa_ip_type ip)
 				continue;
 
 			list_del(&rule->link);
-			if (rule->hdr) {
-				hdr_entry = ipa_id_find(rule->rule.hdr_hdl);
-				if (!hdr_entry ||
-					hdr_entry->cookie != IPA_HDR_COOKIE) {
-					IPAERR("Header already deleted\n");
-					return -EINVAL;
-				}
-			} else if (rule->proc_ctx) {
-				hdr_proc_entry =
-					ipa_id_find(
-						rule->rule.hdr_proc_ctx_hdl);
-				if (!hdr_proc_entry ||
-					hdr_proc_entry->cookie !=
-					IPA_PROC_HDR_COOKIE) {
-					IPAERR(
-						"Proc entry already deleted\n");
-					return -EINVAL;
-				}
-			}
 			tbl->rule_cnt--;
 			if (rule->hdr)
 				__ipa_release_hdr(rule->hdr->id);

--- a/drivers/platform/msm/ipa/ipa_v3/ipa_rt.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_rt.c
@@ -1398,8 +1398,6 @@ int ipa3_reset_rt(enum ipa_ip_type ip)
 	struct ipa3_rt_entry *rule;
 	struct ipa3_rt_entry *rule_next;
 	struct ipa3_rt_tbl_set *rset;
-	struct ipa3_hdr_entry *hdr_entry;
-	struct ipa3_hdr_proc_ctx_entry *hdr_proc_entry;
 	u32 apps_start_idx;
 	int id;
 
@@ -1443,35 +1441,13 @@ int ipa3_reset_rt(enum ipa_ip_type ip)
 				continue;
 
 			list_del(&rule->link);
-			if (rule->hdr) {
-				hdr_entry = ipa3_id_find(
-					rule->rule.hdr_hdl);
-				if (!hdr_entry ||
-					hdr_entry->cookie != IPA_HDR_COOKIE) {
-					IPAERR(
-						"Header already deleted\n");
-					return -EINVAL;
-				}
-			} else if (rule->proc_ctx) {
-				hdr_proc_entry =
-					ipa3_id_find(
-					rule->rule.hdr_proc_ctx_hdl);
-				if (!hdr_proc_entry ||
-					hdr_proc_entry->cookie !=
-						IPA_PROC_HDR_COOKIE) {
-					IPAERR(
-					"Proc entry already deleted\n");
-					return -EINVAL;
-				}
-			}
 			tbl->rule_cnt--;
 			if (rule->hdr)
 				__ipa3_release_hdr(rule->hdr->id);
 			else if (rule->proc_ctx)
 				__ipa3_release_hdr_proc_ctx(rule->proc_ctx->id);
 			rule->cookie = 0;
-			if (!rule->rule_id_valid)
-				idr_remove(&tbl->rule_ids, rule->rule_id);
+			idr_remove(&tbl->rule_ids, rule->rule_id);
 			id = rule->id;
 			kmem_cache_free(ipa3_ctx->rt_rule_cache, rule);
 


### PR DESCRIPTION
- This reverts commit e5d7620af2fd50b50c3a37cd7a27e366e8977477
- Fixes #1997 :: The feature mentioned isn't aviable anyway in 4.4.x