### PR TITLE
[7.1.r1] msm: vidc: Fix warnings

### DIFF
--- a/drivers/media/v4l2-core/v4l2-ioctl.c
+++ b/drivers/media/v4l2-core/v4l2-ioctl.c
@@ -1373,6 +1373,12 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
 		case V4L2_PIX_FMT_MT21C:	descr = "Mediatek Compressed Format"; break;
 		case V4L2_PIX_FMT_TME:
 			descr = "TME"; break;
+		case V4L2_PIX_FMT_HEVC_HYBRID:
+			descr = "HEVC Hybrid"; break;
+		case V4L2_PIX_FMT_DIVX_311:
+			descr = "DIVX311"; break;
+		case V4L2_PIX_FMT_DIVX:
+			descr = "DIVX"; break;
 		default:
 			WARN(1, "Unknown pixelformat 0x%08x\n", fmt->pixelformat);
 			if (fmt->description[0])


### PR DESCRIPTION
A commit picked from 4.9 that adds the missing format descriptions to avoid having v4l2 spew out errors about unknown formats. It consists of a change in vidc_3x and a change in v4l2 core, but the former is already applied in the snapshot vidc_3x, so only the latter change is applied in this PR.