### PR TITLE
block: Force requests onto their origin CPU

### DIFF
--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -516,11 +516,13 @@ struct request_queue {
 #define QUEUE_FLAG_DEFAULT	((1 << QUEUE_FLAG_IO_STAT) |		\
 				 (1 << QUEUE_FLAG_STACKABLE)	|	\
 				 (1 << QUEUE_FLAG_SAME_COMP)	|	\
+				 (1 << QUEUE_FLAG_SAME_FORCE)	|	\
 				 (1 << QUEUE_FLAG_ADD_RANDOM))
 
 #define QUEUE_FLAG_MQ_DEFAULT	((1 << QUEUE_FLAG_IO_STAT) |		\
 				 (1 << QUEUE_FLAG_STACKABLE)	|	\
 				 (1 << QUEUE_FLAG_SAME_COMP)	|	\
+				 (1 << QUEUE_FLAG_SAME_FORCE)	|	\
 				 (1 << QUEUE_FLAG_POLL))
 
 static inline void queue_lockdep_assert_held(struct request_queue *q)


### PR DESCRIPTION
There is a high probability that the specific CPU that makes an I/O
request may be repeated. For example, the same CPU may read the same
data multiple times when reading a database. This flag forces requests
to be completed on the same CPU that requested them.