### PR TITLE
[2.3.2.r1.4] [PLEASE REVIEW] TCM/Clearpad: Fix probe, replace broken ifdefs with DT property

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p2160-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-auo-1080p2160-cmd.dtsi
@@ -99,6 +99,8 @@
 		somc,fps-mode-enable;
 		somc,fps-mode-panel-mode = "dynamic_mode";
 
+		somc,incell-touch-type = <2>;
+
 		qcom,mdss-dsi-display-timings {
 			timing@0 {
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p2160-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-jdi-1080p2160-cmd.dtsi
@@ -99,6 +99,8 @@
 		somc,fps-mode-enable;
 		somc,fps-mode-panel-mode = "dynamic_mode";
 
+		somc,incell-touch-type = <1>;
+
 		qcom,mdss-dsi-display-timings {
 			timing@0 {
 				qcom,mdss-dsi-panel-width = <1080>;
@@ -239,6 +241,8 @@
 
 		somc,fps-mode-enable;
 		somc,fps-mode-panel-mode = "dynamic_mode";
+
+		somc,incell-touch-type = <1>;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0 {

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p2160-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-synaptics-lgd-1080p2160-cmd.dtsi
@@ -99,6 +99,8 @@
 		somc,fps-mode-enable;
 		somc,fps-mode-panel-mode = "dynamic_mode";
 
+		somc,incell-touch-type = <2>;
+
 		qcom,mdss-dsi-display-timings {
 			timing@0 {
 				qcom,mdss-dsi-panel-width = <1080>;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.h
@@ -205,6 +205,7 @@ struct dsi_panel {
 
 #ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 	struct panel_specific_pdata *spec_pdata;
+	int touch_type;
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 };
 

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -928,6 +928,11 @@ int dsi_panel_driver_parse_dt(struct dsi_panel *panel,
 
 	spec_pdata = panel->spec_pdata;
 
+	if (of_property_read_u32(np, "somc,incell-touch-type",
+			&panel->touch_type))
+		panel->touch_type = INCELL_TOUCH_TYPE_DEFAULT;
+	pr_debug("%s: In-Cell touch IC is %d\n", __func__, panel->touch_type);
+
 	rc = somc_panel_parse_dt_colormgr_config(panel, np);
 
 	if (of_find_property(np, "somc,pw-off-rst-b-seq", NULL)) {

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.c
@@ -289,24 +289,13 @@ void incell_driver_init(struct msm_drm_private *priv)
 		incell->state = INCELL_S000;
 }
 
-#if INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS
-incell_touch_type incell_get_touch_type() {
+bool incell_touch_is_compatible(incell_touch_type type) {
 	struct dsi_display *display = dsi_display_get_main_display();
 	struct dsi_panel *panel = display->panel;
-	incell_touch_type type = INCELL_TOUCH_TYPE_CLEARPAD;
 
-#if defined(CONFIG_MACH_SONY_AKARI)
-	if (!strcmp(panel->name, "7"))
-#elif defined(CONFIG_MACH_SONY_APOLLO)
-	if (!strcmp(panel->name, "8"))
-#else
-#error "INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS without AKARI or APOLLO!"
-#endif
-		type = INCELL_TOUCH_TYPE_TCM;
+	if (panel->touch_type == INCELL_TOUCH_TYPE_DEFAULT)
+		/* Default/unset. Any driver is allowed to probe: */
+		return true;
 
-	pr_info("%s: Panel %s is %s\n", __func__, panel->name,
-		type == INCELL_TOUCH_TYPE_TCM ? "TCM" : "CLEARPAD");
-
-	return type;
+	return type == panel->touch_type;
 }
-#endif

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/incell.h
@@ -51,15 +51,11 @@ typedef enum {
 	INCELL_DISPLAY_POWER_LOCK,
 } incell_pw_lock;
 
-#define INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS \
-	(defined(CONFIG_MACH_SONY_AKARI) || defined(CONFIG_MACH_SONY_APOLLO))
-
-#if INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS
 typedef enum {
-	INCELL_TOUCH_TYPE_CLEARPAD,
-	INCELL_TOUCH_TYPE_TCM,
+	INCELL_TOUCH_TYPE_DEFAULT = 0,
+	INCELL_TOUCH_TYPE_CLEARPAD = 1,
+	INCELL_TOUCH_TYPE_TCM = 2,
 } incell_touch_type;
-#endif
 
 /* Compatibility with older incell */
 #define INCELL_DISPLAY_HW_RESET		INCELL_TOUCH_RESET
@@ -146,15 +142,13 @@ extern int incell_get_display_pre_sod(void);
 static inline int incell_get_display_pre_sod(void) {return 0; }
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
-#if INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS
-
 #ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
-extern incell_touch_type incell_get_touch_type(void);
+bool incell_touch_is_compatible(incell_touch_type type);
 #else
-static inline incell_touch_type incell_get_touch_type(void) {return 0; }
+static inline bool incell_touch_is_compatible(incell_touch_type) {
+	return true;
+}
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#endif /* INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS */
 
 #endif /* __INCELL_H__ */
 

--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -8709,9 +8709,9 @@ static int clearpad_probe(struct platform_device *pdev)
 	if (type != INCELL_TOUCH_TYPE_CLEARPAD) {
 		dev_notice(&pdev->dev,
 			"%s: Detected panel is not CLEARPAD,"
-			" returning successful probe\n",
+			" returning ENODEV\n",
 			__func__);
-		return 0;
+		return -ENODEV;
 	}
 #endif
 

--- a/drivers/input/touchscreen/clearpad_incell_core.c
+++ b/drivers/input/touchscreen/clearpad_incell_core.c
@@ -8704,16 +8704,15 @@ static int clearpad_probe(struct platform_device *pdev)
 	struct platform_device *rmi_dev;
 #endif
 
-#if INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS
-	incell_touch_type type = incell_get_touch_type();
-	if (type != INCELL_TOUCH_TYPE_CLEARPAD) {
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+	if (!incell_touch_is_compatible(INCELL_TOUCH_TYPE_CLEARPAD)) {
 		dev_notice(&pdev->dev,
 			"%s: Detected panel is not CLEARPAD,"
 			" returning ENODEV\n",
 			__func__);
 		return -ENODEV;
 	}
-#endif
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
 	this = devm_kzalloc(&pdev->dev, sizeof(struct clearpad_t), GFP_KERNEL);
 	if (!this) {

--- a/drivers/input/touchscreen/synaptics_tcm/synaptics_tcm_core.c
+++ b/drivers/input/touchscreen/synaptics_tcm/synaptics_tcm_core.c
@@ -3335,9 +3335,9 @@ static int syna_tcm_probe(struct platform_device *pdev)
 	if (type != INCELL_TOUCH_TYPE_TCM) {
 		dev_notice(&pdev->dev,
 			"%s: Detected panel is not TCM,"
-			" returning successful probe\n",
+			" returning ENODEV\n",
 			__func__);
-		return 0;
+		return -ENODEV;
 	}
 #endif
 

--- a/drivers/input/touchscreen/synaptics_tcm/synaptics_tcm_core.c
+++ b/drivers/input/touchscreen/synaptics_tcm/synaptics_tcm_core.c
@@ -3330,17 +3330,13 @@ static int syna_tcm_probe(struct platform_device *pdev)
 	int retry;
 	incell_pw_status status = { false, false };
 
-#if INCELL_TAMA_MULTIPLE_TOUCH_DRIVERS
-	incell_touch_type type = incell_get_touch_type();
-	if (type != INCELL_TOUCH_TYPE_TCM) {
+	if (!incell_touch_is_compatible(INCELL_TOUCH_TYPE_TCM)) {
 		dev_notice(&pdev->dev,
 			"%s: Detected panel is not TCM,"
 			" returning ENODEV\n",
 			__func__);
 		return -ENODEV;
 	}
-#endif
-
 #endif
 
 	hw_if = pdev->dev.platform_data;


### PR DESCRIPTION
For https://github.com/sonyxperiadev/kernel/pull/2053#issuecomment-539958913

input: ts: clearpad/tcm: Return ENODEV when a different device is found. 

> The probe must be failed since this device doesn't exist. A successful
> probe leaves an uninitialized device in the tree, where pm functions are
> called in certain circumstances.
> This crashes the device as drvdata that is used pretty much everywhere
> remains unset.

panel/touchscreen: Replace broken macro with DT property.

> This macro throws warnings about undefined behaviour when expanding
> defined() preprocessor functions. Instead of coming up with a different
> solution, store the behaviour in a DT property since it is panel-bound
> anyway. This saves the unnecessary panel name comparison.
> 
> This is safe as long as all devices using TCM define somc,has-tcm-touch.
> If we ever get a device with purely TCM and no CLEARPAD, just stating so
> in the defconfig doesn't work. Should this patch include ifdefs to fall
> back to the right type?

@kholk Let me know if this is close to what you wanted to see following https://github.com/sonyxperiadev/kernel/pull/2053#issuecomment-539978713.