### PR TITLE
[7.1.r1] SoMC Yoshino audio enablement

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-audio.dtsi
@@ -27,6 +27,16 @@
 };
 
 &soc {
+	wcd_rst_gpio: msm_cdc_pinctrl@64 {
+		compatible = "qcom,msm-cdc-pinctrl";
+		#gpio-cells = <0>;
+		qcom,cdc-rst-n-gpio = <&tlmm 64 0>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&cdc_reset_active>;
+		pinctrl-1 = <&cdc_reset_sleep>;
+		status = "ok";
+	};
+
 	trans_loopback: qcom,msm-transcode-loopback {
 		compatible = "qcom,msm-transcode-loopback";
 	};
@@ -85,16 +95,6 @@
 		pinctrl-names = "aud_active", "aud_sleep";
 		pinctrl-0 = <&wcd_usbc_analog_en2n_active>;
 		pinctrl-1 = <&wcd_usbc_analog_en2n_idle>;
-	};
-
-	wcd_rst_gpio: msm_cdc_pinctrl@64 {
-		compatible = "qcom,msm-cdc-pinctrl";
-		#gpio-cells = <0>;
-		qcom,cdc-rst-n-gpio = <&tlmm 64 0>;
-		pinctrl-names = "aud_active", "aud_sleep";
-		pinctrl-0 = <&cdc_reset_active>;
-		pinctrl-1 = <&cdc_reset_sleep>;
-		status = "ok";
 	};
 
 	hph_en0_gpio: msm_cdc_pinctrl@67 {
@@ -398,7 +398,6 @@
 			      17 18 19 20 21 22 23 24 25 26 27 28 29
 			      30>;
 
-		qcom,wcd-uses-q6core;
 		qcom,wcd-rst-gpio-node = <&wcd_rst_gpio>;
 
 		clock-names = "wcd_clk";

--- a/arch/arm64/boot/dts/qcom/msm8998-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-audio.dtsi
@@ -97,6 +97,22 @@
 		status = "ok";
 	};
 
+	hph_en0_gpio: msm_cdc_pinctrl@67 {
+		compatible = "qcom,msm-cdc-pinctrl";
+		#gpio-cells = <0>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&hph_en0_active>;
+		pinctrl-1 = <&hph_en0_idle>;
+	};
+
+	hph_en1_gpio: msm_cdc_pinctrl@68 {
+		compatible = "qcom,msm-cdc-pinctrl";
+		#gpio-cells = <0>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&hph_en1_active>;
+		pinctrl-1 = <&hph_en1_idle>;
+	};
+
 	clock_audio: audio_ext_clk {
 		status = "ok";
 		compatible = "qcom,audio-ref-clk";
@@ -245,22 +261,6 @@
 				<&wsa881x_213>, <&wsa881x_214>;
 		qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrRight",
 					  "SpkrLeft", "SpkrRight";
-
-		hph_en0_gpio: msm_cdc_pinctrl@67 {
-			compatible = "qcom,msm-cdc-pinctrl";
-			#gpio-cells = <0>;
-			pinctrl-names = "aud_active", "aud_sleep";
-			pinctrl-0 = <&hph_en0_active>;
-			pinctrl-1 = <&hph_en0_idle>;
-		};
-
-		hph_en1_gpio: msm_cdc_pinctrl@68 {
-			compatible = "qcom,msm-cdc-pinctrl";
-			#gpio-cells = <0>;
-			pinctrl-names = "aud_active", "aud_sleep";
-			pinctrl-0 = <&hph_en1_active>;
-			pinctrl-1 = <&hph_en1_idle>;
-		};
 	};
 
 	snd_934x: sound-tavil {

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -28,7 +28,7 @@
 	};
 
 	reserved-memory {
-		ramoops {
+		ramoops@ffc00000 {
 			compatible = "removed-dma-pool", "ramoops";
 			no-map;
 			reg = <0 0xffc00000 0 0x00100000>;
@@ -76,6 +76,10 @@
 
 &cont_splash_mem {
 	reg = <0x0 0x9d400000 0x0 0x02400000>;
+};
+
+&dfps_data_memory {
+	reg = <0x0 0x9f800000 0x0 0x1000>;
 };
 
 &soc {


### PR DESCRIPTION
This patchset, along with other patchsets on defconfig and techpack-audio, is
enabling audio support on MSM8998 Yoshino.

Tested on SoMC Lilac RoW.