### PR TITLE
[7.1.r1] arm64: DT: Seine: Fix audio related pinctrl configuration

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
@@ -245,253 +245,28 @@
 		};
 	};
 
-	pri_i2s_sck_ws {
-		pri_i2s_sck_sleep: pri_i2s_sck_sleep {
-			mux {
-				pins = "gpio113";
-				function = "pri_mi2s";
-			};
-
-				config {
-				pins = "gpio113";
-				drive-strength = <2>; /* 2 mA */
-			};
-		};
-
-		pri_i2s_sck_active: pri_i2s_sck_active {
-			mux {
-				pins = "gpio113";
-				function = "pri_mi2s";
-			};
-
-			config {
-				pins = "gpio113";
-				drive-strength = <2>; /* 2 mA */
-				bias-disable;
-				output-low;
-			};
-		};
-
-		pri_i2s_ws_sleep: pri_i2s_ws_sleep {
-			mux {
-				pins = "gpio114";
-				function = "pri_mi2s_ws";
-			};
-
-			config {
-				pins = "gpio114";
-				drive-strength = <2>; /* 2 mA */
-			};
-		};
-
-		pri_i2s_ws_active: pri_i2s_ws_active {
-			mux {
-				pins = "gpio114";
-				function = "pri_mi2s_ws";
-			};
-
-				config {
-				pins = "gpio114";
-				drive-strength = <2>; /* 2 mA */
-				bias-disable;
-				output-low;
-			};
-		};
-	};
-
-	pri_i2s_data0 {
-		pri_i2s_data0_sleep: pri_i2s_data0_sleep {
-			mux {
-				pins = "gpio115";
-				function = "pri_mi2s";
-			};
-
-			config {
-				pins = "gpio115";
-				drive-strength = <2>; /* 2 mA */
-			};
-		};
-
-		pri_i2s_data0_active: pri_i2s_data0_active {
-			mux {
-				pins = "gpio115";
-				function = "pri_mi2s";
-			};
-
-			config {
-				pins = "gpio115";
-				drive-strength = <2>; /* 2 mA */
-				bias-disable;
-				output-low;
-			};
-		};
-	};
-
-	pri_i2s_data1 {
-		pri_i2s_data1_sleep: pri_i2s_data1_sleep {
-			mux {
-				pins = "gpio116";
-				function = "pri_mi2s";
-			};
-
-			config {
-				pins = "gpio116";
-				drive-strength = <2>; /* 2 mA */
-			};
-		};
-
-		pri_i2s_data1_active: pri_i2s_data1_active {
-			mux {
-				pins = "gpio116";
-				function = "pri_mi2s";
-			};
-
-			config {
-				pins = "gpio116";
-				drive-strength = <2>; /* 2 mA */
-				bias-disable;
-				input-enable;
-			};
-		};
-	};
-
 	cdc_pri_mi2s_gpios: msm_cdc_pinctrl_pri {
 		compatible = "qcom,msm-cdc-pinctrl";
-		pinctrl-name = "aud_active","aud_sleep";
+
+		pinctrl-names = "aud_active", "aud_sleep";
 		pinctrl-0 = <&pri_i2s_sck_active &pri_i2s_ws_active
 			    &pri_i2s_data0_active &pri_i2s_data1_active>;
 		pinctrl-1 = <&pri_i2s_sck_sleep &pri_i2s_ws_sleep
 			    &pri_i2s_data0_sleep &pri_i2s_data1_sleep>;
 	};
 
-	dmic01_clk {
-		dmic01_clk_active: dmic01_clk_active {
-			mux {
-				pins = "gpio125";
-				function = "DMIC0_CLK";
-			};
-
-			config {
-				pins = "gpio125";
-				drive-strength = <2>;
-				output-high;
-			};
-		};
-
-		dmic01_clk_sleep: dmic01_clk_sleep {
-			mux {
-				pins = "gpio125";
-				function = "DMIC0_CLK";
-			};
-
-			config {
-				pins = "gpio125";
-				drive-strength = <2>;
-				bias-disable;
-				output-low;
-			};
-		};
-	};
-
-	dmic01_data {
-		dmic01_data_active: dmic01_data_active {
-			mux {
-				pins = "gpio126";
-				function = "DMIC0_DATA";
-			};
-
-			config {
-				pins = "gpio126";
-				drive-strength = <8>;
-				input-enable;
-			};
-		};
-
-		dmic01_data_sleep: dmic01_data_sleep {
-			mux {
-				pins = "gpio126";
-				function = "DMIC0_DATA";
-			};
-
-			config {
-				pins = "gpio126";
-				drive-strength = <2>;
-				pull-down;
-				input-enable;
-			};
-		};
-	};
-
-	dmic23_clk {
-		dmic23_clk_active: dmic23_clk_active {
-			mux {
-				pins = "gpio127";
-				function = "DMIC1_CLK";
-			};
-
-			config {
-				pins = "gpio127";
-				drive-strength = <2>;
-				output-high;
-			};
-		};
-
-		dmic23_clk_sleep: dmic23_clk_sleep {
-			mux {
-				pins = "gpio127";
-				function = "DMIC1_CLK";
-			};
-
-			config {
-				pins = "gpio127";
-				drive-strength = <2>;
-				bias-disable;
-				output-low;
-			};
-		};
-	};
-
-	dmic23_data {
-		dmic23_data_active: dmic23_data_active {
-			mux {
-				pins = "gpio128";
-				function = "DMIC1_DATA";
-			};
-
-			config {
-				pins = "gpio128";
-				drive-strength = <8>;
-				input-enable;
-			};
-		};
-
-		dmic23_data_sleep: dmic23_data_sleep {
-			mux {
-				pins = "gpio128";
-				function = "DMIC1_DATA";
-			};
-
-			config {
-				pins = "gpio128";
-				drive-strength = <2>;
-				pull-down;
-				input-enable;
-			};
-		};
-	};
-
 	pri_dmic_gpios: pri_dmic_pinctrl {
 		compatible = "qcom,msm-cdc-pinctrl";
-		pinctrl-names = "aud_active","aud_sleep";
-		pinctrl-0 = <&dmic01_clk_active &dmic01_data_active>;
-		pinctrl-1 = <&dmic01_clk_sleep &dmic01_data_sleep>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&cdc_dmic01_clk_active &cdc_dmic01_data_active>;
+		pinctrl-1 = <&cdc_dmic01_clk_sleep &cdc_dmic01_data_sleep>;
 	};
 
 	sec_dmic_gpios: sec_dmic_pinctrl {
 		compatible = "qcom,msm-cdc-pinctrl";
-		pinctrl-names = "aud_active","aud_sleep";
-		pinctrl-0 = <&dmic23_clk_active &dmic23_data_active>;
-		pinctrl-1 = <&dmic23_clk_sleep &dmic23_data_sleep>;
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&cdc_dmic23_clk_active &cdc_dmic23_data_active>;
+		pinctrl-1 = <&cdc_dmic23_clk_sleep &cdc_dmic23_data_sleep>;
 	};
 
 
@@ -507,6 +282,15 @@
 	status = "okay";
 
 	/delete-node/ nq@28;
+};
+
+/* Disable trinket-audio-overlay unused nodes */
+&cdc_dmic01_gpios {
+	status = "disabled";
+};
+
+&cdc_dmic23_gpios {
+	status = "disabled";
 };
 
 &sm6150_snd {
@@ -2251,6 +2035,218 @@
 			bias-pull-down; /* PULL DOWN */
 			drive-strength = <2>; /* 2 MA */
 		};
+	};
+
+	pri_i2s_sck_sleep: pri_i2s_sck_sleep {
+		mux {
+			pins = "gpio113";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio113";
+			drive-strength = <2>; /* 2 mA */
+		};
+	};
+
+	pri_i2s_sck_active: pri_i2s_sck_active {
+		mux {
+			pins = "gpio113";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio113";
+			drive-strength = <2>; /* 2 mA */
+			bias-disable;
+			output-low;
+		};
+	};
+
+	pri_i2s_ws_sleep: pri_i2s_ws_sleep {
+		mux {
+			pins = "gpio114";
+			function = "pri_mi2s_ws";
+		};
+
+		config {
+			pins = "gpio114";
+			drive-strength = <2>; /* 2 mA */
+		};
+	};
+
+	pri_i2s_ws_active: pri_i2s_ws_active {
+		mux {
+			pins = "gpio114";
+			function = "pri_mi2s_ws";
+		};
+
+		config {
+			pins = "gpio114";
+			drive-strength = <2>; /* 2 mA */
+			bias-disable;
+			output-low;
+		};
+	};
+
+	pri_i2s_data0_sleep: pri_i2s_data0_sleep {
+		mux {
+			pins = "gpio115";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio115";
+			drive-strength = <2>; /* 2 mA */
+		};
+	};
+
+	pri_i2s_data0_active: pri_i2s_data0_active {
+		mux {
+			pins = "gpio115";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio115";
+			drive-strength = <2>; /* 2 mA */
+			bias-disable;
+			output-low;
+		};
+	};
+
+	pri_i2s_data1_sleep: pri_i2s_data1_sleep {
+		mux {
+			pins = "gpio116";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio116";
+			drive-strength = <2>; /* 2 mA */
+		};
+	};
+
+	pri_i2s_data1_active: pri_i2s_data1_active {
+		mux {
+			pins = "gpio116";
+			function = "pri_mi2s";
+		};
+
+		config {
+			pins = "gpio116";
+			drive-strength = <2>; /* 2 mA */
+			bias-disable;
+			input-enable;
+		};
+	};
+};
+
+&cdc_dmic01_clk_active {
+	mux {
+		pins = "gpio125";
+		function = "DMIC0_CLK";
+	};
+
+	config {
+		pins = "gpio125";
+		drive-strength = <2>;
+		output-high;
+	};
+};
+
+&cdc_dmic01_clk_sleep {
+	mux {
+		pins = "gpio125";
+		function = "DMIC0_CLK";
+	};
+
+	config {
+		pins = "gpio125";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cdc_dmic01_data_active {
+	mux {
+		pins = "gpio126";
+		function = "DMIC0_DATA";
+	};
+
+	config {
+		pins = "gpio126";
+		drive-strength = <8>;
+		input-enable;
+	};
+};
+
+&cdc_dmic01_data_sleep {
+	mux {
+		pins = "gpio125";
+		function = "DMIC0_CLK";
+	};
+
+	config {
+		pins = "gpio125";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cdc_dmic23_clk_active {
+	mux {
+		pins = "gpio127";
+		function = "DMIC1_CLK";
+	};
+
+	config {
+		pins = "gpio127";
+		drive-strength = <2>;
+		output-high;
+	};
+};
+
+&cdc_dmic23_clk_sleep {
+	mux {
+		pins = "gpio127";
+		function = "DMIC1_CLK";
+	};
+
+	config {
+		pins = "gpio127";
+		drive-strength = <2>;
+		bias-disable;
+		output-low;
+	};
+};
+
+&cdc_dmic23_data_active {
+	mux {
+		pins = "gpio128";
+		function = "DMIC1_DATA";
+	};
+
+	config {
+		pins = "gpio128";
+		drive-strength = <8>;
+		input-enable;
+	};
+};
+
+&cdc_dmic23_data_sleep {
+	mux {
+		pins = "gpio128";
+		function = "DMIC1_DATA";
+	};
+
+	config {
+		pins = "gpio128";
+		drive-strength = <2>;
+		pull-down;
+		input-enable;
 	};
 };
 


### PR DESCRIPTION
The audio pinctrl configuration as erroneously put in the
soc node, instead of the tlmm one... plus, fix typos around.

Tested on Sony Seine PDX201 DSDS