### PR TITLE
LA.UM.6.4.r1: input: ts: synaptics_dsx_td4322: fix display panel detection.

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.c
+++ b/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.c
@@ -4122,26 +4122,20 @@ static int synaptics_rmi4_probe(struct platform_device *pdev)
 
 	/* tp_source default set to 0xFF (unknow) */
 	rmi4_data->tp_source = TP_SOURCE_UNKNOW;
-	rmi4_data->project_id = 0x00;
 
 	/* For TouchView TD4322 firmware upgrade -and repair- */
-	if (of_machine_is_compatible("somc,nile")) {
-		if (of_machine_is_compatible("somc,pioneer")) {
-			rmi4_data->project_id = 0x01;
-			if (rmi4_data->lcd_id == 1)
-				rmi4_data->tp_source = TP_SOURCE_TRULY;
-			else if (rmi4_data->lcd_id == 0)
-				rmi4_data->tp_source = TP_SOURCE_CSOT;
-		} else if (of_machine_is_compatible("somc,discovery")) {
-			rmi4_data->project_id = 0x02;
-			rmi4_data->tp_source = TP_SOURCE_INX;
-		}
+	if (strstr(saved_command_line, "qcom,mdss_dsi_td4322_csot_fhd_cmd") != NULL) {
+		rmi4_data->tp_source = TP_SOURCE_CSOT;
+	} else if (strstr(saved_command_line, "qcom,mdss_dsi_td4322_innolux_fhd_cmd") != NULL) {
+		rmi4_data->tp_source = TP_SOURCE_INX;
+	} else if (strstr(saved_command_line, "qcom,mdss_dsi_td4322_truly_fhd_cmd") != NULL) {
+		rmi4_data->tp_source = TP_SOURCE_TRULY;
+	} else {
+		TP_LOGI("Unable to detect the panel type.");
 	}
 
-	TP_LOGI("rmi4_data->project_id = 0x%02X, "
-		"rmi4_data->lcd_id = %d, "
+	TP_LOGI("rmi4_data->lcd_id = %d, "
 		"rmi4_data->tp_source = 0x%02X (%s)\n",
-		rmi4_data->project_id,
 		rmi4_data->lcd_id,
 		rmi4_data->tp_source,
 		rmi4_data->tp_source == TP_SOURCE_TRULY ? "Truly" :

--- a/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.h
+++ b/drivers/input/touchscreen/synaptics_dsx_td4322/synaptics_dsx_core.h
@@ -404,7 +404,6 @@ struct synaptics_rmi4_data {
 	unsigned int firmware_id;
 	unsigned int config_id;
 	unsigned int tp_source;
-	unsigned int project_id;
 	int lcd_id;
 	int irq;
 	int sensor_max_x;


### PR DESCRIPTION
When flashing Android 9 to XA2 pioneer devices and afterwards flashing AOSP the
kernel will flash the wrong firmware due to incorrect panel detection resulting
in garbage to be displayed. This uses the detected panel information from
mdss_dsi to flash the correct firmware.

Together with the downgrade patch this will hopefully fix the remaining panel issues.