### PR TITLE
[2.3.2.r1.4] Fix missing POWER_SUPPLY_PROP_SDP_CURRENT_MAX getter

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smbcharger.c
+++ b/drivers/power/supply/qcom/qpnp-smbcharger.c
@@ -6343,6 +6343,7 @@ static int smbchg_usb_get_property(struct power_supply *psy,
 	struct smbchg_chip *chip = power_supply_get_drvdata(psy);
 
 	switch (psp) {
+	case POWER_SUPPLY_PROP_SDP_CURRENT_MAX:
 	case POWER_SUPPLY_PROP_CURRENT_MAX:
 		val->intval = chip->usb_current_max;
 		break;


### PR DESCRIPTION

Should fix following message on Loire (and probably Tone too):
[    1.302239] power_supply usb: driver failed to report `sdp_current_max' property: -22
While not seemingly harmful on Android, on SailfishOS it led to log flood
and eventually reboot.