### PR TITLE
[7.1.r1] CAF Security

### DIFF
--- a/net/qrtr/qrtr.c
+++ b/net/qrtr/qrtr.c
@@ -563,8 +563,13 @@ static int qrtr_node_enqueue(struct qrtr_node *node, struct sk_buff *skb,
 	hdr->size = cpu_to_le32(len);
 	hdr->confirm_rx = !!confirm_rx;
 
-	skb_put_padto(skb, ALIGN(len, 4) + sizeof(*hdr));
 	qrtr_log_tx_msg(node, hdr, skb);
+	rc = skb_put_padto(skb, ALIGN(len, 4) + sizeof(*hdr));
+	if (rc) {
+		pr_err("%s: failed to pad size %lu to %lu rc:%d\n", __func__,
+		       len, ALIGN(len, 4) + sizeof(*hdr), rc);
+		return rc;
+	}
 
 	mutex_lock(&node->ep_lock);
 	if (node->ep)


### PR DESCRIPTION
Saw this was missing from [thanks to this](https://sx.ix5.org/info/post/sodp-2020-04-05-security-state/) so lets get it in the kernel.