### PR TITLE
[LA.UM.7.1.r1] ARM64: dts: poplar: power the hybrid in-cell panel

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-sde.dtsi
@@ -19,6 +19,7 @@
 	qcom,mdss-dsi-touch-reset-sequence = <1 5>;
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
 	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
+	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
 	somc,pw-on-rst-seq = "after_power_on";
 	qcom,mdss-dsi-display-timings {
 		1080p60 {
@@ -37,7 +38,6 @@
 	qcom,mdss-dsi-touch-reset-sequence = <1 5>;
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
 	qcom,panel-vspvsn-supply-entries = <&dsi_panel_vspvsn_pwr_supply>;
-	qcom,panel-touch-supply-entries = <&dsi_panel_touch_pwr_supply>;
 	somc,pw-on-rst-seq = "after_power_on";
 	qcom,mdss-dsi-display-timings {
 		1080p60 {


### PR DESCRIPTION
Previously, we had the full in-cell panel (9) being given a supply which
was needed for the hybrid in-cell panel (6). Probably a mistake during the
FBDEV -> DRM switch. Correct this.

Acked-by: MarijnS95 <marijns95@gmail.com>
Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>