### PR TITLE
[7.1.r1] CamX enhancements

### DIFF
--- a/drivers/media/platform/msm/camera/cam_icp/hfi.c
+++ b/drivers/media/platform/msm/camera/cam_icp/hfi.c
@@ -42,7 +42,7 @@
 
 #define HFI_MAX_POLL_TRY 5
 
-#define HFI_MAX_PC_POLL_TRY 150
+#define HFI_MAX_PC_POLL_TRY 400
 #define HFI_POLL_TRY_SLEEP 1
 
 static struct hfi_info *g_hfi;

--- a/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
+++ b/drivers/media/platform/msm/camera/cam_isp/isp_hw_mgr/cam_ife_hw_mgr.c
@@ -6265,7 +6265,7 @@ static int cam_ife_hw_mgr_debug_register(void)
 		goto err;
 	}
 
-	g_ife_hw_mgr.debug_cfg.enable_recovery = 0;
+	g_ife_hw_mgr.debug_cfg.enable_recovery = 1;
 
 	return 0;
 

--- a/drivers/media/platform/msm/camera/cam_sensor_module/cam_csiphy/cam_csiphy_core.c
+++ b/drivers/media/platform/msm/camera/cam_sensor_module/cam_csiphy/cam_csiphy_core.c
@@ -838,6 +838,7 @@ int32_t cam_csiphy_core_cfg(void *phy_dev,
 		break;
 	case CAM_RELEASE_DEV: {
 		struct cam_release_dev_cmd release;
+		int32_t offset;
 
 		if (!csiphy_dev->acquire_count) {
 			CAM_ERR(CAM_CSIPHY, "No valid devices to release");
@@ -878,6 +879,15 @@ int32_t cam_csiphy_core_cfg(void *phy_dev,
 			csiphy_dev->csiphy_info.lane_mask = 0;
 			csiphy_dev->csiphy_info.lane_cnt = 0;
 			csiphy_dev->csiphy_info.combo_mode = 0;
+		}
+
+		/* reset secure mode */
+		offset = cam_csiphy_get_instance_offset(csiphy_dev,
+		release.dev_handle);
+		if (csiphy_dev->csiphy_info.secure_mode[offset] ==
+			CAM_SECURE_MODE_SECURE) {
+			csiphy_dev->csiphy_info.secure_mode[offset] =
+				CAM_SECURE_MODE_NON_SECURE;
 		}
 	}
 		break;


### PR DESCRIPTION
This patchset aims to enhance the experience with the Spectra based CamX:
an issue with HFI shutdown has been solved, leaving the entire hardware in a
clean state and mostly ensuring that subsequent camera openings will be as
fast as the first one.

Also, allow the IFE to recover in order to speedup some error cases happening
while going back and forth between cameras.

Tested OK on SoMC Tama Akatsuki RoW.