### PR TITLE
[7.1.r1] media: msm: rotator: Properly implement shared IOMMU context quirk

### DIFF
--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
@@ -138,6 +138,7 @@ enum sde_rot_type {
  * @SDE_CAPS_SBUF_1: stream buffer support for inline rotation
  * @SDE_CAPS_UBWC_2: universal bandwidth compression version 2
  * @SDE_CAPS_PARTIALWR: partial write override
+ * @SDE_CAPS_SPLIT_CTX: quirk: same iommu context for rotator and mdp
  * @SDE_CAPS_HW_TIMESTAMP: rotator has hw timestamp support
  * @SDE_CAPS_UBWC_3: universal bandwidth compression version 3
  */
@@ -149,6 +150,7 @@ enum sde_caps_settings {
 	SDE_CAPS_SBUF_1,
 	SDE_CAPS_UBWC_2,
 	SDE_CAPS_PARTIALWR,
+	SDE_CAPS_SPLIT_CTX,
 	SDE_CAPS_HW_TIMESTAMP,
 	SDE_CAPS_UBWC_3,
 	SDE_CAPS_MAX,

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_r3_internal.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_r3_internal.h
@@ -339,6 +339,7 @@ struct sde_hw_rotator {
 
 	bool    dbgmem;
 	bool reset_hw_ts;
+	bool swts_created;
 	u32 last_hwts[ROT_QUEUE_MAX];
 	u32 koff_timeout;
 	u32 vid_trigger;


### PR DESCRIPTION
Some MDP versions (3.2.0, 3.3.0, found in SDM630/660) are configured
to share one IOMMU context between MDP and ROT devices: in these
cases we cannot totally free and remap the memory there from the
rotator driver because, in the event of a free, we would also be
freeing the MDP mapped space, creating havoc (as that's being used
for the display in general).

For this reason, this kind of configuration requires us to map
only once (in the mdp driver, actually) and just make use (and
invalidation) of the portion of memory associated to the rotator
hardware, hence we need to differentiate the handling for this.

This commit also assumes that only rotator hardware requiring
software timestamp needs the quirk (as, anyway, the mapping is
actually done only in that case).

So, define a new SDE_CAPS_SPLIT_CTX cap entry and assign it to
MDP versions 3.2.0, 3.3.0, then use this codepath only if the
cap is set, else, just go on with the regular code that assumes
that we have one iommu context for mdp and one for rotator.

FIXES:
- Full screen video kernel panic
- Camera API2 apps kernel panic

Tested on SoMC SM8150 Kumano Griffin DSDS. 