### PR TITLE
[LA.UM.7.1.r1] Decrease panel current to dim brightness

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -661,7 +661,7 @@
 		qcom,pmic-revid = <&pmi8998_revid>;
 		qcom,loop-auto-gm-en;
 		qcom,auto-calibration-enable;
-		somc,init-br-ua = <10000>;
+		somc,init-br-ua = <1200>;
 		somc-s1,br-power-save-ua = <800>;
 		somc,bl-scale-enabled;
 		somc,area_count_table_size = <0>;


### PR DESCRIPTION
Author: ix5
Tested on tama platform by kholk.
Work on  Apollo and Akari, but not for Akatsuki.

10mA is too bright and burn our eyes at night. So fix it to protect our eyes.

---------EDIT-------
kholk didn't test it, we need someone test this commit on Akatsuki. thx!