### PR TITLE
[7.1.r1] Solve easy kernel panics around

### DIFF
--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -185,6 +185,9 @@ static void gov_slack_timer_start(struct interactive_cpu *icpu, int cpu)
 {
 	struct interactive_tunables *tunables = icpu->ipolicy->tunables;
 
+	/* Remove the current slack timer if it's pending for some race */
+	del_timer_sync(&icpu->slack_timer);
+
 	icpu->slack_timer.expires = jiffies + tunables->timer_slack_delay;
 	add_timer_on(&icpu->slack_timer, cpu);
 }

--- a/drivers/usb/pd/policy_engine.c
+++ b/drivers/usb/pd/policy_engine.c
@@ -1280,17 +1280,12 @@ static void phy_shutdown(struct usbpd *pd)
 	if (pd->vbus_enabled) {
 		regulator_disable(pd->vbus);
 		pd->vbus_enabled = false;
-	}
-
 #ifdef CONFIG_EXTCON_SOMC_EXTENSION
-	if (regulator_is_enabled(pd->vbus)) {
-		usbpd_info(&pd->dev, "turn off VBUS");
-		regulator_disable(pd->vbus);
 		phy_wait_vbus_settled_down(pd,
 				USB_VBUS_WAIT_VOLT, USB_VBUS_WAIT_ITVL,
 				USB_VBUS_WAIT_TMOUT);
-	}
 #endif
+	}
 }
 
 static enum hrtimer_restart pd_timeout(struct hrtimer *timer)


### PR DESCRIPTION
Solve the PDPHY/policy engine panic to cleanly shutdown or reboot the OS
and apply a temporary workaround in the interactive governor to stop kernel
panic due to timer pending in cpu hotplugging usecase.