### PR TITLE
[7.1.r1] Silence GIC redist messages, enlarge 8998 CMA for performance

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8998-ion.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998-ion.dtsi
@@ -27,6 +27,12 @@
 			qcom,ion-heap-type = "DMA";
 		};
 
+		qcom,ion-heap@26 { /* USER CONTIG HEAP */
+			reg = <26>;
+			memory-region = <&user_contig_mem>;
+			qcom,ion-heap-type = "DMA";
+		};
+
 		qcom,ion-heap@27 { /* QSEECOM HEAP */
 			reg = <27>;
 			memory-region = <&qseecom_mem>;

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -390,6 +390,14 @@
 			size = <0 0x1000000>;
 		};
 
+		user_contig_mem: user_contig_region {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1000000>;
+		};
+
 		qseecom_mem: qseecom_region {
 			compatible = "shared-dma-pool";
 			alloc-ranges = <0 0x00000000 0 0xffffffff>;

--- a/arch/arm64/boot/dts/qcom/msm8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8998.dtsi
@@ -408,6 +408,7 @@
 
 		qseecom_ta_mem: qseecom_ta_region {
 			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
 			reusable;
 			alignment = <0 0x400000>;
 			size = <0 0x1000000>;
@@ -435,7 +436,7 @@
 			alloc-ranges = <0 0x00000000 0 0xffffffff>;
 			reusable;
 			alignment = <0 0x400000>;
-			size = <0 0x2000000>;
+			size = <0 0x2800000>;
 			linux,cma-default;
 		};
 

--- a/drivers/irqchip/irq-gic-v3.c
+++ b/drivers/irqchip/irq-gic-v3.c
@@ -907,7 +907,7 @@ static int __gic_populate_rdist(struct redist_region *region, void __iomem *ptr)
 		gic_data_rdist_rd_base() = ptr;
 		gic_data_rdist()->phys_base = region->phys_base + offset;
 
-		pr_info("CPU%d: found redistributor %lx region %d:%pa\n",
+		pr_info_once("CPU%d: found redistributor %lx region %d:%pa\n",
 			smp_processor_id(), mpidr,
 			(int)(region - gic_data.redist_regions),
 			&gic_data_rdist()->phys_base);


### PR DESCRIPTION
This message
GICv3: CPU5: found redistributor 500 region 0:0x0000000017b00000
is beautiful, right?
Not when it gets printed continuously, in that case it's useless spam,
since the redist info never changes, so let's just disable it.

Also, let's enlarge the CMA region a bit to stop continuous memory
reclaiming when asking for video recording / playback or camera
operations: this gives a nice performance boost now that we are on
kernel 4.14 with proper proprietaries.

