### PR TITLE
[7.1.r1] IIO/ADC5 fixes for SM6125, touchscreen fixes for Seine

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/qcom,spmi-adc5.txt
+++ b/Documentation/devicetree/bindings/iio/adc/qcom,spmi-adc5.txt
@@ -125,6 +125,17 @@ Channel node properties:
             Valid values are: 1, 2, 4, 8, 16
             If property is not found, 1 sample will be used.
 
+- qcom,lut-index:
+    Usage: optional
+    Value type: <u32>
+    Definition: Lookup table index (only for bat_therm channels).
+            A bat_therm channel (for 30k, 100k or 400k pull-up resistance)
+            requires a voltage-temperature look-up table which depends on the target.
+            The LUT to be used for a channel is selected from a table of LUTs
+            for that particular channel.
+            If property is not found, a default LUT is used for that channel,
+            corresponding to index 0.
+
 Example:
 
         /* VADC node */

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -105,6 +105,10 @@
 		sec,aod_mode_supported = <1>;
 		sec,sod_mode_supported = <1>;
 		sec,stamina_mode_supported = <1>;
+
+		/* Open Devices specific */
+		somc,touch-rst-gpio = <&tlmm 54 0>;
+		somc,expected-device-id = <0xAC 0x37 0x71>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/trinket-seine-touch.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-touch.dtsi
@@ -39,5 +39,9 @@
 		sec,stamina_mode_supported = <1>;
 		sec,rejection_area_portrait = <25 150 60 200>;
 		sec,rejection_area_landscape = <150 20 200 60>;
+
+		/* Open Devices specific */
+		somc,touch-rst-gpio = <&tlmm 97 0>;
+		somc,expected-device-id = <0xAC 0x37 0x61>;
 	};
 };

--- a/drivers/iio/adc/qcom-spmi-adc5.c
+++ b/drivers/iio/adc/qcom-spmi-adc5.c
@@ -134,6 +134,8 @@ struct adc_channel_prop {
 	unsigned int			prescale;
 	unsigned int			hw_settle_time;
 	unsigned int			avg_samples;
+	/*lut_index is used only for bat_therm LUTs*/
+	unsigned int			lut_index;
 	enum vadc_scale_fn_type		scale_fn_type;
 	const char			*datasheet_name;
 };
@@ -625,7 +627,7 @@ static int adc_read_raw(struct iio_dev *indio_dev,
 		if ((chan->type == IIO_VOLTAGE) || (chan->type == IIO_TEMP))
 			ret = qcom_vadc_hw_scale(prop->scale_fn_type,
 				&adc_prescale_ratios[prop->prescale],
-				adc->data,
+				adc->data, prop->lut_index,
 				adc_code_volt, val);
 		if (ret)
 			break;
@@ -633,14 +635,14 @@ static int adc_read_raw(struct iio_dev *indio_dev,
 		if (chan->type == IIO_POWER) {
 			ret = qcom_vadc_hw_scale(SCALE_HW_CALIB_DEFAULT,
 				&adc_prescale_ratios[VADC_DEF_VBAT_PRESCALING],
-				adc->data,
+				adc->data, prop->lut_index,
 				adc_code_volt, val);
 			if (ret)
 				break;
 
 			ret = qcom_vadc_hw_scale(prop->scale_fn_type,
 				&adc_prescale_ratios[prop->prescale],
-				adc->data,
+				adc->data, prop->lut_index,
 				adc_code_cur, val2);
 			if (ret)
 				break;
@@ -762,6 +764,10 @@ static const struct adc_channels adc_chans_pmic5[ADC_MAX_CHANNEL] = {
 					SCALE_HW_CALIB_PM5_SMB_TEMP)
 	[ADC_GPIO1_PU2]	= ADC_CHAN_TEMP("gpio1_pu2", 1,
 					SCALE_HW_CALIB_THERM_100K_PULLUP)
+	[ADC_GPIO2_PU2]	= ADC_CHAN_TEMP("gpio2_pu2", 1,
+					SCALE_HW_CALIB_THERM_100K_PULLUP)
+	[ADC_GPIO3_PU2]	= ADC_CHAN_TEMP("gpio3_pu2", 1,
+					SCALE_HW_CALIB_THERM_100K_PULLUP)
 	[ADC_GPIO4_PU2]	= ADC_CHAN_TEMP("gpio4_pu2", 1,
 					SCALE_HW_CALIB_THERM_100K_PULLUP)
 };
@@ -871,6 +877,12 @@ static int adc_get_dt_channel_data(struct device *dev,
 	} else {
 		prop->avg_samples = VADC_DEF_AVG_SAMPLES;
 	}
+
+	prop->lut_index = VADC_DEF_LUT_INDEX;
+
+	ret = of_property_read_u32(node, "qcom,lut-index", &value);
+	if (!ret)
+		prop->lut_index = value;
 
 	if (of_property_read_bool(node, "qcom,ratiometric"))
 		prop->cal_method = ADC_RATIOMETRIC_CAL;

--- a/drivers/iio/adc/qcom-spmi-adc5.c
+++ b/drivers/iio/adc/qcom-spmi-adc5.c
@@ -1034,7 +1034,7 @@ static int adc_probe(struct platform_device *pdev)
 	revid_dev_node = of_parse_phandle(node, "qcom,pmic-revid", 0);
 	if (revid_dev_node) {
 		pmic_rev_id = get_revid_data(revid_dev_node);
-		if (!(IS_ERR(pmic_rev_id)))
+		if (!(IS_ERR_OR_NULL(pmic_rev_id)))
 			skip_usb_wa = skip_usb_in_wa(pmic_rev_id);
 		else {
 			pr_err("Unable to get revid\n");

--- a/drivers/iio/adc/qcom-vadc-common.c
+++ b/drivers/iio/adc/qcom-vadc-common.c
@@ -166,6 +166,83 @@ static const struct vadc_map_pt adcmap_batt_therm_100k[] = {
 };
 
 /*
+ * Voltage to temperature table for 100k pull up for bat_therm with
+ * MLP356477.
+ */
+static const struct vadc_map_pt adcmap_batt_therm_100k_6125[] = {
+	{1770,	-400},
+	{1757,	-380},
+	{1743,	-360},
+	{1727,	-340},
+	{1710,	-320},
+	{1691,	-300},
+	{1671,	-280},
+	{1650,	-260},
+	{1627,	-240},
+	{1602,	-220},
+	{1576,	-200},
+	{1548,	-180},
+	{1519,	-160},
+	{1488,	-140},
+	{1456,	-120},
+	{1423,	-100},
+	{1388,	-80},
+	{1353,	-60},
+	{1316,	-40},
+	{1278,	-20},
+	{1240,	0},
+	{1201,	20},
+	{1162,	40},
+	{1122,	60},
+	{1082,	80},
+	{1042,	100},
+	{1003,	120},
+	{964,	140},
+	{925,	160},
+	{887,	180},
+	{849,	200},
+	{812,	220},
+	{777,	240},
+	{742,	260},
+	{708,	280},
+	{675,	300},
+	{643,	320},
+	{613,	340},
+	{583,	360},
+	{555,	380},
+	{528,	400},
+	{502,	420},
+	{477,	440},
+	{453,	460},
+	{430,	480},
+	{409,	500},
+	{388,	520},
+	{369,	540},
+	{350,	560},
+	{333,	580},
+	{316,	600},
+	{300,	620},
+	{285,	640},
+	{271,	660},
+	{257,	680},
+	{245,	700},
+	{233,	720},
+	{221,	740},
+	{210,	760},
+	{200,	780},
+	{190,	800},
+	{181,	820},
+	{173,	840},
+	{164,	860},
+	{157,	880},
+	{149,	900},
+	{142,	920},
+	{136,	940},
+	{129,	960},
+	{124,	980},
+};
+
+/*
  * Voltage to temperature table for 30k pull up for bat_therm with
  * Alium.
  */
@@ -243,6 +320,83 @@ static const struct vadc_map_pt adcmap_batt_therm_30k[] = {
 };
 
 /*
+ * Voltage to temperature table for 30k pull up for bat_therm with
+ * MLP356477.
+ */
+static const struct vadc_map_pt adcmap_batt_therm_30k_6125[] = {
+	{1842,	-400},
+	{1838,	-380},
+	{1833,	-360},
+	{1828,	-340},
+	{1822,	-320},
+	{1816,	-300},
+	{1809,	-280},
+	{1801,	-260},
+	{1793,	-240},
+	{1784,	-220},
+	{1774,	-200},
+	{1763,	-180},
+	{1752,	-160},
+	{1739,	-140},
+	{1726,	-120},
+	{1712,	-100},
+	{1697,	-80},
+	{1680,	-60},
+	{1663,	-40},
+	{1645,	-20},
+	{1625,	0},
+	{1605,	20},
+	{1583,	40},
+	{1561,	60},
+	{1537,	80},
+	{1513,	100},
+	{1487,	120},
+	{1461,	140},
+	{1433,	160},
+	{1405,	180},
+	{1376,	200},
+	{1347,	220},
+	{1316,	240},
+	{1286,	260},
+	{1254,	280},
+	{1223,	300},
+	{1191,	320},
+	{1159,	340},
+	{1126,	360},
+	{1094,	380},
+	{1062,	400},
+	{1029,	420},
+	{997,	440},
+	{966,	460},
+	{934,	480},
+	{903,	500},
+	{873,	520},
+	{843,	540},
+	{813,	560},
+	{784,	580},
+	{756,	600},
+	{728,	620},
+	{702,	640},
+	{675,	660},
+	{650,	680},
+	{625,	700},
+	{601,	720},
+	{578,	740},
+	{556,	760},
+	{534,	780},
+	{513,	800},
+	{493,	820},
+	{474,	840},
+	{455,	860},
+	{437,	880},
+	{420,	900},
+	{403,	920},
+	{387,	940},
+	{372,	960},
+	{357,	980},
+};
+
+/*
  * Voltage to temperature table for 400k pull up for bat_therm with
  * Alium.
  */
@@ -317,6 +471,103 @@ static const struct vadc_map_pt adcmap_batt_therm_400k[] = {
 	{32,	940},
 	{30,	960},
 	{28,	980}
+};
+
+/*
+ * Voltage to temperature table for 400k pull up for bat_therm with
+ * MLP356477.
+ */
+static const struct vadc_map_pt adcmap_batt_therm_400k_6125[] = {
+	{1516,	-400},
+	{1478,	-380},
+	{1438,	-360},
+	{1396,	-340},
+	{1353,	-320},
+	{1307,	-300},
+	{1261,	-280},
+	{1213,	-260},
+	{1164,	-240},
+	{1115,	-220},
+	{1066,	-200},
+	{1017,	-180},
+	{968,	-160},
+	{920,	-140},
+	{872,	-120},
+	{826,	-100},
+	{781,	-80},
+	{737,	-60},
+	{694,	-40},
+	{654,	-20},
+	{615,	0},
+	{578,	20},
+	{542,	40},
+	{509,	60},
+	{477,	80},
+	{447,	100},
+	{419,	120},
+	{392,	140},
+	{367,	160},
+	{343,	180},
+	{321,	200},
+	{301,	220},
+	{282,	240},
+	{264,	260},
+	{247,	280},
+	{231,	300},
+	{216,	320},
+	{203,	340},
+	{190,	360},
+	{178,	380},
+	{167,	400},
+	{157,	420},
+	{147,	440},
+	{138,	460},
+	{130,	480},
+	{122,	500},
+	{115,	520},
+	{108,	540},
+	{102,	560},
+	{96,	580},
+	{90,	600},
+	{85,	620},
+	{80,	640},
+	{76,	660},
+	{72,	680},
+	{68,	700},
+	{64,	720},
+	{61,	740},
+	{57,	760},
+	{54,	780},
+	{52,	800},
+	{49,	820},
+	{46,	840},
+	{44,	860},
+	{42,	880},
+	{40,	900},
+	{38,	920},
+	{36,	940},
+	{34,	960},
+	{32,	980},
+};
+
+struct lut_table {
+	const struct vadc_map_pt *table;
+	u32 tablesize;
+};
+
+static const struct lut_table lut_table_30[] = {
+	{adcmap_batt_therm_30k,	ARRAY_SIZE(adcmap_batt_therm_30k)},
+	{adcmap_batt_therm_30k_6125, ARRAY_SIZE(adcmap_batt_therm_30k_6125)},
+};
+
+static const struct lut_table lut_table_100[] = {
+	{adcmap_batt_therm_100k, ARRAY_SIZE(adcmap_batt_therm_100k)},
+	{adcmap_batt_therm_100k_6125, ARRAY_SIZE(adcmap_batt_therm_100k_6125)},
+};
+
+static const struct lut_table lut_table_400[] = {
+	{adcmap_batt_therm_400k, ARRAY_SIZE(adcmap_batt_therm_400k)},
+	{adcmap_batt_therm_400k_6125, ARRAY_SIZE(adcmap_batt_therm_400k_6125)},
 };
 
 static int qcom_vadc_map_voltage_temp(const struct vadc_map_pt *pts,
@@ -512,11 +763,18 @@ static int qcom_vadc_scale_hw_calib_therm(
 static int qcom_vadc_scale_hw_calib_batt_therm_100(
 				const struct vadc_prescale_ratio *prescale,
 				const struct adc_data *data,
+				unsigned int lut_index,
 				u16 adc_code, int *result_mdec)
 {
 	s64 voltage = 0, result = 0, adc_vdd_ref_mv = 1875;
 	int ret;
+	u32 size;
+	const struct vadc_map_pt *lut;
 
+	if (lut_index >= ARRAY_SIZE(lut_table_100)) {
+		pr_err("LUT index out of range\n");
+		return -EINVAL;
+	}
 	if (adc_code > VADC5_MAX_CODE)
 		adc_code = 0;
 
@@ -524,9 +782,12 @@ static int qcom_vadc_scale_hw_calib_batt_therm_100(
 	voltage = (s64) adc_code * adc_vdd_ref_mv * 1000;
 	voltage = div64_s64(voltage, (data->full_scale_code_volt
 								* 1000));
-	ret = qcom_vadc_map_voltage_temp(adcmap_batt_therm_100k,
-				 ARRAY_SIZE(adcmap_batt_therm_100k),
-				 voltage, &result);
+
+	lut = lut_table_100[lut_index].table;
+	size = lut_table_100[lut_index].tablesize;
+
+	ret = qcom_vadc_map_voltage_temp(lut, size, voltage, &result);
+
 	if (ret)
 		return ret;
 
@@ -538,11 +799,18 @@ static int qcom_vadc_scale_hw_calib_batt_therm_100(
 static int qcom_vadc_scale_hw_calib_batt_therm_30(
 				const struct vadc_prescale_ratio *prescale,
 				const struct adc_data *data,
+				unsigned int lut_index,
 				u16 adc_code, int *result_mdec)
 {
 	s64 voltage = 0, result = 0, adc_vdd_ref_mv = 1875;
 	int ret;
+	u32 size;
+	const struct vadc_map_pt *lut;
 
+	if (lut_index >= ARRAY_SIZE(lut_table_30)) {
+		pr_err("LUT index out of range\n");
+		return -EINVAL;
+	}
 	if (adc_code > VADC5_MAX_CODE)
 		adc_code = 0;
 
@@ -550,9 +818,12 @@ static int qcom_vadc_scale_hw_calib_batt_therm_30(
 	voltage = (s64) adc_code * adc_vdd_ref_mv * 1000;
 	voltage = div64_s64(voltage, (data->full_scale_code_volt
 								* 1000));
-	ret = qcom_vadc_map_voltage_temp(adcmap_batt_therm_30k,
-				 ARRAY_SIZE(adcmap_batt_therm_30k),
-				 voltage, &result);
+
+	lut = lut_table_30[lut_index].table;
+	size = lut_table_30[lut_index].tablesize;
+
+	ret = qcom_vadc_map_voltage_temp(lut, size, voltage, &result);
+
 	if (ret)
 		return ret;
 
@@ -564,11 +835,18 @@ static int qcom_vadc_scale_hw_calib_batt_therm_30(
 static int qcom_vadc_scale_hw_calib_batt_therm_400(
 				const struct vadc_prescale_ratio *prescale,
 				const struct adc_data *data,
+				unsigned int lut_index,
 				u16 adc_code, int *result_mdec)
 {
 	s64 voltage = 0, result = 0, adc_vdd_ref_mv = 1875;
 	int ret;
+	u32 size;
+	const struct vadc_map_pt *lut;
 
+	if (lut_index >= ARRAY_SIZE(lut_table_400)) {
+		pr_err("LUT index out of range\n");
+		return -EINVAL;
+	}
 	if (adc_code > VADC5_MAX_CODE)
 		adc_code = 0;
 
@@ -576,9 +854,12 @@ static int qcom_vadc_scale_hw_calib_batt_therm_400(
 	voltage = (s64) adc_code * adc_vdd_ref_mv * 1000;
 	voltage = div64_s64(voltage, (data->full_scale_code_volt
 								* 1000));
-	ret = qcom_vadc_map_voltage_temp(adcmap_batt_therm_400k,
-				 ARRAY_SIZE(adcmap_batt_therm_400k),
-				 voltage, &result);
+
+	lut = lut_table_400[lut_index].table;
+	size = lut_table_400[lut_index].tablesize;
+
+	ret = qcom_vadc_map_voltage_temp(lut, size, voltage, &result);
+
 	if (ret)
 		return ret;
 
@@ -730,7 +1011,7 @@ EXPORT_SYMBOL(qcom_vadc_scale);
 
 int qcom_vadc_hw_scale(enum vadc_scale_fn_type scaletype,
 		    const struct vadc_prescale_ratio *prescale,
-		    const struct adc_data *data,
+		    const struct adc_data *data, unsigned int lut_index,
 		    u16 adc_code, int *result)
 {
 	switch (scaletype) {
@@ -743,13 +1024,13 @@ int qcom_vadc_hw_scale(enum vadc_scale_fn_type scaletype,
 						adc_code, result);
 	case SCALE_HW_CALIB_BATT_THERM_100K:
 		return qcom_vadc_scale_hw_calib_batt_therm_100(prescale,
-						data, adc_code, result);
+					data, lut_index, adc_code, result);
 	case SCALE_HW_CALIB_BATT_THERM_30K:
 		return qcom_vadc_scale_hw_calib_batt_therm_30(prescale,
-						data, adc_code, result);
+					data, lut_index, adc_code, result);
 	case SCALE_HW_CALIB_BATT_THERM_400K:
 		return qcom_vadc_scale_hw_calib_batt_therm_400(prescale,
-						data, adc_code, result);
+					data, lut_index, adc_code, result);
 	case SCALE_HW_CALIB_PMIC_THERM:
 		return qcom_vadc_scale_hw_calib_die_temp(prescale, data,
 						adc_code, result);

--- a/drivers/iio/adc/qcom-vadc-common.h
+++ b/drivers/iio/adc/qcom-vadc-common.h
@@ -25,6 +25,8 @@
 #define VADC_DEF_CALIB_TYPE			VADC_CALIB_ABSOLUTE
 #define VADC_DEF_VBAT_PRESCALING		1 /* 1:3 */
 
+#define VADC_DEF_LUT_INDEX			0 /* Default or no LUT used */
+
 #define VADC_DECIMATION_MIN			512
 #define VADC_DECIMATION_MAX			4096
 #define ADC5_DECIMATION_SHORT			250
@@ -164,7 +166,7 @@ int qcom_vadc_scale(enum vadc_scale_fn_type scaletype,
 
 int qcom_vadc_hw_scale(enum vadc_scale_fn_type scaletype,
 		    const struct vadc_prescale_ratio *prescale,
-		    const struct adc_data *data,
+		    const struct adc_data *data, unsigned int lut_index,
 		    u16 adc_code, int *result_mdec);
 
 int qcom_vadc_decimation_from_dt(u32 value);

--- a/drivers/input/touchscreen/sec_ts/include/sec_ts.h
+++ b/drivers/input/touchscreen/sec_ts/include/sec_ts.h
@@ -830,6 +830,8 @@ struct sec_ts_plat_data {
 	int bringup;
 	int mis_cal_check;
 
+	unsigned int touch_rst_gpio;
+
 	const char *firmware_name;
 	const char *model_name;
 	const char *project_name;
@@ -843,6 +845,7 @@ struct sec_ts_plat_data {
 	u8 config_version_of_bin[4];
 	u8 img_version_of_ic[4];
 	u8 img_version_of_bin[4];
+	u32 expected_device_id[3];
 
 	struct pinctrl *pinctrl;
 

--- a/drivers/input/touchscreen/sec_ts/include/sec_ts.h
+++ b/drivers/input/touchscreen/sec_ts/include/sec_ts.h
@@ -326,12 +326,6 @@
 #define AOD_MODE_DOUBLE_TAP	2
 #define MAX_PRESSURE	255
 
-/* Watchdog */
-#define DEVICE_ID_0	0xAC
-#define DEVICE_ID_1	0x37
-#define DEVICE_ID_2	0x71
-#define RESET_GPIO	54
-
 /*
  * sec Log
  */

--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -1609,11 +1609,13 @@ static void sec_ts_watchdog_func(struct work_struct *work_watchdog)
 		goto unlock;
 	}
 
-	if (deviceId[0] != DEVICE_ID_0 || deviceId[1] != DEVICE_ID_1 || deviceId[2] != DEVICE_ID_2) {
+	if (deviceId[0] != ts->plat_data->expected_device_id[0] ||
+	    deviceId[1] != ts->plat_data->expected_device_id[1] ||
+	    deviceId[2] != ts->plat_data->expected_device_id[2]) {
 		input_err(true, &ts->client->dev, "improper device id\n");
-		gpio_set_value(RESET_GPIO, 0);
+		gpio_set_value(ts->plat_data->touch_rst_gpio, 0);
 		mdelay(5);
-		gpio_set_value(RESET_GPIO, 1);
+		gpio_set_value(ts->plat_data->touch_rst_gpio, 1);
 		mdelay(200);
 	}
 


### PR DESCRIPTION
This patchset brings full thermal sensors reading (and other ADC) on
the Seine platform and enables touchscreen avoiding the OCP
condition when the sec_ts driver tries to reset the TS.
