### PR TITLE
[7.1.r1] clk: qcom: osm-legacy: Fix parent list for osm_clk_src

### DIFF
--- a/drivers/clk/qcom/clk-cpu-osm-legacy.c
+++ b/drivers/clk/qcom/clk-cpu-osm-legacy.c
@@ -794,7 +794,7 @@ static const struct parent_map gcc_parent_map_1[] = {
 };
 
 static const char * const gcc_parent_names_1[] = {
-	"xo",
+	"bi_tcxo_ao",
 	"hmss_gpll0_clk_src",
 };
 


### PR DESCRIPTION
The "xo" clock doesn't exist anymore! This clock is anyway tied
to the always-on set of the RPM XO, so let's go for it.

Tested on MSM8998 Yoshino Maple RoW