### PR TITLE
[7.1.r1] Fixes for Nile/Ganges mobile data throughput

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1324,6 +1324,7 @@
 		qcom,rmnet-ipa-ssr;
 		qcom,ipa-platform-type-msm;
 		qcom,ipa-advertise-sg-support;
+		qcom,ipa-napi-enable;
 	};
 
 	clock_cpu: qcom,clk-cpu-630@179c0000 {

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1267,6 +1267,7 @@
 		clock-names = "core_clk", "smmu_clk";
 		qcom,arm-smmu;
 		qcom,smmu-disable-htw;
+		qcom,smmu-s1-bypass;
 		qcom,ee = <0>;
 		qcom,use-ipa-tethering-bridge;
 		qcom,modem-cfg-emb-pipe-flt;
@@ -1604,6 +1605,7 @@
 		qcom,vdd-3.3-ch0-config = <3200000 3400000>;
 		qcom,wlan-msa-memory = <0x100000>;
 		qcom,wlan-msa-fixed-region = <&wlan_msa_mem>;
+		qcom,smmu-s1-bypass;
 
                 qcom,smp2p_map_wlan_1_in {
                         interrupts-extended = <&smp2p_wlan_1_in 0 0>,

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -1427,6 +1427,7 @@
 		qcom,rmnet-ipa-ssr;
 		qcom,ipa-platform-type-msm;
 		qcom,ipa-advertise-sg-support;
+		qcom,ipa-napi-enable;
 	};
 
 	qcom,msm-cdsp-loader {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -1370,6 +1370,7 @@
 		clock-names = "core_clk", "smmu_clk";
 		qcom,arm-smmu;
 		qcom,smmu-disable-htw;
+		qcom,smmu-s1-bypass;
 		qcom,ee = <0>;
 		qcom,use-ipa-tethering-bridge;
 		qcom,modem-cfg-emb-pipe-flt;
@@ -1865,6 +1866,7 @@
 		qcom,vdd-3.3-ch0-config = <3200000 3400000>;
 		qcom,wlan-msa-memory = <0x100000>;
 		qcom,wlan-msa-fixed-region = <&wlan_msa_mem>;
+		qcom,smmu-s1-bypass;
 
                 qcom,smp2p_map_wlan_1_in {
                         interrupts-extended = <&smp2p_wlan_1_in 0 0>,

--- a/net/rmnet_data/rmnet_data_config.c
+++ b/net/rmnet_data/rmnet_data_config.c
@@ -800,6 +800,7 @@ int rmnet_set_egress_data_format(struct net_device *dev,
 				 u16 agg_count)
 {
 	struct rmnet_phys_ep_config *config;
+	unsigned long flags;
 
 	ASSERT_RTNL();
 
@@ -815,8 +816,11 @@ int rmnet_set_egress_data_format(struct net_device *dev,
 		return RMNET_CONFIG_UNKNOWN_ERROR;
 
 	config->egress_data_format = egress_data_format;
+
+	spin_lock_irqsave(&config->agg_lock, flags);
 	config->egress_agg_size = agg_size;
 	config->egress_agg_count = agg_count;
+	spin_unlock_irqrestore(&config->agg_lock, flags);
 
 	return RMNET_CONFIG_OK;
 }

--- a/net/rmnet_data/rmnet_data_handlers.c
+++ b/net/rmnet_data/rmnet_data_handlers.c
@@ -350,6 +350,7 @@ static rx_handler_result_t __rmnet_deliver_skb
 			napi = get_current_napi_context();
 
 			skb_size = skb->len;
+			skb_get_hash(skb);
 			gro_res = napi_gro_receive(napi, skb);
 			trace_rmnet_gro_downlink(gro_res);
 			rmnet_optional_gro_flush(napi, ep, skb_size);

--- a/net/rmnet_data/rmnet_data_vnd.c
+++ b/net/rmnet_data/rmnet_data_vnd.c
@@ -578,7 +578,7 @@ int rmnet_vnd_create_dev(int id, struct net_device **new_device,
 		LOGE("Failed to to register netdev [%s]", dev->name);
 		free_netdev(dev);
 		*new_device = 0;
-		rc = RMNET_CONFIG_UNKNOWN_ERROR;
+		return RMNET_CONFIG_UNKNOWN_ERROR;
 	} else {
 		rmnet_devices[id] = dev;
 		*new_device = dev;

--- a/net/rmnet_data/rmnet_data_vnd.c
+++ b/net/rmnet_data/rmnet_data_vnd.c
@@ -564,13 +564,14 @@ int rmnet_vnd_create_dev(int id, struct net_device **new_device,
 		/* Configuring UL checksum offload on rmnet_data interfaces */
 		dev->hw_features |= NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM;
 		/* Configuring GRO on rmnet_data interfaces */
-		dev->hw_features |= NETIF_F_GRO;
+		dev->hw_features |= NETIF_F_GRO_HW;
 		/* Configuring Scatter-Gather on rmnet_data interfaces */
 		dev->hw_features |= NETIF_F_SG;
 		/* Configuring GSO on rmnet_data interfaces */
-		dev->hw_features |= NETIF_F_GSO;
+/*		dev->hw_features |= NETIF_F_GSO;
 		dev->hw_features |= NETIF_F_GSO_UDP_TUNNEL;
 		dev->hw_features |= NETIF_F_GSO_UDP_TUNNEL_CSUM;
+*/
 	}
 
 	rc = register_netdevice(dev);

--- a/net/rmnet_data/rmnet_map_data.c
+++ b/net/rmnet_data/rmnet_map_data.c
@@ -262,8 +262,10 @@ new_packet:
 		 * sparse, don't aggregate. We will need to tune this later
 		 */
 		diff = timespec_sub(config->agg_last, last);
+		size = config->egress_agg_size - skb->len;
 
-		if ((diff.tv_sec > 0) || (diff.tv_nsec > agg_bypass_time)) {
+		if ((diff.tv_sec > 0) || (diff.tv_nsec > agg_bypass_time) ||
+		    (size <= 0)) {
 			spin_unlock_irqrestore(&config->agg_lock, flags);
 			LOGL("delta t: %ld.%09lu\tcount: bypass", diff.tv_sec,
 			     diff.tv_nsec);
@@ -275,7 +277,6 @@ new_packet:
 			return;
 		}
 
-		size = config->egress_agg_size - skb->len;
 		config->agg_skb = skb_copy_expand(skb, 0, size, GFP_ATOMIC);
 		if (!config->agg_skb) {
 			config->agg_skb = 0;

--- a/net/rmnet_data/rmnet_map_data.c
+++ b/net/rmnet_data/rmnet_map_data.c
@@ -293,7 +293,7 @@ new_packet:
 		config->agg_count = 1;
 		getnstimeofday(&config->agg_time);
 		trace_rmnet_start_aggregation(skb);
-		rmnet_kfree_skb(skb, RMNET_STATS_SKBFREE_AGG_CPY_EXPAND);
+		dev_kfree_skb_any(skb);
 		goto schedule;
 	}
 	diff = timespec_sub(config->agg_last, config->agg_time);
@@ -322,7 +322,7 @@ new_packet:
 	dest_buff = skb_put(config->agg_skb, skb->len);
 	memcpy(dest_buff, skb->data, skb->len);
 	config->agg_count++;
-	rmnet_kfree_skb(skb, RMNET_STATS_SKBFREE_AGG_INTO_BUFF);
+	dev_kfree_skb_any(skb);
 
 schedule:
 	if (config->agg_state != RMNET_MAP_TXFER_SCHEDULED) {


### PR DESCRIPTION
This patchset fixes mobile data throughput on Nile/Ganges (SDM630/636) platforms.

** UL/DL (Mbps) **
Before: 6.3/1.2
After: 59.4/20.1

Tested on SDM630 Ganges Kirin DSDS