### PR TITLE
[LA.UM.7.1.r1] Revert "iommu: qcom: iommu-v1: Enable DMA allocations"

### DIFF
--- a/drivers/iommu/qcom/msm_iommu-v1.c
+++ b/drivers/iommu/qcom/msm_iommu-v1.c
@@ -633,7 +633,12 @@ static struct iommu_domain *msm_iommu_domain_alloc(unsigned type)
 	struct msm_iommu_priv *priv;
 	int ret;
 
-	if (type != IOMMU_DOMAIN_UNMANAGED || type != IOMMU_DOMAIN_DMA)
+	/*
+	 * Note: for secure mapping, the IOMMU_DOMAIN_DMA is not allowed,
+	 * hence only UNMANAGED is allowed. TODO: Find a way to differentiate
+	 * between secure mapping ONLY and insecure pagetable allocation.
+	 */
+	if (type != IOMMU_DOMAIN_UNMANAGED)
 		return NULL;
 
 	priv = kzalloc(sizeof(*priv), GFP_KERNEL);
@@ -700,7 +705,7 @@ static int msm_iommu_dynamic_attach(struct iommu_domain *domain, struct device *
 		.ias		= MMU_IAS,
 		.oas		= MMU_OAS,
 		.tlb		= &msm_iommu_gather_ops,
-		.iommu_dev	= &ctx_drvdata->pdev->dev,
+		.iommu_dev	= dev,
 		.iova_base	= domain->geometry.aperture_start,
 		.iova_end	= domain->geometry.aperture_end,
 	};
@@ -839,7 +844,7 @@ static int msm_iommu_attach_dev(struct iommu_domain *domain, struct device *dev)
 			.sec_id = iommu_drvdata->sec_id,
 			.cbndx  = ctx_drvdata->num,
 		},
-		.iommu_dev	= &ctx_drvdata->pdev->dev,
+		.iommu_dev	= iommu_drvdata->dev,
 		.iova_base	= domain->geometry.aperture_start,
 		.iova_end	= domain->geometry.aperture_end,
 	};


### PR DESCRIPTION
This reverts commit 313f4a2fc9eb4af5f540c9e58181c7301c1556bc.