### PR TITLE
[7.1.r1] [CRITICAL] LSE Atomics support, GIC fix for SDM630/660

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996.dtsi
@@ -364,7 +364,7 @@
 		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>;
 
 		interrupt-parent = <&intc>;
-		arm,gicv3-plat-qcom-legacy;
+		arm,qgicv3-plat-msm8996-quirks;
 
 		msi_alias0: interrupt-controller@9bd0000 {
 			compatible = "qcom,gic-msi-aliases";

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -465,7 +465,7 @@
 		redistributor-stride = <0x0 0x20000>;
 		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-parent = <&intc>;
-		arm,gicv3-plat-qcom-legacy;
+		arm,qgicv3-plat-msm8996-quirks;
 
 		gic-its@0x17a20000{
 			compatible = "arm,gic-v3-its";

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -477,7 +477,7 @@
 		redistributor-stride = <0x0 0x20000>;
 		interrupts = <1 9 4>;
 		interrupt-parent = <&intc>;
-		arm,gicv3-plat-qcom-legacy;
+		arm,qgicv3-plat-sdm660-quirks;
 	};
 
 	wakegic: qcom,mpm@7781b8 {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -464,7 +464,7 @@
 		redistributor-stride = <0x0 0x20000>;
 		interrupts = <1 9 4>;
 		interrupt-parent = <&intc>;
-		arm,gicv3-plat-qcom-legacy;
+		arm,qgicv3-plat-sdm660-quirks;
 	};
 
 	wakegic: qcom,mpm@7781b8 {

--- a/arch/arm64/include/asm/spinlock.h
+++ b/arch/arm64/include/asm/spinlock.h
@@ -46,7 +46,9 @@ static inline void arch_spin_lock(arch_spinlock_t *lock)
 	/* LSE atomics */
 "	mov	%w2, %w5\n"
 "	ldadda	%w2, %w0, %3\n"
+#ifdef CONFIG_ARM64_LSE_ATOMICS
 	__nops(3)
+#endif
 	)
 
 	/* Did we get the lock? */
@@ -75,7 +77,9 @@ static inline int arch_spin_trylock(arch_spinlock_t *lock)
 
 	asm volatile(ARM64_LSE_ATOMIC_INSN(
 	/* LL/SC */
+#ifdef CONFIG_ARM64_LSE_ATOMICS
 	__nops(1)
+#endif
 	"1:	ldaxr	%w0, %2\n"
 	"	eor	%w1, %w0, %w0, ror #16\n"
 	"	cbnz	%w1, 2f\n"

--- a/arch/arm64/include/asm/spinlock.h
+++ b/arch/arm64/include/asm/spinlock.h
@@ -75,6 +75,7 @@ static inline int arch_spin_trylock(arch_spinlock_t *lock)
 
 	asm volatile(ARM64_LSE_ATOMIC_INSN(
 	/* LL/SC */
+	__nops(1)
 	"1:	ldaxr	%w0, %2\n"
 	"	eor	%w1, %w0, %w0, ror #16\n"
 	"	cbnz	%w1, 2f\n"


### PR DESCRIPTION
This patchset brings support for ARM64 LSE atomics (v8.1 instruction set), while
keeping 100% compatibility with LL/SC: the feature will not affect any functionality
unless it is enabled in the defconfig.

Also, this brings a fix for an interrupt mess on SDM630/660, while keeping
compatibility with MSM8996(/98) class SoCs, fixing the unability to wake up
the phone when receiving a call while in deep sleep, as reported by @haxk20
and implementing the solution found by @oshmoun.

This PR depends on #2228 and should be merged immediately as it brings
in a CRITICAL BUGFIX for Nile and Ganges platforms.