### PR TITLE
[7.1.r1] dts: msm8996-mtp: fix gpio_11->12 in pm8994_gpios

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-mtp.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-mtp.dtsi
@@ -671,7 +671,7 @@
 	pinctrl-0 = <&pm8994_gpio_1 &pm8994_gpio_2 &pm8994_gpio_3
 		     &pm8994_gpio_4 &pm8994_gpio_5 &pm8994_gpio_6
 		     &pm8994_gpio_7 &pm8994_gpio_8 &pm8994_gpio_9
-		     &pm8994_gpio_10 &pm8994_gpio_11 &pm8994_gpio_11
+		     &pm8994_gpio_10 &pm8994_gpio_11 &pm8994_gpio_12
 		     &pm8994_gpio_13 &pm8994_gpio_14 &pm8994_gpio_15
 		     &pm8994_gpio_16 &pm8994_gpio_17 &pm8994_gpio_18
 		     &pm8994_gpio_19>;


### PR DESCRIPTION
See as well: PR: #2151