### PR TITLE
[7.1.r1] Add missing QSEECOM TA Heaps to SDM630/SDM660/MSM8996.

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-ion.dtsi
@@ -33,6 +33,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@10 { /* SECURE DISPLAY HEAP */
 			reg = <10>;
 			memory-region = <&secure_display_memory>;

--- a/arch/arm64/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996.dtsi
@@ -238,6 +238,14 @@
 			size = <0 0x400000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0 0x00000000 0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x400000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0 0x00000000 0 0xffffffff>;

--- a/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ion.dtsi
@@ -33,6 +33,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@10 { /* SECURE DISPLAY HEAP */
 			reg = <10>;
 			memory-region = <&secure_display_memory>;

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -402,6 +402,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;

--- a/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-ion.dtsi
@@ -33,6 +33,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@19 { /* QSEECOM TA HEAP */
+			reg = <19>;
+			memory-region = <&qseecom_ta_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@10 { /* SECURE DISPLAY HEAP */
 			reg = <10>;
 			memory-region = <&secure_display_memory>;

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -400,6 +400,14 @@
 			size = <0x0 0x800000>;
 		};
 
+		qseecom_ta_mem: qseecom_ta_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0 0x400000>;
+			size = <0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;


### PR DESCRIPTION
The QSEECOM Trust(ed) App heap is used to communicate with trusted
applications running in the TZ, such as the fingerprint apps.

It has already been added to all other platforms (MSM8956, MSM8998, SDM845 and SM8150) but was missing from these 3.