### PR TITLE
[7.1.r1] Ganges - Solve display FB issues, fix back aux cameras, unbalanced vreg ena 

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-common-sde-overlay.dtsi
@@ -101,3 +101,11 @@
 &mdss_dsi0 {
 	qcom,cont-splash-enabled;
 };
+
+&lcdb_ldo_vreg {
+	vreg-cont-splash-enabled;
+};
+
+&lcdb_ncp_vreg {
+	vreg-cont-splash-enabled;
+};

--- a/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-ganges-kirin-camera.dtsi
@@ -167,11 +167,22 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk3_active &cam_sensor_rear2_active>;
 		pinctrl-1 = <&cam_sensor_mclk3_suspend &cam_sensor_rear2_suspend>;
-		gpios = <&tlmm 35 0>, <&tlmm 42 0>;
+		gpios = <&tlmm 35 0>,
+			<&tlmm 42 0>,
+			<&tlmm 52 0>,
+			<&tlmm 64 0>,
+			<&tlmm 13 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-req-tbl-num   = <0 1>;
-		qcom,gpio-req-tbl-flags = <1 0>;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK3", "CAM_RESET1";
+		qcom,gpio-vdig = <2>;
+		qcom,gpio-vana = <3>;
+		qcom,gpio-vio = <4>;
+		qcom,gpio-req-tbl-num = <0 1 2 3 4>;
+		qcom,gpio-req-tbl-flags = <1 0 0 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK3",
+					  "CAM_RESET1",
+					  "CAM_VDIG",
+					  "CAM_VANA",
+					  "CAM_VIO";
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;

--- a/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-ganges-mermaid-camera.dtsi
@@ -168,11 +168,22 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk3_active &cam_sensor_rear2_active>;
 		pinctrl-1 = <&cam_sensor_mclk3_suspend &cam_sensor_rear2_suspend>;
-		gpios = <&tlmm 35 0>, <&tlmm 42 0>;
+		gpios = <&tlmm 35 0>,
+			<&tlmm 42 0>,
+			<&tlmm 52 0>,
+			<&tlmm 51 0>,
+			<&tlmm 13 0>;
 		qcom,gpio-reset = <1>;
-		qcom,gpio-req-tbl-num   = <0 1>;
-		qcom,gpio-req-tbl-flags = <1 0>;
-		qcom,gpio-req-tbl-label = "CAMIF_MCLK3", "CAM_RESET1";
+		qcom,gpio-vdig = <2>;
+		qcom,gpio-vana = <3>;
+		qcom,gpio-vio = <4>;
+		qcom,gpio-req-tbl-num = <0 1 2 3 4>;
+		qcom,gpio-req-tbl-flags = <1 0 0 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK3",
+					  "CAM_RESET1",
+					  "CAM_VDIG",
+					  "CAM_VANA",
+					  "CAM_VIO";
 		qcom,sensor-position = <1>;
 		qcom,sensor-mode = <1>;
 		qcom,cci-master = <1>;

--- a/drivers/gpu/drm/msm/sde/sde_kms.c
+++ b/drivers/gpu/drm/msm/sde/sde_kms.c
@@ -1224,6 +1224,11 @@ static void sde_kms_wait_for_commit_done(struct msm_kms *kms,
 		ret = sde_encoder_wait_for_event(encoder, MSM_ENC_COMMIT_DONE);
 		if (ret && ret != -EWOULDBLOCK) {
 			SDE_ERROR("wait for commit done returned %d\n", ret);
+#ifdef CONFIG_ARCH_SONY_GANGES
+			/* For NT36672a video mode panel on Sony Ganges
+			 * platform: hack the first flip to get recovery UI. */
+			sde_crtc_complete_flip(crtc, NULL);
+#endif
 			break;
 		}
 

--- a/drivers/input/touchscreen/nt36672a/nt36xxx_fw_update.c
+++ b/drivers/input/touchscreen/nt36672a/nt36xxx_fw_update.c
@@ -1059,7 +1059,10 @@ void Boot_Update_Firmware(struct work_struct *work)
 	ret = update_firmware_request(firmware_name);
 	if (ret) {
 		pr_err("update_firmware_request failed. (%d)\n", ret);
-			return;
+		nvt_sw_reset_idle();
+		nvt_bootloader_reset();
+		ret = nvt_check_fw_reset_state(RESET_STATE_INIT);
+		return;
 	}
 
 	mutex_lock(&ts->lock);

--- a/drivers/regulator/qpnp-lcdb-regulator.c
+++ b/drivers/regulator/qpnp-lcdb-regulator.c
@@ -1526,6 +1526,10 @@ static int qpnp_lcdb_regulator_register(struct qpnp_lcdb *lcdb, u8 type)
 				(type == LDO) ? "LDO" : "NCP", rc);
 			return rc;
 		}
+
+		if (of_get_property(lcdb->dev->of_node,
+				    "vreg-cont-splash-enabled", NULL))
+			rdev->use_count = 1;
 	} else {
 		pr_err("%s_regulator name missing\n",
 				(type == LDO) ? "LDO" : "NCP");


### PR DESCRIPTION
This patchset gives the following improvements on the Sony SDM630/636 Ganges platform:
- Ability to use digitizer when no firmware has been provided for upgrade
- Solved unbalanced disables for LCDB regulator when powering down
   the display for the first time after continuous splash
- Bad, ugly, but working and effective hack to solve issues with the Android
   recovery and offline charging UI (by crashing this UI on purpose with a bad
   framebuffer operation and letting it reinitialize the display).
- Back auxilliary camera (second camera) is now declaring the expected power
   GPIOs that userspace sends in the power sequence

Test:
* Recovery has display
* Boot faliure screen works
* Can use digitizer in recovery environment
* Back AUX camera works

Tested on SDM630 Kirin DSDS.