### PR TITLE
[LA.UM.7.1.r1] arm64: DT: sdm660-audio: Shorten cdc-vdd-mic-bias name length

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
@@ -159,16 +159,16 @@
 		qcom,cdc-vdd-pa-voltage = <2040000 2040000>;
 		qcom,cdc-vdd-pa-current = <260000>;
 
-		cdc-vdd-mic-bias-supply = <&pm660l_l7>;
-		qcom,cdc-vdd-mic-bias-voltage = <3088000 3088000>;
-		qcom,cdc-vdd-mic-bias-current = <5000>;
+		cdc-vdd-mbias-supply = <&pm660l_l7>;
+		qcom,cdc-vdd-mbias-voltage = <3088000 3088000>;
+		qcom,cdc-vdd-mbias-current = <5000>;
 
 		qcom,cdc-mclk-clk-rate = <9600000>;
 
 		qcom,cdc-static-supplies = "cdc-vdda-cp",
 					   "cdc-vdd-pa";
 
-		qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
+		qcom,cdc-on-demand-supplies = "cdc-vdd-mbias";
 
 		/*
 		 * Not marking address @ as driver searches this child

--- a/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-audio.dtsi
@@ -168,7 +168,7 @@
 		qcom,cdc-static-supplies = "cdc-vdda-cp",
 					   "cdc-vdd-pa";
 
-		//qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
+		qcom,cdc-on-demand-supplies = "cdc-vdd-mic-bias";
 
 		/*
 		 * Not marking address @ as driver searches this child


### PR DESCRIPTION
The name of a regulator consumer consists of the combined name of the DT
node hierarchy and the name of the regulator property within this node,
concatenated with a dash.
Together they can (including null character) not exceed the max length
denoted by REG_STR_SIZE, currently 64 chars. However, the full path of
the analog-codec node: 800f000.qcom,spmi:qcom,pm660l@3:analog-codec@f000
together with cdc-vdd-mic-bias and a dash inbetween results in a name of
67 characters (including \0).

Shorten the length of the mic-bias supply name to fit within this limit,
making the driver probe correctly and vote for this supply which is
necessarry for audio recordings to have enough bias and not sound
muffled.

WARNING: The same change has to be applied in techpack/audio, which
looks for this specific name.
