### PR TITLE
[KERNEL/KUMANO] arm64: DT: SM8150: Flip mbhc detection switch

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -3252,6 +3252,9 @@
 
 	qcom,wsa-devs = <&wsa881x_70213>, <&wsa881x_70214>;
 	qcom,wsa-aux-dev-prefix = "SpkrLeft", "SpkrRight";
+
+	qcom,msm-mbhc-hphl-swh = <0>;
+	qcom,msm-mbhc-gnd-swh = <0>;
 };
 
 &wsa881x_70211 {


### PR DESCRIPTION
This is the only diff observed when comparing sm8150-audio-overlay.dtsi
to copyleft DT. Plugging in a wired headset results in a _disconnect_
event; unplugging it results in a _connect_ event, leading to the wrong
audio path in both cases.
Override the detection switch - just like stock - from 1 to 0 to achieve
the desired result.