### PR TITLE
[7.1.r1] arm64: DT: SDM660: Fix LNBB audio ref clock node

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-audio.dtsi
@@ -712,7 +712,7 @@
 		compatible = "qcom,audio-ref-clk";
 		clock-names = "osr_clk";
 		clocks = <&clock_rpmcc RPM_SMD_LN_BB_CLK2>;
-		qcom,node_has_rpm_clock;
+		qcom,codec-ext-clk-src = <1>;
 		#clock-cells = <1>;
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
@@ -68,7 +68,7 @@
 		qcom,wcd-rst-gpio-node = <&wcd_rst_gpio>;
 
 		clock-names = "wcd_clk";
-		clocks = <&clock_audio_lnbb AUDIO_PMIC_LNBB_CLK>;
+		clocks = <&clock_audio_lnbb 0>;
 
 		cdc-vdd-mic-bias-supply = <&pm660l_bob>;
 		qcom,cdc-vdd-mic-bias-voltage = <3300000 3300000>;


### PR DESCRIPTION
Declare codec-ext-clk-src and correctly use the phandle.