### PR TITLE
[7.1.r1] [URGENT] Stabilization for MSM8998, SDM630, SDM636, SDM660, plus cleanups

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -326,7 +326,7 @@
 		removed_region1: removed_region1@85800000 {
 			compatible = "removed-dma-pool";
 			no-map;
-			reg = <0x0 0x85800000 0x0 0x200000>;
+			reg = <0x0 0x85800000 0x0 0x800000>;
 		};
 
 		smem_region: smem@85800000 {

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -329,10 +329,10 @@
 			reg = <0x0 0x85700000 0x0 0x100000>;
 		};
 
-		removed_region1: removed_region1@85800000 {
+		removed_region1: qhee_code@85800000 {
 			compatible = "removed-dma-pool";
 			no-map;
-			reg = <0x0 0x85800000 0x0 0x200000>;
+			reg = <0x0 0x85800000 0x0 0x800000>;
 		};
 
 		smem_region: smem@86000000 {
@@ -444,6 +444,14 @@
 		qca,bt-vdd-core-current-level = <1>; /* LPM/PFM */
 		qca,bt-vdd-pa-current-level = <1>; /* LPM/PFM */
 		qca,bt-vdd-ldo-current-level = <1>; /* LPM/PFM */
+	};
+
+	qcom,system-stats {
+		compatible = "qcom,system-stats";
+		qcom,rpm-data-ram = <&rpm_data_ram>;
+		qcom,rpm-msg-ram = <&rpm_msg_ram>;
+		qcom,masters = "APSS", "MPSS", "ADSP", "CDSP", "TZ";
+		status = "disabled";
 	};
 };
 
@@ -655,9 +663,16 @@
 		};
 	};
 
+	/* This region is 0x8000 long, but the hypervisor freezes the device
+	 * for some reason if we declare the entire length... */
 	rpm_msg_ram: memory@778000 {
 		compatible = "qcom,rpm-msg-ram";
 		reg = <0x778000 0x7000>;
+	};
+
+	rpm_data_ram: memory@290000 {
+		compatible = "qcom,rpm-data-ram";
+		reg = <0x290000 0x1000>;
 	};
 
 	tcsr_mutex_block: syscon@1f40000 {

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -336,6 +336,7 @@
 		};
 
 		smem_region: smem@86000000 {
+			compatible = "removed-dma-pool";
 			no-map;
 			reg = <0 0x86000000 0 0x200000>;
 		};
@@ -1956,6 +1957,12 @@
 			<&clock_rpmcc QSEECOM_CE1_CLK>;
 		qcom,ce-opp-freq = <171430000>;
 		qcom,qsee-reentrancy-support = <2>;
+	};
+
+	qcom_smcinvoke: smcinvoke@86d00000 {
+		compatible = "qcom,smcinvoke";
+		reg = <0x86d00000 0x2200000>;
+		reg-names = "secapp-region";
 	};
 
 	qcom_cedev: qcedev@1de0000{

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -329,7 +329,7 @@
 		removed_region1: removed_region1@85800000 {
 			compatible = "removed-dma-pool";
 			no-map;
-			reg = <0x0 0x85800000 0x0 0x200000>;
+			reg = <0x0 0x85800000 0x0 0x800000>;
 		};
 
 		smem_region: smem@86000000 {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -2113,6 +2113,12 @@
 		qcom,qsee-reentrancy-support = <2>;
 	};
 
+	qcom_smcinvoke: smcinvoke@86d00000 {
+		compatible = "qcom,smcinvoke";
+		reg = <0x86d00000 0x2200000>;
+		reg-names = "secapp-region";
+	};
+
 	qcom_cedev: qcedev@1de0000{
 		compatible = "qcom,qcedev";
 		reg = <0x1de0000 0x20000>,

--- a/drivers/gpu/msm/adreno_coresight.c
+++ b/drivers/gpu/msm/adreno_coresight.c
@@ -396,6 +396,7 @@ static const struct coresight_ops adreno_coresight_ops = {
 
 void adreno_coresight_remove(struct adreno_device *adreno_dev)
 {
+#ifdef CONFIG_CORESIGHT
 	int i, adreno_dev_flag = -EINVAL;
 
 	for (i = 0; i < GPU_CORESIGHT_MAX; ++i) {
@@ -411,10 +412,14 @@ void adreno_coresight_remove(struct adreno_device *adreno_dev)
 			adreno_dev->csdev[i] = NULL;
 		}
 	}
+#else
+	return;
+#endif
 }
 
 int adreno_coresight_init(struct adreno_device *adreno_dev)
 {
+#ifdef CONFIG_CORESIGHT
 	int ret = 0;
 	struct adreno_gpudev *gpudev = ADRENO_GPU_DEVICE(adreno_dev);
 	struct kgsl_device *device = KGSL_DEVICE(adreno_dev);
@@ -452,4 +457,7 @@ int adreno_coresight_init(struct adreno_device *adreno_dev)
 	}
 
 	return ret;
+#else
+	return 0;
+#endif
 }

--- a/drivers/soc/qcom/system_stats.c
+++ b/drivers/soc/qcom/system_stats.c
@@ -302,11 +302,11 @@ static int msm_rpmstats_probe(struct platform_device *pdev)
 	if (!pdev)
 		return -EINVAL;
 
-	node = of_parse_phandle(pdev->dev.of_node, "qcom,rpm-msg-ram", 0);
+	node = of_parse_phandle(pdev->dev.of_node, "qcom,rpm-data-ram", 0);
 	if (!node)
 		return -EINVAL;
 
-	ret = of_address_to_resource(node, 1, &res);
+	ret = of_address_to_resource(node, 0, &res);
 	if (ret)
 		return ret;
 
@@ -329,7 +329,7 @@ static int msm_rpmstats_probe(struct platform_device *pdev)
 	if (!ss.rpm_stats_addr)
 		return -ENOMEM;
 
-	node = of_parse_phandle(pdev->dev.of_node, "qcom,rpm-code-ram", 0);
+	node = of_parse_phandle(pdev->dev.of_node, "qcom,rpm-msg-ram", 0);
 	if (!node)
 		return -EINVAL;
 


### PR DESCRIPTION
Fix the !CONFIG_CORESIGHT kernel build failure, system_stats stuff and , on sdm630/660, enable smcinvoke.

Also, fix the memory map for SDM630, SDM636, SDM660 and MSM8998 in order to
stop the system crashes due to hypervisor security faults.