### PR TITLE
[7.1.r1] SoMC Kumano Bahamut

### DIFF
--- a/arch/arm64/Kconfig.platforms
+++ b/arch/arm64/Kconfig.platforms
@@ -635,4 +635,13 @@ config MACH_SONY_GRIFFIN
 	If you enable this config,
 	please use SONY Mobile device tree.
 
+config MACH_SONY_BAHAMUT
+	bool "Sony Mobile Bahamut"
+	depends on ARCH_SONY_KUMANO
+	help
+	Support for the SONY Mobile Bahamut device
+	which is based on SONY Kumano platform.
+	If you enable this config,
+	please use SONY Mobile device tree.
+
 endmenu

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -2,8 +2,11 @@ ifeq ($(CONFIG_BUILD_ARM64_DT_OVERLAY),y)
 # SM8150 - SoMC Kumano
 dtbo-$(CONFIG_MACH_SONY_GRIFFIN) += \
 		sm8150-kumano-griffin_generic-overlay.dtbo
+dtbo-$(CONFIG_MACH_SONY_BAHAMUT) += \
+		sm8150-kumano-bahamut_generic-overlay.dtbo
 
 sm8150-kumano-griffin_generic-overlay.dtbo-base := sm8150.dtb sm8150-v2.dtb
+sm8150-kumano-bahamut_generic-overlay.dtbo-base := sm8150.dtb sm8150-v2.dtb
 
 
 # SDM845 - SoMC Tama

--- a/arch/arm64/boot/dts/qcom/charger-kumano-bahamut.dtsi
+++ b/arch/arm64/boot/dts/qcom/charger-kumano-bahamut.dtsi
@@ -1,0 +1,68 @@
+/* Copyright (c) 2015-2018, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+&pm8150b_charger {
+	qcom,battery-data = <&kumano_batterydata>;
+	qcom,fv-max-uv = <4380000>;
+	qcom,chg-term-src = <1>;
+	qcom,chg-term-current-ma = <(-150)>;
+	somc,product-max-icl-ua = <2600000>;
+};
+
+&pm8150b_pdphy {
+};
+
+&vendor {
+	kumano_batterydata: qcom,battery-data {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-kumano-reference.dtsi"
+	};
+	kumano_batterydata_al0: somc,battery-data-al0 {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-bahamut-tmm-4380mv.dtsi"
+	};
+	kumano_batterydata_al1: somc,battery-data-al1 {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-bahamut-tmm-4340mv.dtsi"
+	};
+	kumano_batterydata_al2: somc,battery-data-al2 {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-bahamut-tmm-4300mv.dtsi"
+	};
+	kumano_batterydata_al3: somc,battery-data-al3 {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-bahamut-tmm-4250mv.dtsi"
+	};
+	kumano_batterydata_al4: somc,battery-data-al4 {
+		qcom,batt-id-range-pct = <17>;
+		#include "fg-gen4-batterydata-bahamut-tmm-4150mv.dtsi"
+	};
+};
+
+&pm8150b_fg {
+	qcom,battery-data = <&kumano_batterydata>;
+	somc,battery-data-al0 = <&kumano_batterydata_al0>;
+	somc,battery-data-al1 = <&kumano_batterydata_al1>;
+	somc,battery-data-al2 = <&kumano_batterydata_al2>;
+	somc,battery-data-al3 = <&kumano_batterydata_al3>;
+	somc,battery-data-al4 = <&kumano_batterydata_al4>;
+	somc,jeita-step-use-real-temp;
+	somc,jeita-batt-temp-correction = <0>;
+	qcom,fg-sys-term-current = <(-200)>;
+};

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-1080p2520-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-1080p2520-cmd.dtsi
@@ -1,0 +1,161 @@
+/* Copyright (c) 2015-2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+&mdss_mdp {
+	/* Samsung FHD OLED ID4 */
+	/* sofef01_m-fhd_plus */
+	dsi_4: somc,4_panel {
+		qcom,mdss-dsi-panel-name = "4";
+		qcom,mdss-dsi-panel-type = "dsi_cmd_mode";
+		qcom,mdss-pan-physical-width-dimension = <61>;
+		qcom,mdss-pan-physical-height-dimension = <142>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-border-color = <0>;
+		qcom,mdss-dsi-underflow-color = <0x0>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,mdss-dsi-te-pin-select = <1>;
+		qcom,mdss-dsi-te-dcs-command = <1>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-t-clk-post = <0x1A>;
+		qcom,mdss-dsi-t-clk-pre = <0x1F>;
+		qcom,mdss-dsi-lp11-init;
+
+		somc,dsi-panel-type = "oled";
+
+		somc,pw-wait-after-on-vddio = <0>;
+		somc,pw-wait-after-on-touch-int-n = <10>;
+		qcom,mdss-dsi-touch-reset-sequence = <1 10>;
+		qcom,mdss-dsi-reset-sequence = <1 10>;
+
+		somc,pw-off-rst-b-seq = <0 5>;
+		somc,pw-wait-after-off-touch-reset = <5>;
+		somc,pw-wait-after-off-lp11 = <10>;
+		somc,pw-wait-after-off-touch-vddh = <4>;
+		somc,pw-wait-after-off-vddio = <100>;
+		somc,area_count_table_size = <17>;
+		somc,area_count_table = <0 68 136 204 273
+				341 409 477 545 613
+				681 749 818 886 954
+				1022 1023>;
+
+		qcom,mdss-dsi-display-timings {
+			timing@0 {
+				qcom,mdss-dsi-timing-default;
+				qcom,mdss-dsi-panel-width = <1080>;
+				qcom,mdss-dsi-panel-height = <2520>;
+				qcom,mdss-dsi-h-back-porch = <8>;
+				qcom,mdss-dsi-h-pulse-width = <8>;
+				qcom,mdss-dsi-h-front-porch = <8>;
+				qcom,mdss-dsi-v-back-porch = <8>;
+				qcom,mdss-dsi-v-pulse-width = <8>;
+				qcom,mdss-dsi-v-front-porch = <8>;
+				qcom,mdss-dsi-panel-framerate = <60>;
+				qcom,mdss-dsi-panel-clockrate = <1132293600>;
+				qcom,mdss-dsi-panel-jitter = <0x5 0x1>;
+				qcom,mdss-dsi-h-sync-skew = <0>;
+				qcom,mdss-dsi-h-left-border = <0>;
+				qcom,mdss-dsi-h-right-border = <0>;
+				qcom,mdss-dsi-v-top-border = <0>;
+				qcom,mdss-dsi-v-bottom-border = <0>;
+				qcom,mdss-dsi-h-sync-pulse = <1>;
+				qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+				qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+
+				qcom,mdss-dsi-on-command = [
+					05 01 00 00 0A 00 01 11
+					39 01 00 00 00 00 02 35 00
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 02 DF 03
+					39 01 00 00 00 00 02 E0 01
+					39 01 00 00 00 00 03 F0 A5 A5
+					39 01 00 00 00 00 05 2B 00 00 09 D7
+					39 01 00 00 00 00 03 51 03 FF
+					39 01 00 00 00 00 02 53 20
+					39 01 00 00 00 00 02 55 00
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 BE 92 29
+					39 01 00 00 00 00 03 F0 A5 A5
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 02 B0 06
+					39 01 00 00 00 00 02 B6 90
+					39 01 00 00 6E 00 03 F0 A5 A5];
+				qcom,mdss-dsi-post-panel-on-command = [
+					05 01 00 00 00 00 01 29];
+				qcom,mdss-dsi-off-command = [
+					05 01 00 00 14 00 01 28
+					05 01 00 00 78 00 01 10];
+
+				somc,mdss-dsi-hbm-on-command = [
+					39 01 00 00 00 00 02 53 E8
+					];
+				somc,mdss-dsi-hbm-off-command = [
+					39 01 00 00 11 00 02 53 28
+					];
+				somc,mdss-dsi-hbm-on-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-hbm-low-command-state = "dsi_lp_mode";
+
+				somc,mdss-dsi-aod-on-command = [
+					05 01 00 00 00 00 01 28
+					39 01 00 00 0A 00 02 53 22
+					05 01 00 00 00 00 01 29];
+				somc,mdss-dsi-aod-low-command = [
+					39 01 00 00 00 00 02 53 23
+					];
+				somc,mdss-dsi-aod-high-command = [
+					39 01 00 00 00 00 02 53 22
+					];
+				somc,mdss-dsi-aod-off-command = [
+					05 01 00 00 22 00 01 28
+					39 01 00 00 00 00 02 53 20
+					05 01 00 00 00 00 01 29];
+				somc,mdss-dsi-aod-on-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-aod-low-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-aod-high-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-aod-off-command-state = "dsi_lp_mode";
+
+				somc,mdss-dsi-flm2-on-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 BE 92 29
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-off-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 BE 92 09
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-on-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-flm2-off-command-state = "dsi_lp_mode";
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4150mv.dtsi
+++ b/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4150mv.dtsi
@@ -1,0 +1,159 @@
+/* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+qcom,bahamut_tmm_4150mv {
+	/* Added or Modified by SOMC */
+	qcom,battery-type = "1318-3746";
+	qcom,fastchg-current-ma = <3000>;
+	somc,initial-capacity-uah = <3130000>;
+	somc,step-cfg = <
+		(-2550) 50    0 4500    0 4150 1
+		   50  100    0 4500  900 4150 2
+		  100  450    0 4250 3000 4150 3
+		  100  450 4250 4300 1500 4150 3
+		  100  450 4300 4500  900 4150 3
+		  450  550    0 4500  900 4150 4
+		  550 2550    0 4500    0 4150 5
+	>;
+	somc,step-cell-impedance-mohm = <25>;
+
+	/* Prepared by Qualcomm */
+	qcom,profile-revision = <24>;
+	/* #3869630_SoMC_LukeMurata_2432mAh_averaged_MasterSlave_Feb26th2019*/
+	qcom,max-voltage-uv = <4150000>;
+	qcom,fg-cc-cv-threshold-mv = <4140>;
+	qcom,nom-batt-capacity-mah = <2432>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4250>;
+	qcom,therm-room-temp = <100000>;
+	/* qcom,battery-type = "3869630_somc_lukemurata_2432mah_averaged_masterslave_feb26th2019"; */
+	qcom,therm-coefficients = <0x2318 0xd0c 0xdaf7 0xc556 0x848d>;
+	qcom,therm-center-offset = <0x70>;
+	qcom,therm-pull-up = <100>;
+	qcom,rslow-normal-coeffs = <0xd2 0x0d 0x39 0x03>;
+	qcom,rslow-low-coeffs = <0xe3 0x04 0xa4 0x0a>;
+	qcom,checksum = <0x745E>;
+	qcom,gui-version = "PM855GUI - 1.0.0.13";
+	qcom,fg-profile-data = [
+		 09 00 27 EB
+		 03 ED BB F2
+		 FE EC 00 00
+		 20 C5 44 9A
+		 D8 87 33 B2
+		 2C AD F3 86
+		 1E 00 D2 0D
+		 39 03 6E 04
+		 90 02 CE 07
+		 32 00 ED EB
+		 2C EC 6D DA
+		 FC 01 3A CC
+		 2F BC 07 03
+		 95 D2 1F CA
+		 60 00 3F 00
+		 41 00 41 00
+		 42 00 3E 00
+		 3B 00 3A 00
+		 40 00 3C 00
+		 33 00 60 00
+		 43 00 4E 00
+		 50 00 5B 00
+		 52 00 47 00
+		 4E 64 5F 00
+		 4F 08 40 08
+		 60 F8 62 00
+		 63 00 61 08
+		 83 00 6F 00
+		 63 20 70 38
+		 83 48 6D 17
+		 65 00 D8 00
+		 C0 21 F1 0D
+		 E1 FA 63 04
+		 2D 1C 92 0A
+		 87 05 E7 23
+		 78 17 91 3A
+		 B1 4C FB 02
+		 A0 18 7C 21
+		 10 14 E8 12
+		 09 0C 7D 1C
+		 2C FA ED 05
+		 6F 03 02 18
+		 55 22 1A 3D
+		 81 4A 9D 19
+		 E1 27 92 ED
+		 30 D3 A2 D5
+		 8B 1C 75 D3
+		 4D 05 32 C2
+		 0E 18 44 9A
+		 39 85 5C AA
+		 BE 88 09 80
+		 AF FA F4 05
+		 B0 03 A0 05
+		 00 00 51 F5
+		 0C EA DD F7
+		 42 E5 E1 C4
+		 8E F1 1F D8
+		 A1 BD F2 02
+		 48 05 D2 01
+		 CE 07 32 00
+		 71 01 69 02
+		 7D 04 6D 03
+		 DF 04 27 03
+		 09 05 AC 02
+		 A8 03 55 00
+		 32 00 45 00
+		 4C 64 51 00
+		 52 E8 51 F0
+		 4F E0 4F 00
+		 52 00 46 08
+		 44 08 32 00
+		 40 20 41 38
+		 44 48 49 15
+		 4E 00 49 08
+		 45 10 4B 00
+		 44 00 3A 00
+		 2F 08 40 08
+		 46 00 46 20
+		 52 38 5F 48
+		 56 16 4C 00
+		 58 08 5A 10
+		 D8 00 98 1E
+		 62 05 87 0A
+		 91 03 7F 1C
+		 17 23 9D 3C
+		 CB 4A 4A 18
+		 8B 02 74 04
+		 7B 03 76 17
+		 3F 0A CB 23
+		 F0 04 30 02
+		 B3 04 8F 1C
+		 8C 02 6E 05
+		 0E 02 83 18
+		 5E 02 C0 04
+		 20 03 A0 00
+		 56 23 27 05
+		 0D 02 F1 04
+		 8E 1C 38 02
+		 F1 05 54 03
+		 88 18 32 02
+		 2C 05 8C 02
+		 A4 00 96 01
+		 C0 00 FA 00
+		 E0 09 00 00
+	];
+};

--- a/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4250mv.dtsi
+++ b/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4250mv.dtsi
@@ -1,0 +1,159 @@
+/* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+qcom,bahamut_tmm_4250mv {
+	/* Added or Modified by SOMC */
+	qcom,battery-type = "1318-3746";
+	qcom,fastchg-current-ma = <3000>;
+	somc,initial-capacity-uah = <3130000>;
+	somc,step-cfg = <
+		(-2550) 50    0 4500    0 4250 1
+		   50  100    0 4500  900 4250 2
+		  100  450    0 4250 3000 4250 3
+		  100  450 4250 4300 1500 4250 3
+		  100  450 4300 4500  900 4250 3
+		  450  550    0 4500  900 4200 4
+		  550 2550    0 4500    0 4200 5
+	>;
+	somc,step-cell-impedance-mohm = <25>;
+
+	/* Prepared by Qualcomm */
+	qcom,profile-revision = <24>;
+	/* #3869629_SoMC_LukeMurata_2694mAh_averaged_MasterSlave_Feb26th2019*/
+	qcom,max-voltage-uv = <4250000>;
+	qcom,fg-cc-cv-threshold-mv = <4240>;
+	qcom,nom-batt-capacity-mah = <2694>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4250>;
+	qcom,therm-room-temp = <100000>;
+	/* qcom,battery-type = "3869629_somc_lukemurata_2694mah_averaged_masterslave_feb26th2019"; */
+	qcom,therm-coefficients = <0x2318 0xd0c 0xdaf7 0xc556 0x848d>;
+	qcom,therm-center-offset = <0x70>;
+	qcom,therm-pull-up = <100>;
+	qcom,rslow-normal-coeffs = <0xc6 0x04 0x7e 0x03>;
+	qcom,rslow-low-coeffs = <0x7f 0xfc 0xd6 0x0a>;
+	qcom,checksum = <0x8195>;
+	qcom,gui-version = "PM855GUI - 1.0.0.13";
+	qcom,fg-profile-data = [
+		 09 00 E6 EA
+		 63 E4 4E EB
+		 4F E4 00 00
+		 3E C5 38 9A
+		 D8 87 B0 AA
+		 1E A5 2B 87
+		 1F 00 C6 04
+		 7E 03 AF 04
+		 60 02 CE 07
+		 32 00 46 EB
+		 D1 EC 34 DB
+		 C1 02 F0 DC
+		 65 C5 27 F4
+		 98 D4 0B 00
+		 60 00 41 00
+		 43 00 42 00
+		 40 00 3C 00
+		 3A 00 3F 00
+		 42 00 3E 00
+		 38 00 60 00
+		 3E 00 4A 00
+		 4E 00 53 00
+		 46 00 44 00
+		 6A 64 58 00
+		 4B 00 41 00
+		 60 00 53 00
+		 54 00 52 08
+		 6F 08 58 00
+		 59 20 88 40
+		 70 50 5F 14
+		 58 00 D8 00
+		 BE 1F A6 0D
+		 EB 03 F5 06
+		 15 1C 34 0B
+		 57 0C 46 23
+		 68 17 F0 3A
+		 D6 4D 3B 02
+		 7E 16 5F 20
+		 04 05 79 0A
+		 68 FE 85 1C
+		 47 02 AD 05
+		 1E 02 F6 17
+		 93 22 82 3C
+		 4A 4B 8C 16
+		 79 20 F3 04
+		 82 D2 B7 DC
+		 81 1C FF D1
+		 75 04 32 C3
+		 1C 18 86 92
+		 7D 84 63 A3
+		 97 A0 09 80
+		 54 00 61 05
+		 07 02 FC 05
+		 00 F8 82 05
+		 BE F3 E0 F7
+		 22 DD 5B C5
+		 5B 01 1F 00
+		 D9 DD 89 01
+		 5E 05 B9 01
+		 CE 07 32 00
+		 0B 03 60 00
+		 A2 05 67 02
+		 1A 02 64 02
+		 21 01 6B 00
+		 8E 05 52 00
+		 32 00 41 00
+		 4B 64 53 00
+		 56 F0 55 F8
+		 54 E0 56 00
+		 55 08 4F 10
+		 44 10 32 00
+		 40 20 41 40
+		 48 50 4E 11
+		 52 00 43 00
+		 4B 08 54 F8
+		 49 00 41 00
+		 32 08 40 08
+		 48 00 4D 20
+		 5C 40 64 50
+		 4B 13 51 00
+		 5A 00 54 08
+		 D8 F8 E7 1E
+		 AD 04 41 0B
+		 79 0D 46 1C
+		 10 22 4D 3D
+		 90 4A 28 18
+		 2A 03 3A 05
+		 71 03 66 15
+		 3F 0A 8C 20
+		 EE 04 93 02
+		 7B 04 78 1C
+		 13 03 68 04
+		 40 03 6D 18
+		 BF 02 D3 05
+		 6C 02 7F 00
+		 62 20 0D 05
+		 88 02 87 04
+		 93 1C 6C 02
+		 79 05 4E 02
+		 97 18 61 02
+		 A7 04 4C 03
+		 88 00 8E 01
+		 C0 00 FA 00
+		 EB 0A 00 00
+	];
+};

--- a/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4300mv.dtsi
+++ b/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4300mv.dtsi
@@ -1,0 +1,159 @@
+/* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+qcom,bahamut_tmm_4300mv {
+	/* Added or Modified by SOMC */
+	qcom,battery-type = "1318-3746";
+	qcom,fastchg-current-ma = <3000>;
+	somc,initial-capacity-uah = <3130000>;
+	somc,step-cfg = <
+		(-2550) 50    0 4500    0 4300 1
+		   50  100    0 4500  900 4300 2
+		  100  450    0 4250 3000 4300 3
+		  100  450 4250 4300 1500 4300 3
+		  100  450 4300 4500  900 4300 3
+		  450  550    0 4500  900 4200 4
+		  550 2550    0 4500    0 4200 5
+	>;
+	somc,step-cell-impedance-mohm = <25>;
+
+	/* Prepared by Qualcomm */
+	qcom,profile-revision = <24>;
+	/* #3869628_SoMC_LukeMurata_2821mAh_averaged_MasterSlave_Feb26th2019*/
+	qcom,max-voltage-uv = <4300000>;
+	qcom,fg-cc-cv-threshold-mv = <4290>;
+	qcom,nom-batt-capacity-mah = <2821>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4250>;
+	qcom,therm-room-temp = <100000>;
+	/* qcom,battery-type = "3869628_somc_lukemurata_2821mah_averaged_masterslave_feb26th2019"; */
+	qcom,therm-coefficients = <0x2318 0xd0c 0xdaf7 0xc556 0x848d>;
+	qcom,therm-center-offset = <0x70>;
+	qcom,therm-pull-up = <100>;
+	qcom,rslow-normal-coeffs = <0x9c 0x0d 0x0d 0x03>;
+	qcom,rslow-low-coeffs = <0xcc 0x05 0x54 0x0b>;
+	qcom,checksum = <0xE8DE>;
+	qcom,gui-version = "PM855GUI - 1.0.0.13";
+	qcom,fg-profile-data = [
+		 09 00 64 00
+		 1F ED A9 F2
+		 0F ED 00 00
+		 4B C5 2A 9A
+		 D9 87 50 AA
+		 1A A4 B2 87
+		 1A 00 9C 0D
+		 0D 03 73 04
+		 83 02 CE 07
+		 32 00 12 EB
+		 12 ED DE DA
+		 35 03 36 DC
+		 27 C5 1B 04
+		 D6 DC BA D3
+		 60 00 40 00
+		 43 00 42 00
+		 3E 00 3A 00
+		 3A 00 3E 00
+		 42 00 3D 00
+		 37 00 60 00
+		 41 00 52 00
+		 5B 00 5A 00
+		 4C 00 54 00
+		 78 64 60 00
+		 53 00 44 08
+		 60 F8 61 00
+		 66 00 70 08
+		 86 08 6C 00
+		 7F 20 A9 40
+		 89 50 75 14
+		 6B 00 D8 00
+		 19 20 33 0D
+		 5B 02 43 05
+		 31 1C 09 0B
+		 8B 0C 2E 23
+		 77 17 F5 3A
+		 D1 4D 41 02
+		 80 15 DB 1F
+		 79 05 42 0A
+		 9A 06 83 1C
+		 6A FA 65 05
+		 7F 02 F1 17
+		 B4 22 2A 3C
+		 C7 4B 82 16
+		 20 20 3E 05
+		 69 D2 74 DE
+		 8F 1C EB D3
+		 7C 04 5B C3
+		 19 18 8F 92
+		 6F 84 71 93
+		 91 A0 09 80
+		 55 00 4B 04
+		 5B 03 0B FC
+		 00 00 AC 05
+		 70 F3 E3 F7
+		 7C DD A6 BC
+		 F6 F8 1D E8
+		 E6 D5 F8 01
+		 5C 05 61 03
+		 CE 07 32 00
+		 77 01 52 00
+		 D2 05 85 03
+		 84 03 6D 02
+		 CD 02 97 02
+		 63 04 51 00
+		 33 00 3F 00
+		 49 64 51 00
+		 54 F8 54 00
+		 53 E8 54 00
+		 54 08 4F 10
+		 4B 10 34 00
+		 42 20 44 40
+		 4C 58 52 10
+		 4E 00 47 00
+		 4F 08 58 00
+		 4D 00 44 00
+		 36 08 44 08
+		 4B 00 53 20
+		 64 40 5C 50
+		 50 12 55 00
+		 5F 00 58 08
+		 D8 F8 4D 1F
+		 57 05 75 0A
+		 13 0C 54 1C
+		 07 22 5E 3D
+		 7F 4A 28 18
+		 63 03 D4 04
+		 18 02 6A 14
+		 3F 0A B4 20
+		 AF 04 D7 02
+		 04 06 81 1C
+		 15 03 57 04
+		 69 03 65 18
+		 EF 02 8A 05
+		 E5 02 7E 00
+		 A4 1F C1 05
+		 28 02 2F 05
+		 89 1C B4 02
+		 E6 04 05 03
+		 8B 18 82 02
+		 4F 04 CF 03
+		 78 00 AA 01
+		 C0 00 FA 00
+		 71 0B 00 00
+	];
+};

--- a/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4340mv.dtsi
+++ b/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4340mv.dtsi
@@ -1,0 +1,159 @@
+/* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+qcom,bahamut_tmm_4340mv {
+	/* Added or Modified by SOMC */
+	qcom,battery-type = "1318-3746";
+	qcom,fastchg-current-ma = <3000>;
+	somc,initial-capacity-uah = <3130000>;
+	somc,step-cfg = <
+		(-2550) 50    0 4500    0 4340 1
+		   50  100    0 4500  900 4340 2
+		  100  450    0 4250 3000 4340 3
+		  100  450 4250 4300 1500 4340 3
+		  100  450 4300 4500  900 4340 3
+		  450  550    0 4500  900 4200 4
+		  550 2550    0 4500    0 4200 5
+	>;
+	somc,step-cell-impedance-mohm = <25>;
+
+	/* Prepared by Qualcomm */
+	qcom,profile-revision = <24>;
+	/* #3869626_SoMC_LukeMurata_2939mAh_averaged_MasterSlave_Feb26th2019*/
+	qcom,max-voltage-uv = <4340000>;
+	qcom,fg-cc-cv-threshold-mv = <4330>;
+	qcom,nom-batt-capacity-mah = <2939>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4250>;
+	qcom,therm-room-temp = <100000>;
+	/* qcom,battery-type = "3869626_somc_lukemurata_2939mah_averaged_masterslave_feb26th2019"; */
+	qcom,therm-coefficients = <0x2318 0xd0c 0xdaf7 0xc556 0x848d>;
+	qcom,therm-center-offset = <0x70>;
+	qcom,therm-pull-up = <100>;
+	qcom,rslow-normal-coeffs = <0xfb 0x04 0x9b 0x03>;
+	qcom,rslow-low-coeffs = <0x12 0xf5 0x67 0x0b>;
+	qcom,checksum = <0xC068>;
+	qcom,gui-version = "PM855GUI - 1.0.0.13";
+	qcom,fg-profile-data = [
+		 09 00 DE EA
+		 9E E4 0D EB
+		 A9 E4 00 00
+		 5F C5 11 9A
+		 DC 87 DD A3
+		 3C A5 A9 87
+		 1E 00 FB 04
+		 9B 03 E2 04
+		 1D 02 CE 07
+		 32 00 EC EA
+		 3B ED CC DA
+		 75 03 1D DC
+		 DA C4 44 0D
+		 CF ED 45 DA
+		 60 00 42 00
+		 45 00 42 00
+		 3D 00 3B 00
+		 3C 00 40 00
+		 44 00 3F 00
+		 39 00 60 00
+		 3C 00 4A 00
+		 54 00 4F 00
+		 43 00 5C 00
+		 6F 64 58 00
+		 4A 00 42 00
+		 60 F0 52 00
+		 54 00 64 10
+		 68 10 57 00
+		 8B 20 87 40
+		 6C 50 5F 13
+		 57 00 D8 00
+		 4E 1F F9 0D
+		 D0 FB 1A 04
+		 12 1C 98 0B
+		 B3 0D 45 22
+		 5F 17 1F 43
+		 98 55 9C 02
+		 6E 15 B3 1F
+		 96 05 42 0A
+		 39 05 89 1C
+		 6E FA 51 05
+		 AB 02 F1 17
+		 C7 22 FB 3D
+		 0A 4A 7D 15
+		 CC 20 80 EC
+		 FB D2 F7 DD
+		 9B 1C BB CB
+		 CC 04 2D C3
+		 0D 18 A9 92
+		 32 84 C3 93
+		 96 A8 09 80
+		 97 02 F5 04
+		 11 02 A6 04
+		 00 F8 BA ED
+		 52 F3 E5 F7
+		 68 CA 85 BD
+		 03 01 1E F0
+		 51 D6 43 02
+		 6A 05 9F 01
+		 CE 07 32 00
+		 E5 02 56 02
+		 D3 05 D9 03
+		 B5 03 8B 03
+		 12 02 1D 02
+		 AB 04 52 00
+		 33 00 3F 00
+		 46 64 4D 00
+		 51 F8 50 00
+		 51 E8 50 00
+		 50 08 4D 10
+		 48 10 33 00
+		 41 20 43 40
+		 4B 58 52 0F
+		 47 00 48 00
+		 4D 08 57 00
+		 4A 00 43 00
+		 37 08 45 08
+		 4A 00 54 20
+		 65 40 56 50
+		 51 12 55 00
+		 5B 00 4E 08
+		 D8 F8 2A 1F
+		 85 05 6C 0A
+		 87 0C 4A 1C
+		 2C 22 00 45
+		 01 53 1D 18
+		 9D 03 64 04
+		 8B 02 63 13
+		 3F 0A 3B 20
+		 24 05 9A 02
+		 3C 06 88 1C
+		 22 03 21 04
+		 C8 03 74 18
+		 EB 02 8E 05
+		 E0 02 76 00
+		 90 1F C2 05
+		 41 02 FD 04
+		 81 1C E3 02
+		 86 04 85 03
+		 83 18 A3 02
+		 F6 05 37 02
+		 72 00 94 01
+		 C0 00 FA 00
+		 CF 0B 00 00
+	];
+};

--- a/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4380mv.dtsi
+++ b/arch/arm64/boot/dts/qcom/fg-gen4-batterydata-bahamut-tmm-4380mv.dtsi
@@ -1,0 +1,159 @@
+/* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+qcom,bahamut_tmm_4380mv {
+	/* Added or Modified by SOMC */
+	qcom,battery-type = "1318-3746";
+	qcom,fastchg-current-ma = <3000>;
+	somc,initial-capacity-uah = <3130000>;
+	somc,step-cfg = <
+		(-2550) 50    0 4500    0 4380 1
+		   50  100    0 4500  900 4380 2
+		  100  450    0 4250 3000 4380 3
+		  100  450 4250 4300 1500 4380 3
+		  100  450 4300 4500  900 4380 3
+		  450  550    0 4500  900 4200 4
+		  550 2550    0 4500    0 4200 5
+	>;
+	somc,step-cell-impedance-mohm = <25>;
+
+	/* Prepared by Qualcomm */
+	qcom,profile-revision = <24>;
+	/* #3869624_SoMC_LukeMurata_3031mAh_averaged_MasterSlave_Feb26th2019*/
+	qcom,max-voltage-uv = <4380000>;
+	qcom,fg-cc-cv-threshold-mv = <4370>;
+	qcom,nom-batt-capacity-mah = <3031>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4250>;
+	qcom,therm-room-temp = <100000>;
+	/* qcom,battery-type = "3869624_somc_lukemurata_3031mah_averaged_masterslave_feb26th2019"; */
+	qcom,therm-coefficients = <0x2318 0xd0c 0xdaf7 0xc556 0x848d>;
+	qcom,therm-center-offset = <0x70>;
+	qcom,therm-pull-up = <100>;
+	qcom,rslow-normal-coeffs = <0x8b 0xed 0xa4 0x0b>;
+	qcom,rslow-low-coeffs = <0x7d 0x07 0x73 0x0b>;
+	qcom,checksum = <0xDDF3>;
+	qcom,gui-version = "PM855GUI - 1.0.0.13";
+	qcom,fg-profile-data = [
+		 09 00 D3 EA
+		 CE E4 CD EA
+		 04 E5 00 00
+		 5A C5 2A 9A
+		 D8 87 33 A3
+		 03 9C 89 87
+		 1D 00 8B ED
+		 A4 0B AF 04
+		 6D 02 CE 07
+		 32 00 A3 E3
+		 5F E4 BC E3
+		 D9 0A 01 EB
+		 33 92 86 1C
+		 E1 0D EF D5
+		 60 00 48 00
+		 47 00 43 00
+		 3C 00 3B 00
+		 3C 00 40 00
+		 44 00 40 00
+		 39 00 60 00
+		 41 00 4B 00
+		 57 00 4F 00
+		 45 00 70 00
+		 72 64 5A 00
+		 4B 00 45 08
+		 60 F8 4F 00
+		 53 00 68 10
+		 62 10 59 00
+		 AB 20 85 40
+		 6D 50 5E 13
+		 57 00 D8 00
+		 69 1F CF 0D
+		 1B 02 B7 05
+		 34 1C 5A 0B
+		 DB 0D 2C 22
+		 9C 17 1D 43
+		 86 55 C1 02
+		 6F 14 48 1F
+		 FB 05 11 0A
+		 C7 FE 76 1C
+		 BF 02 B2 0C
+		 6E 0B F5 17
+		 E1 22 D0 45
+		 51 52 71 13
+		 BC 1F 7B ED
+		 74 D2 C3 DC
+		 83 1C 39 CA
+		 CD 05 3C C2
+		 3C 18 C6 92
+		 D4 85 5E 9A
+		 82 A8 09 80
+		 8F 02 01 FD
+		 12 02 70 04
+		 00 00 BB ED
+		 4B EB E5 07
+		 38 DA 97 C5
+		 E3 00 1E F0
+		 33 DE FF 03
+		 7F 05 89 01
+		 CE 07 32 00
+		 63 01 36 02
+		 4C 04 13 01
+		 B4 04 37 03
+		 CE 02 B7 03
+		 ED 05 56 00
+		 33 00 40 00
+		 48 64 4C 00
+		 4E F8 4E 00
+		 50 F0 4E 00
+		 4F 08 48 10
+		 47 10 33 00
+		 40 28 43 48
+		 4B 58 54 0D
+		 44 00 4A 00
+		 4E 08 5B 00
+		 43 00 43 00
+		 38 10 46 10
+		 4A 00 57 20
+		 68 40 50 50
+		 53 10 57 00
+		 5C 00 4D 08
+		 D8 00 4D 1F
+		 19 05 E0 0A
+		 79 0D 2E 1C
+		 66 22 8E 44
+		 8C 53 F8 17
+		 06 02 C2 05
+		 83 03 60 12
+		 3F 0A 6E 20
+		 D4 04 ED 02
+		 F0 05 7B 1C
+		 56 03 E3 05
+		 1B 02 5A 18
+		 37 03 0E 05
+		 C7 03 74 00
+		 85 1F BD 05
+		 5D 02 62 06
+		 81 1C FB 02
+		 4B 04 E2 03
+		 84 18 C7 02
+		 BC 05 97 02
+		 6E 00 8D 01
+		 C0 00 FA 00
+		 3A 0C 00 00
+	];
+};

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut-display.dtsi
@@ -1,0 +1,61 @@
+/* Copyright (c) 2015-2019, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2019 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+#include "dsi-panel-somc-sec-1080p2520-cmd.dtsi"
+
+&sde_dsi_kumano_panels {
+	/* Only one possible panel on PROD SoMC Bahamut */
+	somc,bootloader-panel-detect;
+
+	qcom,dsi-panel = <&dsi_4>;
+};
+
+&dsi_4 {
+	qcom,panel-supply-entries = <&dsi_panel_oled_pwr_supply>;
+	/delete-property/ qcom,panel-vspvsn-supply-entries;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <1023>;
+	qcom,mdss-brightness-max-level = <1023>;
+	qcom,mdss-dsi-panel-peak-brightness = <4200000>;
+	qcom,mdss-dsi-panel-blackness-level = <3230>;
+	qcom,mdss-dsi-mode-sel-gpio-state = "single_port";
+	qcom,platform-te-gpio = <&tlmm 8 0>;
+	qcom,platform-reset-gpio = <&tlmm 6 0>;
+	qcom,platform-touch-reset-gpio = <&tlmm 54 0>;
+	qcom,platform-touch-vddio-en-gpio = <&pm8150l_gpios 1 0>;
+	qcom,platform-touch-vddh-en-gpio = <&pm8150b_gpios 7 0>;
+	somc,disp-err-flag-gpio = <&tlmm 101 0>;
+
+	qcom,mdss-dsi-display-timings {
+		timing@0 {
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+			qcom,mdss-dsi-panel-phy-timings = [00 25 0A 0A 27 24 0A 0A 07 02 04 00 1F 1A];
+		};
+	};
+};
+
+&pm8150_l14 {
+	qcom,init-enable = <1>;
+};
+
+&pm8150_l17 {
+	qcom,init-enable = <1>;
+};
+

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_common.dtsi
@@ -1,0 +1,433 @@
+/* arch/arm64/boot/dts/somc/sm8150-kumano-bahamut_common.dtsi
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#include "sm8150-kumano-common.dtsi"
+
+&somc_pinctrl {
+	/* If product common default setting is needed,
+	fill pinctrl-1 value in <product>_common.dtsi */
+	pinctrl-1 = <&sm_gpio_16 &sm_gpio_23 &sm_gpio_33 &sm_gpio_34 /*&sm_gpio_122*/>;
+};
+
+&somc_pinctrl_pmic {
+	/* If product common PMIC default setting is needed,
+	fill pinctrl-1 value in <product>_common.dtsi */
+	pinctrl-1 = <&pm8150_gpio_7 &pm8150l_gpio_3 &pm8150b_gpio_7 &pm8150l_gpio_1>;
+};
+
+&qupv3_se10_i2c {
+	touchscreen@48 {
+		/* override parameter */
+		sec,max_coords = <1080 2520>;
+		sec,cover_mode_supported = <0>;
+		sec,rejection_area_portrait = <25 150 60 200>;
+		sec,rejection_area_landscape = <150 20 200 60>;
+	};
+};
+
+&soc {
+	gpio_keys {
+		pinctrl-0 = <&key_vol_dn_default
+			     &key_cam_focus_default
+			     &key_cam_snapshot_default>;
+
+		cam_snapshot {
+			label = "cam_snapshot";
+			gpios = <&pm8150b_gpios 1 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <766>;
+			gpio-key,wakeup;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+
+		cam_focus {
+			label = "cam_focus";
+			gpios = <&pm8150b_gpios 2 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_CAMERA_FOCUS>;
+			gpio-key,wakeup;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+	};
+};
+
+/* Regulator config */
+&pm8150_l13 {
+	status = "disabled";
+};
+
+/* GPIO_7: SUPWC_PWR_EN */
+&pm8150_gpio_7 {
+	pins = "gpio7";
+	function = "normal";
+	/delete-property/ bias-high-impedance;
+	output-low;
+	drive-push-pull;
+	qcom,drive-strength = <1>; /* Low */
+	power-source = <1>;
+};
+
+/* GPIO_1: TS_VDDIO_EN(do not initialize output value) */
+&pm8150l_gpio_1 {
+	pins = "gpio1";
+	function = "normal";
+	/delete-property/ output-high;
+	drive-push-pull;
+	bias-disable;
+	qcom,drive-strength = <1>;
+	power-source = <0>;
+};
+
+/* GPIO_7: TS_VDDH_EN(do not initialize output value) */
+&pm8150b_gpio_7 {
+	pins = "gpio7";
+	function = "normal";
+	/delete-property/ output-low;
+	drive-push-pull;
+	bias-disable;
+	qcom,drive-strength = <1>;
+	power-source = <1>;
+};
+
+/* GPIO_3: NC */
+&pm8150l_gpio_3 {
+	pins = "gpio3";
+	function = "normal";
+	bias-high-impedance; /* DISABLE GPIO_3 */
+	/delete-property/ output-low;
+	/delete-property/ drive-push-pull;
+	/delete-property/ qcom,drive-strength;
+	/delete-property/ power-source;
+};
+
+/* GPIO_16 : CAM_MCLK3 */
+&sm_gpio_16 {
+	mux {
+		pins = "gpio16";
+		function = "cam_mclk";
+	};
+
+	config {
+		pins = "gpio16";
+		drive-strength = <2>;
+		/delete-property/ bias-pull-down;
+		bias-disable;
+		/delete-property/ input-enable;
+	};
+};
+
+/* GPIO_23 : CAM3_RST_N */
+&sm_gpio_23 {
+	mux {
+		pins = "gpio23";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio23";
+		drive-strength = <2>;
+		/delete-property/ bias-pull-down;
+		bias-disable;
+		/delete-property/ input-enable;
+		output-low;
+	};
+};
+
+/* GPIO_33 : CCI_I2C_SDA3 */
+&sm_gpio_33 {
+	mux {
+		pins = "gpio33";
+		function = "cci_i2c";
+	};
+
+	config {
+		pins = "gpio33";
+		drive-strength = <2>;
+		/delete-property/ bias-pull-down;
+		bias-disable;
+		/delete-property/ input-enable;
+	};
+};
+
+/* GPIO_34 : CCI_I2C_SCL3 */
+&sm_gpio_34 {
+	mux {
+		pins = "gpio34";
+		function = "cci_i2c";
+	};
+
+	config {
+		pins = "gpio34";
+		drive-strength = <2>;
+		/delete-property/ bias-pull-down;
+		bias-disable;
+		/delete-property/ input-enable;
+	};
+};
+
+/* GPIO_122 : TS_INT_N */
+&sm_gpio_122 {
+	mux {
+		pins = "gpio122";
+		function = "gpio";
+	};
+
+	config {
+		pins = "gpio122";
+		drive-strength = <2>;
+		bias-disable;
+		input-enable;
+	};
+};
+
+/* Primary USB port related QMP USB DP Combo PHY */
+&usb_qmp_dp_phy {
+	rxa-equ-tuning-manual;
+	rxb-equ-tuning-manual;
+	qcom,qmp-phy-init-seq =
+		/* <reg_offset, value, delay> */
+		<USB3_DP_QSERDES_COM_SSC_EN_CENTER 0x01 0
+		 USB3_DP_QSERDES_COM_SSC_PER1 0x31 0
+		 USB3_DP_QSERDES_COM_SSC_PER2 0x01 0
+		 USB3_DP_QSERDES_COM_SSC_STEP_SIZE1_MODE0 0xde 0
+		 USB3_DP_QSERDES_COM_SSC_STEP_SIZE2_MODE0 0x07 0
+		 USB3_DP_QSERDES_COM_SSC_STEP_SIZE1_MODE1 0xde 0
+		 USB3_DP_QSERDES_COM_SSC_STEP_SIZE2_MODE1 0x07 0
+		 USB3_DP_QSERDES_COM_SYSCLK_BUF_ENABLE 0x0a 0
+		 USB3_DP_QSERDES_COM_CMN_IPTRIM 0x20 0
+		 USB3_DP_QSERDES_COM_CP_CTRL_MODE0 0x06 0
+		 USB3_DP_QSERDES_COM_CP_CTRL_MODE1 0x06 0
+		 USB3_DP_QSERDES_COM_PLL_RCTRL_MODE0 0x16 0
+		 USB3_DP_QSERDES_COM_PLL_RCTRL_MODE1 0x16 0
+		 USB3_DP_QSERDES_COM_PLL_CCTRL_MODE0 0x36 0
+		 USB3_DP_QSERDES_COM_PLL_CCTRL_MODE1 0x36 0
+		 USB3_DP_QSERDES_COM_SYSCLK_EN_SEL 0x1a 0
+		 USB3_DP_QSERDES_COM_LOCK_CMP_EN 0x04 0
+		 USB3_DP_QSERDES_COM_LOCK_CMP1_MODE0 0x14 0
+		 USB3_DP_QSERDES_COM_LOCK_CMP2_MODE0 0x34 0
+		 USB3_DP_QSERDES_COM_LOCK_CMP1_MODE1 0x34 0
+		 USB3_DP_QSERDES_COM_LOCK_CMP2_MODE1 0x82 0
+		 USB3_DP_QSERDES_COM_DEC_START_MODE0 0x82 0
+		 USB3_DP_QSERDES_COM_DEC_START_MODE1 0x82 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START1_MODE0 0xab 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START2_MODE0 0xea 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START3_MODE0 0x02 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START1_MODE1 0xab 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START2_MODE1 0xea 0
+		 USB3_DP_QSERDES_COM_DIV_FRAC_START3_MODE1 0x02 0
+		 USB3_DP_QSERDES_COM_VCO_TUNE_MAP 0x02 0
+		 USB3_DP_QSERDES_COM_VCO_TUNE1_MODE0 0x24 0
+		 USB3_DP_QSERDES_COM_VCO_TUNE1_MODE1 0x24 0
+		 USB3_DP_QSERDES_COM_VCO_TUNE2_MODE1 0x02 0
+		 USB3_DP_QSERDES_COM_HSCLK_SEL 0x01 0
+		 USB3_DP_QSERDES_COM_CORECLK_DIV_MODE1 0x08 0
+		 USB3_DP_QSERDES_COM_BIN_VCOCAL_CMP_CODE1_MODE0 0xca 0
+		 USB3_DP_QSERDES_COM_BIN_VCOCAL_CMP_CODE2_MODE0 0x1e 0
+		 USB3_DP_QSERDES_COM_BIN_VCOCAL_CMP_CODE1_MODE1 0xca 0
+		 USB3_DP_QSERDES_COM_BIN_VCOCAL_CMP_CODE2_MODE1 0x1e 0
+		 USB3_DP_QSERDES_COM_BIN_VCOCAL_HSCLK_SEL 0x11 0
+		 USB3_DP_QSERDES_TXA_LANE_MODE_1 0xd5 0
+		 USB3_DP_QSERDES_TXA_RCV_DETECT_LVL_2 0x12 0
+		 USB3_DP_QSERDES_TXA_RES_CODE_LANE_TX 0x00 0
+		 USB3_DP_QSERDES_TXA_RES_CODE_LANE_RX 0x00 0
+		 USB3_DP_QSERDES_TXA_RES_CODE_LANE_OFFSET_TX 0x16 0
+		 USB3_DP_QSERDES_TXA_RES_CODE_LANE_OFFSET_RX 0x05 0
+		 USB3_DP_QSERDES_TXA_PI_QEC_CTRL 0x20 0
+		 USB3_DP_QSERDES_RXA_UCDR_SO_GAIN 0x05 0
+		 USB3_DP_QSERDES_RXA_UCDR_FASTLOCK_FO_GAIN 0x2f 0
+		 USB3_DP_QSERDES_RXA_UCDR_SO_SATURATION_AND_ENABLE 0x7f 0
+		 USB3_DP_QSERDES_RXA_UCDR_FASTLOCK_COUNT_LOW 0xff 0
+		 USB3_DP_QSERDES_RXA_UCDR_FASTLOCK_COUNT_HIGH 0x0f 0
+		 USB3_DP_QSERDES_RXA_UCDR_PI_CONTROLS 0x99 0
+		 USB3_DP_QSERDES_RXA_UCDR_SB2_THRESH1 0x04 0
+		 USB3_DP_QSERDES_RXA_UCDR_SB2_THRESH2 0x08 0
+		 USB3_DP_QSERDES_RXA_UCDR_SB2_GAIN1 0x05 0
+		 USB3_DP_QSERDES_RXA_UCDR_SB2_GAIN2 0x05 0
+		 USB3_DP_QSERDES_RXA_AUX_DATA_TCOARSE_TFINE 0xa0 0
+		 USB3_DP_QSERDES_RXA_VGA_CAL_CNTRL1 0x54 0
+		 USB3_DP_QSERDES_RXA_VGA_CAL_CNTRL2 0x0e 0
+		 USB3_DP_QSERDES_RXA_GM_CAL 0x1f 0
+		 USB3_DP_QSERDES_RXA_RX_EQU_ADAPTOR_CNTRL2 0x0f 0
+		 USB3_DP_QSERDES_RXA_RX_EQU_ADAPTOR_CNTRL3 0x4a 0
+		 USB3_DP_QSERDES_RXA_RX_EQU_ADAPTOR_CNTRL4 0x0f 0
+		 USB3_DP_QSERDES_RXA_RX_IDAC_TSETTLE_LOW 0xc0 0
+		 USB3_DP_QSERDES_RXA_RX_IDAC_TSETTLE_HIGH 0x00 0
+		 USB3_DP_QSERDES_RXA_RX_EQ_OFFSET_ADAPTOR_CNTRL1 0x77 0
+		 USB3_DP_QSERDES_RXA_SIGDET_CNTRL 0x04 0
+		 USB3_DP_QSERDES_RXA_SIGDET_DEGLITCH_CNTRL 0x0e 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_00_LOW 0xbf 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_00_HIGH 0xbf 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_00_HIGH2 0x3f 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_00_HIGH3 0x7f 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_00_HIGH4 0x94 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_01_LOW 0xdc 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_01_HIGH 0xdc 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_01_HIGH2 0x5c 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_01_HIGH3 0x0b 0
+		 USB3_DP_QSERDES_RXA_RX_MODE_01_HIGH4 0xb3 0
+		 USB3_DP_QSERDES_RXA_DFE_EN_TIMER 0x04 0
+		 USB3_DP_QSERDES_RXA_DFE_CTLE_POST_CAL_OFFSET 0x38 0
+		 USB3_DP_QSERDES_RXA_DCC_CTRL1 0xc 0
+		 USB3_DP_QSERDES_RXA_VTH_CODE 0x10 0
+		 USB3_DP_QSERDES_TXB_LANE_MODE_1 0xd5 0
+		 USB3_DP_QSERDES_TXB_RCV_DETECT_LVL_2 0x12 0
+		 USB3_DP_QSERDES_TXB_RES_CODE_LANE_TX 0x00 0
+		 USB3_DP_QSERDES_TXB_RES_CODE_LANE_RX 0x00 0
+		 USB3_DP_QSERDES_TXB_RES_CODE_LANE_OFFSET_TX 0x16 0
+		 USB3_DP_QSERDES_TXB_RES_CODE_LANE_OFFSET_RX 0x05 0
+		 USB3_DP_QSERDES_TXB_PI_QEC_CTRL 0x01 0
+		 USB3_DP_QSERDES_RXB_UCDR_SO_GAIN 0x05 0
+		 USB3_DP_QSERDES_RXB_UCDR_FASTLOCK_FO_GAIN 0x2f 0
+		 USB3_DP_QSERDES_RXB_UCDR_SO_SATURATION_AND_ENABLE 0x7f 0
+		 USB3_DP_QSERDES_RXB_UCDR_FASTLOCK_COUNT_LOW 0xff 0
+		 USB3_DP_QSERDES_RXB_UCDR_FASTLOCK_COUNT_HIGH 0x0f 0
+		 USB3_DP_QSERDES_RXB_UCDR_PI_CONTROLS 0x99 0
+		 USB3_DP_QSERDES_RXB_UCDR_SB2_THRESH1 0x04 0
+		 USB3_DP_QSERDES_RXB_UCDR_SB2_THRESH2 0x08 0
+		 USB3_DP_QSERDES_RXB_UCDR_SB2_GAIN1 0x05 0
+		 USB3_DP_QSERDES_RXB_UCDR_SB2_GAIN2 0x05 0
+		 USB3_DP_QSERDES_RXB_AUX_DATA_TCOARSE_TFINE 0xa0 0
+		 USB3_DP_QSERDES_RXB_VGA_CAL_CNTRL1 0x54 0
+		 USB3_DP_QSERDES_RXB_VGA_CAL_CNTRL2 0x0e 0
+		 USB3_DP_QSERDES_RXB_GM_CAL 0x1f 0
+		 USB3_DP_QSERDES_RXB_RX_EQU_ADAPTOR_CNTRL2 0x0f 0
+		 USB3_DP_QSERDES_RXB_RX_EQU_ADAPTOR_CNTRL3 0x4a 0
+		 USB3_DP_QSERDES_RXB_RX_EQU_ADAPTOR_CNTRL4 0x0f 0
+		 USB3_DP_QSERDES_RXB_RX_IDAC_TSETTLE_LOW 0xc0 0
+		 USB3_DP_QSERDES_RXB_RX_IDAC_TSETTLE_HIGH 0x00 0
+		 USB3_DP_QSERDES_RXB_RX_EQ_OFFSET_ADAPTOR_CNTRL1 0x77 0
+		 USB3_DP_QSERDES_RXB_SIGDET_CNTRL 0x04 0
+		 USB3_DP_QSERDES_RXB_SIGDET_DEGLITCH_CNTRL 0x0e 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_00_LOW 0xbf 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_00_HIGH 0xbf 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_00_HIGH2 0x3f 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_00_HIGH3 0x7f 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_00_HIGH4 0x94 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_01_LOW 0xdc 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_01_HIGH 0xdc 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_01_HIGH2 0x5c 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_01_HIGH3 0x0b 0
+		 USB3_DP_QSERDES_RXB_RX_MODE_01_HIGH4 0xb3 0
+		 USB3_DP_QSERDES_RXB_DFE_EN_TIMER 0x04 0
+		 USB3_DP_QSERDES_RXB_DFE_CTLE_POST_CAL_OFFSET 0x38 0
+		 USB3_DP_QSERDES_RXB_DCC_CTRL1 0xc 0
+		 USB3_DP_QSERDES_RXB_VTH_CODE 0x10 0
+		 USB3_DP_PCS_LOCK_DETECT_CONFIG1 0xd0 0
+		 USB3_DP_PCS_LOCK_DETECT_CONFIG2 0x07 0
+		 USB3_DP_PCS_LOCK_DETECT_CONFIG3 0x20 0
+		 USB3_DP_PCS_LOCK_DETECT_CONFIG6 0x13 0
+		 USB3_DP_PCS_REFGEN_REQ_CONFIG1 0x21 0
+		 USB3_DP_PCS_RX_SIGDET_LVL 0xaa 0
+		 USB3_DP_PCS_CDR_RESET_TIME 0x0f 0
+		 USB3_DP_PCS_ALIGN_DETECT_CONFIG1 0x88 0
+		 USB3_DP_PCS_ALIGN_DETECT_CONFIG2 0x13 0
+		 USB3_DP_PCS_PCS_TX_RX_CONFIG 0x0c 0
+		 USB3_DP_PCS_EQ_CONFIG1 0x4b 0
+		 USB3_DP_PCS_EQ_CONFIG5 0x10 0
+		 USB3_DP_PCS_USB3_LFPS_DET_HIGH_COUNT_VAL 0xf8 0
+		 USB3_DP_PCS_USB3_RXEQTRAINING_DFE_TIME_S2 0x07 0
+		 USB3_DP_QSERDES_TXA_TX_DRV_LVL 0x3D 0
+		 USB3_DP_QSERDES_TXB_TX_DRV_LVL 0x3D 0
+		 USB3_DP_QSERDES_TXA_PRE_EMPH 0x25 0
+		 USB3_DP_QSERDES_TXB_PRE_EMPH 0x26 0
+		 USB3_DP_QSERDES_TXA_TX_EMP_POST1_LVL 0x35 0
+		 USB3_DP_QSERDES_TXB_TX_EMP_POST1_LVL 0x36 0
+		 0xffffffff 0xffffffff 0x00>;
+};
+
+&pm8150_vadc {
+	pmic_therm {
+		reg = <ADC_AMUX_THM1_PU2>;
+		label = "pmic_therm";
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+	};
+};
+
+&pm8150_adc_tm {
+	io-channels =	<&pm8150_vadc ADC_XO_THERM_PU2>,
+			<&pm8150_vadc ADC_AMUX_THM1_PU2>,
+			<&pm8150_vadc ADC_AMUX_THM2_PU2>;
+
+	pmic_therm {
+		reg = <ADC_AMUX_THM1_PU2>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+	};
+};
+
+&thermal_zones {
+	pmic_therm {
+		polling-delay-passive = <0>;
+		polling-delay = <0>;
+		thermal-governor = "user_space";
+		thermal-sensors = <&pm8150_adc_tm ADC_AMUX_THM1_PU2>;
+		trips {
+			active-config0 {
+				temperature = <125000>;
+				hysteresis = <1000>;
+				type = "passive";
+			};
+		};
+	};
+};
+
+&pm8150b_haptics {
+	qcom,vmax-mv = <2121>;
+	qcom,wave-play-rate-us = <5882>;
+};
+
+&pm8150l_rgb_led {
+	somc,rgb_sync = <1>;
+	red {
+		linux,default-trigger = "none";
+		somc,color_variation_max_num = <4>;
+		somc,max_current = <
+			95 183 137
+			96 183 137
+			97 183 137
+			98 183 137>;
+	};
+	green {
+		linux,default-trigger = "none";
+		somc,color_variation_max_num = <4>;
+		somc,max_current = <
+			95 89 186
+			96 89 186
+			97 89 186
+			98 89 186>;
+	};
+	blue {
+		linux,default-trigger = "none";
+		somc,color_variation_max_num = <4>;
+		somc,max_current = <
+			95 386 80
+			96 386 80
+			97 386 80
+			98 386 80>;
+	};
+};
+
+#include "sm8150-kumano-common-display.dtsi"
+#include "sm8150-kumano-bahamut-display.dtsi"
+#include "charger-kumano-common.dtsi"
+#include "charger-kumano-bahamut.dtsi"

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic-overlay.dts
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic-overlay.dts
@@ -1,0 +1,36 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/qcom,gcc-sm8150.h>
+#include <dt-bindings/clock/qcom,camcc-sm8150.h>
+#include <dt-bindings/clock/qcom,rpmh.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+#include "../qcom/sm8150-mtp.dtsi"
+#include "../qcom/sm8150-mtp-audio-overlay.dtsi"
+#include "sm8150-kumano-bahamut_generic.dtsi"
+
+/ {
+	model = "Sony Mobile Communications Inc., Bahamut(SM8150)";
+	compatible = "somc,bahamut-generic", "qcom,sm8150", "qcom,mtp";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic.dts
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic.dts
@@ -1,0 +1,30 @@
+/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+#include "../qcom/sm8150.dtsi"
+#include "../qcom/sm8150-mtp.dtsi"
+#include "sm8150-kumano-bahamut_generic.dtsi"
+
+/ {
+	model = "Sony Mobile Communications Inc., Bahamut(SM8150 v1)";
+	compatible = "somc,bahamut-generic", "qcom,sm8150", "qcom,mtp";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut_generic.dtsi
@@ -1,0 +1,58 @@
+/* arch/arm64/boot/dts/somc/sm8150-kumano-bahamut_generic.dtsi
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#include "sm8150-kumano-bahamut_common.dtsi"
+
+&soc {
+};
+
+&somc_pinctrl {
+	pinctrl-2 = <&sm_gpio_0 &sm_gpio_3>;
+};
+
+/* GPIO_0 : NFC_ESE_SPI_MISO */
+&sm_gpio_0 {
+	mux {
+		pins = "gpio0";
+		function = "qup0";
+	};
+
+	config {
+		pins = "gpio0";
+		drive-strength = <2>;
+		/delete-property/bias-disable;
+		bias-pull-down;
+	};
+};
+
+/* GPIO_3 : NFC_ESE_SPI_CS_N */
+&sm_gpio_3 {
+	mux {
+		pins = "gpio3";
+		function = "qup0";
+	};
+
+	config {
+		pins = "gpio3";
+		drive-strength = <2>;
+		/delete-property/bias-disable;
+		bias-pull-down;
+		/delete-property/output-low;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -31,6 +31,34 @@
 	};
 };
 
+&qupv3_se10_i2c {
+	status = "ok";
+	touchscreen@48 {
+		compatible = "sec,sec_ts";
+		reg = <0x48>;
+		sec,irq_gpio = <&tlmm 122 0x2008>;
+		sec,irq_type = <8200>;
+		sec,mis_cal_check = <1>;
+		sec,regulator_dvdd = "tsp_io";
+		sec,regulator_avdd = "tsp_avdd";
+		sec,regulator_boot_on;
+		sec,i2c-burstmax = <32>;
+		sec,project_name = "PJT", "MODEL";
+		sec,always_lpmode = <0>;
+		sec,bringup = <3>;
+		sec,firmware_name = "touch_module_id_0x61.img";
+
+		/* feature */
+		sec,watchdog_supported = <1>;
+		sec,watchdog_delay_ms = <10000>;
+		sec,side_touch_supported = <1>;
+		sec,glove_mode_supported = <0>;
+		sec,aod_mode_supported = <1>;
+		sec,sod_mode_supported = <1>;
+		sec,stamina_mode_supported = <1>;
+	};
+};
+
 &cam_cci0 {
 	/* The value of clock that depens on the following parameter is different from Qualcomm.
 	Change the value for Somc. */

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-griffin_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-griffin_common.dtsi
@@ -242,30 +242,8 @@
 &qupv3_se10_i2c {
 	status = "ok";
 	touchscreen@48 {
-		compatible = "sec,sec_ts";
-		reg = <0x48>;
-		sec,irq_gpio = <&tlmm 122 0x2008>;
-		sec,irq_type = <8200>;
-		sec,mis_cal_check = <1>;
-		sec,regulator_dvdd = "tsp_io";
-		sec,regulator_avdd = "tsp_avdd";
-		sec,regulator_boot_on;
-		sec,i2c-burstmax = <32>;
-		sec,project_name = "PJT", "MODEL";
 		sec,max_coords = <1644 3840>;   /* x y */
-		sec,always_lpmode = <0>;
-		sec,bringup = <3>;
-		sec,firmware_name = "touch_module_id_0x61.img";
-
-		/* feature */
-		sec,watchdog_supported = <1>;
-		sec,watchdog_delay_ms = <10000>;
-		sec,side_touch_supported = <1>;
-		sec,glove_mode_supported = <0>;
 		sec,cover_mode_supported = <1>;
-		sec,aod_mode_supported = <1>;
-		sec,sod_mode_supported = <1>;
-		sec,stamina_mode_supported = <1>;
 	};
 };
 


### PR DESCRIPTION
This patchset implements support for the SoMC Kumano Bahamut smartphone,
A.K.A. the Sony Xperia 5, built on the SoMC SM8150 Kumano platform.

Test:
BUILD TEST - OK