### PR TITLE
[7.1.r1] SM8150 DT updates, power consumption fix, binder fix

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm8150b.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8150b.dtsi
@@ -52,6 +52,11 @@
 			clock-names = "xo";
 		};
 
+		pm8150b_pbs1: qcom,pbs@7200 {
+			compatible = "qcom,qpnp-pbs";
+			reg = <0x7200 0x100>;
+		};
+
 		pm8150b_qnovo: qcom,sdam-qnovo@b000 {
 			compatible = "qcom,qpnp-qnovo5";
 			reg = <0xb000 0x100>;
@@ -379,6 +384,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			qcom,pmic-revid = <&pm8150b_revid>;
+			qcom,pmic-pbs = <&pm8150b_pbs1>;
 			status = "okay";
 
 			qcom,fg-batt-soc@4000 {

--- a/arch/arm64/boot/dts/qcom/sm8150-mtp.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-mtp.dtsi
@@ -653,6 +653,8 @@
 };
 
 &smb1390_charger {
+	/delete-property/ compatible;
+	compatible = "qcom,smb1390-charger-psy";
 	io-channels = <&pm8150b_vadc ADC_AMUX_THM2>;
 	io-channel-names = "cp_die_temp";
 	status = "ok";

--- a/arch/arm64/boot/dts/qcom/sm8150-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-pinctrl.dtsi
@@ -253,20 +253,33 @@
 		};
 
 		qupv3_se13_4uart_pins: qupv3_se13_4uart_pins {
-			qupv3_se13_pins_default: qupv3_se13_pins_default {
+			qupv3_se13_default_ctsrtsrx:
+				qupv3_se13_default_ctsrtsrx {
 				mux {
-					pins = "gpio43", "gpio44", "gpio45",
-								"gpio46";
+					pins = "gpio43", "gpio44", "gpio46";
 					function = "gpio";
-					};
+				};
 
 				config {
-					pins = "gpio43", "gpio44", "gpio45",
-								"gpio46";
+					pins = "gpio43", "gpio44", "gpio46";
 					drive-strength = <2>;
-					bias-disable;
-					};
+					bias-pull-down;
+				};
 			};
+
+			qupv3_se13_default_tx: qupv3_se13_default_tx {
+				mux {
+					pins = "gpio45";
+					function = "gpio";
+				};
+
+				config {
+					pins = "gpio45";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
 			qupv3_se13_ctsrx: qupv3_se13_ctsrx {
 				mux {
 					pins = "gpio43", "gpio46";

--- a/arch/arm64/boot/dts/qcom/sm8150-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-pinctrl.dtsi
@@ -253,6 +253,20 @@
 		};
 
 		qupv3_se13_4uart_pins: qupv3_se13_4uart_pins {
+			qupv3_se13_pins_default: qupv3_se13_pins_default {
+				mux {
+					pins = "gpio43", "gpio44", "gpio45",
+								"gpio46";
+					function = "gpio";
+					};
+
+				config {
+					pins = "gpio43", "gpio44", "gpio45",
+								"gpio46";
+					drive-strength = <2>;
+					bias-disable;
+					};
+			};
 			qupv3_se13_ctsrx: qupv3_se13_ctsrx {
 				mux {
 					pins = "gpio43", "gpio46";

--- a/arch/arm64/boot/dts/qcom/sm8150-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-qrd.dtsi
@@ -623,6 +623,8 @@
 };
 
 &smb1390_charger {
+	/delete-property/ compatible;
+	compatible = "qcom,smb1390-charger-psy";
 	io-channels = <&pm8150b_vadc ADC_AMUX_THM2>;
 	io-channel-names = "cp_die_temp";
 	status = "ok";

--- a/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
@@ -421,7 +421,8 @@
 			<&clock_gcc GCC_QUPV3_WRAP_2_M_AHB_CLK>,
 			<&clock_gcc GCC_QUPV3_WRAP_2_S_AHB_CLK>;
 		pinctrl-names = "default", "active", "sleep";
-		pinctrl-0 = <&qupv3_se13_pins_default>;
+		pinctrl-0 = <&qupv3_se13_default_ctsrtsrx>,
+				<&qupv3_se13_default_tx>;
 		pinctrl-1 = <&qupv3_se13_ctsrx>, <&qupv3_se13_rts>,
 						<&qupv3_se13_tx>;
 		pinctrl-2 = <&qupv3_se13_ctsrx>, <&qupv3_se13_rts>,

--- a/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
@@ -420,10 +420,11 @@
 		clocks = <&clock_gcc GCC_QUPV3_WRAP2_S3_CLK>,
 			<&clock_gcc GCC_QUPV3_WRAP_2_M_AHB_CLK>,
 			<&clock_gcc GCC_QUPV3_WRAP_2_S_AHB_CLK>;
-		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&qupv3_se13_ctsrx>, <&qupv3_se13_rts>,
-						<&qupv3_se13_tx>;
+		pinctrl-names = "default", "active", "sleep";
+		pinctrl-0 = <&qupv3_se13_pins_default>;
 		pinctrl-1 = <&qupv3_se13_ctsrx>, <&qupv3_se13_rts>,
+						<&qupv3_se13_tx>;
+		pinctrl-2 = <&qupv3_se13_ctsrx>, <&qupv3_se13_rts>,
 						<&qupv3_se13_tx>;
 		interrupts-extended = <&pdc GIC_SPI 585 0>,
 				<&tlmm 46 0>;

--- a/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-qupv3.dtsi
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1073,6 +1073,7 @@
 		pinctrl-1 = <&qupv3_se22_spi_sleep>;
 		spi-max-frequency = <50000000>;
 		qcom,wrapper-core = <&qupv3_3>;
+		qcom,disable-dma;
 		status = "disabled";
 	};
 };

--- a/arch/arm64/boot/dts/qcom/sm8150-regulator.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-regulator.dtsi
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -658,12 +658,18 @@
 		compatible = "qcom,rpmh-vrm-regulator";
 		mboxes = <&apps_rsc 0>;
 		qcom,resource-name = "smpc8";
+		qcom,regulator-type = "pmic5-hfsmps";
+		qcom,supported-modes =
+			<RPMH_REGULATOR_MODE_RET
+			 RPMH_REGULATOR_MODE_AUTO>;
+		 qcom,mode-threshold-currents = <0 200000>;
 		S8C: pm8150l_s8: regulator-pm8150l-s8 {
 			regulator-name = "pm8150l_s8";
 			qcom,set = <RPMH_REGULATOR_SET_ALL>;
 			regulator-min-microvolt = <1352000>;
 			regulator-max-microvolt = <1352000>;
 			qcom,init-voltage = <1352000>;
+			qcom,init-mode = <RPMH_REGULATOR_MODE_RET>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sm8150-sdx50m-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-sdx50m-qrd.dtsi
@@ -593,6 +593,8 @@
 };
 
 &smb1390_charger {
+	/delete-property/ compatible;
+	compatible = "qcom,smb1390-charger-psy";
 	io-channels = <&pm8150b_vadc ADC_AMUX_THM2>;
 	io-channel-names = "cp_die_temp";
 	status = "ok";

--- a/arch/arm64/boot/dts/qcom/sm8150-thermal.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-thermal.dtsi
@@ -780,7 +780,7 @@
 		wake-capable-sensor;
 		trips {
 			gpu_trip0: gpu-trip0 {
-				temperature = <95000>;
+				temperature = <85000>;
 				hysteresis = <0>;
 				type = "passive";
 			};

--- a/drivers/android/binder.c
+++ b/drivers/android/binder.c
@@ -113,10 +113,6 @@ BINDER_DEBUG_ENTRY(proc);
 #define SZ_1K                               0x400
 #endif
 
-#ifndef SZ_4M
-#define SZ_4M                               0x400000
-#endif
-
 #define FORBIDDEN_MMAP_FLAGS                (VM_WRITE)
 
 enum {
@@ -5156,9 +5152,6 @@ static int binder_mmap(struct file *filp, struct vm_area_struct *vma)
 
 	if (proc->tsk != current->group_leader)
 		return -EINVAL;
-
-	if ((vma->vm_end - vma->vm_start) > SZ_4M)
-		vma->vm_end = vma->vm_start + SZ_4M;
 
 	binder_debug(BINDER_DEBUG_OPEN_CLOSE,
 		     "%s: %d %lx-%lx (%ld K) vma %lx pagep %lx\n",

--- a/drivers/android/binder_alloc.c
+++ b/drivers/android/binder_alloc.c
@@ -30,6 +30,7 @@
 #include <linux/list_lru.h>
 #include <linux/uaccess.h>
 #include <linux/highmem.h>
+#include <linux/sizes.h>
 #include "binder_alloc.h"
 #include "binder_trace.h"
 
@@ -692,15 +693,16 @@ int binder_alloc_mmap_handler(struct binder_alloc *alloc,
 	alloc->buffer = (void __user *)vma->vm_start;
 	mutex_unlock(&binder_alloc_mmap_lock);
 
+	alloc->buffer_size = min_t(unsigned long, vma->vm_end - vma->vm_start,
+				   SZ_4M);
 	alloc->pages = kzalloc(sizeof(alloc->pages[0]) *
-				   ((vma->vm_end - vma->vm_start) / PAGE_SIZE),
+				(alloc->buffer_size / PAGE_SIZE),
 			       GFP_KERNEL);
 	if (alloc->pages == NULL) {
 		ret = -ENOMEM;
 		failure_string = "alloc page array";
 		goto err_alloc_pages_failed;
 	}
-	alloc->buffer_size = vma->vm_end - vma->vm_start;
 
 	buffer = kzalloc(sizeof(*buffer), GFP_KERNEL);
 	if (!buffer) {


### PR DESCRIPTION
This patchset fixes (or partially fixes) SoMC SM8150 Kumano platform sleep power
consumption issues, plus adds a bugfix for high big mappings in binder_alloc.

Tested on SoMC Kumano Griffin DSDS. 