### PR TITLE
[7.1.r1] drm: msm: somc_panel: Don't fail power config parse for optional props

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -1191,7 +1191,7 @@ int dsi_panel_driver_parse_power_cfg(struct dsi_panel *panel)
 	if (rc)
 		pr_err("%s: Not configured vsp/vsn vregs\n", __func__);
 
-	return rc;
+	return 0;
 }
 
 int dsi_panel_driver_parse_gpios(struct dsi_panel *panel,


### PR DESCRIPTION
The VSP/VSN and touch-supply are optional: don't fail the power
configuration parsing because of this.