### PR TITLE
[LA.UM.7.1.r1] Boot, Ganges, boot!

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
@@ -80,6 +80,7 @@
 		et51x,gpio_rst = <&tlmm 20 0>;
 		et51x,gpio_irq = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
+		et51x,no-low-voltage-probe;
 
 		spi-max-frequency = <1000000>;
 

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -120,6 +120,7 @@
 		et51x,gpio_rst    = <&tlmm 20 0>;
 		et51x,gpio_irq    = <&tlmm 72 0>;
 		vdd_ana-supply = <&pm660l_l6>;
+		et51x,check-sensor-type;
 
 		/*
 		 * The device has to stay enabled until the HAL initializes,

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common.dtsi
@@ -122,13 +122,6 @@
 		vdd_ana-supply = <&pm660l_l6>;
 		et51x,check-sensor-type;
 
-		/*
-		 * The device has to stay enabled until the HAL initializes,
-		 * otherwise it'll not send out any IRQ signals even though the
-		 * rest of the initialization runs without errors.
-		 */
-		et51x,enable-on-boot;
-
 		pinctrl-names = "et51x_reset_reset",
 			"et51x_reset_active",
 			"et51x_irq_active";

--- a/arch/arm64/boot/dts/qcom/sdm660-gpu.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-gpu.dtsi
@@ -109,7 +109,7 @@
 
 		/* Cx ipeak limit supprt */
 		qcom,gpu-cx-ipeak = <&cx_ipeak_lm 1>;
-		qcom,gpu-cx-ipeak-clk = <700000000>;
+		qcom,gpu-cx-ipeak-freq = <700000000>;
 
 		/* CPU latency parameter */
 		qcom,pm-qos-active-latency = <518>;

--- a/arch/arm64/boot/dts/qcom/sdm660-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-sde.dtsi
@@ -44,8 +44,8 @@
 		#interrupt-cells = <1>;
 		iommus = <&mmss_bimc_smmu 0>;
 
-		#address-cells = <1>;
-		#size-cells = <0>;
+		// #address-cells = <1>;
+		// #size-cells = <0>;
 
 		#power-domain-cells = <0>;
 
@@ -132,7 +132,7 @@
 		qcom,sde-dest-scaler-size = <0x88>; //<0x800>;
 
 		/* offsets are relative to "mdp_phys + qcom,sde-off */
-		qcom,sde-sspp-clk-ctrl = <0x2ac 0>, <0x2b4 0>, <0x2ac 8>, 
+		qcom,sde-sspp-clk-ctrl = <0x2ac 0>, <0x2b4 0>, <0x2ac 8>,
 					 <0x2b4 8>, <0x2c4 8>, <0x3a8 16>;
 
 		qcom,sde-sspp-csc-off = <0x1a00>;

--- a/arch/arm64/boot/dts/qcom/sdm660-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-sde.dtsi
@@ -115,13 +115,13 @@
 		qcom,sde-dsc-off = <0x81000 0x81400>;
 		qcom,sde-dsc-size = <0x140>;
 
-		qcom,sde-sspp-type = "vig", "vig", "dma", "dma", "dma", "cursor";
+		qcom,sde-sspp-type = "vig", "vig", "dma", "dma", "dma";
 
-		qcom,sde-sspp-off = <0x5000 0x7000 0x25000 0x27000 0x29000 0x35000>;
+		qcom,sde-sspp-off = <0x5000 0x7000 0x25000 0x27000 0x29000>;
 		qcom,sde-sspp-src-size = <0x184>;
 
-		qcom,sde-sspp-xin-id = <0 4 1 5 9 2>;
-		qcom,sde-sspp-excl-rect = <1 1 1 1 1 1>;
+		qcom,sde-sspp-xin-id = <0 4 1 5 9>;
+		qcom,sde-sspp-excl-rect = <1 1 1 1 1>;
 
 		qcom,sde-has-dest-scaler;
 		qcom,sde-max-dest-scaler-input-linewidth = <2048>;

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -721,7 +721,7 @@
 	};
 
 	rpm_bus: qcom,rpm-smd {
-		compatible = "qcom,rpm-glink";
+		compatible = "qcom,rpm-smd";
 		qcom,glink-edge = "rpm";
 		rpm-channel-name = "rpm_requests";
 		interrupts = <GIC_SPI 168 IRQ_TYPE_EDGE_RISING>;

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -210,6 +210,7 @@ static struct clk_rcg2 gfx3d_clk_src = {
 	.mnd_width = 0,
 	.hid_width = 5,
 	.freq_tbl = ftbl_gfx3d_clk_src,
+	.enable_safe_config = true,
 	.parent_map = gpucc_parent_map_1,
 	.flags = FORCE_ENABLE_RCG,
 	.clkr.hw.init = &gpu_clks_init[0],

--- a/drivers/input/misc/cei_fp_detect.h
+++ b/drivers/input/misc/cei_fp_detect.h
@@ -1,15 +1,15 @@
 #ifndef _CEI_FP_DETECT_H
 #define _CEI_FP_DETECT_H
 
+#define FP_HW_TYPE_EGISTEC 0
+#define FP_HW_TYPE_FPC 1
+
 #ifdef CONFIG_ARCH_SONY_NILE
 
 #include <linux/delay.h>
 // #include <linux/gpio.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
-
-#define FP_HW_TYPE_EGISTEC 0
-#define FP_HW_TYPE_FPC 1
 
 #define MSM_TLMM_GPIO14_BASE 0x0390E000
 #define MSM_TLMM_SIZE 0x72000
@@ -38,6 +38,13 @@ static inline int cei_fp_module_detect(void)
 
 	pr_info("fp module is egistec or null");
 	return FP_HW_TYPE_EGISTEC;
+}
+
+#else
+
+static inline int cei_fp_module_detect(void)
+{
+	return 0;
 }
 
 #endif /* CONFIG_ARCH_SONY_NILE */

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -508,9 +508,9 @@ static int et51x_probe(struct platform_device *pdev)
 		dev_info(dev, "Egistec sensor not found, bailing out\n");
 		rc = -ENODEV;
 		goto exit_powerdown;
-	} else {
-		dev_info(dev, "Detected Egistec sensor\n");
 	}
+
+	dev_info(dev, "Detected Egistec sensor\n");
 #endif
 
 	rc = et51x_request_named_gpio(et51x, "et51x,gpio_irq",

--- a/drivers/input/misc/fpc1145_platform.c
+++ b/drivers/input/misc/fpc1145_platform.c
@@ -560,10 +560,10 @@ static int fpc1145_probe(struct platform_device *pdev)
 	int rc = 0;
 	size_t i;
 	int irqf;
+	struct device_node *np = dev->of_node;
 #ifdef CONFIG_ARCH_SONY_NILE
 	int hw_type;
 #endif
-	struct device_node *np = dev->of_node;
 
 	struct fpc1145_data *fpc1145 =
 		devm_kzalloc(dev, sizeof(*fpc1145), GFP_KERNEL);
@@ -598,14 +598,16 @@ static int fpc1145_probe(struct platform_device *pdev)
 		goto exit;
 
 	hw_type = cei_fp_module_detect();
-	dev_info(dev, "Detected hw type %d\n", hw_type);
 
 	(void)vreg_setup(fpc1145, VDD_ANA, false);
 
 	if (hw_type != FP_HW_TYPE_FPC) {
+		dev_info(dev, "FPC sensor not found, bailing out\n");
 		rc = -ENODEV;
 		goto exit;
 	}
+
+	dev_info(dev, "Detected FPC sensor\n");
 #endif
 
 	rc = fpc1145_request_named_gpio(fpc1145, "fpc,gpio_irq",

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
@@ -2938,7 +2938,7 @@ get_res_fail:
 	vfe_dev->vfe_vbif_base_size = 0;
 	vfe_dev->vfe_base_size = 0;
 vfe_irq_fail:
-	msm_camera_put_reg_base(vfe_dev->pdev, vfe_dev->vfe_base,
+	msm_camera_put_reg_base(vfe_dev->pdev, vfe_dev->vfe_vbif_base,
 					"vfe_vbif", 0);
 vbif_base_fail:
 	msm_camera_put_reg_base(vfe_dev->pdev, vfe_dev->vfe_base, "vfe", 0);


### PR DESCRIPTION
The first small patches fix tiny quirks that prevented Ganges from booting at all, and making sure it stays alive.

The second set picks all the FPC/ET51x commits (#1912, #2010, #2017) from kernel 4.9, of which the sensor voltage bump to 3.3v is the most relevant for Ganges. Without it, the sensor is almost completely unresponsive and unusable.

Tested on:
Discovery RoW
Mermaid DSDS
Akatsuki DSDS (to make sure nothing in the FPC got borked)