### PR TITLE
[7.1.r1] Fix regera PLL configuration

### DIFF
--- a/drivers/clk/qcom/clk-alpha-pll.c
+++ b/drivers/clk/qcom/clk-alpha-pll.c
@@ -1808,6 +1808,7 @@ EXPORT_SYMBOL_GPL(clk_trion_pll_postdiv_ops);
 int clk_alpha_pll_regera_configure(struct clk_alpha_pll *pll, struct regmap *regmap,
 				const struct alpha_pll_config *config)
 {
+	u32 mode_regval;
 	int ret = 0;
 
 	if (!config) {
@@ -1818,7 +1819,11 @@ int clk_alpha_pll_regera_configure(struct clk_alpha_pll *pll, struct regmap *reg
 	if (pll->inited)
 		return ret;
 
-	if (pll_is_enabled(pll, PLL_LOCK_DET)) {
+	ret = regmap_read(regmap, PLL_MODE(pll), &mode_regval);
+	if (ret)
+		return ret;
+
+	if (mode_regval & PLL_LOCK_DET) {
 		pr_warn("PLL is already enabled. Skipping configuration.\n");
 		pll->inited = true;
 		return 0;

--- a/drivers/thermal/qcom/adc-tm5.c
+++ b/drivers/thermal/qcom/adc-tm5.c
@@ -273,7 +273,7 @@ static int32_t adc_tm5_thr_update(struct adc_tm_sensor *sensor,
 	uint16_t reg_low_thr_lsb, reg_high_thr_lsb;
 	uint32_t scale_type = 0, mask = 0, btm_chan_idx = 0;
 	struct adc_tm_config tm_config;
-	struct adc_tm_chip *chip;
+	struct adc_tm_chip *chip = sensor->chip;
 
 	ret = adc_tm5_get_btm_idx(chip,
 		sensor->btm_ch, &btm_chan_idx);
@@ -281,8 +281,6 @@ static int32_t adc_tm5_thr_update(struct adc_tm_sensor *sensor,
 		pr_err("Invalid btm channel idx\n");
 		return ret;
 	}
-
-	chip = sensor->chip;
 
 	tm_config.high_thr_voltage = (int64_t)high_thr;
 	tm_config.low_thr_voltage = (int64_t)low_thr;


### PR DESCRIPTION
    We want to call the regera configuration function before actually
    registering the PLL to the clock framework.
    For this reason, open code the regmap_read and use the struct
    regmap that we're passing to it, instead of trying to use the
    not-yet initialized clkr.
