### PR TITLE
Revert "FORWARDPORT: arm64: capabilities: Restrict KPTI detection to …

### DIFF
--- a/arch/arm64/include/asm/cpufeature.h
+++ b/arch/arm64/include/asm/cpufeature.h
@@ -96,15 +96,6 @@ enum {
 	SCOPE_LOCAL_CPU,
 };
 
-/*
- * CPU feature detected at boot time, on one or more CPUs. A late CPU
- * is not allowed to have the capability when the system doesn't have it.
- * It is Ok for a late CPU to miss the feature.
- */
-#define ARM64_CPUCAP_BOOT_RESTRICTED_CPU_LOCAL_FEATURE	\
-	(ARM64_CPUCAP_SCOPE_LOCAL_CPU		|	\
-	 ARM64_CPUCAP_OPTIONAL_FOR_LATE_CPU)
-
 struct arm64_cpu_capabilities {
 	const char *desc;
 	u16 capability;

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -804,9 +804,10 @@ static bool has_no_fpsimd(const struct arm64_cpu_capabilities *entry, int __unus
 static int __kpti_forced; /* 0: not forced, >0: forced on, <0: forced off */
 
 static bool unmap_kernel_at_el0(const struct arm64_cpu_capabilities *entry,
-				int scope)
+				int __unused)
 {
 	char const *str = "command line option";
+	u64 pfr0 = read_sanitised_ftr_reg(SYS_ID_AA64PFR0_EL1);
 
 	/*
 	 * For reasons that aren't entirely clear, enabling KPTI on Cavium
@@ -837,7 +838,8 @@ static bool unmap_kernel_at_el0(const struct arm64_cpu_capabilities *entry,
 	}
 
 	/* Defer to CPU feature registers */
-	return !has_cpuid_feature(entry, scope);
+	return !cpuid_feature_extract_unsigned_field(pfr0,
+						     ID_AA64PFR0_CSV3_SHIFT);
 }
 
 static int __nocfi kpti_install_ng_mappings(void *__unused)
@@ -1064,14 +1066,6 @@ static const struct arm64_cpu_capabilities arm64_features[] = {
 		.desc = "Kernel page table isolation (KPTI)",
 		.capability = ARM64_UNMAP_KERNEL_AT_EL0,
 		.def_scope = SCOPE_SYSTEM,
-		/*
-		 * The ID feature fields below are used to indicate that
-		 * the CPU doesn't need KPTI. See unmap_kernel_at_el0 for
-		 * more details.
-		 */
-		.sys_reg = SYS_ID_AA64PFR0_EL1,
-		.field_pos = ID_AA64PFR0_CSV3_SHIFT,
-		.min_field_value = 1,
 		.matches = unmap_kernel_at_el0,
 		.enable = kpti_install_ng_mappings,
 	},


### PR DESCRIPTION
…boot-time CPUs"

This reverts commit 25969de4e018095e9232cb7ed7e112aef9f8769c.