### PR TITLE
cpuquiet: fix cross referencing, potentially dead loop bug

### DIFF
--- a/drivers/cpuquiet/cpuquiet.c
+++ b/drivers/cpuquiet/cpuquiet.c
@@ -266,7 +266,11 @@ static int minmax_cpus_notify(struct notifier_block *nb, unsigned long n,
 	return NOTIFY_OK;
 }
 
-static struct notifier_block minmax_cpus_notifier = {
+static struct notifier_block min_cpus_notifier = {
+	.notifier_call = minmax_cpus_notify,
+};
+
+static struct notifier_block max_cpus_notifier = {
 	.notifier_call = minmax_cpus_notify,
 };
 
@@ -426,13 +430,13 @@ static int __init cpuquiet_probe(struct platform_device *pdev)
 	cpumask_clear(&cr_offline_requests);
 
 	err = pm_qos_add_notifier(PM_QOS_MIN_ONLINE_CPUS,
-						&minmax_cpus_notifier);
+						&min_cpus_notifier);
 	if (err) {
 		pr_err("Failed to register min cpus PM QoS notifier\n");
 		goto destroy_wq;
 	}
 	err = pm_qos_add_notifier(PM_QOS_MAX_ONLINE_CPUS,
-						&minmax_cpus_notifier);
+						&max_cpus_notifier);
 	if (err) {
 		pr_err("Failed to register max cpus PM QoS notifier\n");
 		goto remove_min;
@@ -449,9 +453,9 @@ static int __init cpuquiet_probe(struct platform_device *pdev)
 	return 0;
 
 remove_max:
-	pm_qos_remove_notifier(PM_QOS_MAX_ONLINE_CPUS, &minmax_cpus_notifier);
+	pm_qos_remove_notifier(PM_QOS_MAX_ONLINE_CPUS, &max_cpus_notifier);
 remove_min:
-	pm_qos_remove_notifier(PM_QOS_MIN_ONLINE_CPUS, &minmax_cpus_notifier);
+	pm_qos_remove_notifier(PM_QOS_MIN_ONLINE_CPUS, &min_cpus_notifier);
 destroy_wq:
 	destroy_workqueue(cpuquiet_wq);
 free_funcs:
@@ -464,8 +468,8 @@ static int cpuquiet_remove(struct platform_device *pdev)
 {
 
 	cpuquiet_unregister_devices();
-	pm_qos_remove_notifier(PM_QOS_MAX_ONLINE_CPUS, &minmax_cpus_notifier);
-	pm_qos_remove_notifier(PM_QOS_MIN_ONLINE_CPUS, &minmax_cpus_notifier);
+	pm_qos_remove_notifier(PM_QOS_MAX_ONLINE_CPUS, &max_cpus_notifier);
+	pm_qos_remove_notifier(PM_QOS_MIN_ONLINE_CPUS, &min_cpus_notifier);
 	destroy_workqueue(cpuquiet_wq);
 
 	return 0;


### PR DESCRIPTION
When _same_ notifier block is registered to different notifier chains,
this actually makes these notifier chains join together, which is
absolutely unwanted. for example:

    chain_add(min, foo);
    chain_add(max, foo);

        chain: min +---> ... +---> foo +---> null
                                    ^
                                    |
        chain: max +---> ... +------+

Then if there are one or more this kind of register pattern which also
register to same chains, this will cause dead loop while walking through
either chains:

    chain_add(min, new);

        chain: min +---> ... +---> foo +---> new +---> null
                                    ^
                                    |
        chain: max +---> ... +------+

    chain_add(max, new);
    notifier_chain_register() will result following:

        chain: min +---> ... +---> foo +---> new +---+
                                    ^         ^      |
                                    |         |      |
        chain: max +---> ... +------+         +------+

Signed-off-by: Ji Huang <cocafehj@gmail.com>