### PR TITLE
[7.1.r1] Fix Spectra camera on SDM845

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-camera.dtsi
@@ -629,9 +629,10 @@
 	cam_vfe0: qcom,vfe0@acaf000 {
 		cell-index = <0>;
 		compatible = "qcom,vfe170";
-		reg-names = "ife";
-		reg = <0xacaf000 0x4000>;
-		reg-cam-base = <0xaf000>;
+		reg-names = "ife", "cam_camnoc";
+		reg = <0xacaf000 0x4000>,
+			<0xac42000 0x5000>;
+		reg-cam-base = <0xaf000 0x42000>;
 		interrupt-names = "ife";
 		interrupts = <0 465 0>;
 		regulator-names = "camss", "ife0";
@@ -717,9 +718,10 @@
 	cam_vfe1: qcom,vfe1@acb6000 {
 		cell-index = <1>;
 		compatible = "qcom,vfe170";
-		reg-names = "ife";
-		reg = <0xacb6000 0x4000>;
-		reg-cam-base = <0xb6000>;
+		reg-names = "ife", "cam_camnoc";
+		reg = <0xacb6000 0x4000>,
+			<0xac42000 0x5000>;
+		reg-cam-base = <0xb6000 0x42000>;
 		interrupt-names = "ife";
 		interrupts = <0 467 0>;
 		regulator-names = "camss", "ife1";

--- a/drivers/clk/qcom/camcc-sdm845.c
+++ b/drivers/clk/qcom/camcc-sdm845.c
@@ -912,6 +912,7 @@ static struct clk_rcg2 cam_cc_slow_ahb_clk_src = {
 	.hid_width = 5,
 	.parent_map = cam_cc_parent_map_0,
 	.freq_tbl = ftbl_cam_cc_slow_ahb_clk_src,
+	.enable_safe_config = true,
 	.clkr.hw.init = &(struct clk_init_data){
 		.name = "cam_cc_slow_ahb_clk_src",
 		.parent_names = cam_cc_parent_names_0,


### PR DESCRIPTION
This patchset fixes the clock driver and the DT in order to successfully probe
the Spectra components in SDM845.