### PR TITLE
[2.3.2.r1.4] clk: qcom: gcc-sdm660: Enable safe config for gfx3d_clk_src.

### DIFF
--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -211,6 +211,7 @@ static struct clk_rcg2 gfx3d_clk_src = {
 	.mnd_width = 0,
 	.hid_width = 5,
 	.freq_tbl = ftbl_gfx3d_clk_src,
+	.enable_safe_config = true,
 	.parent_map = gpucc_parent_map_1,
 	.flags = FORCE_ENABLE_RCG,
 	.clkr.hw.init = &gpu_clks_init[0],


### PR DESCRIPTION
This clock seems to require this configuration. Without it we observe
that the panel turns white in certain situations and does not recover
until after a reboot. The logs contain:
"clk: gfx3d_clk_src: rcg didn't update its configuration."
And all further calls to "update_config" fail with the same config
and the RCG seems to be stuck.
ca4ec317e00b6a7c852ecc865e3de96d493c1fc4 introduced using enable_safe_config
to solve these cases and it helps here.

journal output before the fix:
Jul 08 13:50:26 Sailfish kernel: WARNING: CPU: 0 PID: 8432 at update_config+0xc4/0xd4
Jul 08 13:50:26 Sailfish kernel: Modules linked in:
Jul 08 13:50:26 Sailfish kernel: CPU: 0 PID: 8432 Comm: kworker/u16:31 Tainted: G        W       4.9.182 #1
Jul 08 13:50:26 Sailfish kernel: Hardware name: Sony Mobile Communications. kirin(sdm630) (DT)
Jul 08 13:50:26 Sailfish kernel: Workqueue: kgsl-workqueue kgsl_idle_check
Jul 08 13:50:26 Sailfish kernel: task: fffffff1afa69b80 task.stack: fffffff1a1394000
Jul 08 13:50:26 Sailfish kernel: PC is at update_config+0xc4/0xd4
Jul 08 13:50:26 Sailfish kernel: LR is at update_config+0xc4/0xd4
Jul 08 13:50:26 Sailfish kernel: pc : [<ffffff9d55b8fe80>] lr : [<ffffff9d55b8fe80>] pstate: 60400145
...
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55b8fe80>] update_config+0xc4/0xd4
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55b90d58>] clk_gfx3d_src_set_rate_and_parent+0x6c/0x84
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55b83c48>] clk_change_rate+0x98/0x60c
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55b84204>] clk_core_set_rate_nolock.part.30+0x48/0xc4
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55b842d8>] clk_set_rate+0x58/0xa4
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55de83d0>] kgsl_pwrctrl_clk_set_rate+0x2c/0x74
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55deadcc>] kgsl_clk_set_rate+0xb8/0x12c
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55deafb4>] kgsl_pwrctrl_clk+0x174/0x3fc
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55deb2d0>] kgsl_pwrctrl_disable+0x94/0xbc
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55dec790>] _slumber+0xd8/0x1a8
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55dec9ec>] kgsl_pwrctrl_change_state+0x18c/0x520
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55dece84>] kgsl_idle_check+0x104/0x150
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d554da9e0>] process_one_work+0x154/0x450
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d554dad38>] worker_thread+0x5c/0x474
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d554e2018>] kthread+0xe8/0xfc
Jul 08 13:50:26 Sailfish kernel: [<ffffff9d55483de0>] ret_from_fork+0x10/0x30
Jul 08 13:50:26 Sailfish healthd: battery l=100 v=4234 t=34.0 h=2 st=2 c=6 chg=a
Jul 08 13:50:27 Sailfish kernel: clk: gfx3d_clk_src: rcg didn't update its configuration.

Please let me know whether this patch is correct or not.