### PR TITLE
[7.1.r1] Update Samsung TS driver and add PON support for Seine

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
@@ -59,7 +59,7 @@
 		record-size = <0x1000>;
 		console-size = <0x40000>;
 		ftrace-size = <0x0>;
-		msg-size = <0x20000 0x20000>;
+		pmsg-size = <0x20000 0x20000>;
 		ecc-size = <16>;
 	};
 

--- a/arch/arm64/boot/dts/qcom/trinket-seine-touch.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-touch.dtsi
@@ -12,6 +12,8 @@
 
 &qupv3_se2_i2c {
 	status = "ok";
+	qcom,i2c-touch-active="sec,sec_ts";
+
 	touchscreen@48 {
 		compatible = "sec,sec_ts";
 		reg = <0x48>;

--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -2077,7 +2077,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	input_log_fix();
 
 	ts->after_work.err = true;
-	schedule_delayed_work(&ts->after_work.start, msecs_to_jiffies(10000));
+	schedule_delayed_work(&ts->after_work.start, msecs_to_jiffies(12000));
 
 	return 0;
 
@@ -2463,7 +2463,7 @@ after_work_fail:
 	}
 userspace_not_ready:
 	input_info(true, &ts->client->dev, "retry after_work [%d]\n", ts->after_work.retry);
-	schedule_delayed_work(&ts->after_work.start, 1 * HZ);
+	schedule_delayed_work(&ts->after_work.start, 3 * HZ);
 out:
 	return;
 }

--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -1776,7 +1776,6 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 		sec_ts_delay(ts->plat_data->ack_wait_time);
 	}
 
-	input_info(true, &ts->client->dev, "%s: ts = %s SEC_TS_READ_DEVICE_ID = %d deviceID = %d\n", __func__, ts, SEC_TS_READ_DEVICE_ID, deviceID);
 	ret = sec_ts_i2c_read(ts, SEC_TS_READ_DEVICE_ID, deviceID, 5);
 	if (ret < 0)
 		input_err(true, &ts->client->dev, "%s: failed to read device ID(%d)\n", __func__, ret);

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -55,10 +55,11 @@
 #endif
 #if defined(CONFIG_ARCH_SONY_YOSHINO) || defined(CONFIG_ARCH_SONY_NILE) || \
     defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_GANGES) || \
-    defined(CONFIG_ARCH_SONY_KUMANO)
+    defined(CONFIG_ARCH_SONY_KUMANO) || defined(CONFIG_ARCH_SONY_SEINE)
  #define TARGET_SOMC_XBOOT
 #if defined(CONFIG_ARCH_SONY_NILE) || defined(CONFIG_ARCH_SONY_TAMA) || \
-    defined(CONFIG_ARCH_SONY_GANGES) || defined(CONFIG_ARCH_SONY_KUMANO)
+    defined(CONFIG_ARCH_SONY_GANGES) || defined(CONFIG_ARCH_SONY_KUMANO) || \
+    defined(CONFIG_ARCH_SONY_SEINE)
  #define TARGET_SOMC_XBOOT_FEATURE_AB
 #endif
 #endif

--- a/include/linux/input/qpnp-power-on.h
+++ b/include/linux/input/qpnp-power-on.h
@@ -55,7 +55,7 @@ enum pon_power_off_type {
 
 #if defined(CONFIG_ARCH_SONY_YOSHINO) || defined(CONFIG_ARCH_SONY_NILE) || \
     defined(CONFIG_ARCH_SONY_TAMA) || defined(CONFIG_ARCH_SONY_GANGES) || \
-    defined(CONFIG_ARCH_SONY_KUMANO)
+    defined(CONFIG_ARCH_SONY_KUMANO) || defined(CONFIG_ARCH_SONY_SEINE)
 enum pon_restart_reason {
 	PON_RESTART_REASON_NONE			= 0x00,
 	PON_RESTART_REASON_UNKNOWN		= 0x01,


### PR DESCRIPTION
This patchset updates the Samsung touchscreen driver to get compatible with
the latest bits for Seine.
Also, fix the msm-poweroff support for the Seine platform, so that we can
finally get a decent pstore :)))

Tested on SoMC Kumano Griffin DSDS.