### PR TITLE
[LA.UM.7.1.r1] Uproot vidc_3x to LA.UM.8.2.1.r1-04700-sdm660.0

### DIFF
--- a/drivers/media/platform/msm/vidc_3x/hfi_response_handler.c
+++ b/drivers/media/platform/msm/vidc_3x/hfi_response_handler.c
@@ -1386,13 +1386,8 @@ static int hfi_process_session_prop_info(u32 device_id,
 		cmd_done.status = VIDC_ERR_NONE;
 		cmd_done.data.property.buf_req = buff_req;
 		cmd_done.size = sizeof(buff_req);
+		break;
 
-		*info = (struct msm_vidc_cb_info) {
-			.response_type =  HAL_SESSION_PROPERTY_INFO,
-			.response.cmd = cmd_done,
-		};
-
-		return 0;
 	case HFI_PROPERTY_PARAM_PROFILE_LEVEL_CURRENT:
 		hfi_process_sess_get_prop_profile_level(pkt, &profile_level);
 		cmd_done.device_id = device_id;
@@ -1404,33 +1399,29 @@ static int hfi_process_session_prop_info(u32 device_id,
 				.level = profile_level.level,
 			};
 		cmd_done.size = sizeof(struct hal_profile_level);
+		break;
 
-		*info = (struct msm_vidc_cb_info) {
-			.response_type =  HAL_SESSION_PROPERTY_INFO,
-			.response.cmd = cmd_done,
-		};
-		return 0;
-/*
- *	case HFI_PROPERTY_CONFIG_VDEC_ENTROPY:
- *		hfi_process_sess_get_prop_dec_entropy(pkt, &entropy);
- *		cmd_done.device_id = device_id;
- *		cmd_done.session_id = (void *)(uintptr_t)pkt->session_id;
- *		cmd_done.status = VIDC_ERR_NONE;
- *		cmd_done.data.property.h264_entropy = entropy;
- *		cmd_done.size = sizeof(enum hal_h264_entropy);
- *
- *		*info = (struct msm_vidc_cb_info) {
- *			.response_type =  HAL_SESSION_PROPERTY_INFO,
- *			.response.cmd = cmd_done,
- *		};
- *		return 0;
- */
+	case HFI_PROPERTY_CONFIG_VDEC_ENTROPY:
+		hfi_process_sess_get_prop_dec_entropy(pkt, &entropy);
+		cmd_done.device_id = device_id;
+		cmd_done.session_id = (void *)(uintptr_t)pkt->session_id;
+		cmd_done.status = VIDC_ERR_NONE;
+		cmd_done.data.property.h264_entropy = entropy;
+		cmd_done.size = sizeof(enum hal_h264_entropy);
+		break;
+
 	default:
 		dprintk(VIDC_DBG,
 				"hal_process_session_prop_info: unknown_prop_id: %x\n",
 				pkt->rg_property_data[0]);
 		return -ENOTSUPP;
 	}
+
+	*info = (struct msm_vidc_cb_info) {
+		.response_type =  HAL_SESSION_PROPERTY_INFO,
+		.response.cmd = cmd_done,
+	};
+	return 0;
 }
 
 static int hfi_process_session_init_done(u32 device_id,

--- a/drivers/media/platform/msm/vidc_3x/msm_smem.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_smem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -430,7 +430,12 @@ static int alloc_dma_mem(size_t size, u32 align, u32 flags,
 		}
 
 		ion_flags |= ION_FLAG_SECURE | secure_flag;
-		heap_mask = ION_HEAP(ION_SECURE_HEAP_ID);
+		if (res->cma_status) {
+			heap_mask = ION_HEAP(ION_VIDEO_HEAP_ID);
+			ion_flags |= ION_FLAG_CP_CAMERA_ENCODE;
+		} else {
+			heap_mask = ION_HEAP(ION_SECURE_HEAP_ID);
+		}
 
 		if (res->slave_side_cp) {
 			heap_mask = ION_HEAP(ION_CP_MM_HEAP_ID);

--- a/drivers/media/platform/msm/vidc_3x/msm_smem.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_smem.c
@@ -429,10 +429,12 @@ static int alloc_dma_mem(size_t size, u32 align, u32 flags,
 			goto fail_shared_mem_alloc;
 		}
 
+		if ((secure_flag == ION_FLAG_CP_PIXEL) && res->cma_status)
+			secure_flag = ION_FLAG_CP_CAMERA_ENCODE;
+
 		ion_flags |= ION_FLAG_SECURE | secure_flag;
 		if (res->cma_status) {
 			heap_mask = ION_HEAP(ION_VIDEO_HEAP_ID);
-			ion_flags |= ION_FLAG_CP_CAMERA_ENCODE;
 		} else {
 			heap_mask = ION_HEAP(ION_SECURE_HEAP_ID);
 		}

--- a/drivers/media/platform/msm/vidc_3x/msm_v4l2_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_v4l2_vidc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -584,6 +584,30 @@ static int msm_vidc_probe_vidc_device(struct platform_device *pdev)
 	if (rc) {
 		dprintk(VIDC_ERR,
 				"Failed to create link name sysfs for encoder");
+		goto err_enc_attr_link_name;
+	}
+	/* setup the encoder device with cma */
+	core->vdev[MSM_VIDC_ENCODER_CMA].vdev.release =
+		msm_vidc_release_video_device;
+	core->vdev[MSM_VIDC_ENCODER_CMA].vdev.fops = &msm_v4l2_vidc_fops;
+	core->vdev[MSM_VIDC_ENCODER_CMA].vdev.ioctl_ops = &msm_v4l2_ioctl_ops;
+	core->vdev[MSM_VIDC_ENCODER_CMA].vdev.vfl_dir = VFL_DIR_M2M;
+	core->vdev[MSM_VIDC_ENCODER_CMA].type = MSM_VIDC_ENCODER_CMA;
+	core->vdev[MSM_VIDC_ENCODER_CMA].vdev.v4l2_dev = &core->v4l2_dev;
+	rc = video_register_device(&core->vdev[MSM_VIDC_ENCODER_CMA].vdev,
+				VFL_TYPE_GRABBER, nr + 2);
+	if (rc) {
+		dprintk(VIDC_ERR,
+				"Failed to register video cma encoder device");
+		goto err_enc_register;
+	}
+
+	video_set_drvdata(&core->vdev[MSM_VIDC_ENCODER_CMA].vdev, core);
+	dev = &core->vdev[MSM_VIDC_ENCODER_CMA].vdev.dev;
+	rc = device_create_file(dev, &dev_attr_link_name);
+	if (rc) {
+		dprintk(VIDC_ERR,
+				"Failed to create link name sysfs for encoder cma");
 		goto err_enc_attr_link_name;
 	}
 

--- a/drivers/media/platform/msm/vidc_3x/msm_vdec.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vdec.c
@@ -2023,23 +2023,25 @@ static int try_get_ctrl(struct msm_vidc_inst *inst, struct v4l2_ctrl *ctrl)
 		ctrl->val = inst->capability.secure_output2_threshold.max;
 		break;
 	case V4L2_CID_MPEG_VIDEO_H264_ENTROPY_MODE:
-		rc = msm_comm_try_get_prop(inst,
-				HAL_CONFIG_VDEC_ENTROPY, &hprop);
-		if (rc) {
-			dprintk(VIDC_ERR, "%s: Failed getting entropy type: %d",
+		if (inst->fmts[OUTPUT_PORT].fourcc == V4L2_PIX_FMT_H264) {
+			rc = msm_comm_try_get_prop(inst,
+					HAL_CONFIG_VDEC_ENTROPY, &hprop);
+			if (rc) {
+				dprintk(VIDC_ERR, "%s: Failed getting entropy type: %d",
 					__func__, rc);
-			break;
-		}
-		switch (hprop.h264_entropy) {
-		case HAL_H264_ENTROPY_CAVLC:
-			ctrl->val = V4L2_MPEG_VIDEO_H264_ENTROPY_MODE_CAVLC;
-			break;
-		case HAL_H264_ENTROPY_CABAC:
-			ctrl->val = V4L2_MPEG_VIDEO_H264_ENTROPY_MODE_CABAC;
-			break;
-		case HAL_UNUSED_ENTROPY:
-			rc = -ENOTSUPP;
-			break;
+				break;
+			}
+			switch (hprop.h264_entropy) {
+				case HAL_H264_ENTROPY_CAVLC:
+					ctrl->val = V4L2_MPEG_VIDEO_H264_ENTROPY_MODE_CAVLC;
+					break;
+				case HAL_H264_ENTROPY_CABAC:
+					ctrl->val = V4L2_MPEG_VIDEO_H264_ENTROPY_MODE_CABAC;
+					break;
+				case HAL_UNUSED_ENTROPY:
+					rc = -ENOTSUPP;
+					break;
+			}
 		}
 		break;
 	default:

--- a/drivers/media/platform/msm/vidc_3x/msm_venc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_venc.c
@@ -3640,18 +3640,11 @@ static int try_set_ctrl(struct msm_vidc_inst *inst, struct v4l2_ctrl *ctrl)
 		}
 		break;
 	case V4L2_CID_MPEG_VIDC_VIDEO_OPERATING_RATE:
-		if ((ctrl->val >> 16) < inst->capability.frame_rate.min ||
-			 (ctrl->val >> 16) > inst->capability.frame_rate.max) {
-			dprintk(VIDC_ERR, "Invalid operating rate %u\n",
-				(ctrl->val >> 16));
-			rc = -ENOTSUPP;
-		} else {
-			dprintk(VIDC_DBG,
-				"inst(%pK) operating rate changed from %d to %d\n",
-				inst, inst->prop.operating_rate >> 16,
-					ctrl->val >> 16);
-			inst->prop.operating_rate = ctrl->val;
-		}
+		dprintk(VIDC_DBG,
+			"inst(%pK) operating rate changed from %d to %d\n",
+			inst, inst->prop.operating_rate >> 16,
+				ctrl->val >> 16);
+		inst->prop.operating_rate = ctrl->val;
 		break;
 	case V4L2_CID_MPEG_VIDC_VIDEO_VENC_BITRATE_TYPE:
 	{

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc.c
@@ -656,6 +656,7 @@ int qbuf_cache_operations(struct msm_vidc_inst *inst,
 	enum smem_cache_ops cache_op;
 	bool skip;
 	int i = 0, rc = 0;
+	unsigned int rate;
 
 	skip = true;
 
@@ -678,7 +679,9 @@ int qbuf_cache_operations(struct msm_vidc_inst *inst,
 				}
 			}
 		} else if (inst->session_type == MSM_VIDC_ENCODER) {
-			if (binfo->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
+
+			rate = inst->prop.operating_rate >> 16;
+			if (binfo->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE && rate == 0) {
 				if (!i) { /* yuv */
 					skip = false;
 					offset = binfo->buff_off[i];

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc.c
@@ -649,35 +649,132 @@ int qbuf_dynamic_buf(struct msm_vidc_inst *inst,
 	return -EINVAL;
 }
 
-int output_buffer_cache_invalidate(struct msm_vidc_inst *inst,
+int qbuf_cache_operations(struct msm_vidc_inst *inst,
 				struct buffer_info *binfo)
 {
-	int i = 0;
-	int rc = 0;
+	unsigned long offset, size;
+	enum smem_cache_ops cache_op;
+	bool skip;
+	int i = 0, rc = 0;
+
+	skip = true;
+
+	for (i = 0; i < binfo->num_planes; i++) {
+		if (inst->session_type == MSM_VIDC_DECODER) {
+			if (binfo->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
+				if (!i) { /* bitstream */
+					skip = false;
+					offset = binfo->buff_off[i];
+					size = binfo->size[i];
+					cache_op = SMEM_CACHE_CLEAN_INVALIDATE;
+				}
+			} else if (binfo->type ==
+				V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
+				if (!i) { /* yuv */
+					skip = false;
+					offset = 0;
+					size = binfo->size[i];
+					cache_op = SMEM_CACHE_INVALIDATE;
+				}
+			}
+		} else if (inst->session_type == MSM_VIDC_ENCODER) {
+			if (binfo->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
+				if (!i) { /* yuv */
+					skip = false;
+					offset = binfo->buff_off[i];
+					size = binfo->size[i];
+					cache_op = SMEM_CACHE_CLEAN_INVALIDATE;
+				}
+			} else if (binfo->type ==
+					V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
+				if (!i) { /* bitstream */
+					skip = false;
+					offset = 0;
+					size = binfo->size[i];
+					cache_op = SMEM_CACHE_INVALIDATE;
+				}
+			}
+		}
+		if (!skip) {
+			rc = msm_smem_cache_operations(binfo->smem[i].dma_buf,
+						cache_op, offset, size);
+			if (rc) {
+				dprintk(VIDC_ERR,
+					"Failed to clean caches: %d\n", rc);
+				return rc;
+			}
+		}
+	}
+	return 0;
+}
+int dqbuf_cache_operations(struct msm_vidc_inst *inst,
+			struct v4l2_buffer *b,
+			struct buffer_info *buffer_info)
+{
+	int i = 0, rc = 0;
+	bool skip = true;
 
 	if (!inst) {
 		dprintk(VIDC_ERR, "%s: invalid inst: %pK\n", __func__, inst);
 		return -EINVAL;
 	}
 
-	if (!binfo) {
-		dprintk(VIDC_ERR, "%s: invalid buffer info: %pK\n",
+	if (!b || !buffer_info) {
+		dprintk(VIDC_ERR, "%s: invalid buffer: %pK\n",
 			__func__, inst);
 		return -EINVAL;
 	}
 
-	if (binfo->type != V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)
+	if (b->type != V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)
 		return 0;
 
+	for (i = 0; i < b->length; i++) {
+		unsigned long offset, size;
+		enum smem_cache_ops cache_op;
 
-	for (i = 0; i < binfo->num_planes; i++) {
-		rc = msm_comm_smem_cache_operations(inst,
-			&binfo->smem[i], SMEM_CACHE_INVALIDATE);
-		if (rc) {
-			dprintk(VIDC_ERR,
+		skip = true;
+		if (inst->session_type == MSM_VIDC_DECODER) {
+			if (b->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
+				/* bitstream and extradata */
+				/* we do not need cache operations */
+			} else if (b->type ==
+					V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
+				if (!i) { /* yuv */
+					skip = false;
+					offset = b->m.planes[i].data_offset;
+					size = b->m.planes[i].bytesused;
+					cache_op = SMEM_CACHE_INVALIDATE;
+				}
+			}
+		} else if (inst->session_type == MSM_VIDC_ENCODER) {
+			if (b->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
+				/* yuv and extradata */
+				/* we do not need cache operations */
+			} else if (b->type ==
+				V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
+				if (!i) { /* bitstream */
+					skip = false;
+					/*
+					 * Include vp8e header bytes as well
+					 * by making offset equal to zero
+					 */
+					offset = 0;
+					size = b->m.planes[i].bytesused+
+						b->m.planes[i].data_offset;
+					cache_op = SMEM_CACHE_INVALIDATE;
+				}
+			}
+		}
+		if (!skip && size > 0) {
+			rc = msm_smem_cache_operations(
+				buffer_info->smem[i].dma_buf,
+				cache_op, offset, size);
+			if (rc) {
+				dprintk(VIDC_ERR,
 				"%s: Failed to clean caches: %d\n",
 				__func__, rc);
-			return -EINVAL;
+				return -EINVAL;
+			}
 		}
 	}
 	return 0;
@@ -849,7 +946,7 @@ int msm_vidc_qbuf(void *instance, struct v4l2_buffer *b)
 	for (i = 0; i < b->length; ++i) {
 		if (EXTRADATA_IDX(b->length) &&
 			(i == EXTRADATA_IDX(b->length)) &&
-			!b->m.planes[i].length) {
+		!b->m.planes[i].length) {
 			b->m.planes[i].m.userptr = 0;
 			continue;
 		}
@@ -867,29 +964,11 @@ int msm_vidc_qbuf(void *instance, struct v4l2_buffer *b)
 		b->m.planes[i].m.userptr = binfo->device_addr[i];
 		dprintk(VIDC_DBG, "Queueing device address = %pa\n",
 				&binfo->device_addr[i]);
-
-		if (inst->fmts[OUTPUT_PORT].fourcc ==
-			V4L2_PIX_FMT_HEVC_HYBRID &&
-			b->type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE) {
-			rc = msm_comm_smem_cache_operations(inst,
-				&binfo->smem[i], SMEM_CACHE_INVALIDATE);
-			if (rc) {
-				dprintk(VIDC_ERR,
-					"Failed to inv caches: %d\n", rc);
-				goto err_invalid_buff;
-			}
-		}
-
-		if (b->type == V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE) {
-			rc = msm_comm_smem_cache_operations(inst,
-					&binfo->smem[i], SMEM_CACHE_CLEAN);
-			if (rc) {
-				dprintk(VIDC_ERR,
-					"Failed to clean caches: %d\n", rc);
-				goto err_invalid_buff;
-			}
-		}
 	}
+
+	rc = qbuf_cache_operations(inst, binfo);
+	if (rc)
+		return rc;
 
 	if (inst->session_type == MSM_VIDC_DECODER)
 		return msm_vdec_qbuf(instance, b);
@@ -960,7 +1039,7 @@ int msm_vidc_dqbuf(void *instance, struct v4l2_buffer *b)
 		return -EINVAL;
 	}
 
-	rc = output_buffer_cache_invalidate(inst, buffer_info);
+	rc = dqbuf_cache_operations(inst, b, buffer_info);
 	if (rc)
 		return rc;
 

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc.c
@@ -500,7 +500,7 @@ int map_and_register_buf(struct msm_vidc_inst *inst, struct v4l2_buffer *b)
 			binfo->mapped[i] = false;
 			binfo->smem[i] = *same_fd_handle;
 		} else {
-			binfo->smem[i].buffer_type = binfo->type;
+			binfo->smem[i].buffer_type = get_hal_buffer_type(inst,b);
 			binfo->smem[i].fd = binfo->fd[i];
 			binfo->smem[i].offset = binfo->buff_off[i];
 			binfo->smem[i].size = binfo->size[i];

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc.c
@@ -22,6 +22,7 @@
 #include <linux/delay.h>
 #include "vidc_hfi_api.h"
 #include "msm_vidc_dcvs.h"
+#include "msm_vidc_res_parse.h"
 
 #define MAX_EVENTS 30
 
@@ -1240,6 +1241,9 @@ void *msm_vidc_open(int core_id, int session_type)
 	struct msm_vidc_core *core = NULL;
 	int rc = 0;
 	int i = 0;
+	bool reconfig_core = false;
+	bool is_cma_enabled = false;
+	struct hfi_device *hdev = NULL;
 
 	if (core_id >= MSM_VIDC_CORES_MAX ||
 			session_type >= MSM_VIDC_MAX_DEVICES) {
@@ -1277,6 +1281,18 @@ void *msm_vidc_open(int core_id, int session_type)
 	INIT_MSM_VIDC_LIST(&inst->eosbufs);
 
 	kref_init(&inst->kref);
+
+	is_cma_enabled = core->resources.cma_status;
+	reconfig_core =
+		((!is_cma_enabled && session_type == MSM_VIDC_ENCODER_CMA) ||
+		(is_cma_enabled && session_type != MSM_VIDC_ENCODER_CMA)) ?
+		true : false;
+
+	dprintk(VIDC_DBG, "reconfig_core %d , cma_status %d , session_type %d ",
+		reconfig_core, core->resources.cma_status, session_type);
+
+	if (session_type == MSM_VIDC_ENCODER_CMA)
+		session_type = MSM_VIDC_ENCODER;
 
 	inst->session_type = session_type;
 	inst->state = MSM_VIDC_CORE_UNINIT_DONE;
@@ -1320,6 +1336,49 @@ void *msm_vidc_open(int core_id, int session_type)
 
 	setup_event_queue(inst, &core->vdev[session_type].vdev);
 
+	if (reconfig_core) {
+		mutex_lock(&core->lock);
+		if (!list_empty(&core->instances)) {
+			dprintk(VIDC_ERR,
+				"failed due to pending instances in core");
+			mutex_unlock(&core->lock);
+			goto fail_toggle_cma;
+		}
+		mutex_unlock(&core->lock);
+
+		rc = msm_comm_try_state(inst, MSM_VIDC_CORE_UNINIT);
+		if (rc) {
+			dprintk(VIDC_ERR,
+				"MSM_VIDC_CORE_UNINIT failed\n");
+		}
+		cancel_delayed_work(&core->fw_unload_work);
+
+		mutex_lock(&core->lock);
+		hdev = core->device;
+		rc = call_hfi_op(hdev, core_release,
+					hdev->hfi_device_data);
+		if (rc) {
+			dprintk(VIDC_ERR,
+				"Failed to release core, id = %d\n",
+				core->id);
+			mutex_unlock(&core->lock);
+			goto fail_toggle_cma;
+		}
+		core->state = VIDC_CORE_UNINIT;
+		kfree(core->capabilities);
+		core->capabilities = NULL;
+		msm_vidc_enable_cma(&core->resources, !is_cma_enabled);
+		if (rc) {
+			dprintk(VIDC_ERR,
+				"%s CMA failed\n", is_cma_enabled ?
+				"enable":"disable");
+			mutex_unlock(&core->lock);
+			goto fail_toggle_cma;
+		}
+		core->resources.cma_status = !is_cma_enabled;
+		mutex_unlock(&core->lock);
+	}
+
 	mutex_lock(&core->lock);
 	list_add_tail(&inst->list, &core->instances);
 	mutex_unlock(&core->lock);
@@ -1341,11 +1400,15 @@ void *msm_vidc_open(int core_id, int session_type)
 		msm_vidc_debugfs_init_inst(inst, core->debugfs_root);
 
 	return inst;
+
 fail_init:
+	mutex_lock(&core->lock);
+	list_del(&inst->list);
+	mutex_unlock(&core->lock);
+fail_toggle_cma:
 	mutex_lock(&core->lock);
 	v4l2_fh_del(&inst->event_handler);
 	v4l2_fh_exit(&inst->event_handler);
-	list_del(&inst->list);
 	mutex_unlock(&core->lock);
 	vb2_queue_release(&inst->bufq[OUTPUT_PORT].vb2_bufq);
 

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc.c
@@ -969,9 +969,7 @@ int msm_vidc_qbuf(void *instance, struct v4l2_buffer *b)
 				&binfo->device_addr[i]);
 	}
 
-	rc = qbuf_cache_operations(inst, binfo);
-	if (rc)
-		return rc;
+	qbuf_cache_operations(inst, binfo);
 
 	if (inst->session_type == MSM_VIDC_DECODER)
 		return msm_vdec_qbuf(instance, b);

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_internal.h
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -373,7 +373,11 @@ struct buffer_info *device_to_uvaddr(struct msm_vidc_list *buf_list,
 				phys_addr_t device_addr);
 int buf_ref_get(struct msm_vidc_inst *inst, struct buffer_info *binfo);
 int buf_ref_put(struct msm_vidc_inst *inst, struct buffer_info *binfo);
-int output_buffer_cache_invalidate(struct msm_vidc_inst *inst,
+
+int qbuf_cache_operations(struct msm_vidc_inst *inst,
+				struct buffer_info *binfo);
+int dqbuf_cache_operations(struct msm_vidc_inst *inst,
+				struct v4l2_buffer *b,
 				struct buffer_info *binfo);
 int qbuf_dynamic_buf(struct msm_vidc_inst *inst,
 			struct buffer_info *binfo);

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
@@ -20,8 +20,13 @@
 #include "msm_vidc_resources.h"
 #include "msm_vidc_res_parse.h"
 #include "venus_boot.h"
+#include <soc/qcom/scm.h>
 #include "soc/qcom/secure_buffer.h"
+#include <asm/cacheflush.h>
 #include <linux/io.h>
+
+#define VENUS_DEVICE_ID 0x0
+#define SECURE_SYSCALL_ID 0x18
 
 enum clock_properties {
 	CLOCK_PROP_HAS_SCALING = 1 << 0,
@@ -1265,12 +1270,64 @@ static int get_secure_vmid(struct context_bank_info *cb)
 	return VMID_INVAL;
 }
 
+static int msm_vidc_switch_vmid(int vmid, struct context_bank_info *cb)
+{
+	struct scm_desc desc = {0};
+	uint32_t *sid_info = NULL;
+	int rc = 0;
+
+	dprintk(VIDC_DBG, "%s: In\n", __func__);
+	if (!cb) {
+		dprintk(VIDC_ERR, "%s: invalid context bank device\n",
+			__func__);
+		return -EIO;
+	}
+
+	sid_info = kzalloc(sizeof(uint32_t) * cb->num_sids, GFP_KERNEL);
+	if (!sid_info) {
+		dprintk(VIDC_ERR, "%s: memory allocation failred\n",
+			__func__);
+		return -ENOMEM;
+	}
+
+	memcpy(sid_info, &cb->sids, sizeof(uint32_t) * cb->num_sids);
+	desc.arginfo = SCM_ARGS(4, SCM_VAL, SCM_RW, SCM_VAL, SCM_VAL);
+	desc.args[0] = VENUS_DEVICE_ID;
+	desc.args[1] = SCM_BUFFER_PHYS(sid_info);
+	desc.args[2] = sizeof(uint32_t) * cb->num_sids;
+	desc.args[3] = vmid;
+
+	dmac_flush_range(sid_info, sid_info + 1);
+	if (scm_call2(SCM_SIP_FNID(SCM_SVC_MP, SECURE_SYSCALL_ID), &desc)) {
+		dprintk(VIDC_ERR, "call to hypervisor failed\n");
+		rc = -EINVAL;
+	}
+	dprintk(VIDC_DBG, "%s switched to 0x%x vmid\n", cb->name, vmid);
+	kfree(sid_info);
+
+	return rc;
+}
+
+static void msm_vidc_detach_context_banks(
+		struct msm_vidc_platform_resources *res)
+{
+	struct context_bank_info *cb = NULL;
+
+	list_for_each_entry(cb, &res->context_banks, list) {
+		arm_iommu_detach_device(cb->dev);
+		if (cb->mapping)
+			arm_iommu_release_mapping(cb->mapping);
+	}
+}
+
 static int msm_vidc_setup_context_bank(struct context_bank_info *cb,
-		struct device *dev)
+		struct device *dev, int cma_enable)
 {
 	int rc = 0;
 	int secure_vmid = VMID_INVAL;
 	struct bus_type *bus;
+	u32 start_addr = 0, pool_size = 0;
+	int s1_bypass = 1;
 
 	if (!dev || !cb) {
 		dprintk(VIDC_ERR,
@@ -1286,8 +1343,15 @@ static int msm_vidc_setup_context_bank(struct context_bank_info *cb,
 		goto remove_cb;
 	}
 
-	cb->mapping = arm_iommu_create_mapping(bus, cb->addr_range.start,
-					cb->addr_range.size);
+	if (cma_enable) {
+		start_addr = cb->cma.addr_range.start;
+		pool_size = cb->cma.addr_range.size;
+	} else {
+		start_addr = cb->addr_range.start;
+		pool_size = cb->addr_range.size;
+	}
+
+	cb->mapping = arm_iommu_create_mapping(bus, start_addr, pool_size);
 	if (IS_ERR_OR_NULL(cb->mapping)) {
 		dprintk(VIDC_ERR, "%s - failed to create mapping\n", __func__);
 		rc = PTR_ERR(cb->mapping) ?: -ENODEV;
@@ -1296,12 +1360,25 @@ static int msm_vidc_setup_context_bank(struct context_bank_info *cb,
 
 	if (cb->is_secure) {
 		secure_vmid = get_secure_vmid(cb);
+		if (cma_enable && cb->cma.s1_bypass)
+			secure_vmid = VMID_CP_CAMERA_ENCODE;
 		rc = iommu_domain_set_attr(cb->mapping->domain,
 				DOMAIN_ATTR_SECURE_VMID, &secure_vmid);
 		if (rc) {
 			dprintk(VIDC_ERR,
-					"%s - programming secure vmid failed: %s %d\n",
-					__func__, dev_name(dev), rc);
+				"%s - programming secure vmid failed: %s 0x%x\n",
+				__func__, dev_name(dev), rc);
+			goto release_mapping;
+		}
+	}
+
+	if (cma_enable && cb->cma.s1_bypass) {
+		s1_bypass = cb->cma.s1_bypass;
+		rc = iommu_domain_set_attr(cb->mapping->domain,
+			DOMAIN_ATTR_S1_BYPASS, &s1_bypass);
+		if (rc) {
+			dprintk(VIDC_ERR,
+				"%s S1 bypass failed rc %d ", __func__, rc);
 			goto release_mapping;
 		}
 	}
@@ -1324,11 +1401,12 @@ static int msm_vidc_setup_context_bank(struct context_bank_info *cb,
 	dma_set_max_seg_size(dev, DMA_BIT_MASK(32));
 	dma_set_seg_boundary(dev, (unsigned long)DMA_BIT_MASK(64));
 
-	dprintk(VIDC_DBG, "Attached %s and created mapping\n", dev_name(dev));
+	dprintk(VIDC_DBG, "Attached %s and created mapping cma status %d\n",
+			dev_name(dev), cma_enable);
 	dprintk(VIDC_DBG,
-		"Context bank name:%s, buffer_type: %#x, is_secure: %d, address range start: %#x, size: %#x, dev: %pK, mapping: %pK",
-		cb->name, cb->buffer_type, cb->is_secure, cb->addr_range.start,
-		cb->addr_range.size, cb->dev, cb->mapping);
+		"Context bank name:%s, buffer_type: %#x, is_secure: %d,	 address range start: %#x, size: %#x, dev: %pK, mapping: %pK",
+		cb->name, cb->buffer_type, cb->is_secure, start_addr,
+		pool_size, cb->dev, cb->mapping);
 
 	return rc;
 
@@ -1494,7 +1572,7 @@ static int msm_vidc_populate_context_bank(struct device *dev,
 		cb->name, cb->addr_range.start,
 		cb->addr_range.size, cb->buffer_type);
 
-	rc = msm_vidc_setup_context_bank(cb, dev);
+	rc = msm_vidc_setup_context_bank(cb, dev, false);
 	if (rc) {
 		dprintk(VIDC_ERR, "Cannot setup context bank %d\n", rc);
 		goto err_setup_cb;
@@ -1591,7 +1669,7 @@ static int msm_vidc_populate_legacy_context_bank(
 			goto err_setup_cb;
 		}
 
-		rc = msm_vidc_setup_context_bank(cb, cb->dev);
+		rc = msm_vidc_setup_context_bank(cb, cb->dev, false);
 		if (rc) {
 			dprintk(VIDC_ERR, "Cannot setup context bank %d\n", rc);
 			goto err_setup_cb;
@@ -1677,4 +1755,43 @@ int read_bus_resources_from_dt(struct platform_device *pdev)
 	}
 
 	return msm_vidc_populate_bus(&pdev->dev, &core->resources);
+}
+
+int msm_vidc_enable_cma(struct msm_vidc_platform_resources *res, bool enable)
+{
+	int rc;
+	int secure_vmid = VMID_INVAL;
+	struct context_bank_info *cb = NULL;
+
+	dprintk(VIDC_DBG, "%s: In enable status %d\n", __func__, enable);
+
+	msm_vidc_detach_context_banks(res);
+	list_for_each_entry(cb, &res->context_banks, list) {
+		if (cb->is_secure && cb->cma.s1_bypass) {
+			if (enable) {
+				rc = msm_vidc_switch_vmid(VMID_CP_CAMERA_ENCODE,
+						cb);
+				if (rc) {
+					dprintk(VIDC_ERR,
+						"failed SID switching\n");
+					goto detach_cb;
+				}
+			} else {
+				secure_vmid = get_secure_vmid(cb);
+				rc = msm_vidc_switch_vmid(secure_vmid, cb);
+				if (rc)
+					goto detach_cb;
+			}
+		}
+		rc = msm_vidc_setup_context_bank(cb, cb->dev, enable);
+		if (rc)
+			goto detach_cb;
+	}
+
+	return rc;
+
+detach_cb:
+	dprintk(VIDC_DBG, "%s: - failed %d\n", __func__, enable);
+	msm_vidc_detach_context_banks(res);
+	return rc;
 }

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1312,6 +1312,17 @@ static int msm_vidc_setup_context_bank(struct context_bank_info *cb,
 			__func__);
 		goto release_mapping;
 	}
+
+	/*
+	 * configure device segment size and segment boundary to ensure
+	 * iommu mapping returns one mapping (which is required for partial
+	 * cache operations)
+	 */
+	if (!dev->dma_parms)
+		dev->dma_parms =
+			devm_kzalloc(dev, sizeof(*dev->dma_parms), GFP_KERNEL);
+	dma_set_max_seg_size(dev, DMA_BIT_MASK(32));
+	dma_set_seg_boundary(dev, (unsigned long)DMA_BIT_MASK(64));
 
 	dprintk(VIDC_DBG, "Attached %s and created mapping\n", dev_name(dev));
 	dprintk(VIDC_DBG,

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
@@ -1426,6 +1426,7 @@ static int msm_vidc_populate_context_bank(struct device *dev,
 	int rc = 0;
 	struct context_bank_info *cb = NULL;
 	struct device_node *np = NULL;
+	unsigned int i = 0, j = 0, count = 0;
 
 	if (!dev || !core) {
 		dprintk(VIDC_ERR, "%s - invalid inputs\n", __func__);
@@ -1448,6 +1449,20 @@ static int msm_vidc_populate_context_bank(struct device *dev,
 			"Failed to read cb label from device tree\n");
 		rc = 0;
 	}
+	dprintk(VIDC_DBG, "%s: context bank has name %s\n", __func__, cb->name);
+	of_get_property(np, "iommus", &count);
+	memset(&cb->sids, -1, sizeof(cb->sids));
+	count /= 4;
+	for (i = 1, j = 0 ; i < count; i = i+2, j++) {
+		rc = of_property_read_u32_index(dev->of_node,
+			"iommus", i, &cb->sids[j]);
+		if (rc < 0)
+			dprintk(VIDC_ERR, "can't fetch SID\n");
+
+		dprintk(VIDC_DBG,
+			"%s sid[%d]:0x%x\n",  cb->name, j, cb->sids[j]);
+	}
+	cb->num_sids = j;
 
 	dprintk(VIDC_DBG, "%s: context bank has name %s\n", __func__, cb->name);
 	rc = of_property_read_u32_array(np, "virtual-addr-pool",

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.c
@@ -1474,6 +1474,10 @@ static int msm_vidc_populate_context_bank(struct device *dev,
 		goto err_setup_cb;
 	}
 
+	rc = of_property_read_u32_array(np, "cma-addr-pool",
+			(u32 *)&cb->cma.addr_range, 2);
+
+	cb->cma.s1_bypass = of_property_read_bool(np, "qcom,cma-s1-bypass");
 	cb->is_secure = of_property_read_bool(np, "qcom,secure-context-bank");
 	dprintk(VIDC_DBG, "context bank %s : secure = %d\n",
 			cb->name, cb->is_secure);

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.h
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_res_parse.h
@@ -31,4 +31,5 @@ int msm_vidc_load_u32_table(struct platform_device *pdev,
 		struct device_node *of_node, char *table_name, int struct_size,
 		u32 **table, u32 *num_elements);
 
+int msm_vidc_enable_cma(struct msm_vidc_platform_resources *res, bool enable);
 #endif

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
@@ -199,6 +199,7 @@ struct msm_vidc_platform_resources {
 	uint32_t pm_qos_latency_us;
 	uint32_t max_inst_count;
 	uint32_t max_secure_inst_count;
+	bool cma_status;
 };
 
 static inline bool is_iommu_present(struct msm_vidc_platform_resources *res)

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -18,6 +18,7 @@
 #include <linux/platform_device.h>
 #include <media/msm_vidc.h>
 #define MAX_BUFFER_TYPES 32
+#define VENUS_SID_MAX 32
 
 struct version_table {
 	u32 version_mask;
@@ -75,6 +76,8 @@ struct context_bank_info {
 	struct addr_range addr_range;
 	struct device *dev;
 	struct dma_iommu_mapping *mapping;
+	int sids[VENUS_SID_MAX];
+	int num_sids;
 };
 
 struct buffer_usage_table {

--- a/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
+++ b/drivers/media/platform/msm/vidc_3x/msm_vidc_resources.h
@@ -68,6 +68,11 @@ struct addr_set {
 	int count;
 };
 
+struct cma_info {
+	struct addr_range addr_range;
+	bool s1_bypass;
+};
+
 struct context_bank_info {
 	struct list_head list;
 	const char *name;
@@ -78,6 +83,7 @@ struct context_bank_info {
 	struct dma_iommu_mapping *mapping;
 	int sids[VENUS_SID_MAX];
 	int num_sids;
+	struct cma_info cma;
 };
 
 struct buffer_usage_table {

--- a/drivers/media/platform/msm/vidc_3x/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc_3x/venus_hfi.c
@@ -4049,6 +4049,7 @@ static int __protect_cp_mem(struct venus_hfi_device *device)
 	int rc = 0;
 	struct context_bank_info *cb;
 	struct scm_desc desc = {0};
+	bool is_cma_enabled = false;
 
 	if (!device)
 		return -EINVAL;
@@ -4058,9 +4059,11 @@ static int __protect_cp_mem(struct venus_hfi_device *device)
 	memprot.cp_nonpixel_start = 0x0;
 	memprot.cp_nonpixel_size = 0x0;
 
+	is_cma_enabled = device->res->cma_status;
 	list_for_each_entry(cb, &device->res->context_banks, list) {
 		if (!strcmp(cb->name, "venus_ns")) {
 			desc.args[1] = memprot.cp_size =
+				is_cma_enabled ? cb->cma.addr_range.start :
 				cb->addr_range.start;
 			dprintk(VIDC_DBG, "%s memprot.cp_size: %#x\n",
 				__func__, memprot.cp_size);
@@ -4068,8 +4071,10 @@ static int __protect_cp_mem(struct venus_hfi_device *device)
 
 		if (!strcmp(cb->name, "venus_sec_non_pixel")) {
 			desc.args[2] = memprot.cp_nonpixel_start =
+				is_cma_enabled ? cb->cma.addr_range.start :
 				cb->addr_range.start;
 			desc.args[3] = memprot.cp_nonpixel_size =
+				is_cma_enabled ? cb->cma.addr_range.size :
 				cb->addr_range.size;
 			dprintk(VIDC_DBG,
 				"%s memprot.cp_nonpixel_start: %#x size: %#x\n",

--- a/drivers/media/platform/msm/vidc_3x/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc_3x/venus_hfi.c
@@ -3299,9 +3299,11 @@ static void __dump_venus_debug_registers(struct venus_hfi_device *device)
 	dprintk(VIDC_ERR, "VIDC_CPU_CS_SCIACMDARG0: 0x%x\n", reg);
 }
 
-static void __process_sys_error(struct venus_hfi_device *device)
+static void print_sfr_message(struct venus_hfi_device *device)
 {
 	struct hfi_sfr_struct *vsfr = NULL;
+	u32 vsfr_size = 0;
+	void *p = NULL;
 
 	/* Once SYS_ERROR received from HW, it is safe to halt the AXI.
 	 * With SYS_ERROR, Venus FW may have crashed and HW might be
@@ -3313,13 +3315,11 @@ static void __process_sys_error(struct venus_hfi_device *device)
 
 	vsfr = (struct hfi_sfr_struct *)device->sfr.align_virtual_addr;
 	if (vsfr) {
-		void *p = memchr(vsfr->rg_data, '\0', vsfr->bufSize);
-		/* SFR isn't guaranteed to be NULL terminated
-		 * since SYS_ERROR indicates that Venus is in the
-		 * process of crashing.
-		 */
+		vsfr_size = vsfr->bufSize - sizeof(u32);
+		p = memchr(vsfr->rg_data, '\0', vsfr_size);
+		/* SFR isn't guaranteed to be NULL terminated */
 		if (p == NULL)
-			vsfr->rg_data[vsfr->bufSize - 1] = '\0';
+			vsfr->rg_data[vsfr_size - 1] = '\0';
 
 		dprintk(VIDC_ERR, "SFR Message from FW: %s\n",
 				vsfr->rg_data);
@@ -3433,8 +3433,6 @@ static int __response_handler(struct venus_hfi_device *device)
 	}
 
 	if (device->intr_status & VIDC_WRAPPER_INTR_CLEAR_A2HWD_BMSK) {
-		struct hfi_sfr_struct *vsfr = (struct hfi_sfr_struct *)
-			device->sfr.align_virtual_addr;
 		struct msm_vidc_cb_info info = {
 			.response_type = HAL_SYS_WATCHDOG_TIMEOUT,
 			.response.cmd = {
@@ -3442,9 +3440,7 @@ static int __response_handler(struct venus_hfi_device *device)
 			}
 		};
 
-		if (vsfr)
-			dprintk(VIDC_ERR, "SFR Message from FW: %s\n",
-					vsfr->rg_data);
+		print_sfr_message(device);
 
 		__dump_venus_debug_registers(device);
 		dprintk(VIDC_ERR, "Received watchdog timeout\n");
@@ -3472,7 +3468,7 @@ static int __response_handler(struct venus_hfi_device *device)
 		switch (info->response_type) {
 		case HAL_SYS_ERROR:
 			__dump_venus_debug_registers(device);
-			__process_sys_error(device);
+			print_sfr_message(device);
 			break;
 		case HAL_SYS_RELEASE_RESOURCE_DONE:
 			dprintk(VIDC_DBG, "Received SYS_RELEASE_RESOURCE\n");

--- a/drivers/soc/qcom/secure_buffer.c
+++ b/drivers/soc/qcom/secure_buffer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google, Inc
- * Copyright (c) 2011-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2011-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -457,6 +457,8 @@ const char *msm_secure_vmid_to_string(int secure_vmid)
 		return "VMID_CP_SPSS_SP_SHARED";
 	case VMID_CP_SPSS_HLOS_SHARED:
 		return "VMID_CP_SPSS_HLOS_SHARED";
+	case VMID_CP_CAMERA_ENCODE:
+		return "VMID_CP_CAMERA_ENCODE";
 	case VMID_CP_CDSP:
 		return "VMID_CP_CDSP";
 	case VMID_CP_DSP_EXT:

--- a/drivers/staging/android/ion/ion.h
+++ b/drivers/staging/android/ion/ion.h
@@ -2,7 +2,7 @@
  * drivers/staging/android/ion/ion.h
  *
  * Copyright (C) 2011 Google, Inc.
- * Copyright (c) 2011-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2011-2020, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -44,6 +44,7 @@
 #define ION_SECURE_HEAP_NAME	"secure_heap"
 #define ION_SECURE_DISPLAY_HEAP_NAME "secure_display"
 #define ION_AUDIO_HEAP_NAME    "audio"
+#define ION_VIDEO_HEAP_NAME    "video"
 
 #define ION_IS_CACHED(__flags)  ((__flags) & ION_FLAG_CACHED)
 

--- a/drivers/staging/android/ion/ion_secure_util.c
+++ b/drivers/staging/android/ion/ion_secure_util.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2017-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -31,6 +31,7 @@ bool is_secure_vmid_valid(int vmid)
 		vmid == VMID_CP_SPSS_SP ||
 		vmid == VMID_CP_SPSS_SP_SHARED ||
 		vmid == VMID_CP_SPSS_HLOS_SHARED ||
+		vmid == VMID_CP_CAMERA_ENCODE ||
 		vmid == VMID_CP_CDSP ||
 		vmid == VMID_CP_DSP_EXT);
 }
@@ -59,6 +60,8 @@ int get_secure_vmid(unsigned long flags)
 		return VMID_CP_SPSS_SP_SHARED;
 	if (flags & ION_FLAG_CP_SPSS_HLOS_SHARED)
 		return VMID_CP_SPSS_HLOS_SHARED;
+	if (flags & ION_FLAG_CP_CAMERA_ENCODE)
+		return VMID_CP_CAMERA_ENCODE;
 	if (flags & ION_FLAG_CP_CDSP)
 		return VMID_CP_CDSP;
 	if (flags & ION_FLAG_CP_DSP_EXT)

--- a/drivers/staging/android/ion/ion_system_secure_heap.c
+++ b/drivers/staging/android/ion/ion_system_secure_heap.c
@@ -61,7 +61,8 @@ static bool is_cp_flag_present(unsigned long flags)
 			ION_FLAG_CP_BITSTREAM |
 			ION_FLAG_CP_PIXEL |
 			ION_FLAG_CP_NON_PIXEL |
-			ION_FLAG_CP_CAMERA);
+			ION_FLAG_CP_CAMERA |
+			ION_FLAG_CP_CAMERA_ENCODE);
 }
 
 static void ion_system_secure_heap_free(struct ion_buffer *buffer)

--- a/drivers/staging/android/ion/msm/msm_ion_of.c
+++ b/drivers/staging/android/ion/msm/msm_ion_of.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -74,6 +74,10 @@ static struct ion_heap_desc ion_heap_meta[] = {
 	{
 		.id     = ION_AUDIO_HEAP_ID,
 		.name   = ION_AUDIO_HEAP_NAME,
+	},
+	{
+		.id     = ION_VIDEO_HEAP_ID,
+		.name   = ION_VIDEO_HEAP_NAME,
 	},
 	{
 		.id	= ION_SECURE_CARVEOUT_HEAP_ID,

--- a/drivers/staging/android/uapi/msm_ion.h
+++ b/drivers/staging/android/uapi/msm_ion.h
@@ -34,6 +34,7 @@ enum ion_heap_ids {
 	ION_CP_MM_HEAP_ID = 8,
 	ION_SECURE_HEAP_ID = 9,
 	ION_SECURE_DISPLAY_HEAP_ID = 10,
+	ION_VIDEO_HEAP_ID = 12,
 	ION_SPSS_HEAP_ID = 13, /* Secure Processor ION heap */
 	ION_ADSP_HEAP_ID = 22,
 	ION_SYSTEM_HEAP_ID = 25,

--- a/drivers/staging/android/uapi/msm_ion.h
+++ b/drivers/staging/android/uapi/msm_ion.h
@@ -54,6 +54,7 @@ enum ion_heap_ids {
  * Flags to be used when allocating from the secure heap for
  * content protection
  */
+#define ION_FLAG_CP_CAMERA_ENCODE	ION_BIT(14)
 #define ION_FLAG_CP_DSP_EXT		ION_BIT(15)
 /* ION_FLAG_POOL_FORCE_ALLOC uses ION_BIT(16) */
 #define ION_FLAG_CP_TOUCH		ION_BIT(17)
@@ -72,7 +73,7 @@ enum ion_heap_ids {
 #define ION_FLAG_CP_SPSS_HLOS_SHARED	ION_BIT(30)
 /* ION_FLAG_SECURE uses ION_BIT(31) */
 
-#define ION_FLAGS_CP_MASK	0x6FFE8000
+#define ION_FLAGS_CP_MASK	0x6FFEC000
 
 /**
  * Flag to allow non continguous allocation of memory from secure

--- a/include/media/msm_vidc.h
+++ b/include/media/msm_vidc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -93,6 +93,7 @@ enum core_id {
 enum session_type {
 	MSM_VIDC_ENCODER = 0,
 	MSM_VIDC_DECODER,
+	MSM_VIDC_ENCODER_CMA,
 	MSM_VIDC_UNKNOWN,
 	MSM_VIDC_MAX_DEVICES = MSM_VIDC_UNKNOWN,
 };

--- a/include/soc/qcom/secure_buffer.h
+++ b/include/soc/qcom/secure_buffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2015-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -41,6 +41,7 @@ enum vmid {
 	VMID_CP_CAMERA_PREVIEW = 0x1D,
 	VMID_CP_SPSS_SP_SHARED = 0x22,
 	VMID_CP_SPSS_HLOS_SHARED = 0x24,
+	VMID_CP_CAMERA_ENCODE = 0x29,
 	VMID_CP_CDSP = 0x2A,
 	VMID_CP_DSP_EXT = 0x2E,
 	VMID_LAST,


### PR DESCRIPTION
These patches are necessary to comply with the media HAL update: https://github.com/sonyxperiadev/hardware-qcom-media/pull/7

Without this, `not in avi mode` errors appear and videos (tested on YouTube) have corruption.
 
Patches have been automatically picked (and skipped due to "already applied" conflicts) with:
```
gcp $(glg FETCH_HEAD --no-merges --reverse --pretty=format:"%h" --no-patch drivers/media/platform/msm/vidc_3x)
```
Where `FETCH_HEAD` is the lazy way to access `gf https://source.codeaurora.org/quic/la/kernel/msm-4.14/ LA.UM.8.2.1.r1-04700-sdm660.0` :wink: 

Two stray `ion` patches had to be picked to fix compilation errors.

Fix validated on SoMC SDM636 Ganges Mermaid DSDS and SoMC SDM630 Nile Discovery RoW.