### PR TITLE
[2.3.2.r1.4] sched: use rq_clock if WALT is not enabled

### DIFF
--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -2334,7 +2334,7 @@ void note_task_waking(struct task_struct *p, u64 wallclock);
 #else /* CONFIG_SCHED_WALT */
 static inline u64 sched_ktime_clock(void)
 {
-	return 0;
+	return sched_clock();
 }
 static inline void note_task_waking(struct task_struct *p, u64 wallclock) { }
 #endif /* CONFIG_SCHED_WALT */
@@ -2367,16 +2367,20 @@ DECLARE_PER_CPU(struct update_util_data *, cpufreq_update_util_data);
 static inline void cpufreq_update_util(struct rq *rq, unsigned int flags)
 {
 	struct update_util_data *data;
+	u64 clock;
 
 #ifdef CONFIG_SCHED_WALT
 	if (!(flags & SCHED_CPUFREQ_WALT))
 		return;
+	clock = sched_ktime_clock();
+#else
+	clock = rq_clock(rq);
 #endif
 
 	data = rcu_dereference_sched(*per_cpu_ptr(&cpufreq_update_util_data,
 					cpu_of(rq)));
 	if (data)
-		data->func(data, sched_ktime_clock(), flags);
+		data->func(data, clock, flags);
 }
 
 static inline void cpufreq_update_this_cpu(struct rq *rq, unsigned int flags)


### PR DESCRIPTION
Backport of https://github.com/sonyxperiadev/kernel/pull/2223 to 4.9.
Build-tested for kagura.

---

Use rq_clock to send timestamp to util update handler if WALT is not enabled in the system.

Change-Id: I1e367c506a2fc286a4dfbac9d1f6cdd897d31f2d
Signed-off-by: Santosh Mardi <gsantosh@codeaurora.org>