### PR TITLE
[7.1.r1] Fixes for MSM8998 GSI and non-GSI targets

### DIFF
--- a/drivers/platform/msm/gsi/gsi.c
+++ b/drivers/platform/msm/gsi/gsi.c
@@ -3014,6 +3014,11 @@ int gsi_dealloc_channel(unsigned long chan_hdl)
 		    ctx->state == GSI_CHAN_STATE_NOT_ALLOCATED) {
 			GSIERR("MSM8998 workaround for gsi firmware: avoiding "
 			       "kernel panic for already not allocated CH.\n");
+			if (ctx->allocated) {
+				devm_kfree(gsi_ctx->dev, ctx->user_data);
+				ctx->allocated = false;
+			}
+			atomic_set(&ctx->evtr->chan_ref_cnt, 0);
 			return GSI_STATUS_SUCCESS;
 		}
 

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -2160,9 +2160,10 @@ static void dwc3_msm_notify_event(struct dwc3 *dwc, unsigned int event,
 		break;
 	case DWC3_CONTROLLER_NOTIFY_CLEAR_DB:
 		dev_dbg(mdwc->dev, "DWC3_CONTROLLER_NOTIFY_CLEAR_DB\n");
-		dwc3_msm_write_reg_field(mdwc->base,
-			GSI_GENERAL_CFG_REG(mdwc->gsi_reg[GENERAL_CFG_REG]),
-			BLOCK_GSI_WR_GO_MASK, true);
+		if (mdwc->gsi_reg)
+			dwc3_msm_write_reg_field(mdwc->base,
+			    GSI_GENERAL_CFG_REG(mdwc->gsi_reg[GENERAL_CFG_REG]),
+			    BLOCK_GSI_WR_GO_MASK, true);
 		break;
 	default:
 		dev_dbg(mdwc->dev, "unknown dwc3 event\n");


### PR DESCRIPTION
DWC3 may access GSI register(s) on non-GSI targets (so, an unexistant iospace, "hopefully"), so let's stop this.... moreover, add some more logic to the MSM8998 firmware GSI workaround: it is appropriate to free the channel memory when we are in a strange situation in which the firmware states that the channel is not allocated... also, instead of just returning success.. "perhaps" it's also mentally sane to zero out the channel refcount, so that we actually (uh, hopefully, too) stop IPA3 failures during the deinitialization path, with yet another hope to stop a kernel panic during subsystem restart phase.
