### PR TITLE
[7.1.r1] leds: qti-tri-led: Write known value to TRILED HW at init time

### DIFF
--- a/drivers/leds/leds-qti-tri-led.c
+++ b/drivers/leds/leds-qti-tri-led.c
@@ -406,6 +406,7 @@ static const struct attribute *breath_attrs[] = {
 static int qpnp_tri_led_register(struct qpnp_tri_led_chip *chip)
 {
 	struct qpnp_led_dev *led;
+	enum led_brightness brightness = LED_OFF;
 	int rc, i, j;
 
 	for (i = 0; i < chip->num_leds; i++) {
@@ -437,6 +438,13 @@ static int qpnp_tri_led_register(struct qpnp_tri_led_chip *chip)
 				goto err_out;
 			}
 		}
+
+		/* Make sure to initialize the LEDs to known values */
+		rc = qpnp_tri_led_set(led);
+		if (rc)
+			dev_warn(chip->dev,
+				"Cannot initialize %s LED to OFF value: %d\n",
+				led->label, rc);
 	}
 
 	return 0;


### PR DESCRIPTION
The bootloader may leave one (or more) of the LEDs up when booting
the HLOS: in that case, the LED will be stuck because we are
disallowing to write brightness when br_new==br_old.

We initialize the brightness to zero when initializing the driver,
so also initialize the hardware to known values: this way, the
driver init matches with the hardware status.

Tested on SoMC Kumano Griffin DSDS (@MarijnS95)