### PR TITLE
[LA.UM.7.1] drivers: regulator: implement debug suspend

### DIFF
--- a/drivers/cpuidle/lpm-levels.c
+++ b/drivers/cpuidle/lpm-levels.c
@@ -51,6 +51,7 @@
 #define CREATE_TRACE_POINTS
 #include <trace/events/trace_msm_low_power.h>
 #include <linux/arm-smccc.h>
+#include <linux/regulator/machine.h>
 
 #define SCLK_HZ (32768)
 #define PSCI_POWER_STATE(reset) (reset << 30)
@@ -1108,9 +1109,10 @@ static int cluster_configure(struct lpm_cluster *cluster, int idx,
 		 * clocks that are enabled and preventing the system level
 		 * LPMs(XO and Vmin).
 		 */
-		if (!from_idle)
+		if (!from_idle) {
 			clock_debug_print_enabled(true);
-
+			regulator_debug_suspend();
+		}
 		cpu = get_next_online_cpu(from_idle);
 		cpumask_copy(&cpumask, cpumask_of(cpu));
 		clear_predict_history();

--- a/include/linux/regulator/machine.h
+++ b/include/linux/regulator/machine.h
@@ -227,6 +227,7 @@ struct regulator_init_data {
 void regulator_has_full_constraints(void);
 int regulator_suspend_prepare(suspend_state_t state);
 int regulator_suspend_finish(void);
+void regulator_debug_suspend(void);
 #else
 static inline void regulator_has_full_constraints(void)
 {
@@ -238,6 +239,9 @@ static inline int regulator_suspend_prepare(suspend_state_t state)
 static inline int regulator_suspend_finish(void)
 {
 	return 0;
+}
+static inline void regulator_debug_suspend(void)
+{
 }
 #endif
 


### PR DESCRIPTION
The clock framework has support for debugging clocks during suspend.
Implement similar debugging for regulators.