### PR TITLE
[7.1.r1] Fix rqbalance build and vidc governor typos

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-vidc.dtsi
@@ -120,7 +120,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-ar50-ddr";
+			qcom,bus-governor = "vidc-ar50-ddr";
 			qcom,bus-range-kbps = <1000 2688000>;
 		};
 

--- a/arch/arm64/boot/dts/qcom/msm8996-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-vidc.dtsi
@@ -110,7 +110,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-ar50-ddr";
+			qcom,bus-governor = "vidc-ar50-ddr";
 			qcom,bus-range-kbps = <1000 3388000>;
 		};
 

--- a/arch/arm64/boot/dts/qcom/sdm845-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-vidc.dtsi
@@ -63,7 +63,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-ar50-ddr";
+			qcom,bus-governor = "vidc-ar50-ddr";
 			qcom,bus-range-kbps = <1000 3388000>;
 		};
 		arm9_bus_ddr {
@@ -79,7 +79,7 @@
 			label = "venus-llcc";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_LLCC>;
-			qcom,bus-governor = "msm-ar50-llcc";
+			qcom,bus-governor = "vidc-ar50-llcc";
 			qcom,bus-range-kbps = <17000 125700>;
 		};
 

--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -37,6 +37,7 @@
 #include <linux/cpu.h>
 #include <linux/sched.h>
 #include <linux/slab.h>
+#include <linux/sched/stat.h>
 
 #include "../cpuquiet.h"
 


### PR DESCRIPTION
Now we can build rqbalance again (and works fine on Akari).
Plus, fix vidc governor typos.

Now Venus works fine on SoMC Tama.