### PR TITLE
[LE.UM.2.3.2.r1.4] [3/3] Change et51x voltage to 3.3v.

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
@@ -80,6 +80,7 @@
 		et51x,gpio_rst = <&tlmm 20 0>;
 		et51x,gpio_irq = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
+		et51x,no-low-voltage-probe;
 
 		spi-max-frequency = <1000000>;
 

--- a/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
@@ -27,6 +27,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@27 { /* QSEECOM HEAP */
 			reg = <27>;
 			memory-region = <&qseecom_mem>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -120,6 +120,7 @@
 		et51x,gpio_rst    = <&tlmm 20 0>;
 		et51x,gpio_irq    = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
+		et51x,check-sensor-type;
 
 		/*
 		 * The device has to stay enabled until the HAL initializes,

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -122,13 +122,6 @@
 		vdd_ana-supply = <&pm660l_l6>;
 		et51x,check-sensor-type;
 
-		/*
-		 * The device has to stay enabled until the HAL initializes,
-		 * otherwise it'll not send out any IRQ signals even though the
-		 * rest of the initialization runs without errors.
-		 */
-		et51x,enable-on-boot;
-
 		pinctrl-names = "et51x_reset_reset",
 			"et51x_reset_active",
 			"et51x_irq_active";

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -387,6 +387,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;

--- a/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
@@ -27,6 +27,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@27 { /* QSEECOM HEAP */
 			reg = <27>;
 			memory-region = <&qseecom_mem>;

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -385,6 +385,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;

--- a/drivers/input/misc/cei_fp_detect.h
+++ b/drivers/input/misc/cei_fp_detect.h
@@ -1,15 +1,15 @@
 #ifndef _CEI_FP_DETECT_H
 #define _CEI_FP_DETECT_H
 
+#define FP_HW_TYPE_EGISTEC 0
+#define FP_HW_TYPE_FPC 1
+
 #ifdef CONFIG_ARCH_SONY_NILE
 
 #include <linux/delay.h>
 // #include <linux/gpio.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
-
-#define FP_HW_TYPE_EGISTEC 0
-#define FP_HW_TYPE_FPC 1
 
 #define MSM_TLMM_GPIO14_BASE 0x0390E000
 #define MSM_TLMM_SIZE 0x72000
@@ -38,6 +38,13 @@ static inline int cei_fp_module_detect(void)
 
 	pr_info("fp module is egistec or null");
 	return FP_HW_TYPE_EGISTEC;
+}
+
+#else
+
+static inline int cei_fp_module_detect(void)
+{
+	return 0;
 }
 
 #endif /* CONFIG_ARCH_SONY_NILE */


### PR DESCRIPTION
For https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/49.

Ganges requires 3.3v on the sensor or it'll misbehave most of the time. Nile sensors operate on this voltage as well, but seemed to behave perfectly fine on the lower 1.8v used for FPC.
In the end, it turns out this lower voltage is what required hacks/quirks like `enable-on-boot`, which have been removed now.
Still, to err on the safe side, initialize to 1.8v by default on platforms that can have such lower-voltage sensors. This can be disabled in DT (as is the case for Ganges), or the voltage is upped after detecting the right sensor.

As with Nile, we've seen variations in HW response (https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/commit/375934d2edb2f70f57c9ec438b8e2f2ecbff2094), which is why this needs to be tested on all relevant platforms by someone other than me:
- [ ] Nile with FPC
- [ ] Nile with Egistec
- [ ] Ganges

Keep in mind that this includes commits from a [**closed** pull request](https://github.com/sonyxperiadev/kernel/pull/1950): I don't know if this is the right way to add the heap, apart from it seemingly working fine.