### PR TITLE
 [7.1.r1] Fixes: Override panel current to 10mA for akatsuki

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-akatsuki_common.dtsi
@@ -345,6 +345,13 @@
 	status = "disabled";
 };
 
+&pmi8998_lsid1 {
+	qcom,leds-xboot@d800 {
+		/* Xboot splash */
+		somc,init-br-ua = <10000>;
+	};
+};
+
 &synaptics_clearpad {
 	status = "disabled";
 };


### PR DESCRIPTION
We could override the panel current on XZ3, but this commit needs to be tested. I'm  not sure if it works fine.
#2263 