### PR TITLE
[LA.UM.7.1.r1] kbuild: Disable 'address-of-packed-member' warning not only for clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -673,6 +673,7 @@ KBUILD_CFLAGS	+= $(call cc-disable-warning,frame-address,)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, format-truncation)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, format-overflow)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, int-in-bool-context)
+KBUILD_CFLAGS   += $(call cc-disable-warning, address-of-packed-member)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, attribute-alias)
 
 ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
@@ -754,7 +755,6 @@ KBUILD_AFLAGS += $(CLANG_TARGET) $(CLANG_GCC_TC)
 KBUILD_CPPFLAGS += $(call cc-option,-Qunused-arguments,)
 KBUILD_CFLAGS += $(call cc-disable-warning, format-invalid-specifier)
 KBUILD_CFLAGS += $(call cc-disable-warning, gnu)
-KBUILD_CFLAGS += $(call cc-disable-warning, address-of-packed-member)
 KBUILD_CFLAGS += $(call cc-disable-warning, duplicate-decl-specifier)
 
 KBUILD_CFLAGS += -Wno-asm-operand-widths


### PR DESCRIPTION
GCC also emits those warnings which breaks builds that enable modules
like the audio techpack from qualcomm.

Fix errors like this which are already ignored by clang:
```
kernel/sony/msm-4.14/kernel/techpack/audio/asoc/msm-dai-q6-v2.c:6413:10: error: taking address of packed member of 'str\
uct afe_param_id_group_device_tdm_cfg' may result in an unaligned pointer value [-Werror=address-of-packed-member]                                                                            
 6413 |   (u32 *)&tdm_group_cfg.group_id);     
```        