### PR TITLE
[7.1.r1] Android.mk: 4.14 SOMC_KERNEL_VERSION guard

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -17,7 +17,7 @@
 
 ifeq ($(BUILD_KERNEL),true)
 ifeq ($(PRODUCT_PLATFORM_SOD),true)
-ifeq ($(SOMC_KERNEL_VERSION),4.9)
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
 
 KERNEL_SRC := $(call my-dir)
 


### PR DESCRIPTION
This kernel is 4.14 and no longer 4.9.
Commit 9f2debcc72f63 simply copypasted the 4.9 makefiles without adjustment.