### PR TITLE
[7.1.r1] [URGENT] Revert "arch: dtsi: tama-common: panel: set min brightness to 1.2mA"

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
@@ -42,7 +42,6 @@
 	qcom,mdss-dsi-display-timings {
 		1080p60 {
 			qcom,esd-check-enabled;
-			somc,splash-dms-switch-to-this-timing;
 			qcom,mdss-dsi-panel-status-command = [06 01 00 01 05 00 01 0A];
 			qcom,mdss-dsi-panel-status-command-state = "dsi_hs_mode";
 			qcom,mdss-dsi-panel-status-check-mode = "reg_read";
@@ -74,11 +73,28 @@
 			qcom,display-topology = <2 2 2>;
 			qcom,default-topology-index = <0>;
 		};
-
+		/delete-node/ 4k60;
 	};
 };
 
-/* Enable continuous splash on the slave DSI ctrl, too */
-&sde_dsi1 {
-	qcom,cont-splash-enabled;
+&sde_dsi0 {
+	/delete-property/ qcom,cont-splash-enabled;
+};
+
+&mdss_mdp {
+	/delete-property/ compatible;
+	/delete-property/ reg;
+	/delete-property/ reg-names;
+};
+
+&mdss_dsi {
+	/delete-property/ compatible;
+};
+
+&mdss_dsi0 {
+	/delete-property/ label;
+};
+
+&mdss_dsi1 {
+	/delete-property/ label;
 };

--- a/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-sde.dtsi
@@ -62,7 +62,7 @@
 		qcom,sde-ctl-off = <0x2000 0x2200 0x2400
 				     0x2600 0x2800>;
 		qcom,sde-ctl-size = <0x94>;
-		qcom,sde-ctl-display-pref = "primary", "primary-nosplit",
+		qcom,sde-ctl-display-pref = "primary", "none",
 					    "primary-split", "none", "none";
 
 		qcom,sde-mixer-off = <0x45000 0x46000 0x47000

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -112,8 +112,10 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 		qcom,dsi-phy = <&mdss_dsi_phy0>;
 		clocks = <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>,
 			 <&mdss_dsi0_pll PCLK_MUX_0_CLK>,
-			 <&mdss_dsi1_pll BYTECLK_MUX_1_CLK>,
-			 <&mdss_dsi1_pll PCLK_MUX_1_CLK>,
+			 <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>,
+			 <&mdss_dsi0_pll PCLK_MUX_0_CLK>,
+			 <&mdss_dsi0_pll BYTECLK_SRC_0_CLK>,
+			 <&mdss_dsi0_pll PCLK_SRC_0_CLK>,
 			 <&mdss_dsi0_pll BYTECLK_SRC_0_CLK>,
 			 <&mdss_dsi0_pll PCLK_SRC_0_CLK>,
 			 <&mdss_dsi0_pll SHADOW_BYTECLK_SRC_0_CLK>,
@@ -121,6 +123,7 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 		clock-names = "mux_byte_clk0", "mux_pixel_clk0",
 			      "mux_byte_clk1", "mux_pixel_clk1",
 			      "src_byte_clk0", "src_pixel_clk0",
+			      "src_byte_clk1", "src_pixel_clk1",
 			      "shadow_byte_clk0", "shadow_pixel_clk0";
 
 		pinctrl-names = "panel_active", "panel_suspend",

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -3355,8 +3355,9 @@
 };
 
 &gdsc_bimc_smmu {
-	clock-names = "bus_clk";
-	clocks = <&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>;
+	clock-names = "bus_clk", "mem_clk";
+	clocks = <&clock_mmss MMSS_BIMC_SMMU_AXI_CLK>,
+		 <&clock_mmss MMSS_BIMC_SMMU_AHB_CLK>;
 	proxy-supply = <&gdsc_bimc_smmu>;
 	qcom,proxy-consumer-enable;
 	status = "ok";

--- a/drivers/char/diag/diagchar.h
+++ b/drivers/char/diag/diagchar.h
@@ -209,6 +209,9 @@
 #define DEFAULT_LOW_WM_VAL	15
 #define DEFAULT_HIGH_WM_VAL	85
 
+#define HDLC_CTXT		1
+#define NON_HDLC_CTXT	2
+
 #define TYPE_DATA		0
 #define TYPE_CNTL		1
 #define TYPE_DCI		2

--- a/drivers/char/diag/diagchar.h
+++ b/drivers/char/diag/diagchar.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008-2019, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2008-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -211,6 +211,8 @@
 
 #define HDLC_CTXT		1
 #define NON_HDLC_CTXT	2
+
+#define PKT_PROCESS_TIMEOUT		200
 
 #define TYPE_DATA		0
 #define TYPE_CNTL		1

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -327,6 +327,14 @@ static int diagchar_open(struct inode *inode, struct file *file)
 	if (driver) {
 		mutex_lock(&driver->diagchar_mutex);
 
+		for (i = 0; i < driver->num_clients; i++) {
+			if (driver->client_map[i].pid == current->tgid) {
+				pr_err_ratelimited("diag: Client already present current->tgid: %d\n",
+					current->tgid);
+				mutex_unlock(&driver->diagchar_mutex);
+				return -EEXIST;
+			}
+		}
 		for (i = 0; i < driver->num_clients; i++)
 			if (driver->client_map[i].pid == 0)
 				break;
@@ -3567,9 +3575,12 @@ static ssize_t diagchar_read(struct file *file, char __user *buf, size_t count,
 	int proc = 0;
 
 	mutex_lock(&driver->diagchar_mutex);
-	for (i = 0; i < driver->num_clients; i++)
-		if (driver->client_map[i].pid == current->tgid)
+	for (i = 0; i < driver->num_clients; i++) {
+		if (driver->client_map[i].pid == current->tgid) {
 			index = i;
+			break;
+		}
+	}
 	mutex_unlock(&driver->diagchar_mutex);
 
 	if (index == -1) {

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -272,18 +272,20 @@ void check_drain_timer(void)
 	}
 }
 
-void diag_add_client(int i, struct file *file)
+static int diag_add_client(int i, struct file *file)
 {
-	struct diagchar_priv *diagpriv_data;
+	struct diagchar_priv *diagpriv_data = NULL;
 
-	driver->client_map[i].pid = current->tgid;
 	diagpriv_data = kmalloc(sizeof(struct diagchar_priv),
 							GFP_KERNEL);
-	if (diagpriv_data)
-		diagpriv_data->pid = current->tgid;
+	if (!diagpriv_data)
+		return -ENOMEM;
+	driver->client_map[i].pid = current->tgid;
+	diagpriv_data->pid = current->tgid;
 	file->private_data = diagpriv_data;
 	strlcpy(driver->client_map[i].name, current->comm, 20);
 	driver->client_map[i].name[19] = '\0';
+	return 0;
 }
 
 static void diag_mempool_init(void)
@@ -319,7 +321,7 @@ static void diag_mempool_exit(void)
 
 static int diagchar_open(struct inode *inode, struct file *file)
 {
-	int i = 0;
+	int i = 0, ret = 0;
 	void *temp;
 
 	if (driver) {
@@ -330,7 +332,12 @@ static int diagchar_open(struct inode *inode, struct file *file)
 				break;
 
 		if (i < driver->num_clients) {
-			diag_add_client(i, file);
+			ret = diag_add_client(i, file);
+			if (ret < 0) {
+				mutex_unlock(&driver->diagchar_mutex);
+				pr_err_ratelimited("diag: Insufficient memory for adding new client\n");
+				return ret;
+			}
 		} else {
 			if (i < THRESHOLD_CLIENT_LIMIT) {
 				driver->num_clients++;
@@ -348,7 +355,9 @@ static int diagchar_open(struct inode *inode, struct file *file)
 					goto fail;
 				else
 					driver->data_ready = temp;
-				diag_add_client(i, file);
+				ret = diag_add_client(i, file);
+				if (ret < 0)
+					goto fail;
 			} else {
 				mutex_unlock(&driver->diagchar_mutex);
 				pr_err_ratelimited("diag: Max client limit for DIAG reached\n");
@@ -385,7 +394,7 @@ static int diagchar_open(struct inode *inode, struct file *file)
 fail:
 	driver->num_clients--;
 	mutex_unlock(&driver->diagchar_mutex);
-	pr_err_ratelimited("diag: Insufficient memory for new client");
+	pr_err_ratelimited("diag: Insufficient memory for new client\n");
 	return -ENOMEM;
 }
 
@@ -537,7 +546,19 @@ static int diag_remove_client_entry(struct file *file)
 	}
 
 	diagpriv_data = file->private_data;
-
+	for (i = 0; i < driver->num_clients; i++)
+		if (diagpriv_data && diagpriv_data->pid ==
+			driver->client_map[i].pid)
+			break;
+	if (i == driver->num_clients) {
+		DIAG_LOG(DIAG_DEBUG_USERSPACE,
+			"pid %d, not present in client map\n",
+			diagpriv_data->pid);
+		mutex_unlock(&driver->diag_file_mutex);
+		return -EINVAL;
+	}
+	DIAG_LOG(DIAG_DEBUG_USERSPACE, "diag: %s process exit with pid = %d\n",
+		driver->client_map[i].name, diagpriv_data->pid);
 	/*
 	 * clean up any DCI registrations, if this is a DCI client
 	 * This will specially help in case of ungraceful exit of any DCI client
@@ -545,32 +566,27 @@ static int diag_remove_client_entry(struct file *file)
 	 */
 	mutex_lock(&driver->dci_mutex);
 	do {
-		dci_entry = dci_lookup_client_entry_pid(current->tgid);
+		dci_entry = dci_lookup_client_entry_pid(diagpriv_data->pid);
 		if (dci_entry)
 			diag_dci_deinit_client(dci_entry);
 	} while (dci_entry);
 	mutex_unlock(&driver->dci_mutex);
 
-	diag_close_logging_process(current->tgid);
+	diag_close_logging_process(diagpriv_data->pid);
 
 	/* Delete the pkt response table entry for the exiting process */
-	diag_cmd_remove_reg_by_pid(current->tgid);
+	diag_cmd_remove_reg_by_pid(diagpriv_data->pid);
 
 	mutex_lock(&driver->diagchar_mutex);
 	driver->ref_count--;
 	if (driver->ref_count == 0)
 		diag_mempool_exit();
 
-	for (i = 0; i < driver->num_clients; i++) {
-		if (diagpriv_data && diagpriv_data->pid ==
-						driver->client_map[i].pid) {
-			driver->client_map[i].pid = 0;
-			kfree(diagpriv_data);
-			diagpriv_data = NULL;
-			file->private_data = 0;
-			break;
-		}
-	}
+	driver->client_map[i].pid = 0;
+	kfree(diagpriv_data);
+	diagpriv_data = NULL;
+	file->private_data = NULL;
+
 	mutex_unlock(&driver->diagchar_mutex);
 	mutex_unlock(&driver->diag_file_mutex);
 	return 0;
@@ -579,8 +595,6 @@ static int diagchar_close(struct inode *inode, struct file *file)
 {
 	int ret;
 
-	DIAG_LOG(DIAG_DEBUG_USERSPACE, "diag: %s process exit with pid = %d\n",
-		current->comm, current->tgid);
 	ret = diag_remove_client_entry(file);
 
 	return ret;

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -4322,10 +4322,12 @@ static int __init diagchar_init(void)
 	driver->in_busy_dcipktdata = 0;
 	driver->rsp_buf_ctxt = SET_BUF_CTXT(APPS_DATA, TYPE_CMD, TYPE_CMD);
 	hdlc_data.ctxt = SET_BUF_CTXT(APPS_DATA, TYPE_DATA, 1);
+	hdlc_data.ctxt |= SET_HDLC_CTXT(HDLC_CTXT);
 	hdlc_data.len = 0;
 	hdlc_data.allocated = 0;
 	hdlc_data.flushed = 0;
 	non_hdlc_data.ctxt = SET_BUF_CTXT(APPS_DATA, TYPE_DATA, 1);
+	non_hdlc_data.ctxt |= SET_HDLC_CTXT(NON_HDLC_CTXT);
 	non_hdlc_data.len = 0;
 	non_hdlc_data.allocated = 0;
 	non_hdlc_data.flushed = 0;

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008-2019, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2008-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -553,6 +553,7 @@ static int diag_remove_client_entry(struct file *file)
 		return -EINVAL;
 	}
 
+	mutex_lock(&driver->diagchar_mutex);
 	diagpriv_data = file->private_data;
 	for (i = 0; i < driver->num_clients; i++)
 		if (diagpriv_data && diagpriv_data->pid ==
@@ -562,11 +563,13 @@ static int diag_remove_client_entry(struct file *file)
 		DIAG_LOG(DIAG_DEBUG_USERSPACE,
 			"pid %d, not present in client map\n",
 			diagpriv_data->pid);
+		mutex_unlock(&driver->diagchar_mutex);
 		mutex_unlock(&driver->diag_file_mutex);
 		return -EINVAL;
 	}
 	DIAG_LOG(DIAG_DEBUG_USERSPACE, "diag: %s process exit with pid = %d\n",
 		driver->client_map[i].name, diagpriv_data->pid);
+	mutex_unlock(&driver->diagchar_mutex);
 	/*
 	 * clean up any DCI registrations, if this is a DCI client
 	 * This will specially help in case of ungraceful exit of any DCI client

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -43,6 +43,7 @@
 #include "diag_ipc_logging.h"
 #include "diagfwd_peripheral.h"
 #include "diagfwd_mhi.h"
+#include "diagfwd_hsic.h"
 
 #include <linux/coresight-stm.h>
 #include <linux/kernel.h>
@@ -4466,9 +4467,11 @@ static int __init diagchar_init(void)
 	INIT_LIST_HEAD(&driver->diag_id_list);
 	diag_add_diag_id_to_list(DIAG_ID_APPS, "APPS", APPS_DATA, APPS_DATA);
 	pr_debug("diagchar initialized now");
-	#ifdef CONFIG_DIAGFWD_BRIDGE_CODE
+#if defined(CONFIG_USB_QCOM_DIAG_BRIDGE)
+	diag_register_with_hsic();
+#elif defined(CONFIG_MHI_BUS)
 	diag_register_with_mhi();
-	#endif
+#endif
 	return 0;
 
 fail:
@@ -4498,6 +4501,11 @@ static void diagchar_exit(void)
 	diag_dci_exit();
 	diag_masks_exit();
 	diag_md_session_exit();
+#if defined(CONFIG_USB_QCOM_DIAG_BRIDGE)
+	diag_unregister_hsic();
+#elif defined(CONFIG_MHI_BUS)
+ 	diag_unregister_mhi();
+#endif
 	diag_remote_exit();
 	diag_debugfs_cleanup();
 	diagchar_cleanup();

--- a/drivers/char/diag/diagchar_core.c
+++ b/drivers/char/diag/diagchar_core.c
@@ -22,6 +22,7 @@
 #include <linux/sched.h>
 #include <linux/ratelimit.h>
 #include <linux/timer.h>
+#include <linux/jiffies.h>
 #include <linux/sched/task.h>
 #ifdef CONFIG_DIAG_OVER_USB
 #include <linux/usb/usbdiag.h>
@@ -3018,7 +3019,7 @@ long diagchar_ioctl(struct file *filp,
 static int diag_process_apps_data_hdlc(unsigned char *buf, int len,
 				       int pkt_type)
 {
-	int err = 0;
+	int err = 0, wait_err = 0;
 	int ret = PKT_DROP;
 	struct diag_apps_data_t *data = &hdlc_data;
 	struct diag_send_desc_type send = { NULL, NULL, DIAG_STATE_START, 0 };
@@ -3049,8 +3050,15 @@ static int diag_process_apps_data_hdlc(unsigned char *buf, int len,
 	send.terminate = 1;
 
 wait_for_buffer:
-	wait_event_interruptible(driver->hdlc_wait_q,
-			(data->flushed == 0));
+	wait_err = wait_event_interruptible_timeout(driver->hdlc_wait_q,
+			(data->flushed == 0),
+			msecs_to_jiffies(PKT_PROCESS_TIMEOUT));
+	if (wait_err <= 0) {
+		DIAG_LOG(DIAG_DEBUG_USERSPACE,
+		"diag: Timeout while waiting for hdlc buffer to be flushed, err: %d\n",
+		wait_err);
+		return PKT_DROP;
+	}
 	spin_lock_irqsave(&driver->diagmem_lock, flags);
 	if (data->flushed) {
 		spin_unlock_irqrestore(&driver->diagmem_lock, flags);
@@ -3101,8 +3109,16 @@ wait_for_buffer:
 			goto fail_free_buf;
 		}
 wait_for_agg_buff:
-		wait_event_interruptible(driver->hdlc_wait_q,
-			(data->flushed == 0));
+		wait_err = wait_event_interruptible_timeout(driver->hdlc_wait_q,
+				(data->flushed == 0),
+				msecs_to_jiffies(PKT_PROCESS_TIMEOUT));
+		if (wait_err <= 0) {
+			DIAG_LOG(DIAG_DEBUG_USERSPACE,
+			"diag: Timeout while waiting for hdlc aggregation buffer to be flushed, err: %d\n",
+			wait_err);
+			return PKT_DROP;
+		}
+
 		spin_lock_irqsave(&driver->diagmem_lock, flags);
 		if (data->flushed) {
 			spin_unlock_irqrestore(&driver->diagmem_lock, flags);
@@ -3160,7 +3176,7 @@ fail_ret:
 static int diag_process_apps_data_non_hdlc(unsigned char *buf, int len,
 					   int pkt_type)
 {
-	int err = 0;
+	int err = 0, wait_err = 0;
 	int ret = PKT_DROP;
 	struct diag_pkt_frame_t header;
 	struct diag_apps_data_t *data = &non_hdlc_data;
@@ -3178,8 +3194,16 @@ static int diag_process_apps_data_non_hdlc(unsigned char *buf, int len,
 		return -EIO;
 	}
 wait_for_buffer:
-	wait_event_interruptible(driver->hdlc_wait_q,
-			(data->flushed == 0));
+	wait_err = wait_event_interruptible_timeout(driver->hdlc_wait_q,
+					(data->flushed == 0),
+					msecs_to_jiffies(PKT_PROCESS_TIMEOUT));
+	if (wait_err <= 0) {
+		DIAG_LOG(DIAG_DEBUG_USERSPACE,
+		"diag: Timeout while waiting for non-hdlc buffer to be flushed, err: %d\n",
+		wait_err);
+		return PKT_DROP;
+	}
+
 	spin_lock_irqsave(&driver->diagmem_lock, flags);
 	if (data->flushed) {
 		spin_unlock_irqrestore(&driver->diagmem_lock, flags);

--- a/drivers/char/diag/diagfwd.c
+++ b/drivers/char/diag/diagfwd.c
@@ -1835,9 +1835,8 @@ static int diagfwd_mux_write_done(unsigned char *buf, int len, int buf_ctxt,
 				  int ctxt)
 {
 	unsigned long flags;
-	int peripheral = -1;
-	int type = -1;
-	int num = -1;
+	int peripheral = -1, type = -1;
+	int num = -1, hdlc_ctxt = -1;
 	struct diag_apps_data_t *temp = NULL;
 
 	if (!buf || len < 0)
@@ -1857,16 +1856,19 @@ static int diagfwd_mux_write_done(unsigned char *buf, int len, int buf_ctxt,
 			diag_ws_on_copy(DIAG_WS_MUX);
 		} else if (peripheral == APPS_DATA) {
 			spin_lock_irqsave(&driver->diagmem_lock, flags);
-			if (hdlc_data.allocated)
+			hdlc_ctxt = GET_HDLC_CTXT(buf_ctxt);
+			if ((hdlc_ctxt == HDLC_CTXT) && hdlc_data.allocated)
 				temp = &hdlc_data;
-			else if (non_hdlc_data.allocated)
+			else if ((hdlc_ctxt == NON_HDLC_CTXT) &&
+				non_hdlc_data.allocated)
 				temp = &non_hdlc_data;
 			else
 				DIAG_LOG(DIAG_DEBUG_PERIPHERALS,
 				"No apps data buffer is allocated to be freed\n");
 			if (temp) {
 				DIAG_LOG(DIAG_DEBUG_PERIPHERALS,
-				"Freeing Apps data buffer after write done hdlc.allocated: %d, non_hdlc.allocated: %d\n",
+				"Freeing Apps data buffer after write done hdlc_ctxt: %d, hdlc.allocated: %d, non_hdlc.allocated: %d\n",
+				hdlc_ctxt,
 				hdlc_data.allocated, non_hdlc_data.allocated);
 				diagmem_free(driver, temp->buf, POOL_TYPE_HDLC);
 				temp->buf = NULL;

--- a/drivers/char/diag/diagfwd.h
+++ b/drivers/char/diag/diagfwd.h
@@ -25,6 +25,9 @@
 #define GET_BUF_NUM(n)		((n & 0x0000FF))
 #define GET_PD_CTXT(u)		((u & 0xFF000000) >> 24)
 
+#define SET_HDLC_CTXT(u)	((u & 0xFF) << 24)
+#define GET_HDLC_CTXT(u)	((u & 0xFF000000) >> 24)
+
 #define CHK_OVERFLOW(bufStart, start, end, length) \
 	((((bufStart) <= (start)) && ((end) - (start) >= (length))) ? 1 : 0)
 

--- a/drivers/char/diag/diagfwd_hsic.c
+++ b/drivers/char/diag/diagfwd_hsic.c
@@ -470,13 +470,18 @@ static int hsic_fwd_complete(int id, unsigned char *buf, int len, int ctxt)
 	return 0;
 }
 
+static int hsic_remote_proc_check(void)
+{
+	return diag_hsic[HSIC_1].enabled;
+}
+
 static struct diag_remote_dev_ops diag_hsic_fwd_ops = {
 	.open = hsic_open,
 	.close = hsic_close,
 	.queue_read = hsic_queue_read,
 	.write = hsic_write,
 	.fwd_complete = hsic_fwd_complete,
-	.remote_proc_check = NULL,
+	.remote_proc_check = hsic_remote_proc_check,
 };
 
 int diag_hsic_init(void)

--- a/drivers/char/diag/diagfwd_hsic.c
+++ b/drivers/char/diag/diagfwd_hsic.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2014, 2016-2018 The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2014, 2016-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -538,6 +538,24 @@ void diag_hsic_exit(void)
 		if (ch->hsic_wq)
 			destroy_workqueue(ch->hsic_wq);
 	}
-	platform_driver_unregister(&msm_hsic_ch_driver);
 }
 
+void diag_register_with_hsic(void)
+{
+	int ret = 0;
+
+	ret = diag_remote_init();
+	if (ret)
+		return;
+
+	ret = diag_hsic_init();
+	if (ret)
+		diag_remote_exit();
+}
+
+void diag_unregister_hsic(void)
+{
+	platform_driver_unregister(&msm_hsic_ch_driver);
+	diag_hsic_exit();
+	diag_remote_exit();
+}

--- a/drivers/char/diag/diagfwd_hsic.c
+++ b/drivers/char/diag/diagfwd_hsic.c
@@ -327,13 +327,16 @@ static void hsic_read_complete_work_fn(struct work_struct *work)
 						 read_complete_work);
 	struct diag_hsic_buf_tbl_t *item;
 
-	item = hsic_buf_tbl_pop(ch);
-	if (item) {
-		if (diag_remote_dev_read_done(ch->dev_id, item->buf, item->len))
-			goto fail;
-	}
+	do {
+		item = hsic_buf_tbl_pop(ch);
+		if (item) {
+			if (diag_remote_dev_read_done(ch->dev_id,
+						      item->buf, item->len))
+				goto fail;
+			kfree(item);
+		}
+	} while (item);
 
-	kfree(item);
 	return;
 
 fail:

--- a/drivers/char/diag/diagfwd_hsic.c
+++ b/drivers/char/diag/diagfwd_hsic.c
@@ -50,10 +50,65 @@ struct diag_hsic_info diag_hsic[NUM_HSIC_DEV] = {
 	}
 };
 
+static int hsic_buf_tbl_push(struct diag_hsic_info *ch, void *buf, int len)
+{
+	unsigned long flags;
+	struct diag_hsic_buf_tbl_t *item;
+
+	item = kzalloc(sizeof(struct diag_hsic_buf_tbl_t), GFP_ATOMIC);
+	if (!item)
+		return -ENOMEM;
+	kmemleak_not_leak(item);
+
+	spin_lock_irqsave(&ch->lock, flags);
+	item->buf = buf;
+	item->len = len;
+	list_add_tail(&item->link, &ch->buf_tbl);
+	spin_unlock_irqrestore(&ch->lock, flags);
+
+	return 0;
+}
+
+static struct diag_hsic_buf_tbl_t *hsic_buf_tbl_pop(struct diag_hsic_info *ch)
+{
+	unsigned long flags;
+	struct diag_hsic_buf_tbl_t *item = NULL;
+
+	if (!ch || list_empty(&ch->buf_tbl))
+		return NULL;
+
+	spin_lock_irqsave(&ch->lock, flags);
+	item = list_first_entry(&ch->buf_tbl, struct diag_hsic_buf_tbl_t, link);
+	list_del(&item->link);
+	spin_unlock_irqrestore(&ch->lock, flags);
+
+	return item;
+}
+
+static void hsic_buf_tbl_clear(struct diag_hsic_info *ch)
+{
+	unsigned long flags;
+	struct list_head *start, *temp;
+	struct diag_hsic_buf_tbl_t *item = NULL;
+
+	if (!ch)
+		return;
+
+	/* At this point, the channel should already by closed */
+	spin_lock_irqsave(&ch->lock, flags);
+	list_for_each_safe(start, temp, &ch->buf_tbl) {
+		item = list_entry(start, struct diag_hsic_buf_tbl_t,
+				  link);
+		list_del(&item->link);
+		kfree(item);
+
+	}
+	spin_unlock_irqrestore(&ch->lock, flags);
+}
+
 static void diag_hsic_read_complete(void *ctxt, char *buf, int len,
 				    int actual_size)
 {
-	int err = 0;
 	int index = (int)(uintptr_t)ctxt;
 	struct diag_hsic_info *ch = NULL;
 
@@ -69,11 +124,14 @@ static void diag_hsic_read_complete(void *ctxt, char *buf, int len,
 	 * completes. Also, actual size can be negative error codes - do not
 	 * pass on the buffer.
 	 */
-	if (!ch->opened || actual_size <= 0)
+	if (!ch->opened || !buf || actual_size <= 0)
 		goto fail;
-	err = diag_remote_dev_read_done(ch->dev_id, buf, actual_size);
-	if (err)
+	if (hsic_buf_tbl_push(ch, buf, actual_size)) {
+		pr_err_ratelimited("diag: In %s, OOM! Drop incoming packet\n",
+				   __func__);
 		goto fail;
+	}
+	queue_work(ch->hsic_wq, &ch->read_complete_work);
 	return;
 
 fail:
@@ -183,6 +241,7 @@ static int hsic_open(int id)
 	diagmem_init(driver, ch->mempool);
 	/* Notify the bridge that the channel is open */
 	diag_remote_dev_open(ch->dev_id);
+	INIT_LIST_HEAD(&ch->buf_tbl);
 	queue_work(ch->hsic_wq, &(ch->read_work));
 	return 0;
 }
@@ -220,6 +279,7 @@ static int hsic_close(int id)
 	diag_bridge_close(ch->id);
 	diagmem_exit(driver, ch->mempool);
 	diag_remote_dev_close(ch->dev_id);
+	hsic_buf_tbl_clear(ch);
 	return 0;
 }
 
@@ -259,6 +319,27 @@ static void hsic_read_work_fn(struct work_struct *work)
 	/* Read from the HSIC channel continuously if the channel is present */
 	if (!err)
 		queue_work(ch->hsic_wq, &ch->read_work);
+}
+
+static void hsic_read_complete_work_fn(struct work_struct *work)
+{
+	struct diag_hsic_info *ch = container_of(work, struct diag_hsic_info,
+						 read_complete_work);
+	struct diag_hsic_buf_tbl_t *item;
+
+	item = hsic_buf_tbl_pop(ch);
+	if (item) {
+		if (diag_remote_dev_read_done(ch->dev_id, item->buf, item->len))
+			goto fail;
+	}
+
+	kfree(item);
+	return;
+
+fail:
+	diagmem_free(driver, item->buf, ch->mempool);
+	queue_work(ch->hsic_wq, &ch->read_work);
+	kfree(item);
 }
 
 static int diag_hsic_probe(struct platform_device *pdev)
@@ -406,6 +487,8 @@ int diag_hsic_init(void)
 		ch = &diag_hsic[i];
 		spin_lock_init(&ch->lock);
 		INIT_WORK(&(ch->read_work), hsic_read_work_fn);
+		INIT_WORK(&(ch->read_complete_work),
+			  hsic_read_complete_work_fn);
 		INIT_WORK(&(ch->open_work), hsic_open_work_fn);
 		INIT_WORK(&(ch->close_work), hsic_close_work_fn);
 		strlcpy(wq_name, "DIAG_HSIC_", sizeof(wq_name));

--- a/drivers/char/diag/diagfwd_hsic.h
+++ b/drivers/char/diag/diagfwd_hsic.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2014, 2017, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2014, 2017-2018, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -12,6 +12,8 @@
 
 #ifndef DIAGFWD_HSIC_H
 #define DIAGFWD_HSIC_H
+
+#include <linux/list.h>
 #ifdef CONFIG_DIAG_OVER_USB
 #include <linux/usb/usbdiag.h>
 #endif
@@ -23,6 +25,12 @@
 
 #define DIAG_HSIC_NAME_SZ	24
 
+struct diag_hsic_buf_tbl_t {
+	struct list_head link;
+	unsigned char *buf;
+	int len;
+};
+
 struct diag_hsic_info {
 	int id;
 	int dev_id;
@@ -32,10 +40,12 @@ struct diag_hsic_info {
 	uint8_t suspended;
 	char name[DIAG_HSIC_NAME_SZ];
 	struct work_struct read_work;
+	struct work_struct read_complete_work;
 	struct work_struct open_work;
 	struct work_struct close_work;
 	struct workqueue_struct *hsic_wq;
 	spinlock_t lock;
+	struct list_head buf_tbl;
 };
 
 extern struct diag_hsic_info diag_hsic[NUM_HSIC_DEV];

--- a/drivers/char/diag/diagfwd_hsic.h
+++ b/drivers/char/diag/diagfwd_hsic.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2014, 2017-2018, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2014, 2017-2019, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -52,6 +52,8 @@ extern struct diag_hsic_info diag_hsic[NUM_HSIC_DEV];
 
 int diag_hsic_init(void);
 void diag_hsic_exit(void);
+void diag_register_with_hsic(void);
+void diag_unregister_hsic(void);
 
 #endif
 

--- a/drivers/char/diag/diagfwd_socket.c
+++ b/drivers/char/diag/diagfwd_socket.c
@@ -603,6 +603,7 @@ static void socket_read_work_fn(struct work_struct *work)
 	struct diag_socket_info *info = container_of(work,
 						     struct diag_socket_info,
 						     read_work);
+	struct diagfwd_info *fwd_info;
 
 	if (!info) {
 		diag_ws_release();
@@ -623,8 +624,9 @@ static void socket_read_work_fn(struct work_struct *work)
 		diag_ws_release();
 		return;
 	}
-
-	if (!info->fwd_ctxt && info->port_type == PORT_TYPE_SERVER)
+	fwd_info = info->fwd_ctxt;
+	if (info->port_type == PORT_TYPE_SERVER &&
+		(!fwd_info || !atomic_read(&fwd_info->opened)))
 		diag_socket_drop_data(info);
 
 	if (!atomic_read(&info->opened) && info->port_type == PORT_TYPE_SERVER)

--- a/drivers/clk/qcom/clk-smd-rpm.c
+++ b/drivers/clk/qcom/clk-smd-rpm.c
@@ -838,7 +838,7 @@ DEFINE_CLK_SMD_RPM(msm8998, snoc_clk, snoc_a_clk, QCOM_SMD_RPM_BUS_CLK, 1);
 DEFINE_CLK_SMD_RPM(msm8998, cnoc_clk, cnoc_a_clk, QCOM_SMD_RPM_BUS_CLK, 2);
 DEFINE_CLK_SMD_RPM(msm8998, ipa_clk, ipa_a_clk, QCOM_SMD_RPM_IPA_CLK, 0);
 DEFINE_CLK_SMD_RPM(msm8998, ce1_clk, ce1_a_clk, QCOM_SMD_RPM_CE_CLK, 0);
-DEFINE_CLK_SMD_RPM(msm8998, mmssnoc_axi_clk, mmssnoc_axi_a_clk,
+DEFINE_CLK_SMD_RPM(msm8998, mmssnoc_axi_rpm_clk, mmssnoc_axi_rpm_a_clk,
 		   QCOM_SMD_RPM_MMAXI_CLK, 0);
 DEFINE_CLK_SMD_RPM(msm8998, aggre1_noc_clk, aggre1_noc_a_clk,
 			  QCOM_SMD_RPM_AGGR_CLK, 1);
@@ -909,8 +909,8 @@ static struct clk_hw *msm8998_clks[] = {
 	[RPM_SMD_CNOC_A_CLK]	= &msm8998_cnoc_a_clk.hw,
 	[RPM_SMD_CNOC_PERIPH_CLK] = &msm8998_cnoc_periph_clk.hw,
 	[RPM_SMD_CNOC_PERIPH_A_CLK] = &msm8998_cnoc_periph_a_clk.hw,
-	[MMSSNOC_AXI_CLK]	= &msm8998_mmssnoc_axi_clk.hw,
-	[MMSSNOC_AXI_A_CLK]	= &msm8998_mmssnoc_axi_a_clk.hw,
+	[RPM_SMD_MMAXI_CLK]	= &msm8998_mmssnoc_axi_rpm_clk.hw,
+	[RPM_SMD_MMAXI_A_CLK]	= &msm8998_mmssnoc_axi_rpm_a_clk.hw,
 	[RPM_SMD_IPA_CLK]	= &msm8998_ipa_clk.hw,
 	[RPM_SMD_IPA_A_CLK]	= &msm8998_ipa_a_clk.hw,
 	[RPM_SMD_CE1_CLK]	= &msm8998_ce1_clk.hw,
@@ -921,6 +921,8 @@ static struct clk_hw *msm8998_clks[] = {
 	[RPM_SMD_DIV_CLK2_AO]	= &msm8998_div_clk2_ao.hw,
 	[RPM_SMD_DIV_CLK3]	= &msm8998_div_clk3.hw,
 	[RPM_SMD_DIV_CLK3_AO]	= &msm8998_div_clk3_ao.hw,
+	[MMSSNOC_AXI_CLK]	= &mmssnoc_axi_clk.hw,
+	[MMSSNOC_AXI_A_CLK]	= &mmssnoc_axi_a_clk.hw,
 	[BIMC_MSMBUS_CLK]	= &bimc_msmbus_clk.hw,
 	[BIMC_MSMBUS_A_CLK]	= &bimc_msmbus_a_clk.hw,
 	[CNOC_MSMBUS_CLK]	= &cnoc_msmbus_clk.hw,
@@ -942,7 +944,7 @@ static struct clk_hw *msm8998_clks[] = {
 };
 static const struct rpm_smd_clk_desc rpm_clk_msm8998 = {
 	.clks = msm8998_clks,
-	.num_rpm_clks = MMSSNOC_AXI_A_CLK,
+	.num_rpm_clks = RPM_SMD_CNOC_PERIPH_A_CLK,
 	.num_clks = ARRAY_SIZE(msm8998_clks),
 };
 

--- a/drivers/clk/qcom/mdss/mdss-dsi-pll-10nm.c
+++ b/drivers/clk/qcom/mdss/mdss-dsi-pll-10nm.c
@@ -1507,7 +1507,6 @@ static struct dsi_pll_vco_clk dsi0pll_vco_clk = {
 			.parent_names = (const char *[]){"bi_tcxo"},
 			.num_parents = 1,
 			.ops = &clk_ops_vco_10nm,
-			.flags = CLK_GET_RATE_NOCACHE,
 	},
 };
 
@@ -1520,7 +1519,6 @@ static struct dsi_pll_vco_clk dsi0pll_shadow_vco_clk = {
 			.parent_names = (const char *[]){"bi_tcxo"},
 			.num_parents = 1,
 			.ops = &clk_ops_shadow_vco_10nm,
-			.flags = CLK_GET_RATE_NOCACHE,
 	},
 };
 
@@ -1533,7 +1531,6 @@ static struct dsi_pll_vco_clk dsi1pll_vco_clk = {
 			.parent_names = (const char *[]){"bi_tcxo"},
 			.num_parents = 1,
 			.ops = &clk_ops_vco_10nm,
-			.flags = CLK_GET_RATE_NOCACHE,
 	},
 };
 
@@ -1546,7 +1543,6 @@ static struct dsi_pll_vco_clk dsi1pll_shadow_vco_clk = {
 			.parent_names = (const char *[]){"bi_tcxo"},
 			.num_parents = 1,
 			.ops = &clk_ops_shadow_vco_10nm,
-			.flags = CLK_GET_RATE_NOCACHE,
 	},
 };
 
@@ -1560,7 +1556,7 @@ static struct clk_regmap_div dsi0pll_pll_out_div = {
 			.name = "dsi0pll_pll_out_div",
 			.parent_names = (const char *[]){"dsi0pll_vco_clk"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1577,7 +1573,7 @@ static struct clk_regmap_div dsi0pll_shadow_pll_out_div = {
 			.parent_names = (const char *[]){
 				"dsi0pll_shadow_vco_clk"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1593,7 +1589,7 @@ static struct clk_regmap_div dsi1pll_pll_out_div = {
 			.name = "dsi1pll_pll_out_div",
 			.parent_names = (const char *[]){"dsi1pll_vco_clk"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1610,7 +1606,7 @@ static struct clk_regmap_div dsi1pll_shadow_pll_out_div = {
 			.parent_names = (const char *[]){
 				"dsi1pll_shadow_vco_clk"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1624,7 +1620,7 @@ static struct clk_regmap_div dsi0pll_bitclk_src = {
 			.name = "dsi0pll_bitclk_src",
 			.parent_names = (const char *[]){"dsi0pll_pll_out_div"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1639,7 +1635,7 @@ static struct clk_regmap_div dsi0pll_shadow_bitclk_src = {
 			.parent_names = (const char *[]){
 				"dsi0pll_shadow_pll_out_div"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1653,7 +1649,7 @@ static struct clk_regmap_div dsi1pll_bitclk_src = {
 			.name = "dsi1pll_bitclk_src",
 			.parent_names = (const char *[]){"dsi1pll_pll_out_div"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1668,7 +1664,7 @@ static struct clk_regmap_div dsi1pll_shadow_bitclk_src = {
 			.parent_names = (const char *[]){
 				"dsi1pll_shadow_pll_out_div"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1681,7 +1677,6 @@ static struct clk_fixed_factor dsi0pll_post_vco_div = {
 		.name = "dsi0pll_post_vco_div",
 		.parent_names = (const char *[]){"dsi0pll_pll_out_div"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1693,7 +1688,6 @@ static struct clk_fixed_factor dsi0pll_shadow_post_vco_div = {
 		.name = "dsi0pll_shadow_post_vco_div",
 		.parent_names = (const char *[]){"dsi0pll_shadow_pll_out_div"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1705,7 +1699,6 @@ static struct clk_fixed_factor dsi1pll_post_vco_div = {
 		.name = "dsi1pll_post_vco_div",
 		.parent_names = (const char *[]){"dsi1pll_pll_out_div"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1717,7 +1710,6 @@ static struct clk_fixed_factor dsi1pll_shadow_post_vco_div = {
 		.name = "dsi1pll_shadow_post_vco_div",
 		.parent_names = (const char *[]){"dsi1pll_shadow_pll_out_div"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1729,7 +1721,7 @@ static struct clk_fixed_factor dsi0pll_byteclk_src = {
 		.name = "dsi0pll_byteclk_src",
 		.parent_names = (const char *[]){"dsi0pll_bitclk_src"},
 		.num_parents = 1,
-		.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+		.flags = CLK_SET_RATE_PARENT,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1741,7 +1733,7 @@ static struct clk_fixed_factor dsi0pll_shadow_byteclk_src = {
 		.name = "dsi0pll_shadow_byteclk_src",
 		.parent_names = (const char *[]){"dsi0pll_shadow_bitclk_src"},
 		.num_parents = 1,
-		.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+		.flags = CLK_SET_RATE_PARENT,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1753,7 +1745,7 @@ static struct clk_fixed_factor dsi1pll_byteclk_src = {
 		.name = "dsi1pll_byteclk_src",
 		.parent_names = (const char *[]){"dsi1pll_bitclk_src"},
 		.num_parents = 1,
-		.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+		.flags = CLK_SET_RATE_PARENT,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1765,7 +1757,7 @@ static struct clk_fixed_factor dsi1pll_shadow_byteclk_src = {
 		.name = "dsi1pll_shadow_byteclk_src",
 		.parent_names = (const char *[]){"dsi1pll_shadow_bitclk_src"},
 		.num_parents = 1,
-		.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+		.flags = CLK_SET_RATE_PARENT,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1777,7 +1769,6 @@ static struct clk_fixed_factor dsi0pll_post_bit_div = {
 		.name = "dsi0pll_post_bit_div",
 		.parent_names = (const char *[]){"dsi0pll_bitclk_src"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1789,7 +1780,6 @@ static struct clk_fixed_factor dsi0pll_shadow_post_bit_div = {
 		.name = "dsi0pll_shadow_post_bit_div",
 		.parent_names = (const char *[]){"dsi0pll_shadow_bitclk_src"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1801,7 +1791,6 @@ static struct clk_fixed_factor dsi1pll_post_bit_div = {
 		.name = "dsi1pll_post_bit_div",
 		.parent_names = (const char *[]){"dsi1pll_bitclk_src"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1813,7 +1802,6 @@ static struct clk_fixed_factor dsi1pll_shadow_post_bit_div = {
 		.name = "dsi1pll_shadow_post_bit_div",
 		.parent_names = (const char *[]){"dsi1pll_shadow_bitclk_src"},
 		.num_parents = 1,
-		.flags = CLK_GET_RATE_NOCACHE,
 		.ops = &clk_fixed_factor_ops,
 	},
 };
@@ -1827,7 +1815,7 @@ static struct clk_regmap_mux dsi0pll_byteclk_mux = {
 			.parent_names = (const char *[]){"dsi0pll_byteclk_src",
 				"dsi0pll_shadow_byteclk_src"},
 			.num_parents = 2,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT |
+			.flags = (CLK_SET_RATE_PARENT |
 				  CLK_SET_RATE_NO_REPARENT),
 			.ops = &clk_regmap_mux_closest_ops,
 		},
@@ -1843,7 +1831,7 @@ static struct clk_regmap_mux dsi1pll_byteclk_mux = {
 			.parent_names = (const char *[]){"dsi1pll_byteclk_src",
 				"dsi1pll_shadow_byteclk_src"},
 			.num_parents = 2,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT |
+			.flags = (CLK_SET_RATE_PARENT |
 				  CLK_SET_RATE_NO_REPARENT),
 			.ops = &clk_regmap_mux_closest_ops,
 		},
@@ -1862,7 +1850,6 @@ static struct clk_regmap_mux dsi0pll_pclk_src_mux = {
 					"dsi0pll_pll_out_div",
 					"dsi0pll_post_vco_div"},
 			.num_parents = 4,
-			.flags = CLK_GET_RATE_NOCACHE,
 			.ops = &clk_regmap_mux_closest_ops,
 		},
 	},
@@ -1881,7 +1868,6 @@ static struct clk_regmap_mux dsi0pll_shadow_pclk_src_mux = {
 				"dsi0pll_shadow_pll_out_div",
 				"dsi0pll_shadow_post_vco_div"},
 			.num_parents = 4,
-			.flags = CLK_GET_RATE_NOCACHE,
 			.ops = &clk_regmap_mux_closest_ops,
 		},
 	},
@@ -1899,7 +1885,6 @@ static struct clk_regmap_mux dsi1pll_pclk_src_mux = {
 					"dsi1pll_pll_out_div",
 					"dsi1pll_post_vco_div"},
 			.num_parents = 4,
-			.flags = CLK_GET_RATE_NOCACHE,
 			.ops = &clk_regmap_mux_closest_ops,
 		},
 	},
@@ -1918,7 +1903,6 @@ static struct clk_regmap_mux dsi1pll_shadow_pclk_src_mux = {
 				"dsi1pll_shadow_pll_out_div",
 				"dsi1pll_shadow_post_vco_div"},
 			.num_parents = 4,
-			.flags = CLK_GET_RATE_NOCACHE,
 			.ops = &clk_regmap_mux_closest_ops,
 		},
 	},
@@ -1933,7 +1917,7 @@ static struct clk_regmap_div dsi0pll_pclk_src = {
 			.parent_names = (const char *[]){
 					"dsi0pll_pclk_src_mux"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1948,7 +1932,7 @@ static struct clk_regmap_div dsi0pll_shadow_pclk_src = {
 			.parent_names = (const char *[]){
 					"dsi0pll_shadow_pclk_src_mux"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1963,7 +1947,7 @@ static struct clk_regmap_div dsi1pll_pclk_src = {
 			.parent_names = (const char *[]){
 					"dsi1pll_pclk_src_mux"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1978,7 +1962,7 @@ static struct clk_regmap_div dsi1pll_shadow_pclk_src = {
 			.parent_names = (const char *[]){
 					"dsi1pll_shadow_pclk_src_mux"},
 			.num_parents = 1,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT),
+			.flags = CLK_SET_RATE_PARENT,
 			.ops = &clk_regmap_div_ops,
 		},
 	},
@@ -1993,7 +1977,7 @@ static struct clk_regmap_mux dsi0pll_pclk_mux = {
 			.parent_names = (const char *[]){"dsi0pll_pclk_src",
 				"dsi0pll_shadow_pclk_src"},
 			.num_parents = 2,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT |
+			.flags = (CLK_SET_RATE_PARENT |
 				  CLK_SET_RATE_NO_REPARENT),
 			.ops = &clk_regmap_mux_closest_ops,
 		},
@@ -2009,7 +1993,7 @@ static struct clk_regmap_mux dsi1pll_pclk_mux = {
 			.parent_names = (const char *[]){"dsi1pll_pclk_src",
 				"dsi1pll_shadow_pclk_src"},
 			.num_parents = 2,
-			.flags = (CLK_GET_RATE_NOCACHE | CLK_SET_RATE_PARENT |
+			.flags = (CLK_SET_RATE_PARENT |
 				  CLK_SET_RATE_NO_REPARENT),
 			.ops = &clk_regmap_mux_closest_ops,
 		},

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_clk.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_clk.h
@@ -117,11 +117,13 @@ struct dsi_link_lp_clk_info {
 /**
  * struct link_clk_freq - Clock frequency information for Link clocks
  * @byte_clk_rate:   Frequency of DSI byte_clk in KHz.
+ * @byte_intf_clk_rate:   Frequency of DSI byte_intf_clk in KHz.
  * @pixel_clk_rate:  Frequency of DSI pixel_clk in KHz.
  * @esc_clk_rate:    Frequency of DSI escape clock in KHz.
  */
 struct link_clk_freq {
 	u32 byte_clk_rate;
+	u32 byte_intf_clk_rate;
 	u32 pix_clk_rate;
 	u32 esc_clk_rate;
 };
@@ -313,10 +315,12 @@ int dsi_clk_set_pixel_clk_rate(void *client, u64 pixel_clk, u32 index);
  * dsi_clk_set_byte_clk_rate() - set frequency for byte clock
  * @client:       DSI clock client pointer.
  * @byte_clk: Pixel clock rate in Hz.
+ * @byte_intf_clk: Byte interface clock rate in Hz.
  * @index:      Index of the DSI controller.
  * return: error code in case of failure or 0 for success.
  */
-int dsi_clk_set_byte_clk_rate(void *client, u64 byte_clk, u32 index);
+int dsi_clk_set_byte_clk_rate(void *client, u64 byte_clk,
+				u64 byte_intf_clk, u32 index);
 
 /**
  * dsi_clk_update_parent() - update parent clocks for specified clock

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_clk_manager.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_clk_manager.c
@@ -140,15 +140,16 @@ int dsi_clk_set_pixel_clk_rate(void *client, u64 pixel_clk, u32 index)
  * dsi_clk_set_byte_clk_rate() - set frequency for byte clock
  * @client:	DSI clock client pointer.
  * @byte_clk:	Byte clock rate in Hz.
+ * @byte_intf_clk:	Byte interface clock rate in Hz.
  * @index:	Index of the DSI controller.
  * return: error code in case of failure or 0 for success.
  */
-int dsi_clk_set_byte_clk_rate(void *client, u64 byte_clk, u32 index)
+int dsi_clk_set_byte_clk_rate(void *client, u64 byte_clk,
+					u64 byte_intf_clk, u32 index)
 {
 	int rc = 0;
 	struct dsi_clk_client_info *c = client;
 	struct dsi_clk_mngr *mngr;
-	u64 byte_intf_rate;
 
 	mngr = c->mngr;
 	rc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_clk, byte_clk);
@@ -158,12 +159,14 @@ int dsi_clk_set_byte_clk_rate(void *client, u64 byte_clk, u32 index)
 		mngr->link_clks[index].freq.byte_clk_rate = byte_clk;
 
 	if (mngr->link_clks[index].hs_clks.byte_intf_clk) {
-		byte_intf_rate = mngr->link_clks[index].freq.byte_clk_rate / 2;
 		rc = clk_set_rate(mngr->link_clks[index].hs_clks.byte_intf_clk,
-				  byte_intf_rate);
+				  byte_intf_clk);
 		if (rc)
 			pr_err("failed to set clk rate for byte intf clk=%d\n",
 			       rc);
+		else
+			mngr->link_clks[index].freq.byte_intf_clk_rate =
+				byte_intf_clk;
 	}
 
 	return rc;
@@ -383,12 +386,10 @@ static int dsi_link_hs_clk_set_rate(struct dsi_link_hs_clk_info *link_hs_clks,
 
 	/*
 	 * If byte_intf_clk is present, set rate for that too.
-	 * For DPHY: byte_intf_clk_rate = byte_clk_rate / 2
-	 * todo: this needs to be revisited when support for CPHY is added
 	 */
 	if (link_hs_clks->byte_intf_clk) {
 		rc = clk_set_rate(link_hs_clks->byte_intf_clk,
-			(l_clks->freq.byte_clk_rate / 2));
+				l_clks->freq.byte_intf_clk_rate);
 		if (rc) {
 			pr_err("set_rate failed for byte_intf_clk rc = %d\n",
 				rc);

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_ctrl.c
@@ -827,10 +827,10 @@ static int dsi_ctrl_update_link_freqs(struct dsi_ctrl *dsi_ctrl,
 {
 	int rc = 0;
 	u32 num_of_lanes = 0;
-	u32 bpp;
+	u32 bpp, byte_intf_clk_div;
 	u64 refresh_rate = TICKS_IN_MICRO_SECOND;
 	u64 h_period, v_period, bit_rate, pclk_rate, bit_rate_per_lane,
-	    byte_clk_rate;
+	    byte_clk_rate, byte_intf_clk_rate;
 	struct dsi_host_common_cfg *host_cfg = &config->common_config;
 	struct dsi_split_link_config *split_link = &host_cfg->split_link;
 	struct dsi_mode_info *timing = &config->video_timing;
@@ -865,6 +865,10 @@ static int dsi_ctrl_update_link_freqs(struct dsi_ctrl *dsi_ctrl,
 	do_div(pclk_rate, bpp);
 	byte_clk_rate = bit_rate_per_lane;
 	do_div(byte_clk_rate, 8);
+	byte_intf_clk_rate = byte_clk_rate;
+	byte_intf_clk_div = host_cfg->byte_intf_clk_div;
+	do_div(byte_intf_clk_rate, byte_intf_clk_div);
+
 	pr_debug("bit_clk_rate = %llu, bit_clk_rate_per_lane = %llu\n",
 		 bit_rate, bit_rate_per_lane);
 	pr_debug("byte_clk_rate = %llu, pclk_rate = %llu\n",
@@ -873,6 +877,7 @@ static int dsi_ctrl_update_link_freqs(struct dsi_ctrl *dsi_ctrl,
 	dsi_ctrl->clk_freq.byte_clk_rate = byte_clk_rate;
 	dsi_ctrl->clk_freq.pix_clk_rate = pclk_rate;
 	dsi_ctrl->clk_freq.esc_clk_rate = config->esc_clk_rate_hz;
+	dsi_ctrl->clk_freq.byte_intf_clk_rate = byte_intf_clk_rate;
 	config->bit_clk_rate_hz = dsi_ctrl->clk_freq.byte_clk_rate * 8;
 
 	rc = dsi_clk_set_link_frequencies(clk_handle, dsi_ctrl->clk_freq,

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_defs.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_defs.h
@@ -490,6 +490,7 @@ struct dsi_split_link_config {
  *                       reg config.
  * @force_hs_clk_lane:   Send continuous clock to the panel.
  * @dsi_split_link_config:  Split Link Configuration.
+ * @byte_intf_clk_div:   Determines the factor for calculating byte intf clock.
  */
 struct dsi_host_common_cfg {
 	enum dsi_pixel_format dst_format;
@@ -512,6 +513,7 @@ struct dsi_host_common_cfg {
 	u32 ext_bridge_map[MAX_DSI_CTRLS_PER_DISPLAY];
 	bool force_hs_clk_lane;
 	struct dsi_split_link_config split_link;
+	u32 byte_intf_clk_div;
 };
 
 /**

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy.c
@@ -103,6 +103,11 @@ static const struct of_device_id msm_dsi_phy_of_match[] = {
 	{}
 };
 
+int dsi_phy_get_version(struct msm_dsi_phy *phy)
+{
+	return phy->ver_info->version;
+}
+
 static int dsi_phy_regmap_init(struct platform_device *pdev,
 			       struct msm_dsi_phy *phy)
 {

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy.c
@@ -756,6 +756,28 @@ error:
 	return rc;
 }
 
+int dsi_phy_set_idle_pc(struct msm_dsi_phy *dsi_phy, bool idle_pc_enabled)
+{
+	int rc = 0;
+
+	if (!dsi_phy) {
+		pr_err("PHY is NULL!!!\n");
+		return -EINVAL;
+	}
+
+	/* If PHY does not require special IdlePC handling, go out early */
+	if (!dsi_phy->hw.ops.set_idle_pc)
+		return 0;
+
+	mutex_lock(&dsi_phy->phy_lock);
+
+	dsi_phy->hw.ops.set_idle_pc(&dsi_phy->hw, idle_pc_enabled);
+
+	mutex_unlock(&dsi_phy->phy_lock);
+
+	return rc;
+}
+
 static int dsi_phy_enable_ulps(struct msm_dsi_phy *phy,
 		struct dsi_host_config *config, bool clamp_enabled)
 {

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
@@ -172,6 +172,12 @@ int dsi_phy_validate_mode(struct msm_dsi_phy *dsi_phy,
 int dsi_phy_set_power_state(struct msm_dsi_phy *dsi_phy, bool enable);
 
 /**
+ * dsi_phy_set_idle_pc() - set/unset idle dsi phy idle power collapse
+ *
+ */
+int dsi_phy_set_idle_pc(struct msm_dsi_phy *dsi_phy, bool idle_pc_enabled);
+
+/**
  * dsi_phy_enable() - enable DSI PHY hardware
  * @dsi_phy:            DSI PHY handle.
  * @config:             DSI host configuration.

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy.h
@@ -130,6 +130,14 @@ struct msm_dsi_phy *dsi_phy_get(struct device_node *of_node);
 void dsi_phy_put(struct msm_dsi_phy *dsi_phy);
 
 /**
+ * dsi_phy_get_version() - returns dsi phy version
+ * @dsi_phy:              DSI PHY handle.
+ *
+ * Return: phy version
+ */
+int dsi_phy_get_version(struct msm_dsi_phy *phy);
+
+/**
  * dsi_phy_drv_init() - initialize dsi phy driver
  * @dsi_phy:         DSI PHY handle.
  *

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw.h
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw.h
@@ -262,6 +262,12 @@ struct dsi_phy_hw_ops {
 	void (*phy_idle_off)(struct dsi_phy_hw *phy);
 
 	/**
+	 * set_idle_pc() - Enter/exit PHY idle power collapse
+	 */
+
+	void (*set_idle_pc)(struct dsi_phy_hw *phy, bool idle_pc_enabled);
+
+	/**
 	 * calculate_timing_params() - calculates timing parameters.
 	 * @phy:      Pointer to DSI PHY hardware object.
 	 * @mode:     Mode information for which timing has to be calculated.

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
@@ -511,6 +511,8 @@ void dsi_phy_hw_v3_0_ulps_exit(struct dsi_phy_hw *phy,
 	 * to be in stop state.
 	 */
 	DSI_W32(phy, DSIPHY_CMN_LANE_CTRL3, reg);
+	usleep_range(5, 15);
+
 	DSI_W32(phy, DSIPHY_CMN_LANE_CTRL3, 0);
 	usleep_range(100, 110);
 }

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_phy_hw_v3_0.c
@@ -242,6 +242,33 @@ void dsi_phy_hw_v3_0_clamp_ctrl(struct dsi_phy_hw *phy, bool enable)
 	wmb(); /* Ensure that the freezeio bit is toggled */
 }
 
+void dsi_phy_hw_v3_0_set_idle_pc(struct dsi_phy_hw *phy, bool idle_pc_enabled)
+{
+	u32 reg;
+
+	pr_debug("PHY: %s idle power collapse\n",
+		 idle_pc_enabled ? "Enabling" : "Disabling");
+
+	/* Does SDM845 support PHY idle power collapse, or just FreezeIO? */
+	if (!of_machine_is_compatible("qcom,msm8998"))
+		return;
+
+	if (idle_pc_enabled) {
+		pr_err("PHY: Enable idlepc not supported\n");
+		return;
+	}
+
+	reg = DSI_R32(phy, DSIPHY_CMN_CTRL_1);
+	DSI_W32(phy, DSIPHY_CMN_CTRL_1, reg | BIT(5));
+	wmb();
+	usleep_range(10, 15);
+
+	reg = DSI_R32(phy, DSIPHY_CMN_CTRL_1);
+	reg &= ~(BIT(5));
+	DSI_W32(phy, DSIPHY_CMN_CTRL_1, reg);
+	wmb();
+}
+
 /**
  * enable() - Enable PHY hardware
  * @phy:      Pointer to DSI PHY hardware object.

--- a/drivers/rpmsg/qcom_glink_native.c
+++ b/drivers/rpmsg/qcom_glink_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016-2017, Linaro Ltd
- * Copyright (c) 2018-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2018-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -126,6 +126,8 @@ struct glink_core_rx_intent {
  * @lcids:	idr of all channels with a known local channel id
  * @rcids:	idr of all channels with a known remote channel id
  * @in_reset:	reset status of this edge
+ * @tx_avail_notify: Waitqueue for pending tx tasks
+ * @sent_read_notify: flag to check cmd sent or not
  * @ilc:	ipc logging context reference
  */
 struct qcom_glink {
@@ -158,6 +160,9 @@ struct qcom_glink {
 	unsigned long features;
 
 	bool intentless;
+
+	wait_queue_head_t tx_avail_notify;
+	bool sent_read_notify;
 
 	void *ilc;
 };
@@ -350,6 +355,22 @@ static void qcom_glink_pipe_reset(struct qcom_glink *glink)
 		glink->rx_pipe->reset(glink->rx_pipe);
 }
 
+static void qcom_glink_send_read_notify(struct qcom_glink *glink)
+{
+	struct glink_msg msg;
+
+	msg.cmd = cpu_to_le16(RPM_CMD_READ_NOTIF);
+	msg.param1 = 0;
+	msg.param2 = 0;
+
+	GLINK_INFO(glink->ilc, "send READ NOTIFY cmd\n");
+
+	qcom_glink_tx_write(glink, &msg, sizeof(msg), NULL, 0);
+
+	mbox_send_message(glink->mbox_chan, NULL);
+	mbox_client_txdone(glink->mbox_chan, 0);
+}
+
 static int qcom_glink_tx(struct qcom_glink *glink,
 			 const void *hdr, size_t hlen,
 			 const void *data, size_t dlen, bool wait)
@@ -373,17 +394,27 @@ static int qcom_glink_tx(struct qcom_glink *glink,
 			goto out;
 		}
 
-		if (atomic_read(&glink->in_reset)) {
-			ret = -ECONNRESET;
-			goto out;
+		if (!glink->sent_read_notify) {
+			glink->sent_read_notify = true;
+			qcom_glink_send_read_notify(glink);
 		}
 
 		/* Wait without holding the tx_lock */
 		spin_unlock_irqrestore(&glink->tx_lock, flags);
 
-		usleep_range(10000, 15000);
+		wait_event_timeout(glink->tx_avail_notify,
+				   (qcom_glink_tx_avail(glink) >= tlen
+				   || atomic_read(&glink->in_reset)), 10 * HZ);
 
 		spin_lock_irqsave(&glink->tx_lock, flags);
+
+		if (atomic_read(&glink->in_reset)) {
+			ret = -ECONNRESET;
+			goto out;
+		}
+
+		if (qcom_glink_tx_avail(glink) >= tlen)
+			glink->sent_read_notify = false;
 	}
 
 	qcom_glink_tx_write(glink, hdr, hlen, data, dlen);
@@ -1151,6 +1182,9 @@ static irqreturn_t qcom_glink_native_intr(int irq, void *data)
 	unsigned int cmd;
 	int ret = 0;
 
+	/* To wakeup any blocking writers */
+	wake_up_all(&glink->tx_avail_notify);
+
 	for (;;) {
 		avail = qcom_glink_rx_avail(glink);
 		if (avail < sizeof(msg))
@@ -1899,6 +1933,9 @@ static void qcom_glink_notif_reset(void *data)
 		return;
 	atomic_inc(&glink->in_reset);
 
+	/* To wakeup any blocking writers */
+	wake_up_all(&glink->tx_avail_notify);
+
 	spin_lock_irqsave(&glink->idr_lock, flags);
 	idr_for_each_entry(&glink->lcids, channel, cid) {
 		wake_up(&channel->intent_req_event);
@@ -1935,6 +1972,7 @@ struct qcom_glink *qcom_glink_native_probe(struct device *dev,
 	spin_lock_init(&glink->rx_lock);
 	INIT_LIST_HEAD(&glink->rx_queue);
 	INIT_WORK(&glink->rx_work, qcom_glink_work);
+	init_waitqueue_head(&glink->tx_avail_notify);
 
 	spin_lock_init(&glink->idr_lock);
 	idr_init(&glink->lcids);

--- a/drivers/soc/qcom/icnss.c
+++ b/drivers/soc/qcom/icnss.c
@@ -822,8 +822,16 @@ static int icnss_driver_event_server_arrive(void *data)
 	int ret = 0;
 	bool ignore_assert = false;
 
-	if (!penv)
+	if (!penv) {
+		kfree(data);
 		return -ENODEV;
+	}
+
+	if (test_bit(ICNSS_MODEM_SHUTDOWN, &penv->state)) {
+		icnss_pr_dbg("WLFW server arrive: Modem is down");
+		kfree(data);
+		return -EINVAL;
+	}
 
 	set_bit(ICNSS_WLFW_EXISTS, &penv->state);
 	clear_bit(ICNSS_FW_DOWN, &penv->state);
@@ -1408,13 +1416,19 @@ static int icnss_modem_notifier_nb(struct notifier_block *nb,
 			icnss_pr_err("Not able to Collect msa0 segment dump, Apps permissions not assigned %d\n",
 				     ret);
 		}
+		clear_bit(ICNSS_MODEM_SHUTDOWN, &priv->state);
 		return NOTIFY_OK;
 	}
+
+	if (code == SUBSYS_AFTER_SHUTDOWN)
+		clear_bit(ICNSS_MODEM_SHUTDOWN, &priv->state);
 
 	if (code != SUBSYS_BEFORE_SHUTDOWN)
 		return NOTIFY_OK;
 
 	priv->is_ssr = true;
+
+	set_bit(ICNSS_MODEM_SHUTDOWN, &priv->state);
 
 	if (notif->crashed)
 		set_bit(ICNSS_MODEM_CRASHED, &priv->state);
@@ -2827,6 +2841,9 @@ static int icnss_stats_show_state(struct seq_file *s, struct icnss_priv *priv)
 			continue;
 		case ICNSS_MODEM_CRASHED:
 			seq_puts(s, "MODEM CRASHED");
+			continue;
+		case ICNSS_MODEM_SHUTDOWN:
+			seq_puts(s, "MODEM SHUTDOWN");
 		}
 
 		seq_printf(s, "UNKNOWN-%d", i);

--- a/drivers/soc/qcom/icnss_private.h
+++ b/drivers/soc/qcom/icnss_private.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017-2019, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2017-2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -163,6 +163,7 @@ enum icnss_driver_state {
 	ICNSS_BLOCK_SHUTDOWN,
 	ICNSS_PDR,
 	ICNSS_MODEM_CRASHED,
+	ICNSS_MODEM_SHUTDOWN,
 };
 
 struct ce_irq_list {

--- a/drivers/soc/qcom/icnss_qmi.c
+++ b/drivers/soc/qcom/icnss_qmi.c
@@ -1209,10 +1209,16 @@ int icnss_clear_server(struct icnss_priv *priv)
 static int wlfw_new_server(struct qmi_handle *qmi,
 			   struct qmi_service *service)
 {
+	struct icnss_priv *priv = container_of(qmi, struct icnss_priv, qmi);
 	struct icnss_event_server_arrive_data *event_data;
 
 	icnss_pr_dbg("WLFW server arrive: node %u port %u\n",
 		     service->node, service->port);
+
+	if (test_bit(ICNSS_MODEM_SHUTDOWN, &priv->state)) {
+		icnss_pr_dbg("WLFW server arrive: Modem is down");
+		return -EINVAL;
+	}
 
 	event_data = kzalloc(sizeof(*event_data), GFP_KERNEL);
 	if (event_data == NULL)


### PR DESCRIPTION
This reverts commit 162f8d73d8cd36fffbc9af9581b538988d355168.

This commit disables continuous splash on SoMC Tama Akatsuki.
Reverting it brings cont splash back!

Tested on SoMC SDM845 Tama Akatsuki RoW.