### PR TITLE
input: Do not use HID events as entropy

### DIFF
--- a/drivers/input/input.c
+++ b/drivers/input/input.c
@@ -371,9 +371,6 @@ static void input_handle_event(struct input_dev *dev,
 {
 	int disposition = input_get_disposition(dev, type, code, &value);
 
-	if (disposition != INPUT_IGNORE_EVENT && type != EV_SYN)
-		add_input_randomness(type, code, value);
-
 	if ((disposition & INPUT_PASS_TO_DEVICE) && dev->event)
 		dev->event(dev, type, code, value);
 


### PR DESCRIPTION
The Linux Kernel uses HID inputs as randomness to add to the entropy
pool. However, the add_input_randomness function disables preemption,
taking processing time away from other tasks when processing multiple
events in quick succession. Remove the function call that attempts to
use input data as randomness.