### PR TITLE
[2.3.2.r1.4] adsprpc fixes

### DIFF
--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -2683,6 +2683,7 @@ static int fastrpc_internal_mmap(struct fastrpc_file *fl,
 		mutex_lock(&fl->fl_map_mutex);
 		if (!fastrpc_mmap_find(fl, ud->fd, (uintptr_t)ud->vaddrin,
 				 ud->size, ud->flags, 1, &map)) {
+			ud->vaddrout = map->raddr;
 			mutex_unlock(&fl->fl_map_mutex);
 			mutex_unlock(&fl->map_mutex);
 			return 0;

--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -2629,6 +2629,7 @@ static int fastrpc_internal_munmap_fd(struct fastrpc_file *fl,
 	VERIFY(err, (fl && ud));
 	if (err)
 		goto bail;
+	mutex_lock(&fl->map_mutex);
 	mutex_lock(&fl->fl_map_mutex);
 	if (fastrpc_mmap_find(fl, ud->fd, ud->va, ud->len, 0, 0, &map)) {
 		pr_err("adsprpc: mapping not found to unmap %d va %llx %x\n",
@@ -2636,11 +2637,13 @@ static int fastrpc_internal_munmap_fd(struct fastrpc_file *fl,
 			(unsigned int)ud->len);
 		err = -1;
 		mutex_unlock(&fl->fl_map_mutex);
+		mutex_unlock(&fl->map_mutex);
 		goto bail;
 	}
 	if (map)
 		fastrpc_mmap_free(map, 0);
 	mutex_unlock(&fl->fl_map_mutex);
+	mutex_unlock(&fl->map_mutex);
 bail:
 	return err;
 }

--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -2724,11 +2724,10 @@ static void fastrpc_channel_close(struct kref *kref)
 
 	ctx = container_of(kref, struct fastrpc_channel_ctx, kref);
 	cid = ctx - &gcinfo[0];
-	if (!me->glink)
-		smd_close(ctx->chan);
-	else
+	if (me->glink) {
 		fastrpc_glink_close(ctx->chan, cid);
-	ctx->chan = NULL;
+		ctx->chan = NULL;
+	}
 	mutex_unlock(&me->smd_mutex);
 	pr_info("'closed /dev/%s c %d %d'\n", gcinfo[cid].name,
 						MAJOR(me->dev_no), cid);
@@ -3211,16 +3210,23 @@ static int fastrpc_channel_open(struct fastrpc_file *fl)
 			if (err)
 				goto bail;
 			VERIFY(err, 0 == fastrpc_glink_open(cid));
+		VERIFY(err,
+			 wait_for_completion_timeout(&me->channel[cid].workport,
+						RPC_TIMEOUT));
 		} else {
-		VERIFY(err, !smd_named_open_on_edge(FASTRPC_SMD_GUID,
+			if (me->channel[cid].chan == NULL) {
+				VERIFY(err, !smd_named_open_on_edge(
+				FASTRPC_SMD_GUID,
 				gcinfo[cid].channel,
 				(smd_channel_t **)&me->channel[cid].chan,
 				(void *)(uintptr_t)cid,
 				smd_event_handler));
-		}
 		VERIFY(err,
 			 wait_for_completion_timeout(&me->channel[cid].workport,
 						RPC_TIMEOUT));
+
+			}
+		}
 		if (err) {
 			me->channel[cid].chan = NULL;
 			goto bail;

--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -224,6 +224,8 @@ struct smq_invoke_ctx {
 	unsigned int *attrs;
 	uint32_t *crc;
 	uint64_t ctxid;
+	void *handle;
+	const void *ptr;
 };
 
 struct fastrpc_ctx_lst {
@@ -1987,7 +1989,8 @@ static int fastrpc_internal_invoke(struct fastrpc_file *fl, uint32_t mode,
 		if (err)
 			goto bail;
 	}
-
+	if (ctx->handle)
+		glink_rx_done(ctx->handle, ctx->ptr, true);
 	PERF(fl->profile, GET_COUNTER(perf_counter, PERF_INVARGS),
 	if (!fl->sctx->smmu.coherent)
 		inv_args(ctx);
@@ -2805,11 +2808,13 @@ static void fastrpc_glink_notify_rx(void *handle, const void *priv,
 	if (err)
 		goto bail;
 
+	me->ctxtable[index]->handle = handle;
+	me->ctxtable[index]->ptr = ptr;
+
 	context_notify_user(me->ctxtable[index], rsp->retval);
 bail:
 	if (err)
 		pr_err("adsprpc: invalid response or context\n");
-	glink_rx_done(handle, ptr, true);
 }
 
 static void fastrpc_glink_notify_state(void *handle, const void *priv,


### PR DESCRIPTION
A few adsprpc fixes I hoped would fix the following errors I get on SailfishOS (suzu) but don't seem to help:
```
[  338.206795] PM: Preparing system for sleep (mem)
[  338.207075] Freezing user space processes ... 
[  338.213494] ../../../../../../kernel/sony/msm-4.9/kernel/drivers/char/adsprpc.c:1988:error: -512: 0 == (err = interrupted)
[  338.213713] ../../../../../../kernel/sony/msm-4.9/kernel/drivers/char/adsprpc.c:3420:error: -512: 0 == (err = fastrpc_internal_invoke(fl, fl->mode, 0, &p.inv))
[  338.216608] (elapsed 0.009 seconds) done.
[  338.216629] Freezing remaining freezable tasks ... (elapsed 0.003 seconds) done.
[  338.220095] PM: Suspending system (mem)
[  338.220100] Suspending console(s) (use no_console_suspend to debug)
[  338.254579] PM: suspend of devices complete after 31.699 msecs
[  338.260082] PM: late suspend of devices complete after 5.479 msecs
[  338.265777] PM: noirq suspend of devices complete after 5.677 msecs
[  338.265784] Disabling non-boot CPUs ...
[  338.301298] suspend ns:     338301285093	suspend cycles:       6733998060
[  338.301285] Suspended for 16.378 seconds 
```
Maybe they're useful anyway ?
Didn't have time to test with AOSP yet...
Commits taken from [CAF LE.UM.3.2.1_rb1.13](https://source.codeaurora.org/quic/la/kernel/msm-4.9/log/drivers/char/?h=LE.UM.3.2.1_rb1.13)