### PR TITLE
[LA.UM.7.1.r1] [URGENT] SDM845: Disable inline rotator

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-sde.dtsi
@@ -222,12 +222,13 @@
 		qcom,sde-qos-cpu-mask = <0x3>;
 		qcom,sde-qos-cpu-dma-latency = <300>;
 
+		/* The inline rotator doesn't work correctly yet on 4.14
+		 * so comment it out for now and give it a big TODO
 		qcom,sde-inline-rotator = <&mdss_rotator 0>;
 		qcom,sde-inline-rot-xin = <10 11>;
 		qcom,sde-inline-rot-xin-type = "sspp", "wb";
-
-		/* offsets are relative to "mdp_phys + qcom,sde-off */
 		qcom,sde-inline-rot-clk-ctrl = <0x2bc 0x8>, <0x2bc 0xc>;
+		*/
 
 		qcom,sde-reg-dma-off = <0>;
 		qcom,sde-reg-dma-version = <0x1>;


### PR DESCRIPTION
The inline rotator was enabled but unfortunately freezes fullscreen video playback.

This reverts commit 87cde5ddf4b0274c432463b652781cd9254d083a.