### PR TITLE
[7.1.r1] arm64: DT: MSM8998: Fix mailboxes for GLINK transports

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -624,7 +624,7 @@
 		glink_modem: modem {
 			qcom,remote-pid = <1>;
 			transport = "smem";
-			mboxes = <&apcs_glb 12>;
+			mboxes = <&apcs_glb 15>;
 			mbox-names = "mpss_smem";
 			interrupts = <GIC_SPI 452 IRQ_TYPE_EDGE_RISING>;
 
@@ -659,7 +659,7 @@
 		glink_adsp: adsp {
 			qcom,remote-pid = <2>;
 			transport = "smem";
-			mboxes = <&apcs_glb 8>;
+			mboxes = <&apcs_glb 9>;
 			mbox-names = "adsp_smem";
 			interrupts = <GIC_SPI 157 IRQ_TYPE_EDGE_RISING>;
 
@@ -694,7 +694,7 @@
 		glink_slpi: slpi {
 			qcom,remote-pid = <3>;
 			transport = "smem";
-			mboxes = <&apcs_glb 25>;
+			mboxes = <&apcs_glb 27>;
 			mbox-names = "dsps_smem";
 			interrupts = <GIC_SPI 179 IRQ_TYPE_EDGE_RISING>;
 
@@ -722,7 +722,6 @@
 		};
 
 		glink_spi_xprt_wdsp: wdsp {
-			qcom,remote-pid = <15>; /* or is it 10? */
 			transport = "spi";
 			tx-descriptors = <0x12000 0x12004>;
 			rx-descriptors = <0x1200c 0x12010>;


### PR DESCRIPTION
The GLINK transports had wrong mailbox cells declared: fix them.

Modem and DSP should now work on MSM8998.