### PR TITLE
[7.1.r1] arm64: DT: Yoshino: Globally disable continuous splash

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-maple-sde.dtsi
@@ -76,25 +76,3 @@
 		/delete-node/ 4k60;
 	};
 };
-
-&sde_dsi0 {
-	/delete-property/ qcom,cont-splash-enabled;
-};
-
-&mdss_mdp {
-	/delete-property/ compatible;
-	/delete-property/ reg;
-	/delete-property/ reg-names;
-};
-
-&mdss_dsi {
-	/delete-property/ compatible;
-};
-
-&mdss_dsi0 {
-	/delete-property/ label;
-};
-
-&mdss_dsi1 {
-	/delete-property/ label;
-};

--- a/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-yoshino-common-sde-overlay.dtsi
@@ -153,12 +153,27 @@ msm_drm.dsi_display0=dsi_panel_somc_yoshino_cmd:config0";
 	status = "disabled";
 };
 
-&sde_dsi0 {
-	qcom,cont-splash-enabled;
-};
-
 &sde_kms {
 	/* Set SDE MAX performance */
 	qcom,sde-perf-default-mode = <3>;
 	connectors = <&sde_wb &dsi_panel_cmd_display>;
 };
+
+&mdss_mdp {
+        /delete-property/ compatible;
+        /delete-property/ reg;
+        /delete-property/ reg-names;
+};
+
+&mdss_dsi {
+        /delete-property/ compatible;
+};
+
+&mdss_dsi0 {
+        /delete-property/ label;
+};
+
+&mdss_dsi1 {
+        /delete-property/ label;
+};
+


### PR DESCRIPTION
This reverts commit 1f7f1b95fe400e0f92729096a2e5182d4c64cd57.

With the latest yoshino fixes the disablement can be made available for
all yoshino devices. The disablement fixes a slow response bug of the display
directly after the phone booted.

Fixes: https://github.com/sonyxperiadev/bug_tracker/issues/578

Tested succesfully on Yoshino/Lilac