### PR TITLE
[7.1.r1] arm64: DT: HACK: sdm660-audio: Remove cdc-vdd-mic-bias supply

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
@@ -168,7 +168,7 @@
 		qcom,cdc-static-supplies = "cdc-vdda-cp",
 					   "cdc-vdd-pa";
 
-		qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
+		//qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
 
 		/*
 		 * Not marking address @ as driver searches this child

--- a/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
@@ -19,7 +19,7 @@
 
 &soc {
 	msm_vidc: qcom,vidc@cc00000 {
-		compatible = "qcom,msm-vidc", "sdm660-vidc";
+		compatible = "qcom,msm-vidc", "qcom,sdm660-vidc";
 		status = "ok";
 		reg = <0xcc00000 0x100000>;
 		interrupts = <GIC_SPI 287 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
This supply makes Linux to -ENOMEM fail when devres_alloc'ing
the bulk supplies in the sdm660 audio driver.

The audio works without this supply, though... this is a pure
hack and it's not expected to work without issues in the future.

-----------------------------------------------------

I don't know if it is a good idea to merge this commit. With it in,
audio will work on at least SoMC Nile Discovery.... but I cannot give
any guarantees about future issues, as stated in the commit
description...................
