### PR TITLE
[UNTESTED][DNM] adsprpc: enable error logging by default

### DIFF
--- a/drivers/char/adsprpc_shared.h
+++ b/drivers/char/adsprpc_shared.h
@@ -99,11 +99,13 @@
 #define REMOTE_SCALARS_MAKE(method, in, out) \
 		REMOTE_SCALARS_MAKEX(0, method, in, out, 0, 0)
 
-
+#define VERIFY_PRINT_ERROR
+#define VERIFY_EPRINTF(format, args) pr_err(format, args)
 #ifndef VERIFY_PRINT_ERROR
 #define VERIFY_EPRINTF(format, args) (void)0
 #endif
 
+#define VERIFY_IPRINTF(args) pr_info(args)
 #ifndef VERIFY_PRINT_INFO
 #define VERIFY_IPRINTF(args) (void)0
 #endif


### PR DESCRIPTION
there should be no need to hide adsprpc error messages by default, so always enable them.
also fix a potential compilation error when having either VERIFY_PRINT_INFO or VERIFY_PRINT_ERROR.
Either VERIFY_IPRINTF or VERIFY_EPRINTF will be undefined in such a case.

please check if this change builds and leads to seeing adsprpc errors in dmesg.