### PR TITLE
[2.3.2.r1.4] arm64: DT: Tama: Add display cmdline in bootargs

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common-display.dtsi
@@ -16,6 +16,17 @@
  * it under the terms of the GNU General Public License version 2, as
  * published by the Free Software Foundation.
  */
+ 
+ / {
+	/* Bad indentation is required. Sorry. */
+	chosen {
+
+		bootargs = \
+"rcupdate.rcu_expedited=1 \
+msm_drm.dsi_display0=dsi_panel_cmd_display:config0";
+
+	};
+};
 
 &soc {
 	dsi_panel_lcd_pwr_supply: dsi_panel_lcd_pwr_supply {


### PR DESCRIPTION
This boot argument is normally not variable and it selects
the default display for the platform.
Push it through the DT cmdline.