### PR TITLE
[LA.UM.7.1][VERIFYME]Remove androidboot.mode=cei_charger flag from /proc/cmdline

### DIFF
--- a/arch/arm64/kernel/setup.c
+++ b/arch/arm64/kernel/setup.c
@@ -283,6 +283,24 @@ static int __init sony_param_warmboot(char *p)
 	return 0;
 }
 early_param("warmboot", sony_param_warmboot);
+ 
+/*
+ * HACK: The following function strips off androidboot.mode=cei_charger
+ * from kernel command line so that parameter set by sony_param_warmboot
+ * will be used instead.
+ */
+static int __init androidboot_mode(char *p)
+{
+	char *offset_addr;
+
+	if (strcmp(p, "cei_charger"))
+		return 1;
+
+	if ((offset_addr = strstr(boot_command_line, "androidboot.mode=cei_charger")))
+		memset(offset_addr, ' ', strlen("androidboot.mode=cei_charger"));
+	return 0;
+}
+early_param("androidboot.mode", androidboot_mode);
 
 /*
  * sony_param_restore_uart: Restore pin configuration for UART pins


### PR DESCRIPTION
Xperia 10/10 Plus bootloader sets androidboot.mode=cei_charger, breaking offline charging since the flag isn't supported by AOSP. Removing it so that userspace will parse flag set by sony_param_warmboot() instead fixes it.

Change-Id: I8925d3b6e102902e0e31fda25ffe568fcd37185a
This commit has been tested by LuK on ganges for his port and works to fix the offline charging but this has to be yet tested on SODP. Which i will do tomorrow.