### PR TITLE
[7.1.r1] Fix LCDB on SDM660, fix SM8150 Trion PLL

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-pmic-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-pmic-overlay.dtsi
@@ -297,6 +297,13 @@
 			regulator-min-microvolt = <4000000>;
 			regulator-max-microvolt = <6000000>;
 		};
+
+		lcdb_bst_vreg: bst {
+			label = "bst";
+			regulator-name = "lcdb_bst";
+			regulator-min-microvolt = <4700000>;
+			regulator-max-microvolt = <6275000>;
+		};
 	};
 
 	pm660a_oledb: qpnp-oledb@e000 {

--- a/drivers/clk/qcom/clk-alpha-pll.c
+++ b/drivers/clk/qcom/clk-alpha-pll.c
@@ -121,7 +121,8 @@ const u8 clk_alpha_pll_regs[][PLL_OFF_MAX_REGS] = {
 		[PLL_OFF_FRAC] = 0x38,
 	},
 	[CLK_ALPHA_PLL_TYPE_TRION] =  {
-		[PLL_OFF_L_VAL] = 0x08,
+		[PLL_OFF_L_VAL] = 0x04,
+		[PLL_OFF_CAL_L_VAL] = 0x08,
 		[PLL_OFF_USER_CTL] = 0xc,
 		[PLL_OFF_USER_CTL_U] = 0x10,
 		[PLL_OFF_USER_CTL_U1] = 0x14,
@@ -134,7 +135,6 @@ const u8 clk_alpha_pll_regs[][PLL_OFF_MAX_REGS] = {
 		[PLL_OFF_STATUS] = 0x30,
 		[PLL_OFF_OPMODE] = 0x38,
 		[PLL_OFF_ALPHA_VAL] = 0x40,
-		[PLL_OFF_CAL_L_VAL] = 0x44,
 	},
 	[CLK_ALPHA_PLL_TYPE_REGERA] =  {
 		[PLL_OFF_L_VAL] = 0x04,


### PR DESCRIPTION
LCDB on SDM660 needs to get the BST regulator declared in DT, or it wouldn't
get enabled, unlike kernel 4.9.

Also, the Trion PLL offsets were ... just a lil wrong .....