### PR TITLE
[7.1.r1] [URGENT] platform: msm: ipa_v3: Completely disable ADPL/ODL on IPA HW 3.x to 4.0

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v3/ipa_odl.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_odl.c
@@ -330,6 +330,11 @@ int ipa3_odl_pipe_open(void)
 	int ret = 0;
 	struct ipa_ep_cfg_holb holb_cfg;
 
+	if (ipa3_ctx->ipa_hw_type < IPA_HW_v4_1) {
+		IPADBG("ADPL/ODL not supported on this HW\n");
+		return -ENODEV;
+	}
+
 	if (!ipa3_odl_ctx->odl_state.adpl_open) {
 		IPAERR("adpl pipe not configured\n");
 		return 0;
@@ -372,6 +377,12 @@ static int ipa_adpl_open(struct inode *inode, struct file *filp)
 	int ret = 0;
 
 	IPADBG("Called the function :\n");
+
+	if (ipa3_ctx->ipa_hw_type < IPA_HW_v4_1) {
+		IPADBG("ADPL/ODL not supported on this HW\n");
+		return -ENODEV;
+	}
+
 	if (ipa3_odl_ctx->odl_state.odl_init &&
 				!ipa3_odl_ctx->odl_state.adpl_open) {
 		ipa3_odl_ctx->odl_state.adpl_open = true;
@@ -395,6 +406,11 @@ void ipa3_odl_pipe_cleanup(bool is_ssr)
 {
 	bool ipa_odl_opened = false;
 	struct ipa_ep_cfg_holb holb_cfg;
+
+	if (ipa3_ctx->ipa_hw_type < IPA_HW_v4_1) {
+		IPADBG("ADPL/ODL not supported on this HW\n");
+		return;
+	}
 
 	if (!ipa3_odl_ctx->odl_state.adpl_open) {
 		IPAERR("adpl pipe not configured\n");


### PR DESCRIPTION
The support for this starts from IPAv4.1: trying to enable this on
unsupported hardware will produce undefined behavior and kernel crash.