### PR TITLE
[7.1.r1][URGENT] Revert "mmc: sdhci-msm: Set SDHCI_QUIRK_MULTIBLOCK_READ_ACMD12 quirk"

### DIFF
--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -855,12 +855,6 @@ static int msm_init_cm_dll(struct sdhci_host *host,
 	}
 
 	/*
-	 * Clear tuning_done flag before tuning to ensure proper
-	 * HS400 settings.
-	 */
-	msm_host->tuning_done = 0;
-
-	/*
 	 * Update the lower two bytes of DLL_CONFIG only with HSR values.
 	 * Since these are the static settings.
 	 */

--- a/drivers/mmc/host/sdhci-msm.c
+++ b/drivers/mmc/host/sdhci-msm.c
@@ -5048,7 +5048,6 @@ static int sdhci_msm_probe(struct platform_device *pdev)
 	host->quirks |= SDHCI_QUIRK_BROKEN_CARD_DETECTION;
 	host->quirks |= SDHCI_QUIRK_SINGLE_POWER_WRITE;
 	host->quirks |= SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN;
-	host->quirks |= SDHCI_QUIRK_MULTIBLOCK_READ_ACMD12;
 	host->quirks |= SDHCI_QUIRK_NO_ENDATTR_IN_NOPDESC;
 
 	host->quirks2 |= SDHCI_QUIRK2_ALWAYS_USE_BASE_CLOCK;


### PR DESCRIPTION
This reverts parts of commit c0f9f9d9071e5de260a2104442c471cfb733aa80.
This caused Nile platform to break to not booting state
and breaking keymaster on Ganges platform making 
unlocking lock screen impossible if any authentication
is required impossible.

9b20129 is not applicable to SODP and has been applied
to wrong location by patch.
Revert it.