### PR TITLE
[7.1.r1] Revert "lib/genalloc.c: use vzalloc_node() to allocate the bitmap"

### DIFF
--- a/lib/genalloc.c
+++ b/lib/genalloc.c
@@ -188,7 +188,7 @@ int gen_pool_add_virt(struct gen_pool *pool, unsigned long virt, phys_addr_t phy
 	int nbytes = sizeof(struct gen_pool_chunk) +
 				BITS_TO_LONGS(nbits) * sizeof(long);
 
-	chunk = vzalloc_node(nbytes, nid);
+	chunk = kzalloc_node(nbytes, GFP_KERNEL, nid);
 	if (unlikely(chunk == NULL))
 		return -ENOMEM;
 
@@ -252,7 +252,7 @@ void gen_pool_destroy(struct gen_pool *pool)
 		bit = find_next_bit(chunk->bits, end_bit, 0);
 		BUG_ON(bit < end_bit);
 
-		vfree(chunk);
+		kfree(chunk);
 	}
 	kfree_const(pool->name);
 	kfree(pool);


### PR DESCRIPTION
Fixes sonyxperiadev/bug_tracker#530

This reverts commit d84f622a917d3737dcaedf9c981e660e6bfdb19b.

This causes Yoshino to fail to boot, as discovered with a git bisect.
I do not see any real reason why this should happen but at the same
time, Qualcomm devices are probably not subject to the issue that the
commit notes.

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>