### PR TITLE
[LA.UM.7.1.r1] [REQUIRESTESTING] sdm660: Enable gfx3d_src parent clocks

### DIFF
--- a/drivers/clk/qcom/clk-rcg2.c
+++ b/drivers/clk/qcom/clk-rcg2.c
@@ -1543,6 +1543,8 @@ const struct clk_ops clk_gfx3d_src_ops = {
 	.set_rate = clk_gfx3d_set_rate,
 	.set_rate_and_parent = clk_gfx3d_src_set_rate_and_parent,
 	.determine_rate = clk_gfx3d_src_determine_rate,
+	.list_rate = clk_rcg2_list_rate,
+	.list_registers = clk_rcg2_list_registers,
 };
 EXPORT_SYMBOL_GPL(clk_gfx3d_src_ops);
 

--- a/drivers/clk/qcom/clk-rcg2.c
+++ b/drivers/clk/qcom/clk-rcg2.c
@@ -1536,6 +1536,8 @@ static int clk_gfx3d_src_set_rate_and_parent(struct clk_hw *hw,
 }
 
 const struct clk_ops clk_gfx3d_src_ops = {
+	.enable = clk_rcg2_enable,
+	.disable = clk_rcg2_disable,
 	.is_enabled = clk_rcg2_is_enabled,
 	.get_parent = clk_rcg2_get_parent,
 	.set_parent = clk_rcg2_set_parent,

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2016-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -144,7 +144,7 @@ static struct clk_init_data gpu_clks_init[] = {
 		.parent_names = gpucc_parent_names_1,
 		.num_parents = 4,
 		.ops = &clk_gfx3d_src_ops,
-		.flags = CLK_SET_RATE_PARENT,
+		.flags = CLK_SET_RATE_PARENT | CLK_OPS_PARENT_ENABLE,
 	},
 	[1] = {
 		.name = "gpucc_gfx3d_clk",

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -210,7 +210,6 @@ static struct clk_rcg2 gfx3d_clk_src = {
 	.mnd_width = 0,
 	.hid_width = 5,
 	.freq_tbl = ftbl_gfx3d_clk_src,
-	.enable_safe_config = true,
 	.parent_map = gpucc_parent_map_1,
 	.flags = FORCE_ENABLE_RCG,
 	.clkr.hw.init = &gpu_clks_init[0],


### PR DESCRIPTION
Might fix https://github.com/sonyxperiadev/bug_tracker/issues/559 and https://github.com/sonyxperiadev/bug_tracker/issues/510

Parent clocks on gfx3d_src were not enabled, which is hopefully the reason for failed RCG configuration all of a sudden. The hardware might reject switching to a parent clock that's not actually turned on.

This furthermore aligns with CAF 8.2.1 clocks by adding more debug information to sysfs/WARN_CLK through `.list_registers()`, as well as providing the option to disable the src clock.

Tested on Mermaid to not show any immediate breakage. Aforementioned issues only occur longer-term, which I cannot consistently reproduce.