### PR TITLE
[LA.UM.7.1.r1] Reintroduce merged PCCs for night light

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -724,11 +724,11 @@ static int somc_panel_sde_crtc_set_property_override(struct drm_crtc *crtc,
 		pr_debug("Merging system calibration\n");
 		memcpy(&color_mgr->system_calibration_pcc, blob->data,
 				blob->length);
-		color_mgr->system_calibration_valid = true;
 
 		ret = somc_panel_update_merged_pcc_cache(color_mgr);
 		if (ret)
 			return ret;
+		color_mgr->system_calibration_valid = true;
 	}
 
 	// Copy (updated) cache to blob:
@@ -1335,6 +1335,7 @@ static int somc_panel_crtc_send_cached_pcc(struct dsi_display *display)
 static int somc_panel_send_pcc(struct dsi_display *display,
 			       int color_table_offset)
 {
+	int rc;
 	struct somc_panel_color_mgr *color_mgr =
 			display->panel->spec_pdata->color_mgr;
 
@@ -1348,7 +1349,9 @@ static int somc_panel_send_pcc(struct dsi_display *display,
 
 	color_mgr->pcc_profile = color_table_offset;
 
-	somc_panel_update_merged_pcc_cache(color_mgr);
+	rc = somc_panel_update_merged_pcc_cache(color_mgr);
+	if (rc)
+		return rc;
 
 apply_cached_pcc:
 	return somc_panel_crtc_send_cached_pcc(display);

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/panel_color_manager.c
@@ -662,7 +662,9 @@ use_system_calibration:
 	return -EINVAL;
 }
 
-static int somc_panel_sde_crtc_set_property_override(struct drm_crtc *crtc,
+static int somc_panel_sde_crtc_atomic_set_property_override(
+		struct drm_crtc *crtc,
+		struct drm_crtc_state *state,
 		struct drm_property *property,
 		uint64_t value)
 {
@@ -740,8 +742,8 @@ static int somc_panel_sde_crtc_set_property_override(struct drm_crtc *crtc,
 		memcpy(blob->data, &color_mgr->cached_pcc, blob->length);
 
 default_fn:
-	return color_mgr->original_crtc_funcs->set_property(
-			crtc, property, value);
+	return color_mgr->original_crtc_funcs->atomic_set_property(
+			crtc, state, property, value);
 }
 
 static int somc_panel_inject_crtc_overrides(struct dsi_display *display)
@@ -796,7 +798,7 @@ static int somc_panel_inject_crtc_overrides(struct dsi_display *display)
 	memcpy(new_funcs, crtc->funcs, sizeof(struct drm_crtc_funcs));
 
 	/* Then, override the function: */
-	new_funcs->set_property = somc_panel_sde_crtc_set_property_override;
+	new_funcs->atomic_set_property = somc_panel_sde_crtc_atomic_set_property_override;
 
 	/* Finally, update the funcs buffer with the overridden function: */
 	crtc->funcs = new_funcs;

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -316,7 +316,7 @@ struct somc_panel_color_mgr {
 	const struct drm_crtc_funcs *original_crtc_funcs;
 	struct drm_msm_pcc system_calibration_pcc;
 	struct drm_msm_pcc cached_pcc;
-	bool system_calibration_valid;
+	bool system_calibration_valid, cached_pcc_valid;
 };
 
 struct panel_specific_pdata {


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/522

As it turns out the implementation wasn't really caring too much about validation, running into some broken state. Fix these issues by adding more validation, fallbacks and getting rid of stupid code.

Regarding the u,v command, it could possibly be wrong, unless the panels/dric's found in Kumano really do not contain any calibration value. If so `somc,mdss-dsi-pcc-force-cal` _should_ be added (and we can shave down the calibration table size quite a bit :wink: ).

Tested on Akatsuki DSDS and Griffin DSDS.