### PR TITLE
dts: lilac: add missing battery profiles

### DIFF
--- a/arch/arm/boot/dts/qcom/fg-gen3-batterydata-lilac-send-4245mv-2425mah.dtsi
+++ b/arch/arm/boot/dts/qcom/fg-gen3-batterydata-lilac-send-4245mv-2425mah.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+qcom,send_2425mah {
+	qcom, = <24>;
+	qcom,max-voltage-uv = <4245000>;
+	qcom,fg-cc-cv-threshold-mv = <4235>;
+	qcom,fastchg-current-ma = <2025>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4050>;
+	qcom,battery-type = "1308-1851-4";
+	qcom,checksum = <0xb17b>;
+	qcom,gui-version = "PMI8998GUI - 2.0.0.58";
+	qcom,fg-profile-data = <0xab20ba04 0xa80a3e06 0x6f1c4802 0xce0de503 0x2b187822 0x963c4a4b 0x92000000 0x16000000 0xbec2 0xf9d579ca 0x31000800 0xe8e5f707 0xa70587fa 0x7f054d03 0x65e5b11a 0x43060920 0x27001400 0xe61fb305 0x90ab706 0x791cfc02 0x990c160b 0x8d18aa22 0xe4455a52 0x7c000000 0x13000000 0xf607 0x34c365cb 0x28000000 0x3ae3f707 0xfe05d9f3 0xe5069703 0x1af4e70b 0x9f33ccff 0x7100000 0xb209eb43 0x28004000 0x99010afa 0xff000000 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00>;
+};

--- a/arch/arm/boot/dts/qcom/fg-gen3-batterydata-lilac-send-4297mv-2359mah.dtsi
+++ b/arch/arm/boot/dts/qcom/fg-gen3-batterydata-lilac-send-4297mv-2359mah.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+qcom,send_2539mah {
+	qcom, = <24>;
+	qcom,max-voltage-uv = <4297000>;
+	qcom,fg-cc-cv-threshold-mv = <4287>;
+	qcom,fastchg-current-ma = <2025>;
+	qcom,batt-id-kohm = <330>;
+	qcom,battery-beta = <4050>;
+	qcom,battery-type = "1308-1851-3";
+	qcom,checksum = <0x1d5a>;
+	qcom,gui-version = "PMI8998GUI - 2.0.0.58";
+	qcom,fg-profile-data = <0xec1f6c05 0x4a0a23fd 0x6d1c6a02 0x8a0d4d0a 0x1018a622 0x2a3cdf4b 0x86000000 0x15000000 0x2db3 0x33cc8ccb 0x30000800 0xa8e52dcc 0xc40551fa 0xd6053a03 0xddfda732 0x22060920 0x27001400 0xba20bb04 0xcc0a1dfc 0x8c1cd502 0xdb0ce20a 0x8518cb22 0xb8459d52 0x83000000 0x12000000 0x47cc 0xc4c30200 0x28000000 0x4ee32dcc 0x17fca3f3 0xf2065f03 0xa406a212 0x9c33ccff 0x7100000 0x310ac044 0x28004000 0x93010afa 0xff000000 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00>;
+};

--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-lilac_common.dtsi
@@ -344,6 +344,8 @@
 		#include "fg-gen3-batterydata-lilac-send-4380mv-2729mah.dtsi"
 		#include "fg-gen3-batterydata-lilac-send-4357mv-2688mah.dtsi"
 		#include "fg-gen3-batterydata-lilac-send-4335mv-2647mah.dtsi"
+		#include "fg-gen3-batterydata-lilac-send-4297mv-2359mah.dtsi"
+		#include "fg-gen3-batterydata-lilac-send-4245mv-2425mah.dtsi"
 	};
 };
 


### PR DESCRIPTION
I have an XZ1C device (from about mid 2018) which, when flashed with Sony AOSP, would not show the correct charging percentage for the battery. Basically the type of battery was unknown, and it would always be stuck at 20% capacity.

```
130|lilac:/sys # cat ./devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qpnp,fg/batt_info
Unknown Battery/331000/3/59 fa 07 13|00
lilac:/sys # cat ./devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qpnp,fg/power_supply/bms/battery_type
Unknown Battery
lilac:/sys # cat ./devices/soc/800f000.qcom,spmi/spmi-0/spmi0-02/800f000.qcom,spmi:qcom,pmi8998@2:qcom,qpnp-smb2/power_supply/battery/capacity
20
```

After comparing the output of these queries on the stock kernel, I found out that there were two additional device tree profiles for 1308-1851 type batteries not included in the AOSP release. After ripping them out, converting them from dtb back to dts and adding them to the AOSP kernel device tree, the battery indicator works again as expected.

(The dtsi files in this commit aren't the original files; I extracted these from the stock Sony kernel.)