### PR TITLE
[7.1.r1] Fix QUSB reg offsets for tama

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-670-usb-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-670-usb-common.dtsi
@@ -149,9 +149,9 @@
 			 0x0a8 /* QUSB2PHY_PLL_CORE_INPUT_OVERRIDE */
 			 0x254 /* QUSB2PHY_TEST1 */
 			 0x198 /* PLL_BIAS_CONTROL_2 */
-			 0x228 /* QUSB2PHY_SQ_CTRL1 */
-			 0x22c /* QUSB2PHY_SQ_CTRL2 */
-			 0x27c>; /* QUSB2PHY_DEBUG_CTRL1 */
+			 0x27c /* QUSB2PHY_DEBUG_CTRL1 */
+			 0x280 /* QUSB2PHY_DEBUG_CTRL2 */
+			 0x2a0>; /* QUSB2PHY_STAT5 */
 
 		qcom,qusb-phy-init-seq =
 			/* <value reg_offset> */
@@ -434,9 +434,9 @@
 			 0x0a8 /* QUSB2PHY_PLL_CORE_INPUT_OVERRIDE */
 			 0x254 /* QUSB2PHY_TEST1 */
 			 0x198 /* PLL_BIAS_CONTROL_2 */
-			 0x228 /* QUSB2PHY_SQ_CTRL1 */
-			 0x22c /* QUSB2PHY_SQ_CTRL2 */
-			 0x27c>; /* QUSB2PHY_DEBUG_CTRL1 */
+			 0x27c /* QUSB2PHY_DEBUG_CTRL1 */
+			 0x280 /* QUSB2PHY_DEBUG_CTRL2 */
+			 0x2a0>; /* QUSB2PHY_STAT5 */
 
 		qcom,qusb-phy-init-seq =
 			/* <value reg_offset> */


### PR DESCRIPTION
k4.9 and k4.14 have different definition of "enum qusb_phy_reg",
leading to incorrect registers being used. By an unlucky coincidence,
USB2_PHY_REG_MAX values magically match in both versions, so driver did not
error out.