### PR TITLE
[7.1.r1] Revert "arm64: DT: Yoshino: Globally disable continuous splash feature"

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
@@ -76,3 +76,25 @@
 		/delete-node/ 4k60;
 	};
 };
+
+&sde_dsi0 {
+	/delete-property/ qcom,cont-splash-enabled;
+};
+
+&mdss_mdp {
+	/delete-property/ compatible;
+	/delete-property/ reg;
+	/delete-property/ reg-names;
+};
+
+&mdss_dsi {
+	/delete-property/ compatible;
+};
+
+&mdss_dsi0 {
+	/delete-property/ label;
+};
+
+&mdss_dsi1 {
+	/delete-property/ label;
+};

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -153,27 +153,12 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 	status = "disabled";
 };
 
+&sde_dsi0 {
+	qcom,cont-splash-enabled;
+};
+
 &sde_kms {
 	/* Set SDE MAX performance */
 	qcom,sde-perf-default-mode = <3>;
 	connectors = <&sde_wb &dsi_panel_cmd_display>;
 };
-
-&mdss_mdp {
-        /delete-property/ compatible;
-        /delete-property/ reg;
-        /delete-property/ reg-names;
-};
-
-&mdss_dsi {
-        /delete-property/ compatible;
-};
-
-&mdss_dsi0 {
-        /delete-property/ label;
-};
-
-&mdss_dsi1 {
-        /delete-property/ label;
-};
-


### PR DESCRIPTION
Since with this commit, yoshino lilac is unable to reactivate the panel
once it went off for more than ~5sec it has been reverted. As soon as
the root cause has been found and the underlying problem has been fixed
this revert should be reverted.

This reverts commit b71379c4717912dd945637291217aa438d5b71d2.

For further details, see as well https://github.com/sonyxperiadev/bug_tracker/issues/590