### PR TITLE
[2.3.2.1.r1.4] arm64: DT: Tone: Fix custom mapping for PM(I)8994 MPPs

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common.dtsi
@@ -934,7 +934,7 @@
 	/* MPP_6: NC(STAT_SMB1351) */
 	pm8994_mpp6 {
 		pm_mpp6_def: gpio {
-			pins = "mpp5";
+			pins = "mpp6";
 			function = "digital";
 			bias-high-impedance;
 		};
@@ -947,7 +947,7 @@
 	/* MPP_8: RF_ID */
 	pm8994_mpp8 {
 		pm_mpp8_def: gpio {
-			pins = "mpp5";
+			pins = "mpp8";
 			function = "analog";
 			input-enable;
 			qcom,amux-route = <PMIC_MPP_AMUX_ROUTE_CH8>;
@@ -982,7 +982,7 @@
 	/* MPP_2: FLASH_LED_NOW */
 	pmi8994_mpp2 {
 		pmi_mpp2_def: gpio {
-			pins = "mpp4";
+			pins = "mpp2";
 			function = "digital";
 			input-enable;
 			power-source = <PM8994_VPP_1P8>;


### PR DESCRIPTION
Backport from Angelo's 7.1 branch

During porting of the MPPs to the new pinctrl scheme a long time ago a bad typo happened. All the pins were ... bad.