### PR TITLE
[7.1.r1] [!!TOTALLY-URGENT!!] Fix CPU scaling on legacy and early kernel panic

### DIFF
--- a/drivers/clk/qcom/clk-cpu-osm-legacy.c
+++ b/drivers/clk/qcom/clk-cpu-osm-legacy.c
@@ -832,13 +832,13 @@ static struct clk_fixed_factor sys_apcsaux_clk_gcc = {
 static struct clk_init_data osm_clks_init[] = {
 	[0] = {
 		.name = "pwrcl_clk",
-		.parent_names = (const char *[]){ "cxo_a" },
+		.parent_names = (const char *[]){ "bi_tcxo_ao" },
 		.num_parents = 1,
 		.ops = &clk_ops_cpu_osm,
 	},
 	[1] = {
 		.name = "perfcl_clk",
-		.parent_names = (const char *[]){ "cxo_a" },
+		.parent_names = (const char *[]){ "bi_tcxo_ao" },
 		.num_parents = 1,
 		.ops = &clk_ops_cpu_osm,
 	},

--- a/drivers/clk/qcom/mmcc-msm8998.c
+++ b/drivers/clk/qcom/mmcc-msm8998.c
@@ -251,7 +251,7 @@ static const struct parent_map disp_cc_parent_map_0[] = {
 };
 
 static const char * const disp_cc_parent_names_0[] = {
-	"xo",
+	"bi_tcxo",
 	"dsi0_phy_pll_out_byteclk",
 	"dsi1_phy_pll_out_byteclk",
 };
@@ -1248,6 +1248,7 @@ static struct clk_rcg2 esc0_clk_src = {
 	.cmd_rcgr = 0x02160,
 	.hid_width = 5,
 	.parent_map = disp_cc_parent_map_0,
+	.freq_tbl = ftbl_esc_clk_src,
 	.clkr.hw.init = &(struct clk_init_data) {
 		.name = "esc0_clk_src",
 		.parent_names = disp_cc_parent_names_0,
@@ -1261,6 +1262,7 @@ static struct clk_rcg2 esc1_clk_src = {
 	.cmd_rcgr = 0x02180,
 	.hid_width = 5,
 	.parent_map = disp_cc_parent_map_0,
+	.freq_tbl = ftbl_esc_clk_src,
 	.clkr.hw.init = &(struct clk_init_data) {
 		.name = "esc1_clk_src",
 		.parent_names = disp_cc_parent_names_0,

--- a/drivers/cpufreq/Kconfig
+++ b/drivers/cpufreq/Kconfig
@@ -111,16 +111,6 @@ config CPU_FREQ_DEFAULT_GOV_SCHEDUTIL
 	  have a look at the help section of that governor. The fallback
 	  governor will be 'performance'.
 
-config CPU_FREQ_DEFAULT_GOV_INTERACTIVE
-	bool "interactive"
-	select CPU_FREQ_GOV_INTERACTIVE
-	select CPU_FREQ_GOV_PERFORMANCE
-	help
-	  Use the CPUFreq governor 'interactive' as default. This allows
-	  you to get a full dynamic cpu frequency capable system by simply
-	  loading your cpufreq low-level hardware driver, using the
-	  'interactive' governor for latency-sensitive workloads.
-
 endchoice
 
 config CPU_FREQ_GOV_PERFORMANCE

--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -1390,17 +1390,7 @@ static int __init cpufreq_interactive_gov_init(void)
 
 	return cpufreq_register_governor(CPU_FREQ_GOV_INTERACTIVE);
 }
-
-#ifdef CONFIG_CPU_FREQ_DEFAULT_GOV_INTERACTIVE
-struct cpufreq_governor *cpufreq_default_governor(void)
-{
-	return CPU_FREQ_GOV_INTERACTIVE;
-}
-
 fs_initcall(cpufreq_interactive_gov_init);
-#else
-module_init(cpufreq_interactive_gov_init);
-#endif
 
 static void __exit cpufreq_interactive_gov_exit(void)
 {


### PR DESCRIPTION
This patchset fixes CPU DVFS on MSM and SDM630/660.
This is REALLY urgent, as CPU stays at bootloader configured rates right now and risks
overheating!!!!!!

Tested on SoMC MSM8998 Yoshino Maple RoW
