### PR TITLE
[KERNEL] [URGENT] Correct handling for new egistec sensors

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -1015,7 +1015,7 @@
 		function = "normal";
 		output-low;
 		drive-push-pull;
-		qcom,drive-strength = <1>; /* Low */
+		qcom,drive-strength = <3>;
 		power-source = <1>;
 	};
 

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -53,10 +53,7 @@
 #include <linux/uaccess.h>
 
 
-#define PWR_ON_STEP_SLEEP 100
-#define PWR_ON_STEP_RANGE1 100
-#define PWR_ON_STEP_RANGE2 900
-
+#define ET51X_VDDANA_ON_US 10000
 #define ET51X_RESET_LOW_US 1000
 #define ET51X_RESET_HIGH1_US 100
 
@@ -140,6 +137,7 @@ static int et51x_vreg_set_voltage(struct device *dev, struct regulator *vreg,
 		rc = regulator_enable(vreg);
 		if (rc)
 			dev_err(dev, "Unable to enable: %d\n", rc);
+                usleep_range(ET51X_VDDANA_ON_US, ET51X_VDDANA_ON_US + 1000);
 	}
 
 	return rc;
@@ -218,17 +216,17 @@ static int hw_reset(struct et51x_data *et51x)
 	int rc = select_pin_ctl(et51x, "et51x_reset_active");
 	if (rc)
 		goto exit;
-	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 100);
+	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 1000);
 
 	rc = select_pin_ctl(et51x, "et51x_reset_reset");
 	if (rc)
 		goto exit;
-	usleep_range(ET51X_RESET_LOW_US, ET51X_RESET_LOW_US + 100);
+	usleep_range(ET51X_RESET_LOW_US, ET51X_RESET_LOW_US + 1000);
 
 	rc = select_pin_ctl(et51x, "et51x_reset_active");
 	if (rc)
 		goto exit;
-	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 100);
+	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 1000);
 
 	irq_gpio = et51x_get_gpio_triggered(et51x);
 	dev_dbg(dev, "IRQ after reset %d\n", irq_gpio);

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -54,9 +54,9 @@
 
 
 #define ET51X_VDDANA_ON_US 10000
-#define ET51X_RESET_LOW_US 1000
-#define ET51X_RESET_HIGH1_US 100
-
+#define ET51X_RESET_LOW_US 30000
+#define ET51X_RESET_HIGH1_US 1000
+#define ET51X_RESET_ACTIVE_US 20000
 #define ET51X_IRQPOLL_TIMEOUT_MS 500
 #define ET51X_MAX_HAL_PROCESSING_TIME 400
 
@@ -226,7 +226,7 @@ static int hw_reset(struct et51x_data *et51x)
 	rc = select_pin_ctl(et51x, "et51x_reset_active");
 	if (rc)
 		goto exit;
-	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 1000);
+	usleep_range(ET51X_RESET_ACTIVE_US, ET51X_RESET_ACTIVE_US + 1000);
 
 	irq_gpio = et51x_get_gpio_triggered(et51x);
 	dev_dbg(dev, "IRQ after reset %d\n", irq_gpio);


### PR DESCRIPTION
The drive strength for the ET580 VDD fixed-LDO was wrongly set
to LOW, even when the LDO was being pulled high: drive it
correctly to ensure low dropout noise, as this is going in a
chip that needs high precision and - beware - it is doing
capacitive readouts (so it's critical to have clean power here).

Also, push the correct powerup sequence (sleep times were
too short!) in the kernel driver for egistec sensors.

Tested on SoMC SM8150 Kumano Griffin DSDS