### PR TITLE
[7.1.r1] Kumano display fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common-display.dtsi
@@ -93,7 +93,7 @@
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
 	};
 
-	dsi_panel_cmd_display: qcom,dsi-display-primary@12 {
+	dsi_panel_cmd_display: qcom,dsi-display@12 {
 		compatible = "somc,dsi-display";
 		label = "primary";
 

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -2261,6 +2261,7 @@ static int dsi_display_parse_boot_display_selection(void)
 		boot_displays[i].name[j] = '\0';
 
 		boot_displays[i].boot_disp_en = true;
+		pr_err("Selected %s as boot display %d\n", disp_buf, i);
 	}
 
 	return 0;


### PR DESCRIPTION
Fix the Kumano display node to have the right name.
Plus, add an informative message so that if anyone misconfigures the
display DT or the cmdline it comes right to the eye.