### PR TITLE
[KERNEL/7.1.r1] scripts: dtbo: Fixup test script path for out-of-tree builds

### DIFF
--- a/scripts/Makefile.dtbo
+++ b/scripts/Makefile.dtbo
@@ -8,7 +8,7 @@ dtbo-base	:= $(addprefix $(obj)/,$(dtbo-base))
 dtbo	:= $(addprefix $(obj)/,$(dtbo))
 
 ifeq ($(CONFIG_DTC_OVERLAY_TEST_ENABLED),y)
-DTC_OVERLAY_TEST = scripts/ufdt_apply_overlay.bin
+DTC_OVERLAY_TEST = $(srctree)/scripts/ufdt_apply_overlay.bin
 quiet_cmd_dtbo_verify	= VERIFY  $@
 cmd_dtbo_verify = $(foreach m,\
 	$(addprefix $(obj)/,$($(@F)-base)),\


### PR DESCRIPTION
When building out of tree the command passed to cmd_dtbo_verify runs
with that output directory as PWD while the script remains in the source
directory. Prefix it with $(srctree) to fix scenario:

      VERIFY  arch/arm64/boot/dts/qcom/trinket-seine-pdx201_generic-overlay.dtbo
    /bin/sh: scripts/ufdt_apply_overlay.bin: No such file or directory
    make[3]: *** [scripts/Makefile.dtbo:29: arch/arm64/boot/dts/qcom/trinket-seine-pdx201_generic-overlay.dtbo] Error 127

I am fully aware that this is just a test script which'll likely be disabled from defconfig in the very near future, when Seine DT stabilizes. However, let's do our current and future selves a favour.