### PR TITLE
[2.3.2.r1.4] arm64: DT: sdm660-vidc: reduce number of iommu groups

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
@@ -256,9 +256,9 @@
 				<&mmss_bimc_smmu 0x50d>,
 				<&mmss_bimc_smmu 0x50f>,
 				<&mmss_bimc_smmu 0x525>,
-				<&mmss_bimc_smmu 0x528>,
-				<&mmss_bimc_smmu 0x52d>,
-				<&mmss_bimc_smmu 0x540>;
+				<&mmss_bimc_smmu 0x528>;
+/*				<&mmss_bimc_smmu 0x52d>,
+				<&mmss_bimc_smmu 0x540>;*/
 			buffer-types = <0x480>;
 			virtual-addr-pool = <0x1000000 0x28000000>;
 			qcom,secure-context-bank;


### PR DESCRIPTION
The number of iommu register groups assigned to vidc is too high.
The maximum number of register groups available at IOMMU init time is
reached.
No more groups can be registered, and that causes other devices to fail.
One such device is jpeg_dma, which renders the camera nonfunctional.
Specifically, the snapshot capability in opencamera does not work.
Removing two iommus from vidc dt makes jpeg_dma able to register.