### PR TITLE
[7.1.r1] RPMSG hacks and other fixes for a successful boot on new bootloaders

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996.dtsi
@@ -458,6 +458,12 @@
 		rpm-channel-name = "rpm_requests";
 		interrupts = <GIC_SPI 168 IRQ_TYPE_EDGE_RISING>;
 		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+
+		clock_rpmcc: qcom,rpmcc {
+			compatible = "qcom,rpmcc-msm8996", "qcom,rpmcc";
+			#clock-cells = <1>;
+			status = "ok";
+		};
 	};
 
 	rpm-glink {
@@ -852,12 +858,6 @@
 			< 1420800 >,
 			< 1497600 >,
 			< 1593600 >;
-	};
-
-	clock_rpmcc: qcom,rpmcc {
-		compatible = "qcom,rpmcc-msm8996", "qcom,rpmcc";
-		#clock-cells = <1>;
-		status = "ok";
 	};
 
 	clock_cpu: qcom,msm8996-apcc@6400000 {

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -563,6 +563,11 @@
 		rpm-channel-name = "rpm_requests";
 		interrupts = <GIC_SPI 168 IRQ_TYPE_EDGE_RISING>;
 		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+
+		clock_rpmcc: qcom,rpmcc {
+			compatible = "qcom,rpmcc-msm8998", "qcom,rpmcc";
+			#clock-cells = <1>;
+		};
 	};
 
 	rpm-glink {
@@ -1022,11 +1027,6 @@
 				  "sec-ext-irq";
 
 		poll-delay-ms = <5000>;
-	};
-
-	clock_rpmcc: qcom,rpmcc {
-		compatible = "qcom,rpmcc-msm8998", "qcom,rpmcc";
-		#clock-cells = <1>;
 	};
 
 	clock_gcc: qcom,gcc@100000 {

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -706,6 +706,11 @@
 		rpm-channel-name = "rpm_requests";
 		interrupts = <GIC_SPI 168 IRQ_TYPE_EDGE_RISING>;
 		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+
+		clock_rpmcc: qcom,rpmcc {
+			compatible = "qcom,rpmcc-sdm660", "qcom,rpmcc";
+			#clock-cells = <1>;
+		};
 	};
 
 
@@ -1207,11 +1212,6 @@
 				  "sec-ext-irq";
 
 		poll-delay-ms = <5000>;
-	};
-
-	clock_rpmcc: qcom,rpmcc {
-		compatible = "qcom,rpmcc-sdm660", "qcom,rpmcc";
-		#clock-cells = <1>;
 	};
 
 	clock_gcc: qcom,gcc@100000 {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -727,6 +727,11 @@
 		rpm-channel-name = "rpm_requests";
 		interrupts = <GIC_SPI 168 IRQ_TYPE_EDGE_RISING>;
 		rpm-channel-type = <15>; /* SMD_APPS_RPM */
+
+		clock_rpmcc: qcom,rpmcc {
+			compatible = "qcom,rpmcc-sdm660", "qcom,rpmcc";
+			#clock-cells = <1>;
+		};
 	};
 
 	thermal_zones: thermal-zones {};
@@ -1126,11 +1131,6 @@
 				  "sec-ext-irq";
 
 		poll-delay-ms = <5000>;
-	};
-
-	clock_rpmcc: qcom,rpmcc {
-		compatible = "qcom,rpmcc-sdm660", "qcom,rpmcc";
-		#clock-cells = <1>;
 	};
 
 	clock_gcc: qcom,gcc@100000 {

--- a/drivers/clk/qcom/clk-rcg2.c
+++ b/drivers/clk/qcom/clk-rcg2.c
@@ -134,7 +134,7 @@ static int update_config(struct clk_rcg2 *rcg, u32 cfg)
 		udelay(1);
 	}
 
-	pr_err("CFG_RCGR old frequency configuration 0x%x !\n", cfg);
+	pr_err("%s: CFG_RCGR old frequency configuration 0x%x !\n", name, cfg);
 
 	WARN_CLK(hw->core, name, count == 0,
 			"rcg didn't update its configuration.");

--- a/drivers/rpmsg/rpm-smd.c
+++ b/drivers/rpmsg/rpm-smd.c
@@ -1615,12 +1615,13 @@ static int qcom_smd_rpm_probe(struct rpmsg_device *rpdev)
 	probe_status = 0;
 
 skip_init:
+	spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
+
 	probe_status = of_platform_populate(p, NULL, NULL, &rpdev->dev);
 
 	if (standalone)
 		pr_info("RPM running in standalone mode\n");
 
-	spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
 fail:
 	return probe_status;
 }

--- a/drivers/rpmsg/rpm-smd.c
+++ b/drivers/rpmsg/rpm-smd.c
@@ -1557,11 +1557,15 @@ static int qcom_smd_rpm_probe(struct rpmsg_device *rpdev)
 	int irq;
 	void __iomem *reg_base;
 	uint32_t version = V0_PROTOCOL_VERSION; /* set to default v0 format */
+	unsigned long flags;
+
+	spin_lock_irqsave(&msm_rpm_list_lock, flags);
 
 	p = of_find_compatible_node(NULL, NULL, "qcom,rpm-smd");
 	if (!p) {
 		pr_err("Unable to find rpm-smd\n");
 		probe_status = -ENODEV;
+		spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
 		goto fail;
 	}
 
@@ -1587,12 +1591,14 @@ static int qcom_smd_rpm_probe(struct rpmsg_device *rpdev)
 	if (!irq) {
 		pr_err("Unable to get rpm-smd interrupt number\n");
 		probe_status = -ENODEV;
+		spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
 		goto fail;
 	}
 
 	rpm = devm_kzalloc(&rpdev->dev, sizeof(*rpm), GFP_KERNEL);
 	if (!rpm) {
 		probe_status = -ENOMEM;
+		spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
 		goto fail;
 	}
 
@@ -1612,6 +1618,8 @@ skip_init:
 
 	if (standalone)
 		pr_info("RPM running in standalone mode\n");
+
+	spin_unlock_irqrestore(&msm_rpm_list_lock, flags);
 fail:
 	return probe_status;
 }

--- a/drivers/rpmsg/rpm-smd.c
+++ b/drivers/rpmsg/rpm-smd.c
@@ -1612,6 +1612,7 @@ static int qcom_smd_rpm_probe(struct rpmsg_device *rpdev)
 	init_completion(&rpm->ack);
 	spin_lock_init(&msm_rpm_data.smd_lock_write);
 	spin_lock_init(&msm_rpm_data.smd_lock_read);
+	probe_status = 0;
 
 skip_init:
 	probe_status = of_platform_populate(p, NULL, NULL, &rpdev->dev);

--- a/drivers/usb/pd/policy_engine.c
+++ b/drivers/usb/pd/policy_engine.c
@@ -3655,7 +3655,15 @@ static int psy_changed(struct notifier_block *nb, unsigned long evt, void *ptr)
 	case POWER_SUPPLY_TYPEC_SOURCE_DEFAULT:
 	case POWER_SUPPLY_TYPEC_SOURCE_MEDIUM:
 	case POWER_SUPPLY_TYPEC_SOURCE_HIGH:
-		if (pd->psy_type == POWER_SUPPLY_TYPE_UNKNOWN) {
+		ret = power_supply_get_property(pd->usb_psy,
+				POWER_SUPPLY_PROP_REAL_TYPE, &val);
+		if (ret) {
+			usbpd_err(&pd->dev, "Unable to read USB TYPE: %d\n",
+					ret);
+			return ret;
+		}
+
+		if (val.intval == POWER_SUPPLY_TYPE_UNKNOWN) {
 			usbpd_dbg(&pd->dev, "SNK states but APSD is not done yet.\n");
 			return 0;
 		}


### PR DESCRIPTION
New bootloaders are sometimes shutting down the RPM related communication
channels and the kernel boots only when they don't get closed.

Workaround this issue by hacking the rpm-smd downstream frankenstein to always
allow to create RPM requests at the end of its probe, removing the requirement to
fail the subdevices probe before actually succeeding.

To workaround a new bug that gets up after this behavior modification, protect the
probe of the devices on the rpm bus with a spinlock.

I'm sorry for this, but it's the only way to get this done fast.