### PR TITLE
[2.3.2.r1.4] Fix slimbus crashes on legacy devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -1796,6 +1796,7 @@
 		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
 		qcom,apps-ch-pipes = <0x600000>;
 		qcom,ea-pc = <0x170>;
+		qcom,legacy-pwr-msg;
 
 		msm_dai_slim {
 			compatible = "qcom,msm-dai-slim";

--- a/arch/arm64/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996.dtsi
@@ -1087,6 +1087,7 @@
 		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
 		qcom,apps-ch-pipes = <0x60000000>;
 		qcom,ea-pc = <0x160>;
+		qcom,legacy-pwr-msg;
 
 		msm_dai_slim {
 			compatible = "qcom,msm-dai-slim";

--- a/drivers/slimbus/slim-msm-ngd.c
+++ b/drivers/slimbus/slim-msm-ngd.c
@@ -1824,6 +1824,8 @@ static int ngd_slim_probe(struct platform_device *pdev)
 		}
 		rxreg_access = of_property_read_bool(pdev->dev.of_node,
 					"qcom,rxreg-access");
+		dev->legacy_pwr_msg = of_property_read_bool(pdev->dev.of_node,
+					"qcom,legacy-pwr-msg");
 		of_property_read_u32(pdev->dev.of_node, "qcom,apps-ch-pipes",
 					&dev->pdata.apps_pipes);
 		of_property_read_u32(pdev->dev.of_node, "qcom,ea-pc",

--- a/drivers/slimbus/slim-msm.c
+++ b/drivers/slimbus/slim-msm.c
@@ -1333,6 +1333,7 @@ void msm_slim_sps_exit(struct msm_slim_ctrl *dev, bool dereg)
 #define SLIMBUS_QMI_DEFERRED_STATUS_RESP 0x0023
 
 #define SLIMBUS_QMI_POWER_REQ_MAX_MSG_LEN 14
+#define SLIMBUS_QMI_POWER_REQ_MAX_MSG_LEN_V0 7
 #define SLIMBUS_QMI_POWER_RESP_MAX_MSG_LEN 7
 #define SLIMBUS_QMI_SELECT_INSTANCE_REQ_MAX_MSG_LEN 14
 #define SLIMBUS_QMI_SELECT_INSTANCE_RESP_MAX_MSG_LEN 7
@@ -1461,6 +1462,27 @@ static struct elem_info slimbus_select_inst_resp_msg_v01_ei[] = {
 		.offset    = offsetof(struct slimbus_select_inst_resp_msg_v01,
 				      resp),
 		.ei_array  = get_qmi_response_type_v01_ei(),
+	},
+	{
+		.data_type = QMI_EOTI,
+		.elem_len  = 0,
+		.elem_size = 0,
+		.is_array  = NO_ARRAY,
+		.tlv_type  = 0x00,
+		.offset    = 0,
+		.ei_array  = NULL,
+	},
+};
+
+static struct elem_info slimbus_power_req_msg_v00_legacy[] = {
+	{
+		.data_type = QMI_UNSIGNED_4_BYTE,
+		.elem_len  = 1,
+		.elem_size = sizeof(enum slimbus_pm_enum_type_v01),
+		.is_array  = NO_ARRAY,
+		.tlv_type  = 0x01,
+		.offset    = offsetof(struct slimbus_power_req_msg_v01, pm_req),
+		.ei_array  = NULL,
 	},
 	{
 		.data_type = QMI_EOTI,
@@ -1672,8 +1694,14 @@ static int msm_slim_qmi_send_power_request(struct msm_slim_ctrl *dev,
 	int rc;
 
 	req_desc.msg_id = SLIMBUS_QMI_POWER_REQ_V01;
-	req_desc.max_msg_len = SLIMBUS_QMI_POWER_REQ_MAX_MSG_LEN;
-	req_desc.ei_array = slimbus_power_req_msg_v01_ei;
+
+	if (dev->legacy_pwr_msg) {
+		req_desc.max_msg_len = SLIMBUS_QMI_POWER_REQ_MAX_MSG_LEN_V0;
+		req_desc.ei_array = slimbus_power_req_msg_v00_legacy;
+	} else {
+		req_desc.max_msg_len = SLIMBUS_QMI_POWER_REQ_MAX_MSG_LEN;
+		req_desc.ei_array = slimbus_power_req_msg_v01_ei;
+	}
 
 	resp_desc->msg_id = SLIMBUS_QMI_POWER_RESP_V01;
 	resp_desc->max_msg_len = SLIMBUS_QMI_POWER_RESP_MAX_MSG_LEN;

--- a/drivers/slimbus/slim-msm.h
+++ b/drivers/slimbus/slim-msm.h
@@ -321,6 +321,7 @@ struct msm_slim_ctrl {
 	int			default_ipc_log_mask;
 	int			ipc_log_mask;
 	bool			sysfs_created;
+	bool			legacy_pwr_msg;
 	void			*ipc_slimbus_log;
 	void (*rx_slim)(struct msm_slim_ctrl *dev, u8 *buf);
 	u32			current_rx_buf[10];


### PR DESCRIPTION
On legacy targets, such as MSM8916, MSM8956/76, MSM8996 (and APQ
variants), the power request message has a shorter form compared
to the new one, missing two entire chunks of data and
when sending the new message to legacy targets, they will fail
with a malformed message error, since their firmware is set to
receive a specific message length for each message ID: this will
make the SLIM to lockup forever, producing a permanent loss of
audio in the system, until the device is manually rebooted.

To solve this issue, provide the right message struct for the
old power message, activatable with a specific DT property
"qcom,legacy-pwr-msg" that will be provided in the configuration
for this device.

Also, add the property to MSM8956 and MSM8996.