### PR TITLE
[LA.UM.7.1.r1] gpu: drm: panel_color_manager: SDE_CP_CRTC_DSPP_PCC is atomically set.

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -634,7 +634,9 @@ static int somc_panel_update_merged_pcc_cache(
 	return 0;
 }
 
-static int somc_panel_sde_crtc_set_property_override(struct drm_crtc *crtc,
+static int somc_panel_sde_crtc_atomic_set_property_override(
+		struct drm_crtc *crtc,
+		struct drm_crtc_state *state,
 		struct drm_property *property,
 		uint64_t value)
 {
@@ -711,8 +713,8 @@ static int somc_panel_sde_crtc_set_property_override(struct drm_crtc *crtc,
 	memcpy(blob->data, &color_mgr->cached_pcc, blob->length);
 
 default_fn:
-	return color_mgr->original_crtc_funcs->set_property(
-			crtc, property, value);
+	return color_mgr->original_crtc_funcs->atomic_set_property(
+			crtc, state, property, value);
 }
 
 static int somc_panel_inject_crtc_overrides(struct dsi_display *display)
@@ -767,7 +769,7 @@ static int somc_panel_inject_crtc_overrides(struct dsi_display *display)
 	memcpy(new_funcs, crtc->funcs, sizeof(struct drm_crtc_funcs));
 
 	/* Then, override the function: */
-	new_funcs->set_property = somc_panel_sde_crtc_set_property_override;
+	new_funcs->atomic_set_property = somc_panel_sde_crtc_atomic_set_property_override;
 
 	/* Finally, update the funcs buffer with the overridden function: */
 	crtc->funcs = new_funcs;


### PR DESCRIPTION
Starting with kernel 4.14, the color transform property that we were
overriding is now set atomically. Override atomic_set_property to be
able to merge requested color transformations with the color
calibrations coming from the panel driver again.

... And finally I have night light back... For what's still left of those burnt-away eyes :grin: 