### PR TITLE
[LA.UM.7.1] drivers: misc: Select SWITCH for SIM Detect

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -378,6 +378,7 @@ config SENSORS_APDS990X
 
 config SIM_DETECT
 	tristate "SIM_DETECT driver support"
+	select SWITCH
 	default n
 	help
 	  Say Y here


### PR DESCRIPTION
The SIM Detect driver directly depends on switch functions.
Select SWITCH to not run into compile errors.