### PR TITLE
[LA.UM.7.1.r1] arm64: DT: ganges-common: Upgrade to mainline WLED.

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common.dtsi
@@ -157,8 +157,8 @@
 };
 
 &pm660l_wled {
-	qcom,fs-current-limit = <20000>;
-	qcom,string-cfg = <5>; /* 00 01 */
+	qcom,current-limit-microamp = <20000>;
+	qcom,enabled-strings = <0 1>;
 
 	/* Bootloader only properties */
 	somc,init-br-ua = <10000>;


### PR DESCRIPTION
Ganges was accidentally left out in the conversion. Update the current
limit to the new prop name, and limit the strings to 2 (default for
pm660l is 3) to prevent nasty OVP interrupts as can be observed with:
grep wled /proc/interrupts