### PR TITLE
[2.3.2.r1.4] init: initramfs: Add config option to change the skip_initramfs bp name

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -2342,6 +2342,18 @@ config INIT_ALL_POSSIBLE
 	  it was better to provide this option than to break all the archs
 	  and have several arch maintainers pursuing me down dark alleys.
 
+config DEBUG_RENAME_SKIP_INITRAMFS_BOOTPARAM
+	bool "Rename skip_initramfs boot parameter to do_skip_initramfs"
+	help
+	  Some bootloaders will set this boot parameter whenever a direct
+	  boot from a newly uploaded-to-RAM boot image is requested.
+	  Sometimes though we want it to load the initramfs anyway, even
+	  if it's a direct boot.
+	  This configuration option will rename the "skip_initramfs" to
+	  "do_skip_initramfs".
+
+	  This is a kernel hack. Definitely say N.
+
 source "block/Kconfig"
 
 config PREEMPT_NOTIFIERS

--- a/init/initramfs.c
+++ b/init/initramfs.c
@@ -616,7 +616,11 @@ static int __init skip_initramfs_param(char *str)
 	do_skip_initramfs = 1;
 	return 1;
 }
+#ifdef CONFIG_DEBUG_RENAME_SKIP_INITRAMFS_BOOTPARAM
+__setup("do_skip_initramfs", skip_initramfs_param);
+#else
 __setup("skip_initramfs", skip_initramfs_param);
+#endif
 
 static int __init populate_rootfs(void)
 {


### PR DESCRIPTION
Part of the following pull request:
https://github.com/sonyxperiadev/kernel/pull/2024

Backported from 4.14 to 4.9

Description by kholk:
> Some bootloaders will set this boot parameter whenever a direct
> boot from a newly uploaded-to-RAM boot image is requested.
> Sometimes though we want it to load the initramfs anyway, even
> if it's a direct boot.
> This configuration option will rename the "skip_initramfs" to
> "do_skip_initramfs".
> 
> This is a kernel hack. Definitely say N.

TL;DR
Makes it possible to "fastboot boot twrp.img"
(Workarounds the current bootloader ?bug?, if it wasn't intended)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonyxperiadev/kernel/2040)
<!-- Reviewable:end -->
