### PR TITLE
[7.1.r1] arm64: DT: Kumano: Handle GPIO100 in msm-cdc-pinctrl

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -517,14 +517,12 @@
 		};
 	};
 
-/*
 	wcd_usbc_analog_en1_gpio: msm_cdc_pinctrl@100 {
 		compatible = "qcom,msm-cdc-pinctrl";
 		pinctrl-names = "aud_active", "aud_sleep";
 		pinctrl-0 = <&wcd_usbc_analog_en1_active>;
 		pinctrl-1 = <&wcd_usbc_analog_en1_idle>;
 	};
-*/
 
 	/* SPI: QUP3 */
 	spi@88c000 {
@@ -763,6 +761,17 @@
 
 &display_panel_avdd_eldo {
 	status = "disabled";
+};
+
+&fsa4480 {
+	/*
+	 * Use GPIO100 based on audio state...
+	 * The platform should anyway never go to sleep while
+	 * DisplayPort is connected, so nothing breaks.
+	 *
+	 * P.S.: We cannot /delete-property/ from DTBO....
+	 */
+	pinctrl-names = "nouse";
 };
 
 &pm8150_gpios {
@@ -3248,7 +3257,7 @@
 		"SpkrLeft IN", "SPK1 OUT",
 		"SpkrRight IN", "SPK2 OUT";
 
-	//qcom,usbc-analog-en1-gpio = <&wcd_usbc_analog_en1_gpio>;
+	qcom,usbc-analog-en1-gpio = <&wcd_usbc_analog_en1_gpio>;
 	qcom,usbc-analog-en2-gpio = <&tlmm 152 0>;
 	pinctrl-names = "aud_active", "aud_sleep";
 	pinctrl-0 = <&wcd_usbc_analog_en2_active>;


### PR DESCRIPTION
This GPIO is shared between FSA4480 and analog TypeC to 3.5mm jack
cable analog detection: if we let it stay at bootloader settings,
we are keeping it high... if we let it stay at fsa4480 defaults,
then we keep it low, but not pulled down and this was drawing
power from the battery unexpectedly, making the power consumption
oscillating between 1.8-2.2% per hour (on my unit) on Android 10.

The power measurement way is not great, but it's still sort of
representative of what's happening.

After this commit, the measured battery drain, in the very same
conditions, oscillates between 1.1-1.4% per hour: it's still not
good, but it's anyway a good step forward.