### PR TITLE
[7.1.r1] Enable protected HBM range on Griffin and Bahamut

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-1080p2520-cmd.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-sec-1080p2520-cmd.dtsi
@@ -124,7 +124,7 @@
 					39 01 00 00 11 00 02 53 28
 					];
 				somc,mdss-dsi-hbm-on-command-state = "dsi_lp_mode";
-				somc,mdss-dsi-hbm-low-command-state = "dsi_lp_mode";
+				somc,mdss-dsi-hbm-off-command-state = "dsi_lp_mode";
 
 				somc,mdss-dsi-aod-on-command = [
 					05 01 00 00 00 00 01 28

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-bahamut-display.dtsi
@@ -42,6 +42,9 @@
 	qcom,platform-touch-vddh-en-gpio = <&pm8150b_gpios 7 0>;
 	somc,disp-err-flag-gpio = <&tlmm 101 0>;
 
+	/* Enable protected HBM range */
+	somc,set-hbm-usable;
+
 	qcom,mdss-dsi-display-timings {
 		timing@0 {
 			qcom,display-topology = <1 0 1>;

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-griffin-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-griffin-display.dtsi
@@ -43,6 +43,9 @@
 	qcom,platform-touch-vddh-en-gpio = <&pm8150b_gpios 7 0>;
 	somc,disp-err-flag-gpio = <&tlmm 101 0>;
 
+	/* Enable HBM protected range */
+	somc,set-hbm-usable;
+
 	qcom,mdss-dsi-display-timings {
 		timing@0 {
 			qcom,display-topology = <2 2 1>;


### PR DESCRIPTION
This patchset enables using the HBM range on SoMC SM8150 Kumano Griffin and Bahamut,
with the protection algorithm that's been recently merged in somc_panel.

Please note: Both of the panels are using the lower gamma HBM range, not the
bright-as-the-sun eye-damaging world-destroyng max nits gamma, so it is totally
safe to enable it.

Tested on SoMC SM8150 Kumano Griffin DSDS.