### PR TITLE
[2.3.2.r1.4] Decrease panel current to dim brightness

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8996-tone-dora-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-dora-common.dtsi
@@ -118,7 +118,7 @@
 		qcom,leds@d800 {
 			qcom,fs-curr-ua = <20000>;
 			qcom,led-strings-list = [00 01 02];
-			somc,init-br-ua = <10000>;
+			somc,init-br-ua = <1200>;
 			somc-s1,br-power-save-ua = <800>;
 			qcom,ilim-ma = <660>;
 		};

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-kagura-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-kagura-common.dtsi
@@ -365,7 +365,7 @@
 		qcom,leds@d800 {
 			qcom,fs-curr-ua = <20000>;
 			qcom,led-strings-list = [00 01 02];
-			somc,init-br-ua = <10000>;
+			somc,init-br-ua = <1200>;
 			somc-s1,br-power-save-ua = <800>;
 			qcom,ilim-ma = <660>;
 			somc,bl-scale-enabled;

--- a/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-tone-keyaki-common.dtsi
@@ -449,7 +449,7 @@
 		qcom,leds@d800 {
 			qcom,fs-curr-ua = <20000>;
 			qcom,led-strings-list = [00 01 02];
-			somc,init-br-ua = <10000>;
+			somc,init-br-ua = <1200>;
 			somc-s1,br-power-save-ua = <800>;
 			qcom,ilim-ma = <660>;
 			somc,bl-scale-enabled;

--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -621,7 +621,7 @@
 
 &pmi8998_wled {
 	qcom,fs-curr-ua = <20000>;
-	somc,init-br-ua = <10000>;
+	somc,init-br-ua = <1200>;
 	somc-s1,br-power-save-ua = <800>;
 	somc,bl-scale-enabled;
 	somc,area_count_table_size = <0>;


### PR DESCRIPTION
Author: ix5
Tested on tone platform.
Tested on tama platform by kholk.
Work on  Apollo and Akari, but not for Akatsuki.

10mA is too bright and burn our eyes at night. So fix it to protect our eyes.

---------EDIT-------
kholk didn't test it, we need someone test this commit on Akatsuki. thx!