### PR TITLE
[7.1.r1] [URGENT] Fix camera video recording on MSM8998, SDM630/660

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp48.h
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp48.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016, 2018-2019, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2016, 2018-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -22,12 +22,19 @@ enum msm_vfe_clk_rates {
 	MSM_VFE_MAX_CLK_RATES = 3,
 };
 
-#define MSM_VFE48_HW_VERSION 0x9
+#define MSM_VFE48_HW_VERSION 0x8
+#define MSM_VFE48_HW_VERSION_TRINKET 0x9
 #define MSM_VFE48_HW_VERSION_SHIFT 28
 #define MSM_VFE48_HW_VERSION_MASK 0xF
 
 static inline int msm_vfe_is_vfe48(struct vfe_device *vfe_dev)
 {
+	/* Check for Trinket specific as it uses h/w version 0x9 */
+	if ((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT) ==
+		MSM_VFE48_HW_VERSION_TRINKET)
+		return (((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT)
+			& MSM_VFE48_HW_VERSION_MASK)
+			== MSM_VFE48_HW_VERSION_TRINKET);
 	return (((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT) &
 		MSM_VFE48_HW_VERSION_MASK) == MSM_VFE48_HW_VERSION);
 }

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp_axi_util.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp_axi_util.c
@@ -2471,6 +2471,10 @@ static void msm_isp_input_disable(struct vfe_device *vfe_dev, int cmd_type)
 		/* deactivate the input line */
 		axi_data->src_info[i].active = 0;
 		src_info = &axi_data->src_info[i];
+		if (i == VFE_PIX_0)
+			vfe_dev->isp_page->kernel_sofid = 0;
+
+		vfe_dev->axi_data.src_info[i].frame_id = 0;
 
 		if (src_info->dual_hw_type == DUAL_HW_MASTER_SLAVE) {
 			struct master_slave_resource_info *ms_res =


### PR DESCRIPTION
This patchset fixes camera video recording mode on MSM8998, SDM630/660.

Tested on SoMC MSM8998 Yoshino Maple RoW.