### PR TITLE
[VERIFYME][2.3.2.r1.4] remove unneeded branch halt skipping

### DIFF
--- a/drivers/clk/qcom/clk-branch.c
+++ b/drivers/clk/qcom/clk-branch.c
@@ -92,11 +92,8 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 	if (enabling && voted)
 		udelay(5);
 
-	/*
-	 * Skip checking halt bit if we're explicitly ignoring the bit or the
-	 * clock is in hardware gated mode
-	 */
-	if (br->halt_check == BRANCH_HALT_SKIP || clk_branch_in_hwcg_mode(br))
+	/* Skip checking halt bit if the clock is in hardware gated mode */
+	if (clk_branch_in_hwcg_mode(br))
 		return 0;
 
 	if (br->halt_check == BRANCH_HALT_DELAY || (!enabling && voted)) {

--- a/drivers/clk/qcom/clk-branch.c
+++ b/drivers/clk/qcom/clk-branch.c
@@ -81,7 +81,6 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 		bool (check_halt)(const struct clk_branch *, bool))
 {
 	bool voted = br->halt_check & BRANCH_VOTED;
-	bool halt_warnonly = br->halt_check & BRANCH_WARNONLY;
 	const char *name = clk_hw_get_name(&br->clkr.hw);
 
 	/*
@@ -104,7 +103,6 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 		udelay(10);
 	} else if (br->halt_check == BRANCH_HALT_ENABLE ||
 		   br->halt_check == BRANCH_HALT ||
-		   br->halt_check == BRANCH_HALT_WARNONLY ||
 		   (enabling && voted)) {
 		int count = 500;
 
@@ -115,10 +113,6 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 		}
 		WARN(1, "clk: %s status stuck at 'o%s'", name,
 				enabling ? "ff" : "n");
-
-		if (halt_warnonly)
-			return 0;
-
 		return -EBUSY;
 	}
 	return 0;

--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -40,8 +40,8 @@ struct clk_branch {
 	u8	halt_check;
 	bool	aggr_sibling_rates;
 	unsigned long rate;
-#define BRANCH_WARNONLY			BIT(6) /* No error on halt check fail*/
 #define BRANCH_VOTED			BIT(7) /* Delay on disable */
+#define BRANCH_WARNONLY			BIT(8) /* No error on halt check fail*/
 #define BRANCH_HALT			0 /* pol: 1 = halt */
 #define BRANCH_HALT_VOTED		(BRANCH_HALT | BRANCH_VOTED)
 #define BRANCH_HALT_WARNONLY		(BRANCH_HALT | BRANCH_WARNONLY)

--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -46,7 +46,6 @@ struct clk_branch {
 #define BRANCH_HALT_ENABLE		1 /* pol: 0 = halt */
 #define BRANCH_HALT_ENABLE_VOTED	(BRANCH_HALT_ENABLE | BRANCH_VOTED)
 #define BRANCH_HALT_DELAY		2 /* No bit to check; just delay */
-#define BRANCH_HALT_SKIP		3 /* Don't check halt bit */
 
 	struct clk_regmap clkr;
 };

--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -41,10 +41,8 @@ struct clk_branch {
 	bool	aggr_sibling_rates;
 	unsigned long rate;
 #define BRANCH_VOTED			BIT(7) /* Delay on disable */
-#define BRANCH_WARNONLY			BIT(8) /* No error on halt check fail*/
 #define BRANCH_HALT			0 /* pol: 1 = halt */
 #define BRANCH_HALT_VOTED		(BRANCH_HALT | BRANCH_VOTED)
-#define BRANCH_HALT_WARNONLY		(BRANCH_HALT | BRANCH_WARNONLY)
 #define BRANCH_HALT_ENABLE		1 /* pol: 0 = halt */
 #define BRANCH_HALT_ENABLE_VOTED	(BRANCH_HALT_ENABLE | BRANCH_VOTED)
 #define BRANCH_HALT_DELAY		2 /* No bit to check; just delay */

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -218,7 +218,7 @@ static struct clk_rcg2 gfx3d_clk_src = {
 
 static struct clk_branch gpucc_gfx3d_clk = {
 	.halt_reg = 0x1098,
-	.halt_check = BRANCH_HALT_WARNONLY,
+	.halt_check = BRANCH_HALT,
 	.hwcg_reg = 0x1098,
 	.hwcg_bit = 1,
 	.clkr = {


### PR DESCRIPTION
These patches ended up only replacing the original issue (crashing) with a different one (frozen device with a white screen).
Revert them now that the root cause was handled.