### PR TITLE
[WIP] [2.3.2.r1.4] Fix binder change in merge of 4.9.188

### DIFF
--- a/drivers/android/binder_alloc.c
+++ b/drivers/android/binder_alloc.c
@@ -218,6 +218,11 @@ static int binder_update_page_range(struct binder_alloc *alloc, int allocate,
 
 	if (mm) {
 		down_read(&mm->mmap_sem);
+		if (!mmget_still_valid(mm)) {
+			if (allocate == 0)
+				goto free_range;
+			goto err_no_vma;
+		}
 		vma = alloc->vma;
 	}
 


### PR DESCRIPTION
https://source.android.com/security/bulletin/2020-02-01#kernel-components
https://android.googlesource.com/kernel/common/+/3378ce511d7a792ddf0d69d11ce5e284309893fd

The 4.9.188 merge was missing the change to the binder driver associated with the linux-4.9.y
commit 16903f1a5ba7 ("coredump: fix race condition between mmget_not_zero()/get_task_mm() and core dumping").
It was left out because the android-4.9 binder driver has been significantly refactored compared
to linux-4.9.y.

This patch applies the missing change from that patch to the binder driver.

---

Build-tested on kagura