### PR TITLE
[7.1.r1] Enable SMMU deep prefetch errata for SDM845 on msm-4.14 source

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm-arm-smmu-sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-arm-smmu-sdm845.dtsi
@@ -62,6 +62,7 @@
 		qcom,use-3-lvl-tables;
 		qcom,no-asid-retention;
 		qcom,disable-atos;
+		qcom,min-iova-align;
 		#global-interrupts = <1>;
 		#size-cells = <1>;
 		#address-cells = <1>;


### PR DESCRIPTION
969cdfb: Compilation fix
08bc31c: SoCs like sm6150 are not affected by that errata, so QCOM made w/a optional. SDM845 IS affected, so enable it explictly.
c7dc624: "efficiency" property is obsolete in k4.14, rename it to "capacity-dmips-mhz"
edfabae: Just a cleanup, no functional change
