### PR TITLE
[2.3.2.r1.4] Improve ION driver for low-memory device configurations

### DIFF
--- a/drivers/staging/android/ion/ion_cma_heap.c
+++ b/drivers/staging/android/ion/ion_cma_heap.c
@@ -107,7 +107,7 @@ static int ion_cma_allocate(struct ion_heap *heap, struct ion_buffer *buffer,
 
 	info->table = kmalloc(sizeof(struct sg_table), GFP_KERNEL);
 	if (!info->table)
-		goto err;
+		goto free_mem;
 
 	info->is_cached = ION_IS_CACHED(flags);
 
@@ -123,6 +123,12 @@ static int ion_cma_allocate(struct ion_heap *heap, struct ion_buffer *buffer,
 	buffer->priv_virt = info;
 	return 0;
 
+free_mem:
+	if (!ION_IS_CACHED(flags))
+		dma_free_writecombine(dev, len, info->cpu_addr, info->handle);
+	else
+		dma_free_attrs(dev, len, info->cpu_addr, info->handle,
+			       DMA_ATTR_FORCE_COHERENT);
 err:
 	kfree(info);
 	return ION_CMA_ALLOCATE_FAILED;

--- a/drivers/staging/android/ion/ion_page_pool.c
+++ b/drivers/staging/android/ion/ion_page_pool.c
@@ -20,11 +20,17 @@
 #include <linux/err.h>
 #include <linux/fs.h>
 #include <linux/list.h>
+#include <linux/migrate.h>
+#include <linux/mount.h>
 #include <linux/init.h>
+#include <linux/page-flags.h>
 #include <linux/slab.h>
 #include <linux/swap.h>
 #include <linux/vmalloc.h>
+#include <linux/compaction.h>
 #include "ion_priv.h"
+
+#define ION_PAGE_CACHE	1
 
 static void *ion_page_pool_alloc_pages(struct ion_page_pool *pool)
 {
@@ -52,12 +58,18 @@ static void ion_page_pool_free_pages(struct ion_page_pool *pool,
 				     struct page *page)
 {
 	ion_page_pool_free_set_cache_policy(pool, page);
+	if (pool->inode && pool->order == 0) {
+		lock_page(page);
+		__ClearPageMovable(page);
+		unlock_page(page);
+	}
 	__free_pages(page, pool->order);
 }
 
 static int ion_page_pool_add(struct ion_page_pool *pool, struct page *page)
 {
 	mutex_lock(&pool->mutex);
+	page->private = ION_PAGE_CACHE;
 	if (PageHighMem(page)) {
 		list_add_tail(&page->lru, &pool->high_items);
 		pool->high_count++;
@@ -66,6 +78,8 @@ static int ion_page_pool_add(struct ion_page_pool *pool, struct page *page)
 		pool->low_count++;
 	}
 
+	if (pool->inode && pool->order == 0)
+		__SetPageMovable(page, pool->inode->i_mapping);
 	mod_node_page_state(page_pgdat(page), NR_INDIRECTLY_RECLAIMABLE_BYTES,
 			    (1 << (PAGE_SHIFT + pool->order)));
 	mutex_unlock(&pool->mutex);
@@ -86,7 +100,9 @@ static struct page *ion_page_pool_remove(struct ion_page_pool *pool, bool high)
 		pool->low_count--;
 	}
 
-	list_del(&page->lru);
+	clear_bit(ION_PAGE_CACHE, &page->private);
+
+	list_del_init(&page->lru);
 	mod_node_page_state(page_pgdat(page), NR_INDIRECTLY_RECLAIMABLE_BYTES,
 			    -(1 << (PAGE_SHIFT + pool->order)));
 	return page;
@@ -110,6 +126,10 @@ void *ion_page_pool_alloc(struct ion_page_pool *pool, bool *from_pool)
 	if (!page) {
 		page = ion_page_pool_alloc_pages(pool);
 		*from_pool = false;
+	} else {
+		lock_page(page);
+		__ClearPageMovable(page);
+		unlock_page(page);
 	}
 	return page;
 }
@@ -131,7 +151,11 @@ void *ion_page_pool_alloc_pool_only(struct ion_page_pool *pool)
 			page = ion_page_pool_remove(pool, false);
 		mutex_unlock(&pool->mutex);
 	}
-
+	if (page) {
+		lock_page(page);
+		__ClearPageMovable(page);
+		unlock_page(page);
+	}
 	return page;
 }
 
@@ -193,8 +217,144 @@ int ion_page_pool_shrink(struct ion_page_pool *pool, gfp_t gfp_mask,
 	return freed;
 }
 
+static bool ion_page_pool_isolate(struct page *page, isolate_mode_t mode)
+{
+	struct ion_page_pool *pool;
+	struct address_space *mapping = page_mapping(page);
+
+	VM_BUG_ON_PAGE(PageIsolated(page), page);
+
+	if (!mapping)
+		return false;
+	pool = mapping->private_data;
+
+	mutex_lock(&pool->mutex);
+	/* could be removed from the cache pool and thus become unmovable */
+	if (!__PageMovable(page)) {
+		mutex_unlock(&pool->mutex);
+		return false;
+	}
+
+	if (unlikely(!test_bit(ION_PAGE_CACHE, &page->private))) {
+		mutex_unlock(&pool->mutex);
+		return false;
+	}
+
+	list_del(&page->lru);
+	if (PageHighMem(page))
+		pool->high_count--;
+	else
+		pool->low_count--;
+	mutex_unlock(&pool->mutex);
+
+	return true;
+}
+
+static int ion_page_pool_migrate(struct address_space *mapping,
+				 struct page *newpage,
+				 struct page *page, enum migrate_mode mode)
+{
+	struct ion_page_pool *pool = mapping->private_data;
+
+	VM_BUG_ON_PAGE(!PageMovable(page), page);
+	VM_BUG_ON_PAGE(!PageIsolated(page), page);
+
+	lock_page(page);
+	newpage->private = ION_PAGE_CACHE;
+	__SetPageMovable(newpage, page_mapping(page));
+	get_page(newpage);
+	__ClearPageMovable(page);
+	ClearPagePrivate(page);
+	unlock_page(page);
+	mutex_lock(&pool->mutex);
+	if (PageHighMem(newpage)) {
+		list_add_tail(&newpage->lru, &pool->high_items);
+		pool->high_count++;
+	} else {
+		list_add_tail(&newpage->lru, &pool->low_items);
+		pool->low_count++;
+	}
+	mutex_unlock(&pool->mutex);
+	put_page(page);
+	return 0;
+}
+
+static void ion_page_pool_putback(struct page *page)
+{
+	/*
+	 * migrate function either succeeds or returns -EAGAIN, which
+	 * results in calling it again until it succeeds, sothis callback
+	 * is not needed.
+	 */
+}
+
+static struct dentry *ion_pool_do_mount(struct file_system_type *fs_type,
+				int flags, const char *dev_name, void *data)
+{
+	static const struct dentry_operations ops = {
+		.d_dname = simple_dname,
+	};
+
+	return mount_pseudo(fs_type, "ion_pool:", NULL, &ops, 0x77);
+}
+
+static struct file_system_type ion_pool_fs = {
+	.name		= "ion_pool",
+	.mount		= ion_pool_do_mount,
+	.kill_sb	= kill_anon_super,
+};
+
+static int ion_pool_cnt;
+static struct vfsmount *ion_pool_mnt;
+static int ion_pool_mount(void)
+{
+	int ret = 0;
+
+	ion_pool_mnt = kern_mount(&ion_pool_fs);
+	if (IS_ERR(ion_pool_mnt))
+		ret = PTR_ERR(ion_pool_mnt);
+
+	return ret;
+}
+
+static const struct address_space_operations ion_pool_aops = {
+	.isolate_page = ion_page_pool_isolate,
+	.migratepage = ion_page_pool_migrate,
+	.putback_page = ion_page_pool_putback,
+};
+
+static int ion_pool_register_migration(struct ion_page_pool *pool)
+{
+	int  ret = simple_pin_fs(&ion_pool_fs, &ion_pool_mnt, &ion_pool_cnt);
+
+	if (ret < 0) {
+		pr_err("Cannot mount pseudo fs: %d\n", ret);
+		return ret;
+	}
+	pool->inode = alloc_anon_inode(ion_pool_mnt->mnt_sb);
+	if (IS_ERR(pool->inode)) {
+		ret = PTR_ERR(pool->inode);
+		pool->inode = NULL;
+		simple_release_fs(&ion_pool_mnt, &ion_pool_cnt);
+		return ret;
+	}
+
+	pool->inode->i_mapping->private_data = pool;
+	pool->inode->i_mapping->a_ops = &ion_pool_aops;
+	return 0;
+}
+
+static void ion_pool_unregister_migration(struct ion_page_pool *pool)
+{
+	if (pool->inode) {
+		iput(pool->inode);
+		pool->inode = NULL;
+		simple_release_fs(&ion_pool_mnt, &ion_pool_cnt);
+	}
+}
+
 struct ion_page_pool *ion_page_pool_create(struct device *dev, gfp_t gfp_mask,
-					   unsigned int order)
+					   unsigned int order, bool movable)
 {
 	struct ion_page_pool *pool = kmalloc(sizeof(*pool), GFP_KERNEL);
 
@@ -210,16 +370,21 @@ struct ion_page_pool *ion_page_pool_create(struct device *dev, gfp_t gfp_mask,
 	mutex_init(&pool->mutex);
 	plist_node_init(&pool->list, order);
 
+	pool->inode = NULL;
+	if (movable)
+		ion_pool_register_migration(pool);
+
 	return pool;
 }
 
 void ion_page_pool_destroy(struct ion_page_pool *pool)
 {
+	ion_pool_unregister_migration(pool);
 	kfree(pool);
 }
 
 static int __init ion_page_pool_init(void)
 {
-	return 0;
+	return ion_pool_mount();
 }
 device_initcall(ion_page_pool_init);

--- a/drivers/staging/android/ion/ion_priv.h
+++ b/drivers/staging/android/ion/ion_priv.h
@@ -536,6 +536,7 @@ void ion_carveout_free(struct ion_heap *heap, ion_phys_addr_t addr,
  * @gfp_mask:		gfp_mask to use from alloc
  * @order:		order of pages in the pool
  * @list:		plist node for list of pools
+ * @inode:		inode for ion_pool pseudo filesystem
  *
  * Allows you to keep a pool of pre allocated pages to use from your heap.
  * Keeping a pool of pages that is ready for dma, ie any cached mapping have
@@ -552,10 +553,11 @@ struct ion_page_pool {
 	gfp_t gfp_mask;
 	unsigned int order;
 	struct plist_node list;
+	struct inode *inode;
 };
 
 struct ion_page_pool *ion_page_pool_create(struct device *dev, gfp_t gfp_mask,
-					   unsigned int order);
+					   unsigned int order, bool movable);
 void ion_page_pool_destroy(struct ion_page_pool *);
 void *ion_page_pool_alloc(struct ion_page_pool *a, bool *from_pool);
 void *ion_page_pool_alloc_pool_only(struct ion_page_pool *a);

--- a/drivers/staging/android/ion/ion_system_heap.c
+++ b/drivers/staging/android/ion/ion_system_heap.c
@@ -782,7 +782,8 @@ static void ion_system_heap_destroy_pools(struct ion_page_pool **pools)
  * ion_system_heap_destroy_pools to destroy the pools.
  */
 static int ion_system_heap_create_pools(struct device *dev,
-					struct ion_page_pool **pools)
+					struct ion_page_pool **pools,
+					bool movable)
 {
 	int i;
 	for (i = 0; i < num_orders; i++) {
@@ -791,7 +792,8 @@ static int ion_system_heap_create_pools(struct device *dev,
 
 		if (orders[i])
 			gfp_flags = high_order_gfp_flags;
-		pool = ion_page_pool_create(dev, gfp_flags, orders[i]);
+		pool = ion_page_pool_create(dev, gfp_flags, orders[i],
+					movable);
 		if (!pool)
 			goto err_create_pool;
 		pools[i] = pool;
@@ -830,15 +832,15 @@ struct ion_heap *ion_system_heap_create(struct ion_platform_heap *data)
 			if (!heap->secure_pools[i])
 				goto err_create_secure_pools;
 			if (ion_system_heap_create_pools(
-					dev, heap->secure_pools[i]))
+					dev, heap->secure_pools[i], false))
 				goto err_create_secure_pools;
 		}
 	}
 
-	if (ion_system_heap_create_pools(dev, heap->uncached_pools))
+	if (ion_system_heap_create_pools(dev, heap->uncached_pools, false))
 		goto err_create_uncached_pools;
 
-	if (ion_system_heap_create_pools(dev, heap->cached_pools))
+	if (ion_system_heap_create_pools(dev, heap->cached_pools, true))
 		goto err_create_cached_pools;
 
 	mutex_init(&heap->split_page_mutex);

--- a/drivers/staging/android/ion/msm/msm_ion.c
+++ b/drivers/staging/android/ion/msm/msm_ion.c
@@ -939,17 +939,8 @@ int msm_ion_heap_alloc_pages_mem(struct pages_mem *pages_mem)
 	pages_mem->free_fn = kfree;
 	page_tbl_size = sizeof(struct page *) * (pages_mem->size >> PAGE_SHIFT);
 	if (page_tbl_size > SZ_8K) {
-		/*
-		 * Do fallback to ensure we have a balance between
-		 * performance and availability.
-		 */
-		pages = kmalloc(page_tbl_size,
-				__GFP_COMP | __GFP_NORETRY |
-				__GFP_NOWARN);
-		if (!pages) {
-			pages = vmalloc(page_tbl_size);
-			pages_mem->free_fn = vfree;
-		}
+		pages = vmalloc(page_tbl_size);
+		pages_mem->free_fn = vfree;
 	} else {
 		pages = kmalloc(page_tbl_size, GFP_KERNEL);
 	}


### PR DESCRIPTION
This PR makes ION cached pools movable and removes usage of kmalloc for big allocations. These changes aim to reduce memory fragmentation which experience devices with insufficient (nowadays) amount of RAM (let's say, <6GB).

Quoting Vitaly Vul from his LKML message:

> We see that memory fragmentation increases sharply over time when the camera is used a lot. Neither background compaction nor user-triggered one help it that much:
>
```# cat /proc/buddyinfo
Node 0, zone DMA 4366 2404 6 1 0 1 1 1 0 0 0
Node 0, zone Normal 2736 2094 91 21 8 0 1 1 0 0 0
# echo 1 > /proc/sys/vm/compact_memory
# cat /proc/buddyinfo
Node 0, zone DMA 2591 1955 391 113 13 2 1 1 0 0 0
Node 0, zone Normal 2159 1155 487 158 9 0 1 1 0 0 0
```
>With the patch, triggering compaction gives far better results:
>
```# cat /proc/buddyinfo
Node 0, zone DMA 3101 4845 605 0 0 0 0 0 0 0 0
Node 0, zone Normal 5271 4459 573 20 3 2 3 3 1 0 0
# echo 1 > /proc/sys/vm/compact_memory
# cat /proc/buddyinfo
Node 0, zone DMA 579 303 151 114 91 67 30 24 7 2 1
Node 0, zone Normal 762 508 400 271 195 100 45 10 5 0 0
```

Also, PR includes fix for a possible memory leak