### PR TITLE
[7.1.r1] [URGENT] arm64: DT: msm-arm-smmu-8998: Add init quirks for new security model

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm-arm-smmu-8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-arm-smmu-8998.dtsi
@@ -22,6 +22,8 @@
 		qcom,use-3-lvl-tables;
 		qcom,register-save;
 		qcom,skip-init;
+		qcom,no-smr-check;
+		qcom,no-actlr-read;
 		#global-interrupts = <0>;
 		interrupts = <GIC_SPI 364 IRQ_TYPE_EDGE_RISING>,
 			   <GIC_SPI 365 IRQ_TYPE_EDGE_RISING>,
@@ -50,6 +52,8 @@
 		qcom,use-3-lvl-tables;
 		qcom,register-save;
 		qcom,skip-init;
+		qcom,no-smr-check;
+		qcom,no-actlr-read;
 		#global-interrupts = <0>;
 		interrupts = <GIC_SPI 373 IRQ_TYPE_EDGE_RISING>,
 			   <GIC_SPI 374 IRQ_TYPE_EDGE_RISING>,
@@ -166,6 +170,7 @@
 		qcom,use-3-lvl-tables;
 		qcom,register-save;
 		qcom,skip-init;
+		qcom,no-actlr-read;
 		#global-interrupts = <0>;
 		interrupts = <GIC_SPI 329 IRQ_TYPE_LEVEL_HIGH>,
 			   <GIC_SPI 330 IRQ_TYPE_LEVEL_HIGH>,


### PR DESCRIPTION
The latest bootloader for MSM8998 changes the security model and
now we aren't allowed (by the hypervisor) anymore to read the ACTLR
register on some IOMMUs.