### PR TITLE
[7.1.r1] sched: features: Disable EAS_PREFER_IDLE

### DIFF
--- a/kernel/sched/features.h
+++ b/kernel/sched/features.h
@@ -121,7 +121,7 @@ SCHED_FEAT(ENERGY_AWARE, false)
  *   ON: If the target CPU saves any energy, use that.
  *   OFF: Use whichever of target or backup saves most.
  */
-SCHED_FEAT(EAS_PREFER_IDLE, true)
+SCHED_FEAT(EAS_PREFER_IDLE, false)
 SCHED_FEAT(FIND_BEST_TARGET, true)
 SCHED_FEAT(FBT_STRICT_ORDER, false)
 


### PR DESCRIPTION
This option tends to assign tasks to the best (in energy terms)
idle CPU, but if there is no totally idle core, then the task
will be assigned to a very high power core, generating a lot of
heat and a lot of power consumption for literally NO REASON.