### PR TITLE
[7.1.r1] drm: msm: somc_panel: Send AOD OFF only if coming from AOD

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/dsi_panel_driver.c
@@ -1469,7 +1469,8 @@ int somc_panel_set_doze_mode(struct drm_connector *connector,
 	switch (power_mode) {
 		case SDE_MODE_DPMS_ON:
 			pr_debug("Requested DPMS ON state.\n");
-			rc = dsi_panel_set_aod_off(panel);
+			if (display_aod_mode != SDE_MODE_DPMS_OFF)
+				rc = dsi_panel_set_aod_off(panel);
 			spec_pdata->aod_mode = power_mode;
 			display_aod_mode = 0;
 			dsi_panel_driver_notify_resume(panel);


### PR DESCRIPTION
It is wrong (and useless, actually) to send the AOD OFF command
while we are powering up the display from display-off state.

Besides that, some DriverIC (Samsung, for instance) really does
dislike getting this command when powering up the display from
a complete DPMS_OFF state, showing unesthetic corruption for
the first frame.

Tested on SoMC SM8150 Kumano Bahamut DSDS
Display corruption is gone.