### PR TITLE
[7.1.r1] Implement generic support for HBM

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -1797,10 +1797,10 @@ const char *cmd_set_prop_map[DSI_CMD_SET_MAX] = {
 	"somc,mdss-dsi-aod-low-command",
 	"somc,mdss-dsi-aod-high-command",
 	"somc,mdss-dsi-aod-off-command",
-	"somc,mdss-dsi-vr-on-command",
-	"somc,mdss-dsi-vr-off-command",
 	"somc,mdss-dsi-hbm-on-command",
 	"somc,mdss-dsi-hbm-off-command",
+	"somc,mdss-dsi-vr-on-command",
+	"somc,mdss-dsi-vr-off-command",
 	"somc,mdss-dsi-display-off-command",
 	"somc,mdss-dsi-display-on-command",
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.h
@@ -220,6 +220,7 @@ struct dsi_panel {
 
 #ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 	struct panel_specific_pdata *spec_pdata;
+	struct delayed_work hbm_protect_work;
 	int touch_type;
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 };

--- a/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
+++ b/drivers/gpu/drm/msm/dsi-staging/somc_panel/somc_panel_exts.h
@@ -223,6 +223,17 @@ struct dsi_m_plus {
 	m_plus_mode mode;
 };
 
+#define HBM_MAX_COOLDOWNS		3
+#define HBM_OFF_TIMER_MS		(3 * 60 * 1000)		// 3 mins
+#define HBM_ON_TIMER_MS			(10 * 60 * 1000)	// 10 mins
+
+struct dsi_samsung_hbm {
+	bool hbm_supported;
+	bool force_hbm_off;
+	int hbm_mode;
+	int ncooldowns;
+};
+
 /* lab/ibb control default data */
 #define OVR_LAB_VOLTAGE			BIT(0)
 #define OVR_IBB_VOLTAGE			BIT(1)
@@ -358,11 +369,11 @@ struct panel_specific_pdata {
 	int sod_mode;
 	int pre_sod_mode;
 	int vr_mode;
-	int hbm_mode;
 	unsigned int aod_threshold;
 	bool light_state;
 
 	struct dsi_m_plus m_plus;
+	struct dsi_samsung_hbm hbm;
 
 	struct dsi_panel_labibb_data labibb;
 	struct short_detection_ctrl short_det;
@@ -452,6 +463,8 @@ void dsi_panel_driver_oled_short_det_enable(
 void dsi_panel_driver_oled_short_det_disable(
 			struct panel_specific_pdata *spec_pdata);
 int dsi_panel_driver_toggle_light_off(struct dsi_panel *panel, bool state);
+int somc_panel_set_dyn_hbm_backlight(struct dsi_panel *panel,
+				     int prev_bl_lvl, int bl_lvl);
 
 /* For incell driver */
 struct incell_ctrl *incell_get_info(void);


### PR DESCRIPTION
This patchset implements support for HBM with safe handling:

The High Brightness Mode (HBM) allows the panel to reach up to
20% more nits, but also provides some stress to the OLED matrix:
in order to avoid burn-in, the user will be allowed to stay in
HBM mode for a maximum of 10 minutes, with a cooldown time of
3 minutes.

If the user doesn't exit HBM (through auto-brightness in the
userspace, or through manual bightness setting), then this
driver will enable it for 10 minutes, disable it for 3, then
re-enable it for 10 - for up to 3 times.

Entering the HBM mode requires the userspace requesting MAXIMUM
brightness for the target panel.

This feature will not be enabled by default for all panels that
support the High Brightness Mode commands: these have to be
validated manually before deciding on its safety, so each panel
needs to declare in its device-tree configuration the property
"somc,set-hbm-usable", otherwise the automatic switch to HBM
will be made impossible.


This patchset does NOT include HBM enablement for SoMC Kumano panels:
that will come later, if feasible.