### PR TITLE
[7.1.r1] [ URGENT] Android.mk: TARGET_KERNEL_MODULES is no longer supported

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -152,10 +152,6 @@ else
 endif
 endif
 
-ifeq ($(TARGET_KERNEL_MODULES),)
-    TARGET_KERNEL_MODULES := no-external-modules
-endif
-
 $(KERNEL_OUT_STAMP):
 	$(hide) mkdir -p $(KERNEL_OUT)
 	$(hide) rm -rf $(KERNEL_MODULES_OUT)


### PR DESCRIPTION
This is no longer supported in AOSP and the build will error out if
we define it.

The kernel modules are compiled and installed in a different way now.