### PR TITLE
[4/4] [2.3.2.r1.4] [Tone/Yoshino] Enable clearpad glove_supported.

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -274,7 +274,7 @@
 			watchdog_delay_ms = <3000>;
 			charger_supported = <0>;
 			pen_supported = <0>;
-			glove_supported = <0>;
+			glove_supported = <1>;
 			cover_supported = <1>;
 			touch_pressure_enabled = <1>;
 			touch_size_enabled = <0>;

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -205,7 +205,7 @@
 			watchdog_delay_ms = <3000>;
 			charger_supported = <0>;
 			pen_supported = <0>;
-			glove_supported = <0>;
+			glove_supported = <1>;
 			cover_supported = <1>;
 			touch_pressure_enabled = <1>;
 			touch_size_enabled = <0>;


### PR DESCRIPTION
For https://github.com/sonyxperiadev/packages_apps_ExtendedSettings/pull/49.

These features should work just fine now that these devices are brought up on 4.9 (for a while). Given that we have a toggle for it, allow the user to enable glove mode again on Tone/Yoshino.