### PR TITLE
[LA.UM.7.1.r1] arm64: DT: yoshino: Rename lilac/poplar pcc table nodes for SDE.

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-id5_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-id5_pcc.dtsi
@@ -18,8 +18,8 @@
  */
 
 /* pcc-table for Lilac LGD */
-&mdss_mdp {
-	dsi_5: somc,5_panel {
+&sde_kms {
+	sde_dsi_5: somc,5_panel {
 		somc,mdss-dsi-pcc-enable;
 		somc,mdss-dsi-uv-command = [
 			06 01 00 00 00 00 01 DA

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-id8_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-lilac-id8_pcc.dtsi
@@ -18,8 +18,8 @@
  */
 
 /* pcc-table for Lilac JDI */
-&mdss_mdp {
-	dsi_8: somc,8_panel {
+&sde_kms {
+	sde_dsi_8: somc,8_panel {
 		somc,mdss-dsi-pcc-enable;
 		somc,mdss-dsi-uv-command = [
 			06 01 00 00 00 00 01 DA

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-id6_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-id6_pcc.dtsi
@@ -18,8 +18,8 @@
  */
 
 /* pcc-table for Poplar JDI */
-&mdss_mdp {
-	dsi_6: somc,6_panel {
+&sde_kms {
+	sde_dsi_6: somc,6_panel {
 		somc,mdss-dsi-pcc-enable;
 		somc,mdss-dsi-uv-command = [
 			06 01 00 00 00 00 01 DA

--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-id9_pcc.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-poplar-id9_pcc.dtsi
@@ -18,8 +18,8 @@
  */
 
 /* pcc-table for Poplar Sharp */
-&mdss_mdp {
-	dsi_9: somc,9_panel {
+&sde_kms {
+	sde_dsi_9: somc,9_panel {
 		somc,mdss-dsi-pcc-enable;
 		somc,panel-colormgr-pcc-prof-avail;
 		somc,mdss-dsi-uv-command = [

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -120,7 +120,7 @@ static int dsi_parse_dcs_cmds(struct device_node *np,
 
 	data = of_get_property(np, cmd_key, &length);
 	if (!data) {
-		pr_debug("%s :failed to get , key=%s\n", __func__, cmd_key);
+		pr_warn("%s: failed to get property %s\n", __func__, cmd_key);
 		rc = -ENOTSUPP;
 		goto error;
 	}
@@ -384,8 +384,11 @@ int somc_panel_parse_dt_colormgr_config(struct dsi_panel *panel,
 			"somc,mdss-dsi-pcc-force-cal");
 
 	if (color_mgr->standard_pcc_enable) {
-		dsi_parse_dcs_cmds(np, &color_mgr->uv_read_cmds,
+		rc = dsi_parse_dcs_cmds(np, &color_mgr->uv_read_cmds,
 			"somc,mdss-dsi-uv-command", NULL);
+		if (rc)
+			pr_err("%s (%d): Failed to parse dsi-uv-command: %d\n",
+					__func__, __LINE__, rc);
 
 		rc = of_property_read_u32(np,
 			"somc,mdss-dsi-uv-param-type", &tmp);
@@ -849,6 +852,9 @@ static int somc_panel_pcc_setup(struct dsi_display *display)
 
 	if (color_mgr->uv_read_cmds.cmds.send_cmd) {
 		get_uv_data(display, &color_mgr->u_data, &color_mgr->v_data);
+	} else {
+		pr_warn("%s (%d): Cannot read uv data: missing command\n",
+				__func__, __LINE__);
 	}
 
 	if (color_mgr->u_data == 0 && color_mgr->v_data == 0) {


### PR DESCRIPTION
@MarijnS95 this pull request pulls your PR #2011 for k4.14. See comment: https://github.com/sonyxperiadev/bug_tracker/issues/512#issuecomment-569419656. Would be great if you can confirm resp. comment on this.

Just did a kernel-build without flashing it, because lilac/yoshino is still not ready to my knowledge. So state is compiles without errors.