### PR TITLE
[7.1.r1] SDM845 online rotator, Akatsuki display jitter fix, LP11-out fix

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-atmel-lgd-1440p2880-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-atmel-lgd-1440p2880-cmd.dtsi
@@ -101,7 +101,7 @@
 				qcom,mdss-dsi-h-front-porch = <312>;
 				qcom,mdss-dsi-v-back-porch = <8>;
 				qcom,mdss-dsi-v-pulse-width = <8>;
-				qcom,mdss-dsi-v-front-porch = <16>;
+				qcom,mdss-dsi-v-front-porch = <48>;
 				qcom,mdss-dsi-panel-framerate = <60>;
 				qcom,mdss-dsi-panel-jitter = <0x5 0x1>;
 				qcom,mdss-dsi-h-sync-skew = <0>;
@@ -211,7 +211,7 @@
 				qcom,mdss-dsc-encoders = <2>;
 				qcom,mdss-dsc-block-prediction-enable;
 
-				qcom,mdss-dsi-panel-clockrate = <964260000>;
+				qcom,mdss-dsi-panel-clockrate = <970452940>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
@@ -222,13 +222,12 @@
 		qcom,sde-qos-cpu-mask = <0x3>;
 		qcom,sde-qos-cpu-dma-latency = <300>;
 
-		/* The inline rotator doesn't work correctly yet on 4.14
-		 * so comment it out for now and give it a big TODO
 		qcom,sde-inline-rotator = <&mdss_rotator 0>;
 		qcom,sde-inline-rot-xin = <10 11>;
 		qcom,sde-inline-rot-xin-type = "sspp", "wb";
+
+		/* offsets are relative to "mdp_phys + qcom,sde-off */
 		qcom,sde-inline-rot-clk-ctrl = <0x2bc 0x8>, <0x2bc 0xc>;
-		*/
 
 		qcom,sde-reg-dma-off = <0>;
 		qcom,sde-reg-dma-version = <0x1>;

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -569,6 +569,10 @@ int dsi_panel_driver_post_power_off(struct dsi_panel *panel)
 	}
 	spec_pdata = panel->spec_pdata;
 
+	if (spec_pdata->lp11_off)
+		usleep_range(spec_pdata->lp11_off * 1000,
+				spec_pdata->lp11_off * 1000 + 100);
+
 	if (!spec_pdata->oled_disp) {
 		rc = somc_panel_vreg_ctrl(
 			&spec_pdata->vspvsn_power_info, "ibb", false);
@@ -1153,6 +1157,9 @@ int dsi_panel_driver_parse_dt(struct dsi_panel *panel,
 	rc = of_property_read_u32(np,
 			"somc,pw-wait-after-off-touch-int-n", &tmp);
 	spec_pdata->touch_intn_off = !rc ? tmp : 0;
+
+	rc = of_property_read_u32(np, "somc,pw-wait-after-off-lp11", &tmp);
+	spec_pdata->lp11_off = !rc ? tmp : 0;
 
 	rc = of_property_read_u32(np,
 			"somc,aod-threshold", &tmp);

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -342,6 +342,7 @@ struct panel_specific_pdata {
 	int touch_vddio_off;
 	int touch_intn_off;
 	int touch_reset_off;
+	int lp11_off;
 
 	struct dsi_reset_cfg on_seq;
 	struct dsi_reset_cfg off_seq;


### PR DESCRIPTION
This patchset re-enables the online rotator on SDM845, plus fixes
a rare jitter issue on SoMC Tama Akatsuki and fixes some issues
with display resume on all devices featuring a OLED panel, including
Tama Akatsuki, Kumano Griffin and Kumano Bahamut.


Tested on SoMC Tama Akatsuki