### PR TITLE
[2.3.2.r1.4] Revert behaviour changes in fib_rules.c

### DIFF
--- a/net/core/fib_rules.c
+++ b/net/core/fib_rules.c
@@ -486,9 +486,9 @@ int fib_nl_newrule(struct sk_buff *skb, struct nlmsghdr *nlh)
 		rule->uid_range = fib_kuid_range_unset;
 	}
 
-	if (rule_exists(ops, frh, tb, rule)) {
-		if (nlh->nlmsg_flags & NLM_F_EXCL)
-			err = -EEXIST;
+	if ((nlh->nlmsg_flags & NLM_F_EXCL) &&
+	    rule_exists(ops, frh, tb, rule)) {
+		err = -EEXIST;
 		goto errout_free;
 	}
 

--- a/net/core/fib_rules.c
+++ b/net/core/fib_rules.c
@@ -487,7 +487,6 @@ int fib_nl_newrule(struct sk_buff *skb, struct nlmsghdr *nlh)
 	}
 
 	if (rule_exists(ops, frh, tb, rule)) {
-		err = 0;
 		if (nlh->nlmsg_flags & NLM_F_EXCL)
 			err = -EEXIST;
 		goto errout_free;


### PR DESCRIPTION
Should fix some network-related crashes.

Reverted commits:
https://github.com/sonyxperiadev/kernel/commit/e9919a24d3022f72bcadc407e73a6ef17093a849 (as part of https://github.com/sonyxperiadev/kernel/pull/1990)
https://github.com/sonyxperiadev/kernel/commit/ce891f9a57333a1c4006e52b1b73418b48b939a3

Upstream:
[Revert "fib_rules: return 0 directly if an exactly same rule exists when NLM_F_EXCL not supplied"](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/net/core/fib_rules.c?h=linux-4.9.y&id=294ec2da8996e4ded38edafd4a3bb22f770e88cf)
[Revert "fib_rules: fix error in backport of e9919a24d302 ("fib_rules: return 0...")"](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/net/core/fib_rules.c?h=linux-4.9.y&id=73a1cbfe8ece62bf88932a5f69f5db1b616ccdd6)