### PR TITLE
[7.1.r1] Cleanup compiler warnings

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
@@ -41,7 +41,6 @@
 
 #define CEIL(x, y)              (((x) + ((y)-1)) / (y))
 
-#define TICKS_IN_MICRO_SECOND    1000000
 
 struct dsi_ctrl_list_item {
 	struct dsi_ctrl *ctrl;
@@ -828,7 +827,6 @@ static int dsi_ctrl_update_link_freqs(struct dsi_ctrl *dsi_ctrl,
 	int rc = 0;
 	u32 num_of_lanes = 0;
 	u32 bpp;
-	u64 refresh_rate = TICKS_IN_MICRO_SECOND;
 	u64 h_period, v_period, bit_rate, pclk_rate, bit_rate_per_lane,
 	    byte_clk_rate;
 	struct dsi_host_common_cfg *host_cfg = &config->common_config;

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -70,7 +70,6 @@ static const struct of_device_id dsi_display_dt_match[] = {
 };
 
 static struct dsi_display *primary_display;
-static struct dsi_display *secondary_display;
 
 struct dsi_display *dsi_display_get_main_display(void)
 {

--- a/drivers/leds/leds-qti-tri-led.c
+++ b/drivers/leds/leds-qti-tri-led.c
@@ -406,7 +406,6 @@ static const struct attribute *breath_attrs[] = {
 static int qpnp_tri_led_register(struct qpnp_tri_led_chip *chip)
 {
 	struct qpnp_led_dev *led;
-	enum led_brightness brightness = LED_OFF;
 	int rc, i, j;
 
 	for (i = 0; i < chip->num_leds; i++) {

--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -725,7 +725,6 @@ static bool is_debug_batt_id(struct fg_dev *fg)
 }
 
 #define DEBUG_BATT_SOC	67
-#define BATT_MISS_SOC	50
 #ifdef CONFIG_QPNP_SMBFG_NEWGEN_EXTENSION
 #define	UNKNOWN_BATT_SOC	20
 #endif

--- a/drivers/soc/qcom/peripheral-loader.c
+++ b/drivers/soc/qcom/peripheral-loader.c
@@ -1655,7 +1655,9 @@ static int __init msm_pil_init(void)
 	struct device_node *np;
 	struct resource res;
 	int i;
+#ifndef TARGET_NO_MINIDUMP_SUPPORT
 	size_t size;
+#endif
 
 	np = of_find_compatible_node(NULL, NULL, "qcom,msm-imem-pil");
 	if (!np) {


### PR DESCRIPTION
Several cleanups and a functional change because I think the macro redefinition is not correct.

Please review if the suggested changes are okay that way or if I should change some things.

Build-Tested and verified that with this changeset the warnings previously reported for
these files are no longer being reported.