### PR TITLE
[LA.UM.7.1.r1] platform: msm: ipa_v3: Do not write unsupported COUNTER_CFG on < ipa v3.5.

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v3/ipa_utils.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa_utils.c
@@ -3583,7 +3583,9 @@ int ipa3_init_hw(void)
 
 	ipa3_cfg_qsb();
 
-	if (ipa3_ctx->ipa_hw_type < IPA_HW_v4_5) {
+	if (ipa3_ctx->ipa_hw_type < IPA_HW_v3_5) {
+		/* Not supported */
+	} else if (ipa3_ctx->ipa_hw_type < IPA_HW_v4_5) {
 		/* set aggr granularity for 0.5 msec*/
 		cnt_cfg.aggr_granularity = GRAN_VALUE_500_USEC;
 		ipahal_write_reg_fields(IPA_COUNTER_CFG, &cnt_cfg);


### PR DESCRIPTION
IPA_COUNTER_CFG was added in k4.14, with a special case for ipa_v4.5 and
up.  However, this feature has never existed in on IPA versions older
than v3.5, leading to a jump to a NULL function in
ipahal_write_reg_n_fields as the ipahal_reg_objs array doesn't have an
entry for IPA_COUNTER_CFG on these older versions.

Add a check for < v3.5 to prevent a kernel panic on devices with older
IPA versions.

Part of the stack trace:
[   15.547091] Call trace:
[   15.554151]            (null)
[   15.556456]  ipa3_init_hw+0x1c8/0xca8
[   15.559585]  ipa3_post_init+0xe4/0x26ec

The nullptr jump happens in an inlined function, right before returning
here:
[   15.378589] lr : ipahal_write_reg_n_fields+0x1c0/0x2a0