### PR TITLE
[2.3.2.r1.4] Fix build failure: ext_ioctl_data has to be extend_ioctl_data

### DIFF
--- a/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v3/rmnet_ipa.c
@@ -1661,9 +1661,9 @@ static int ipa3_wwan_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
 		/*  Get driver name  */
 		case RMNET_IOCTL_GET_DRIVER_NAME:
 			if (IPA_NETDEV() != NULL) {
-				memcpy(&ext_ioctl_data.u.if_name,
+				memcpy(&extend_ioctl_data.u.if_name,
 					IPA_NETDEV()->name, IFNAMSIZ);
-				ext_ioctl_data.u.if_name[IFNAMSIZ - 1] = '\0';
+				extend_ioctl_data.u.if_name[IFNAMSIZ - 1] = '\0';
 				if (copy_to_user((u8 *)ifr->ifr_ifru.ifru_data,
 					&extend_ioctl_data,
 					sizeof(struct rmnet_ioctl_extended_s)))


### PR DESCRIPTION
Fixes a build failure for the backported commit:
msm: ipa: Add check for NULL pointer reference

Change-Id: Id50022a0b2c3e4ad1b4f7f5307070f41ae133b16
commit: 0f9f461a36c71af65d0918dbc351bfe2bb844fd7

The variable ext_ioctl_data has to be extend_ioctl_data