### PR TITLE
[2.3.2.r1.4] Remove problematic Android.mk file

### DIFF
--- a/drivers/input/touchscreen/siw/mon/Android.mk
+++ b/drivers/input/touchscreen/siw/mon/Android.mk
@@ -1,6 +1,0 @@
-LOCAL_PATH := $(call my-dir)
-include $(CLEAR_VARS)
-LOCAL_MODULE              := ssw_mon.ko
-LOCAL_MODULE_TAGS         := optional
-LOCAL_MODULE_PATH         := $(KERNEL_MODULES_OUT)
-include $(DLKM_DIR)/AndroidKernelModule.mk


### PR DESCRIPTION
Follow @kholk changes to remove `drivers/input/touchscreen/siw/mon/Android.mk` as it produces errors on legacy build.
See [Build System Changes](https://android.googlesource.com/platform/build/+/master/Changes.md#phony_targets)

Should be merged together with [device-sony-common/PR704](https://github.com/sonyxperiadev/device-sony-common/pull/704)

Kernel are now prebuilt by script and driver apparently is build with kernel, so files are not needed.

I am currently testing this for Kugo/Loire. Other device/platform tests would be nice.