### PR TITLE
[7.1.r1] supply: qcom: qg-soc: Don't return soc 0 if FVSS is disabled

### DIFF
--- a/drivers/power/supply/qcom/qg-soc.c
+++ b/drivers/power/supply/qcom/qg-soc.c
@@ -64,7 +64,7 @@ static int qg_process_fvss_soc(struct qpnp_qg *chip, int sys_soc)
 	int soc_vbat = 0, wt_vbat = 0, wt_sys = 0, soc_fvss = 0;
 
 	if (!chip->dt.fvss_enable)
-		return 0;
+		goto exit_soc_scale;
 
 	if (chip->charge_status == POWER_SUPPLY_STATUS_CHARGING)
 		goto exit_soc_scale;


### PR DESCRIPTION
If the FVSS is disabled, we are currently returning 0, but this
function is meant to return a soc value: that was driving the
JEITA functions crazy, lowering the reported soc until 0 for
absolutely no reason.


Solves battery gauge issues on Sony Seine platform.