### PR TITLE
[LA.UM.7.1.r1]trinket.dtsi: Fix a typo

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket.dtsi
@@ -420,7 +420,7 @@
 			fstab {
 				compatible = "android,fstab";
 				vendor {
-					compatble = "android,vendor";
+					compatible = "android,vendor";
 					dev = "/dev/block/platform/soc/4804000.ufshc/by-name/vendor";
 					type = "ext4";
 					mnt_flags = "ro,barrier=1,discard";


### PR DESCRIPTION
This would cause issues later on. 
This got introduced in 3eb18474c6405b652fbbe3779021f3b5ae0a4b4c.
Qcom typo :O
Thanks for @ix5 for pointing me here.