### PR TITLE
[7.1.r1] Fixup critical clocks for MSM8998 Yoshino

### DIFF
--- a/drivers/clk/qcom/gcc-msm8998.c
+++ b/drivers/clk/qcom/gcc-msm8998.c
@@ -2768,8 +2768,7 @@ static struct clk_branch gcc_mss_q6_bimc_axi_clk = {
 		.enable_mask = BIT(0),
 		.hw.init = &(struct clk_init_data) {
 			.name = "gcc_mss_q6_bimc_axi_clk",
-			//.flags = CLK_IS_CRITICAL, //.always_on = true,
-			.flags = CLK_ENABLE_HAND_OFF | CLK_IGNORE_UNUSED,
+			.flags = CLK_IS_CRITICAL,
 			.ops = &clk_branch2_ops,
 		},
 	},

--- a/drivers/clk/qcom/gcc-msm8998.c
+++ b/drivers/clk/qcom/gcc-msm8998.c
@@ -2187,7 +2187,7 @@ static struct clk_branch gcc_hmss_dvm_bus_clk = {
 		.enable_mask = BIT(0),
 		.hw.init = &(struct clk_init_data) {
 			.name = "gcc_hmss_dvm_bus_clk",
-			.flags = CLK_IGNORE_UNUSED,
+			.flags = CLK_IS_CRITICAL,
 			.ops = &clk_branch2_ops,
 		},
 	},

--- a/drivers/clk/qcom/gpucc-msm8998.c
+++ b/drivers/clk/qcom/gpucc-msm8998.c
@@ -108,7 +108,7 @@ static struct clk_branch gpucc_xo = {
 			"bi_tcxo_ao",
 		},
 		.num_parents = 1,
-		.flags = CLK_ENABLE_HAND_OFF,
+		.flags = CLK_IS_CRITICAL,
 		.ops = &clk_branch2_ops,
 	},
 };


### PR DESCRIPTION
This patchset solves issues with platform freezes happening especially when suspending (deep sleep) the device.

Tested on MSM8998 Lilac RoW by @stefanhh0 