### PR TITLE
[7.1.r1] Fix SDM845 v2 bw table

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-v2.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-v2.dtsi
@@ -74,6 +74,17 @@
 		interrupt-controller;
 	};
 
+	llcc_bw_opp_table_v2: llcc-bw-opp-table-sdm845-v2 {
+		compatible = "operating-points-v2";
+
+		BW_OPP_ENTRY(150, 16); /*  2288 MB/s */
+		BW_OPP_ENTRY(300, 16); /*  4577 MB/s */
+		BW_OPP_ENTRY(426, 16); /*  6500 MB/s */
+		BW_OPP_ENTRY(533, 16); /*  8132 MB/s */
+		BW_OPP_ENTRY(600, 16); /*  9155 MB/s */
+		BW_OPP_ENTRY(806, 16); /* 12298 MB/s */
+		BW_OPP_ENTRY(933, 16); /* 14236 MB/s */
+	};
 };
 
 &pil_modem {
@@ -287,14 +298,7 @@
 };
 
 &cpubw {
-	qcom,bw-tbl =
-		< MHZ_TO_MBPS(150, 16) >, /*  2288 MB/s */
-		< MHZ_TO_MBPS(300, 16) >, /*  4577 MB/s */
-		< MHZ_TO_MBPS(426, 16) >, /*  6500 MB/s */
-		< MHZ_TO_MBPS(533, 16) >, /*  8132 MB/s */
-		< MHZ_TO_MBPS(600, 16) >, /*  9155 MB/s */
-		< MHZ_TO_MBPS(806, 16) >, /* 12298 MB/s */
-		< MHZ_TO_MBPS(933, 16) >; /* 14236 MB/s */
+	operating-points-v2 = <&llcc_bw_opp_table_v2>;
 };
 
 &devfreq_cpufreq {

--- a/arch/arm64/boot/dts/qcom/sdm845.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845.dtsi
@@ -1593,17 +1593,17 @@
 		qcom,serial-loading;
 
 		/* Inputs from mss */
-		interrupts-extended = <&pdc 0 266 1>,
-				<&modem_smp2p_in 0 0>,
-				<&modem_smp2p_in 2 0>,
-				<&modem_smp2p_in 1 0>,
-				<&modem_smp2p_in 3 0>,
-				<&modem_smp2p_in 7 0>;
+		interrupts-extended = <&pdc GIC_SPI 266 IRQ_TYPE_EDGE_RISING>,
+				<&modem_smp2p_in 0 IRQ_TYPE_EDGE_RISING>,
+				<&modem_smp2p_in 1 IRQ_TYPE_EDGE_RISING>,
+				<&modem_smp2p_in 2 IRQ_TYPE_EDGE_RISING>,
+				<&modem_smp2p_in 3 IRQ_TYPE_EDGE_RISING>,
+				<&modem_smp2p_in 7 IRQ_TYPE_EDGE_RISING>;
 
 		interrupt-names = "qcom,wdog",
 				"qcom,err-fatal",
-				"qcom,proxy-unvote",
 				"qcom,err-ready",
+				"qcom,proxy-unvote",
 				"qcom,stop-ack",
 				"qcom,shutdown-ack";
 


### PR DESCRIPTION
The BW table for SDM845v2 LLCC was never overridden after the migration
of the v1 table.

Fix it :)