### PR TITLE
[7.1.r1] Kumano Touchscreen and ION errors fix

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150.dtsi
@@ -696,7 +696,7 @@
 		qseecom_mem: qseecom_region@0x9e400000 {
 			compatible = "shared-dma-pool";
 			no-map;
-			reg = <0 0x9e400000 0 0x1400000>;
+			reg = <0 0x9e400000 0 0x1a00000>;
 		};
 
 		cdsp_sec_mem: cdsp_sec_regions@0xa4c00000 {

--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -1898,6 +1898,9 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	input_info(true, &ts->client->dev, "%s: done\n", __func__);
 	input_log_fix();
 
+	ts->after_work.err = true;
+//	schedule_delayed_work(&ts->after_work.start, 0);
+
 	return 0;
 
 err_input_side_register_device:

--- a/drivers/input/touchscreen/sec_ts/sec_ts_fn.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts_fn.c
@@ -3515,7 +3515,7 @@ static void run_trx_short_test_all(void *device_data)
 	}
 
 	memset(rBuff, 0x00, size);
-	memset(data, 0x00, 32);
+	memset(data, 0x00, 24);
 
 	input_info(true, &ts->client->dev, "%s: Read self test result\n", __func__);
 

--- a/drivers/input/touchscreen/siw/mon/Android.mk
+++ b/drivers/input/touchscreen/siw/mon/Android.mk
@@ -1,6 +1,0 @@
-LOCAL_PATH := $(call my-dir)
-include $(CLEAR_VARS)
-LOCAL_MODULE              := ssw_mon.ko
-LOCAL_MODULE_TAGS         := optional
-LOCAL_MODULE_PATH         := $(KERNEL_MODULES_OUT)
-include $(DLKM_DIR)/AndroidKernelModule.mk


### PR DESCRIPTION
Enjoy the touchscreen and fix qseecom ion allocations.

Tested on SoMC Kumano Griffin DSDS