### PR TITLE
[7.1.r1] Rename efficiency property to capacity-dmips-mhz

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956.dtsi
@@ -77,7 +77,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,ea = <&ea0>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
 			L2_0: l2-cache {
@@ -106,7 +106,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,ea = <&ea1>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
 			L1_I_1: l1-icache {
@@ -129,7 +129,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,ea = <&ea2>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
 			L1_I_2: l1-icache {
@@ -152,7 +152,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,ea = <&ea3>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
 			L1_I_3: l1-icache {
@@ -175,7 +175,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile1>;
 			qcom,ea = <&ea4>;
-			efficiency = <1830>;
+			capacity-dmips-mhz = <1830>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;
 			L2_1: l2-cache {
@@ -202,7 +202,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile2>;
 			qcom,ea = <&ea5>;
-			efficiency = <1830>;
+			capacity-dmips-mhz = <1830>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;
 			L1_I_101: l1-icache {
@@ -225,7 +225,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile3>;
 			qcom,ea = <&ea6>;
-			efficiency = <1830>;
+			capacity-dmips-mhz = <1830>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;
 			L1_I_102: l1-icache {
@@ -248,7 +248,7 @@
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,ea = <&ea7>;
-			efficiency = <1830>;
+			capacity-dmips-mhz = <1830>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;
 			L1_I_103: l1-icache {

--- a/arch/arm64/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996.dtsi
@@ -75,7 +75,7 @@
 			reg = <0x0 0x0>;
 			qcom,limits-info = <&mitigation_profile0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			qcom,ea = <&ea0>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
@@ -99,7 +99,7 @@
 			reg = <0x0 0x1>;
 			qcom,limits-info = <&mitigation_profile1>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			qcom,ea = <&ea1>;
 			next-level-cache = <&L2_0>;
 			#cooling-cells = <2>;
@@ -118,7 +118,7 @@
 			reg = <0x0 0x100>;
 			qcom,limits-info = <&mitigation_profile2>;
 			enable-method = "psci";
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			qcom,ea = <&ea2>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;
@@ -142,7 +142,7 @@
 			reg = <0x0 0x101>;
 			enable-method = "psci";
 			qcom,limits-info = <&mitigation_profile3>;
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			qcom,ea = <&ea3>;
 			next-level-cache = <&L2_1>;
 			#cooling-cells = <2>;

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -60,7 +60,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			qcom,ea = <&ea0>;
@@ -89,7 +89,7 @@
 			qcom,limits-info = <&mitigation_profile1>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			qcom,ea = <&ea1>;
@@ -113,7 +113,7 @@
 			qcom,limits-info = <&mitigation_profile2>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			qcom,ea = <&ea2>;
@@ -137,7 +137,7 @@
 			qcom,limits-info = <&mitigation_profile3>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			qcom,ea = <&ea3>;
@@ -161,7 +161,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			enable-method = "psci";
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			qcom,ea = <&ea4>;
@@ -189,7 +189,7 @@
 			qcom,limits-info = <&mitigation_profile5>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			enable-method = "psci";
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			qcom,ea = <&ea5>;
@@ -213,7 +213,7 @@
 			qcom,limits-info = <&mitigation_profile6>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			enable-method = "psci";
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			qcom,ea = <&ea6>;
@@ -237,7 +237,7 @@
 			qcom,limits-info = <&mitigation_profile7>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			enable-method = "psci";
-			efficiency = <1536>;
+			capacity-dmips-mhz = <1536>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			qcom,ea = <&ea7>;

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -57,7 +57,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea0>;
-			efficiency = <1126>;
+			capacity-dmips-mhz = <1126>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L2_1: l2-cache {
@@ -87,7 +87,7 @@
 			qcom,limits-info = <&mitigation_profile1>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea1>;
-			efficiency = <1126>;
+			capacity-dmips-mhz = <1126>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_101: l1-icache {
@@ -111,7 +111,7 @@
 			qcom,limits-info = <&mitigation_profile2>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea2>;
-			efficiency = <1126>;
+			capacity-dmips-mhz = <1126>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_102: l1-icache {
@@ -135,7 +135,7 @@
 			qcom,limits-info = <&mitigation_profile3>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea3>;
-			efficiency = <1126>;
+			capacity-dmips-mhz = <1126>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_103: l1-icache {
@@ -159,7 +159,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea4>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L2_0: l2-cache {
@@ -189,7 +189,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea5>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_1: l1-icache {
@@ -213,7 +213,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea6>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_2: l1-icache {
@@ -237,7 +237,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea7>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_3: l1-icache {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -57,7 +57,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea0>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L2_0: l2-cache {
@@ -87,7 +87,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea1>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_1: l1-icache {
@@ -111,7 +111,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea2>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_2: l1-icache {
@@ -135,7 +135,7 @@
 			qcom,limits-info = <&mitigation_profile0>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
 			qcom,ea = <&ea3>;
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_0>;
 			L1_I_3: l1-icache {
@@ -159,7 +159,7 @@
 			qcom,limits-info = <&mitigation_profile1>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea4>;
-			efficiency = <1638>;
+			capacity-dmips-mhz = <1638>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L2_1: l2-cache {
@@ -187,7 +187,7 @@
 			qcom,limits-info = <&mitigation_profile2>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea5>;
-			efficiency = <1638>;
+			capacity-dmips-mhz = <1638>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_101: l1-icache {
@@ -211,7 +211,7 @@
 			qcom,limits-info = <&mitigation_profile3>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea6>;
-			efficiency = <1638>;
+			capacity-dmips-mhz = <1638>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_102: l1-icache {
@@ -235,7 +235,7 @@
 			qcom,limits-info = <&mitigation_profile4>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
 			qcom,ea = <&ea7>;
-			efficiency = <1638>;
+			capacity-dmips-mhz = <1638>;
 			#cooling-cells = <2>;
 			next-level-cache = <&L2_1>;
 			L1_I_103: l1-icache {

--- a/arch/arm64/boot/dts/qcom/sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845.dtsi
@@ -60,7 +60,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x0>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			cache-size = <0x8000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
@@ -97,7 +97,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x100>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			cache-size = <0x8000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
@@ -128,7 +128,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x200>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			cache-size = <0x8000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
@@ -159,7 +159,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x300>;
 			enable-method = "psci";
-			efficiency = <1024>;
+			capacity-dmips-mhz = <1024>;
 			cache-size = <0x8000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs0>;
@@ -190,7 +190,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x400>;
 			enable-method = "psci";
-			efficiency = <1740>;
+			capacity-dmips-mhz = <1740>;
 			cache-size = <0x20000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
@@ -221,7 +221,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x500>;
 			enable-method = "psci";
-			efficiency = <1740>;
+			capacity-dmips-mhz = <1740>;
 			cache-size = <0x20000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
@@ -252,7 +252,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x600>;
 			enable-method = "psci";
-			efficiency = <1740>;
+			capacity-dmips-mhz = <1740>;
 			cache-size = <0x20000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;
@@ -283,7 +283,7 @@
 			compatible = "arm,armv8";
 			reg = <0x0 0x700>;
 			enable-method = "psci";
-			efficiency = <1740>;
+			capacity-dmips-mhz = <1740>;
 			cache-size = <0x20000>;
 			cpu-release-addr = <0x0 0x90000000>;
 			qcom,lmh-dcvs = <&lmh_dcvs1>;


### PR DESCRIPTION
"efficiency" property is obsolete in k4.14, rename it to "capacity-dmips-mhz"