### PR TITLE
[LA.UM.7.1.r1] Update Griffin panel cmds from stock, clean up display-active property

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-3840p3288-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-3840p3288-cmd.dtsi
@@ -119,7 +119,7 @@
 					39 01 00 00 00 00 03 B9 00 60
 					39 01 00 00 00 00 03 F0 A5 A5
 					39 01 00 00 00 00 03 F0 5A 5A
-					39 01 00 00 00 00 03 C5 2E 01
+					39 01 00 00 00 00 03 C5 2E 21
 					39 01 00 00 00 00 03 F0 A5 A5];
 				qcom,mdss-dsi-post-panel-on-command = [
 					05 01 00 00 00 00 01 29];
@@ -158,10 +158,10 @@
 					39 01 00 00 00 00 03 F0 A5 A5
 					05 01 00 00 00 00 01 29];
 				somc,mdss-dsi-hbm-on-command = [
-					39 01 00 00 00 00 02 53 E0
+					39 01 00 00 00 00 02 53 E8
 					];
 				somc,mdss-dsi-hbm-off-command = [
-					39 01 00 00 11 00 02 53 20
+					39 01 00 00 11 00 02 53 28
 					];
 				somc,mdss-dsi-aod-on-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-aod-low-command-state = "dsi_lp_mode";
@@ -169,6 +169,18 @@
 				somc,mdss-dsi-aod-off-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-hbm-on-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-hbm-low-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-flm2-on-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 C5 2E 21
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-off-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 C5 2E 01
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-on-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-flm2-off-command-state = "dsi_lp_mode";
 			};
 			timing@1 {
 				qcom,mdss-dsi-panel-width = <1644>;
@@ -219,7 +231,7 @@
 					39 01 00 00 00 00 03 B9 00 60
 					39 01 00 00 00 00 03 F0 A5 A5
 					39 01 00 00 00 00 03 F0 5A 5A
-					39 01 00 00 00 00 03 C5 2E 01
+					39 01 00 00 00 00 03 C5 2E 21
 					39 01 00 00 00 00 03 F0 A5 A5];
 				qcom,mdss-dsi-post-panel-on-command = [
 					05 01 00 00 00 00 01 29];
@@ -258,10 +270,10 @@
 					39 01 00 00 00 00 03 F0 A5 A5
 					05 01 00 00 00 00 01 29];
 				somc,mdss-dsi-hbm-on-command = [
-					39 01 00 00 00 00 02 53 E0
+					39 01 00 00 00 00 02 53 E8
 					];
 				somc,mdss-dsi-hbm-off-command = [
-					39 01 00 00 11 00 02 53 20
+					39 01 00 00 11 00 02 53 28
 					];
 				somc,mdss-dsi-aod-on-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-aod-low-command-state = "dsi_lp_mode";
@@ -269,8 +281,19 @@
 				somc,mdss-dsi-aod-off-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-hbm-on-command-state = "dsi_lp_mode";
 				somc,mdss-dsi-hbm-low-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-flm2-on-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 C5 2E 21
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-off-command = [
+					39 01 00 00 00 00 03 F0 5A 5A
+					39 01 00 00 00 00 03 C5 2E 01
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
+				somc,mdss-dsi-flm2-on-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-flm2-off-command-state = "dsi_lp_mode";
 			};
 		};
 	};
 };
-

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-common-sde-overlay.dtsi
@@ -90,6 +90,8 @@ msm_drm.dsi_display0=dsi_panel_somc_tone_cmd:config0";
 		qcom,dsi-ctrl-num = <0>;
 		qcom,dsi-phy-num = <0>;
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
+
+		qcom,dsi-display-active;
 	};
 
 	/* SDE */
@@ -109,8 +111,6 @@ msm_drm.dsi_display0=dsi_panel_somc_tone_cmd:config0";
 		pinctrl-2 = <&mdss_touch_active>;
 		pinctrl-3 = <&mdss_touch_suspend>;
 
-		qcom,dsi-display-active;
-
 		qcom,platform-te-gpio = <&tlmm 10 0>;
 		qcom,panel-te-source = <0>;
 
@@ -124,7 +124,7 @@ msm_drm.dsi_display0=dsi_panel_somc_tone_cmd:config0";
 		ibb-supply = <&ibb_regulator>;
 
 		qcom,dsi-display-list = <&sde_dsi_tone_panels>;
-	};	
+	};
 };
 
 &mdss_mdp {
@@ -142,4 +142,3 @@ msm_drm.dsi_display0=dsi_panel_somc_tone_cmd:config0";
 &dfps_data_mem {
 	reg = <0 0x857FF000 0 0x1000>;
 };
-

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -99,6 +99,8 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 		qcom,dsi-phy-num = <0>;
 
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
+
+		qcom,dsi-display-active;
 	};
 
 	/* SDE */
@@ -127,8 +129,6 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 		pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
 		pinctrl-2 = <&mdss_touch_active>;
 		pinctrl-3 = <&mdss_touch_suspend>;
-
-		qcom,dsi-display-active;
 
 		qcom,platform-te-gpio = <&tlmm 10 0>;
 		qcom,panel-te-source = <0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common-sde-overlay.dtsi
@@ -60,6 +60,7 @@
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
 
 		somc,bootloader-panel-detect;
+		qcom,dsi-display-active;
 	};
 
 	/* SDE */
@@ -76,8 +77,6 @@
 		pinctrl-names = "panel_active", "panel_suspend";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
 		pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
-
-		qcom,dsi-display-active;
 
 		qcom,platform-te-gpio = <&tlmm 59 0>;
 		qcom,panel-te-source = <0>;

--- a/arch/arm64/boot/dts/qcom/sdm630-nile-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-nile-common-sde-overlay.dtsi
@@ -188,6 +188,7 @@
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
 
 		somc,bootloader-panel-detect;
+		qcom,dsi-display-active;
 	};
 
 	/* SDE */
@@ -205,8 +206,6 @@
 				"sde_touch_active", "sde_touch_suspend";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
 		pinctrl-1 = <&mdss_dsi_suspend &mdss_te_suspend>;
-
-		qcom,dsi-display-active;
 
 		qcom,platform-te-gpio = <&tlmm 59 0>;
 		qcom,panel-te-source = <0>;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common-display.dtsi
@@ -107,6 +107,8 @@ msm_drm.dsi_display0=dsi_panel_somc_tama_cmd:config0";
 		qcom,dsi-phy-num = <0>;
 
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
+
+		qcom,dsi-display-active;
 	};
 
 	dsi_panel_cmd_display: qcom,dsi-display@12 {
@@ -125,8 +127,6 @@ msm_drm.dsi_display0=dsi_panel_somc_tama_cmd:config0";
 		pinctrl-1 = <&sde_dsi_suspend &sde_te_suspend>;
 		pinctrl-2 = <&sde_touch_active>;
 		pinctrl-3 = <&sde_touch_suspend>;
-
-		qcom,dsi-display-active;
 
 		qcom,platform-te-gpio = <&tlmm 10 0>;
 		qcom,panel-te-source = <0>;
@@ -229,4 +229,3 @@ msm_drm.dsi_display0=dsi_panel_somc_tama_cmd:config0";
 	/delete-property/ qcom,dp-usbpd-detection;
 	status = "disabled";
 };
-

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common-display.dtsi
@@ -91,6 +91,8 @@
 		qcom,dsi-phy-num = <0>;
 
 		qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0";
+
+		qcom,dsi-display-active;
 	};
 
 	dsi_panel_cmd_display: qcom,dsi-display@1012 {
@@ -113,8 +115,6 @@
 		pinctrl-1 = <&sm_gpio_6 &te_suspend>;
 		pinctrl-2 = <&ts_int_active>;
 		pinctrl-3 = <&ts_suspend>;
-
-		qcom,dsi-display-active;
 
 		qcom,platform-te-gpio = <&tlmm 8 0>;
 		qcom,panel-te-source = <0>;


### PR DESCRIPTION
Pull in a fresh display DT from 55.1.A.3.49. Only Griffin changed, the
panel found in Bahamut remains the same.

---

Move `qcom,dsi-display-active` to the node where it's actually being read.