### PR TITLE
[LA.UM.7.1.r1] arm64: DT: Seine: Correct bootloader-panel-detect

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket-seine-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-display.dtsi
@@ -58,7 +58,7 @@
 					 "shadow_byte_clk0", "shadow_pixel_clk0";
 
 		/* Only one possible panel on CDB/PROD SoMC Seine platform */
-		somc,bootloader-panel-select;
+		somc,bootloader-panel-detect;
 
 		/* This is the active display node */
 		qcom,dsi-display-active;


### PR DESCRIPTION
The driver looks for `somc,bootloader-panel-detect`. Correct this typo.