### PR TITLE
[VERIFYME][7.1.r1] Forwardport HALT_WARNONLY and use BRANCH_HALT_WARNONLY for gpucc_gfx3d_clk

### DIFF
--- a/drivers/clk/qcom/clk-branch.c
+++ b/drivers/clk/qcom/clk-branch.c
@@ -85,13 +85,6 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 	const char *name = clk_hw_get_name(hw);
 
 	/*
-	 * Skip checking halt bit if we're explicitly ignoring the bit or the
-	 * clock is in hardware gated mode
-	 */
-	if (br->halt_check == BRANCH_HALT_SKIP || clk_branch_in_hwcg_mode(br))
-		return 0;
-
-	/*
 	 * Some of the BRANCH_VOTED clocks could be controlled by other
 	 * masters via voting registers, and would require to add delay
 	 * polling for the status bit to allow previous clk_disable
@@ -99,6 +92,13 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 	 */
 	if (enabling && voted)
 		udelay(5);
+
+	/*
+	 * Skip checking halt bit if we're explicitly ignoring the bit or the
+	 * clock is in hardware gated mode
+	 */
+	if (br->halt_check == BRANCH_HALT_SKIP || clk_branch_in_hwcg_mode(br))
+		return 0;
 
 	if (br->halt_check == BRANCH_HALT_DELAY || (!enabling && voted)) {
 		udelay(10);

--- a/drivers/clk/qcom/clk-branch.c
+++ b/drivers/clk/qcom/clk-branch.c
@@ -80,6 +80,7 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 		bool (check_halt)(const struct clk_branch *, bool))
 {
 	bool voted = br->halt_check & BRANCH_VOTED;
+	bool halt_warnonly = br->halt_check & BRANCH_WARNONLY;
 	const struct clk_hw *hw = &br->clkr.hw;
 	const char *name = clk_hw_get_name(hw);
 
@@ -103,6 +104,7 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 		udelay(10);
 	} else if (br->halt_check == BRANCH_HALT_ENABLE ||
 		   br->halt_check == BRANCH_HALT ||
+		   br->halt_check == BRANCH_HALT_WARNONLY ||
 		   (enabling && voted)) {
 		int count = 500;
 
@@ -114,6 +116,9 @@ static int clk_branch_wait(const struct clk_branch *br, bool enabling,
 
 		WARN_CLK(hw->core, name, 1, "status stuck at 'o%s'",
 						enabling ? "ff" : "n");
+
+		if (halt_warnonly)
+			return 0;
 
 		return -EBUSY;
 	}

--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -40,8 +40,8 @@ struct clk_branch {
 	u8	halt_check;
 	bool	aggr_sibling_rates;
 	unsigned long rate;
+#define BRANCH_WARNONLY			BIT(6) /* No error on halt check fail*/
 #define BRANCH_VOTED			BIT(7) /* Delay on disable */
-#define BRANCH_WARNONLY			BIT(8) /* No error on halt check fail*/
 #define BRANCH_HALT			0 /* pol: 1 = halt */
 #define BRANCH_HALT_VOTED		(BRANCH_HALT | BRANCH_VOTED)
 #define BRANCH_HALT_WARNONLY		(BRANCH_HALT | BRANCH_WARNONLY)

--- a/drivers/clk/qcom/clk-branch.h
+++ b/drivers/clk/qcom/clk-branch.h
@@ -41,8 +41,10 @@ struct clk_branch {
 	bool	aggr_sibling_rates;
 	unsigned long rate;
 #define BRANCH_VOTED			BIT(7) /* Delay on disable */
+#define BRANCH_WARNONLY			BIT(8) /* No error on halt check fail*/
 #define BRANCH_HALT			0 /* pol: 1 = halt */
 #define BRANCH_HALT_VOTED		(BRANCH_HALT | BRANCH_VOTED)
+#define BRANCH_HALT_WARNONLY		(BRANCH_HALT | BRANCH_WARNONLY)
 #define BRANCH_HALT_ENABLE		1 /* pol: 0 = halt */
 #define BRANCH_HALT_ENABLE_VOTED	(BRANCH_HALT_ENABLE | BRANCH_VOTED)
 #define BRANCH_HALT_DELAY		2 /* No bit to check; just delay */

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -218,7 +218,7 @@ static struct clk_rcg2 gfx3d_clk_src = {
 
 static struct clk_branch gpucc_gfx3d_clk = {
 	.halt_reg = 0x1098,
-	.halt_check = BRANCH_HALT,
+	.halt_check = BRANCH_HALT_WARNONLY,
 	.hwcg_reg = 0x1098,
 	.hwcg_bit = 1,
 	.clkr = {


### PR DESCRIPTION
Forward port BRANCH_HALT_WARNONLY and set it for gfx3d clock.
This has been set back to default state in the process of porting to k4.14
It seems its still needed as the clock halts and gets stuck in some scenarios.
@kholk As always say what you think about it.