### PR TITLE
[7.1.r1] [URGENT] drm: msm: somc_panel: Remove DMS internal mode flag after switching

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -7466,6 +7466,9 @@ int dsi_display_enable(struct dsi_display *display)
 	 * resource init and hence we return early
 	 */
 	if (display->is_cont_splash_enabled) {
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+		struct dsi_display_mode *adj_mode = NULL;
+#endif
 
 		dsi_display_config_ctrl_for_cont_splash(display);
 
@@ -7520,6 +7523,24 @@ int dsi_display_enable(struct dsi_display *display)
 				display->name, rc);
 			return rc;
 		}
+
+		/*
+		 * Find the entry for the current DRM mode structure:
+		 * beware that panel->cur_mode is only an internal cache.
+		 */
+		rc = dsi_display_find_mode(display, mode, &adj_mode);
+		if (unlikely(rc)) {
+			pr_err("[%s] This is impossible! Can't find mode!\n",
+				__func__);
+			return rc;
+		}
+
+		/* Reset the splash_dms flag: we're out of cont splash now */
+		adj_mode->splash_dms = false;
+
+		/* Remove the DMS flag, since we have already switched */
+		adj_mode->dsi_mode_flags &= ~DSI_MODE_FLAG_DMS;
+
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 		return 0;
 	}


### PR DESCRIPTION
After switching to the target resolution remove the DMS mode
flag, otherwise we stay in a weird limbo that is "waiting" for
the modeset to happen, even though it's happened already:
this causes the DRM/MSM code to ignore every panel DPMS
requests, including all the LP states and even DPMS_ON/DPMS_OFF,
keeping the panel constantly powered on and the entire DSI up,
wasting precious energy when totally not required.

Removing this flag cleans up the state and gets us back to the
regular power management functionality of the panel, now being
able to receive again the DPMS events - including AoD.

Tested on SoMC SM8150 Kumano Griffin DSDS.