### PR TITLE
[7.1.r1] uapi: media: msm_vidc_utils: Compatibility for old Venus MISR struct

### DIFF
--- a/include/uapi/media/msm_vidc_utils.h
+++ b/include/uapi/media/msm_vidc_utils.h
@@ -3,6 +3,21 @@
 
 #include <linux/types.h>
 
+/*
+ * Some targets need to use a different structure for the MISR
+ * informations, since that goes back and forth to the Venus
+ * firmware, which is old on these targets and obviously cannot
+ * understand a different struct when sending/receiving packed
+ * data.
+ */
+#if !defined(VENUS_USES_LEGACY_MISR_INFO)
+ #if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996) || \
+     defined(CONFIG_ARCH_MSM8998) || defined(CONFIG_ARCH_SDM630) ||  \
+     defined(CONFIG_ARCH_SDM660)  || defined(CONFIG_ARCH_SDM845)
+	#define VENUS_USES_LEGACY_MISR_INFO
+ #endif
+#endif
+
 #define MSM_VIDC_HAL_INTERLACE_COLOR_FORMAT_NV12	0x2
 #define MSM_VIDC_HAL_INTERLACE_COLOR_FORMAT_NV12_UBWC	0x8002
 #define MSM_VIDC_EXTRADATA_FRAME_QP_ADV 0x1
@@ -66,6 +81,14 @@ struct msm_vidc_input_crop_payload {
 	unsigned int height;
 };
 
+#ifdef VENUS_USES_LEGACY_MISR_INFO
+struct msm_vidc_misr_info {
+	unsigned int misr_dpb_luma;
+	unsigned int misr_dpb_chroma;
+	unsigned int misr_opb_luma;
+	unsigned int misr_opb_chroma;
+};
+#else
 struct msm_vidc_misr_info {
 	unsigned int misr_set;
 	unsigned int misr_dpb_luma[8];
@@ -73,6 +96,8 @@ struct msm_vidc_misr_info {
 	unsigned int misr_opb_luma[8];
 	unsigned int misr_opb_chroma[8];
 };
+#endif
+
 struct msm_vidc_output_crop_payload {
 	unsigned int size;
 	unsigned int version;


### PR DESCRIPTION
Some targets need to use a different structure for the MISR
informations, since that goes back and forth to the Venus
firmware, which is old on these targets and obviously cannot
understand a different struct when sending/receiving packed
data.