### PR TITLE
[LA.UM.7.1.r1] backlight: qcom-wled: Add PMI8994 with different ovp/boost values.

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_common.dtsi
@@ -341,7 +341,8 @@
 };
 
 &pmi8998_wled {
-	linux,name = "wled";
+	/* OLED panel */
+	status = "disabled";
 };
 
 &synaptics_clearpad {


### PR DESCRIPTION
PMI8994 has different curves to convert these values to indices written
to the appropriate registers. The values in the DT are matched exactly
to the values in the arrays, and a failed match fails the probe.
Especially ovp doesn't have a value close enough on the same index in
PMI8998 and up, which rules out changing the DT to abuse the wrong
values.

This patchset adds a separation between WLED_4_0 used by PMI8994, and
WLED_4_1 used by the other PMICs.

Also disable this WLED driver entirely on Akatsuki, which doesn't have a backlight...