### PR TITLE
[7.1.r1] Fix vidc probe crash on SDM630/660

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-vidc.dtsi
@@ -120,7 +120,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,bus-governor = "msm-ar50-ddr";
 			qcom,bus-range-kbps = <1000 2688000>;
 		};
 
@@ -145,58 +145,6 @@
 				qcom,low-power-mode-factor = <65536>;
 			};
 		};
-
-		/* Bus governor tables */
-		venus-ddr-gov {
-		    compatible = "qcom,msm-vidc,governor,table";
-		    name = "venus-ddr-gov";
-		    status = "ok";
-		    qcom,bus-freq-table {
-			qcom,profile-enc {
-				/* Codec mask for "all encoders" */
-				qcom,codec-mask = <0x55555555>;
-				qcom,load-busfreq-tbl =
-					<979200 1964000>,  /* UHD30E     */
-					<864000 1562000>,  /* 720p240LPE */
-					<489600 1530000>,  /* 1080p60E   */
-					<432000 1148000>,  /* 720p120E   */
-					<244800 775000>,   /* 1080p30E   */
-					<216000 677000>,   /* 720p60E    */
-					<108000 342000>,   /* 720p30E    */
-					<0 0>;
-			};
-
-			qcom,profile-dec {
-				/* Codec mask for "all decoders" */
-				qcom,codec-mask = <0xffffffff>;
-				qcom,load-busfreq-tbl =
-					<979200 2458000>,  /* UHD30D     */
-					<864000 1967000>,  /* 720p240D   */
-					<489600 1148000>,  /* 1080p60D   */
-					<432000 775000>,   /* 720p120D   */
-					<244800 574000>,   /* 1080p30D   */
-					<216000 496000>,   /* 720p60E    */
-					<108000 252000>,   /* 720p30D    */
-					<0 0>;
-			};
-
-			qcom,profile-low-latency-enc {
-				/* Codec mask for "all encoders" */
-				qcom,codec-mask = <0x55555555>;
-				qcom,low-latency-mode;
-				qcom,load-busfreq-tbl =
-					<979200 2688000>,  /* UHD30E     */
-					<864000 2306000>,  /* 720p240LPE */
-					<489600 2276000>,  /* 1080p60E   */
-					<432000 2159000>,  /* 720p120E   */
-					<244800 1149000>,  /* 1080p30E   */
-					<216000 1010000>,  /* 720p60E    */
-					<108000 508000>,   /* 720p30E    */
-					<0 0>;
-			};
-		    };
-		};
-
 
 		/* IOMMU Contexts: Non Secure */
 		/* venus_ns

--- a/arch/arm64/boot/dts/qcom/msm8996-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-vidc.dtsi
@@ -110,7 +110,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,bus-governor = "msm-ar50-ddr";
 			qcom,bus-range-kbps = <1000 3388000>;
 		};
 

--- a/arch/arm64/boot/dts/qcom/msm8998-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-vidc.dtsi
@@ -110,7 +110,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,bus-governor = "vidc-ar50-ddr";
 			qcom,bus-range-kbps = <1000 4946000>;
 		};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
@@ -91,7 +91,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "venus-ddr-gov";
+			qcom,bus-governor = "vidc-ar50-ddr";
 			qcom,bus-range-kbps = <1000 2365000>;
 		};
 
@@ -119,65 +119,6 @@
 				qcom,cycles-per-mb = <400>;
 			};
 	    };
-
-	    venus-ddr-gov {
-		compatible = "qcom,msm-vidc,governor,table";
-		name = "venus-ddr-gov";
-		status = "ok";
-		qcom,bus-freq-table {
-			qcom,profile-enc {
-				qcom,codec-mask = <0x55555555>;
-				qcom,load-busfreq-tbl =
-					<979200 1044000>,  /* UHD30E     */
-					<864000 887000>,   /* 720p240LPE */
-					<489600 666000>,   /* 1080p60E   */
-					<432000 578000>,   /* 720p120E   */
-					<244800 346000>,   /* 1080p30E   */
-					<216000 293000>,   /* 720p60E    */
-					<108000 151000>,   /* 720p30E    */
-					<0 0>;
-			};
-			qcom,profile-dec {
-				qcom,codec-mask = <0xffffffff>;
-				qcom,load-busfreq-tbl =
-					<979200 2365000>,  /* UHD30D     */
-					<864000 1978000>,  /* 720p240D   */
-					<489600 1133000>,  /* 1080p60D   */
-					<432000 994000>,   /* 720p120D   */
-					<244800 580000>,   /* 1080p30D   */
-					<216000 501000>,   /* 720p60E    */
-					<108000 255000>,   /* 720p30D    */
-					<0 0>;
-			};
-			qcom,profile-dec-ubwc {
-				qcom,codec-mask = <0xffffffff>;
-				qcom,ubwc-mode;
-				qcom,load-busfreq-tbl =
-					<979200 1892000>,  /* UHD30D     */
-					<864000 1554000>,  /* 720p240D   */
-					<489600 895000>,   /* 1080p60D   */
-					<432000 781000>,   /* 720p120D   */
-					<244800 460000>,   /* 1080p30D   */
-					<216000 301000>,   /* 720p60E    */
-					<108000 202000>,   /* 720p30D    */
-					<0 0>;
-			};
-			qcom,profile-dec-ubwc-10bit {
-				qcom,codec-mask = <0xffffffff>;
-				qcom,ubwc-10bit;
-				qcom,load-busfreq-tbl =
-					<979200 2446336>,  /* UHD30D     */
-					<864000 2108416>,  /* 720p240D   */
-					<489600 1207296>,  /* 1080p60D   */
-					<432000 1058816>,  /* 720p120D   */
-					<244800 616448>,   /* 1080p30D   */
-					<216000 534528>,   /* 720p60D    */
-					<108000 271360>,   /* 720p30D    */
-					<0 0>;
-			};
-		};
-	};
-
 
 		/* MMUs */
 		non_secure_cb {

--- a/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
@@ -19,7 +19,7 @@
 
 &soc {
 	msm_vidc: qcom,vidc@cc00000 {
-		compatible = "qcom,msm-vidc", "sdm660-vidc";
+		compatible = "qcom,msm-vidc", "qcom,sdm660-vidc";
 		status = "ok";
 		reg = <0xcc00000 0x100000>;
 		interrupts = <GIC_SPI 287 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm64/boot/dts/qcom/sdm845-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-vidc.dtsi
@@ -63,7 +63,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,bus-governor = "msm-ar50-ddr";
 			qcom,bus-range-kbps = <1000 3388000>;
 		};
 		arm9_bus_ddr {
@@ -79,7 +79,7 @@
 			label = "venus-llcc";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_LLCC>;
-			qcom,bus-governor = "msm-vidc-llcc";
+			qcom,bus-governor = "msm-ar50-llcc";
 			qcom,bus-range-kbps = <17000 125700>;
 		};
 


### PR DESCRIPTION
The compatible string to select SDM660 platform data was missing
the "qcom," prefix.