### PR TITLE
[7.1.r1] [URGENT] dt-bindings: mmcc-msm8998: Add postdivider definitions

### DIFF
--- a/drivers/clk/qcom/clk-smd-rpm.c
+++ b/drivers/clk/qcom/clk-smd-rpm.c
@@ -1462,6 +1462,13 @@ static int rpm_smd_clk_probe(struct platform_device *pdev)
 		 */
 		clk_prepare_enable(msm8998_bi_tcxo_ao.hw.clk);
 
+		pr_warn("*** WARNING: Disallowing XO shutdown as a workaround "
+			"for platform components death on this SoC. Hopefully "
+			"this will get solved in the future. In the meanwhile,"
+			" you WILL experience battery consumption issues."
+			" *** Sorry!");
+		clk_prepare_enable(msm8998_bi_tcxo.hw.clk);
+
 		/* Hold an active set vote for the cnoc_periph resource */
 		clk_set_rate(cnoc_periph_keepalive_a_clk.hw.clk, 19200000);
 		clk_prepare_enable(cnoc_periph_keepalive_a_clk.hw.clk);

--- a/drivers/clk/qcom/gcc-msm8998.c
+++ b/drivers/clk/qcom/gcc-msm8998.c
@@ -3258,7 +3258,7 @@ static int gcc_msm8998_probe(struct platform_device *pdev)
 	 * Clear the HMSS_AHB_CLK_ENA bit to allow the gcc_hmss_ahb_clk clock
 	 * to be gated by RPM during VDD_MIN.
 	 */
-	ret = regmap_update_bits(regmap, 0x52008, BIT(21), 0); //BIT(21));
+	ret = regmap_update_bits(regmap, 0x52008, BIT(21), BIT(21));
 	if (ret)
 		return ret;
 

--- a/include/dt-bindings/clock/qcom,mmcc-msm8998.h
+++ b/include/dt-bindings/clock/qcom,mmcc-msm8998.h
@@ -23,6 +23,15 @@
 #define MMPLL7_PLL			6
 #define MMPLL10_PLL			7
 
+#define MMPLL0_OUT_EVEN			8
+#define MMPLL1_OUT_EVEN			9
+#define MMPLL3_OUT_EVEN			10
+#define MMPLL4_OUT_EVEN			11
+#define MMPLL5_OUT_EVEN			12
+#define MMPLL6_OUT_EVEN			13
+#define MMPLL7_OUT_EVEN			14
+#define MMPLL10_OUT_EVEN		15
+
 /* MMCC block clocks */
 #define AHB_CLK_SRC			20
 #define CSI0_CLK_SRC			21


### PR DESCRIPTION
This file was missed in the postdivider introduction commit:
fix the build.