### PR TITLE
[7.1.r1] Ganges secondary cameras fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
@@ -183,8 +183,8 @@
 					  "CAM_VDIG",
 					  "CAM_VANA",
 					  "CAM_VIO";
-		qcom,sensor-position = <1>;
-		qcom,sensor-mode = <1>;
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
 		qcom,cci-master = <1>;
 		status = "ok";
 		clocks = <&clock_mmss MCLK3_CLK_SRC>,

--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
@@ -252,8 +252,8 @@
 		qcom,hw-tsu-sta = <18>;
 		qcom,hw-thd-dat = <16>;
 		qcom,hw-thd-sta = <15>;
-		qcom,hw-tbuf = <19>;
-		qcom,hw-scl-stretch-en = <1>;
+		qcom,hw-tbuf = <24>;
+		qcom,hw-scl-stretch-en = <0>;
 		qcom,hw-trdhld = <3>;
 		qcom,hw-tsp = <3>;
 		qcom,cci-clk-src = <37500000>;

--- a/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
@@ -184,8 +184,8 @@
 					  "CAM_VDIG",
 					  "CAM_VANA",
 					  "CAM_VIO";
-		qcom,sensor-position = <1>;
-		qcom,sensor-mode = <1>;
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
 		qcom,cci-master = <1>;
 		status = "ok";
 		clocks = <&clock_mmss MCLK3_CLK_SRC>,

--- a/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
@@ -253,8 +253,8 @@
 		qcom,hw-tsu-sta = <18>;
 		qcom,hw-thd-dat = <16>;
 		qcom,hw-thd-sta = <15>;
-		qcom,hw-tbuf = <19>;
-		qcom,hw-scl-stretch-en = <1>;
+		qcom,hw-tbuf = <24>;
+		qcom,hw-scl-stretch-en = <0>;
 		qcom,hw-trdhld = <3>;
 		qcom,hw-tsp = <3>;
 		qcom,cci-clk-src = <37500000>;


### PR DESCRIPTION
This PR includes few changes.
Lets change fast_plus to the values from stock. They are nearly the same just some improvements.
And change the location and sensor mode of the secondary camera dts node.