### PR TITLE
[LA.UM.7.1.r1] media: sde: rotator: Remove legacy swts code without hwts guard

### DIFF
--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_r3.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_r3.c
@@ -2525,14 +2525,6 @@ static int sde_hw_rotator_swts_map(struct sde_hw_rotator *rot)
 		goto err_unmap;
 	}
 
-	dma_buf_begin_cpu_access(data->srcp_dma_buf, DMA_FROM_DEVICE);
-	rot->swts_buffer = dma_buf_kmap(data->srcp_dma_buf, 0);
-	if (IS_ERR_OR_NULL(rot->swts_buffer)) {
-		SDEROT_ERR("ion kernel memory mapping failed\n");
-		rc = IS_ERR(rot->swts_buffer);
-		goto kmap_err;
-	}
-
 	data->mapped = true;
 	SDEROT_DBG("swts buffer mapped: %pad/%lx va:%p\n", &data->addr,
 			data->len, rot->swts_buffer);
@@ -2559,10 +2551,6 @@ static void sde_hw_rotator_swts_unmap(struct sde_hw_rotator *rot)
 	struct sde_mdp_img_data *data;
 
 	data = &rot->swts_buf;
-
-	dma_buf_end_cpu_access(data->srcp_dma_buf, DMA_FROM_DEVICE);
-	dma_buf_kunmap(data->srcp_dma_buf, 0, rot->swts_buffer);
-	rot->swts_buffer = NULL;
 
 	sde_smmu_unmap_dma_buf(data->srcp_table, SDE_IOMMU_DOMAIN_ROT_UNSECURE,
 			DMA_FROM_DEVICE, data->srcp_dma_buf);


### PR DESCRIPTION
The rotator driver attained hardware timestamp support on 4.14 but the
ported quirks for sdm6xx were not hidden behind this feature flag. This
meant a rogue sde_hw_rotator_swts_map would have executed on platforms
with hwts causing undefined behaviour such as panics due to accessing
uninitialized pointers, as sde_hw_rotator_swts_create is never called.

Merging the logic together causes sde_hw_rotator_swts_map to become
superfluous as sde_hw_rotator_swts_create - which maps the buffer too -
is always called when no HW timestamp support is available and the
swts_buf is not yet mapped.

Also remove the unused cpu-mapped swts_buffer from ported code,
which has been removed upstream from sde_hw_rotator_swts_create too [1].
Note that the struct and print statements retain this legacy field.

[1]: 6e2d3ce466b50ca43124f9e62177feefe9647bb5

---

This fixes a crash observed when opening Open Camera on Kumano, to test freshly added camera support in https://github.com/sonyxperiadev/kernel/pull/2196