### PR TITLE
[LA.UM.7.1.r1] media: msm: camera_v2: Drop remaining uses of $(CROSS_COMPILE)gcc

### DIFF
--- a/drivers/media/platform/msm/camera_v2/fd/Makefile
+++ b/drivers/media/platform/msm/camera_v2/fd/Makefile
@@ -1,4 +1,3 @@
-GCC_VERSION      := $(shell $(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
 ccflags-y += -Idrivers/media/video/msm
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/common
 ccflags-y += -Idrivers/media/platform/msm/camera_v2

--- a/drivers/media/platform/msm/camera_v2/jpeg_10/Makefile
+++ b/drivers/media/platform/msm/camera_v2/jpeg_10/Makefile
@@ -1,5 +1,3 @@
-GCC_VERSION      := $(shell $(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
-
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/jpeg_10
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/sensor/io
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/common

--- a/drivers/media/platform/msm/camera_v2/jpeg_dma/Makefile
+++ b/drivers/media/platform/msm/camera_v2/jpeg_dma/Makefile
@@ -1,4 +1,3 @@
-GCC_VERSION      := $(shell $(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
 ccflags-y += -Idrivers/media/video/msm
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/common
 obj-$(CONFIG_MSM_JPEGDMA) += msm_jpeg_dma_dev.o msm_jpeg_dma_hw.o


### PR DESCRIPTION
gcc is deprecated in Android and we're (usually) compiling with clang: there's no
need to extract the gcc version for this specific driver.
This variable is commonly used to switch macros for specific gcc
versions, which are not included in clang builds anyway.

Related comment: https://github.com/sonyxperiadev/kernel/pull/2248#issuecomment-625091546
@nathanchance apologies for rejecting your judgement initially.