### PR TITLE
arm64: DT: SDM660-vidc: Use less IOMMUs for secure pixel cb

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-vidc.dtsi
@@ -239,9 +239,9 @@
 			compatible = "qcom,msm-vidc,context-bank";
 			label = "venus_sec_pixel";
 			iommus = <&mmss_bimc_smmu 0x504>,
-				<&mmss_bimc_smmu 0x50c>,
-				<&mmss_bimc_smmu 0x510>,
-				<&mmss_bimc_smmu 0x52c>;
+				<&mmss_bimc_smmu 0x50c>;
+//				<&mmss_bimc_smmu 0x510>,
+//				<&mmss_bimc_smmu 0x52c>;
 			buffer-types = <0x106>;
 			virtual-addr-pool = <0x29000000 0x28000000>;
 			qcom,secure-context-bank;


### PR DESCRIPTION
Use less contexts for the secure pixel context bank to behave
to the limit imposed by the IOMMU configuration.

Using more register groups is bad for many reasons, much much
more important than a probe failure.

Based on the same commit for MSM8996: bd2a67217e757ed152786b42c21077be8d990ce7

---
This fixes the following error observed when trying to take a picture on the Camera1 API on Ganges:
```[ 1174.379894] msm_cam_smmu soc:qcom,cam_smmu:msm_cam_smmu_cb5: No iommu associated with device
[ 1174.380090] CAM-SMMU cam_smmu_attach_device:535 Error: ARM IOMMU attach failed. ret = -22
[ 1174.380226] CAM-SMMU cam_smmu_attach:770 Error: ATTACH fail
[ 1174.380304] msm_jpegdma caa0000.qcom,jpeg: Can not attach smmu.
[ 1174.380475] msm_jpegdma caa0000.qcom,jpeg: QBuf fail```