### PR TITLE
[LA.UM.6.4.R1] fpc1145: fix build on none-NILE targets

### DIFF
--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -559,7 +559,9 @@ static int fpc1145_probe(struct platform_device *pdev)
 	int rc = 0;
 	size_t i;
 	int irqf;
+#ifdef CONFIG_ARCH_SONY_NILE
 	int hw_type;
+#endif
 	struct device_node *np = dev->of_node;
 
 	struct fpc1145_data *fpc1145 =


### PR DESCRIPTION
fix unused variable 'hw_type'