### PR TITLE
[7.1.r1] Revert "dts: seine: disable hibernate for cirrus"

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-seine-common.dtsi
@@ -346,6 +346,7 @@
 		cirrus,boost-peak-milliamp = <4000>;
 		cirrus,boost-ind-nanohenry = <1000>;
 		cirrus,boost-cap-microfarad = <15>;
+		cirrus,hibernate-enable = <1>;
 		cirrus,asp-sdout-hiz = <3>;
 		cirrus,gpio-config2 {
 			cirrus,gpio-src-select = <0x2>;


### PR DESCRIPTION
As discussed yeasterday in call with @kholk it is a good idea to revert the disabling of cirrus hibernation so it can hibernate again.
While disabling the hibernation can increase the time that cirrus takes to shut down and not wake up it also has a side effect.
The chip will never shut down. And when its not in shutdown state it will output the base voltage to the speaker which can reduce the life span of it drastically.
And having the chip always enabled isnt great either as it can fry itself if it cant go to hibernation over time.

Marijn found a mixerpath that could be able to hibernate it without having this in kernel but for now it is safer to enable hibernation as we cannot fry chips this way.

This reverts commit 7aaaf731280bc3d5ac84e06ae55b8bab52b5709e.