### PR TITLE
media: msm: vidc_3x: Source vmem Kconfig file; rename to VIDC_3X_VMEM.

### DIFF
--- a/drivers/media/platform/msm/vidc_3x/Kconfig
+++ b/drivers/media/platform/msm/vidc_3x/Kconfig
@@ -6,5 +6,5 @@ menuconfig MSM_VIDC_3X_V4L2
 		depends on ARCH_QCOM && VIDEO_V4L2
 		select VIDEOBUF2_CORE
 
-source "drivers/media/platform/msm/vidc_3x/governors/Kconfig"
+source "drivers/media/platform/msm/vidc_3x/vmem/Kconfig"
 source "drivers/media/platform/msm/vidc_3x/governors/Kconfig"

--- a/drivers/media/platform/msm/vidc_3x/Makefile
+++ b/drivers/media/platform/msm/vidc_3x/Makefile
@@ -15,4 +15,4 @@ obj-$(CONFIG_MSM_VIDC_3X_V4L2) := 	msm_v4l2_vidc.o \
 
 obj-$(CONFIG_MSM_VIDC_3X_V4L2) += governors/
 
-obj-$(CONFIG_MSM_VIDC_VMEM) += vmem/
+obj-$(CONFIG_MSM_VIDC_3X_VMEM) += vmem/

--- a/drivers/media/platform/msm/vidc_3x/vmem/Kconfig
+++ b/drivers/media/platform/msm/vidc_3x/vmem/Kconfig
@@ -1,3 +1,3 @@
-menuconfig MSM_VIDC_VMEM
+menuconfig MSM_VIDC_3X_VMEM
 	bool "Qualcomm Technologies Inc MSM VMEM driver"
-	depends on ARCH_MSM && MSM_VIDC_V4L2
+	depends on ARCH_QCOM && MSM_VIDC_3X_V4L2

--- a/drivers/media/platform/msm/vidc_3x/vmem/Makefile
+++ b/drivers/media/platform/msm/vidc_3x/vmem/Makefile
@@ -1,2 +1,2 @@
-obj-$(CONFIG_MSM_VIDC_VMEM) := vmem.o \
+obj-$(CONFIG_MSM_VIDC_3X_VMEM) := vmem.o \
 				vmem_debugfs.o

--- a/drivers/media/platform/msm/vidc_3x/vmem/vmem.h
+++ b/drivers/media/platform/msm/vidc_3x/vmem/vmem.h
@@ -14,7 +14,7 @@
 #ifndef __VMEM_H__
 #define __VMEM_H__
 
-#ifdef CONFIG_MSM_VIDC_VMEM
+#ifdef CONFIG_MSM_VIDC_3X_VMEM
 
 int vmem_allocate(size_t size, phys_addr_t *addr);
 void vmem_free(phys_addr_t to_free);


### PR DESCRIPTION
The governors Kconfig file was accidentally sourced twice, instead of
vmem. This, together with a duplicate name causes CONFIG_MSM_VIDC_VMEM
to disappear in 594792ea98c8c5cea05486d9b387ee8fd6b802f2.

Source the right file and rename the config option to resolve the issue.