### PR TITLE
[2.3.2.r1.4] Revert "arm64: DT: Yoshino: Enable glove_supported again after device…

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -205,7 +205,7 @@
 			watchdog_delay_ms = <3000>;
 			charger_supported = <0>;
 			pen_supported = <0>;
-			glove_supported = <1>;
+			glove_supported = <0>;
 			cover_supported = <1>;
 			touch_pressure_enabled = <1>;
 			touch_size_enabled = <0>;


### PR DESCRIPTION
… bringup."

This reverts commit 1a0c59c4e17ac2cff7f14820867fe05d231ecb7b, as it blocks touch
input on maple, maple_dsds, and possibly even poplar.

Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>