### PR TITLE
[7.1.r1] media: msm: camera_v2: Fix dual vfe sync mode on SDM630/660

### DIFF
--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp47.c
@@ -1437,7 +1437,7 @@ void msm_vfe47_cfg_camif(struct vfe_device *vfe_dev,
 		bus_sub_en = 0;
 
 	vfe_dev->dual_vfe_enable = camif_cfg->is_split;
-	vfe_dev->dual_vfe_sync_mode =
+	vfe_dev->dual_vfe_sync_mode = !msm_vfe_is_vfe48_660(vfe_dev) &&
 		(vfe_dev->dual_vfe_sync_enable && camif_cfg->is_split);
 
 	msm_camera_io_w(pix_cfg->input_mux << 5 | pix_cfg->pixel_pattern,

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp48.h
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp48.h
@@ -27,6 +27,12 @@ enum msm_vfe_clk_rates {
 #define MSM_VFE48_HW_VERSION_SHIFT 28
 #define MSM_VFE48_HW_VERSION_MASK 0xF
 
+static inline int msm_vfe_is_vfe48_660(struct vfe_device *vfe_dev)
+{
+	return (((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT) &
+		MSM_VFE48_HW_VERSION_MASK) == MSM_VFE48_HW_VERSION);
+}
+
 static inline int msm_vfe_is_vfe48(struct vfe_device *vfe_dev)
 {
 	/* Check for Trinket specific as it uses h/w version 0x9 */
@@ -35,8 +41,7 @@ static inline int msm_vfe_is_vfe48(struct vfe_device *vfe_dev)
 		return (((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT)
 			& MSM_VFE48_HW_VERSION_MASK)
 			== MSM_VFE48_HW_VERSION_TRINKET);
-	return (((vfe_dev->vfe_hw_version >> MSM_VFE48_HW_VERSION_SHIFT) &
-		MSM_VFE48_HW_VERSION_MASK) == MSM_VFE48_HW_VERSION);
+	return msm_vfe_is_vfe48_660(vfe_dev);
 }
 
 void msm_vfe48_stats_cfg_ub(struct vfe_device *vfe_dev);


### PR DESCRIPTION
The VFE48 interface on SDM630/660 is not exposing any dual vfe
specific interrupt, so we cannot rely on that: differentiate
the check for msm_vfe_is_vfe48 by adding a _660 variant that
returns the specific "vfe48 on sdm630/636/660" info and use it
in the CAMIF configuration function to disallow enabling the
dual_vfe_sync_mode parameter, forcing the code to fall back
to the old dual vfe paths.

Tested on SDM630 Nile Pioneer DSDS.

Tested: AOSP Camera works. Can do snapshot. Can cycle between cameras.