### PR TITLE
[DNM][7.1.r1] Add CLK_IGNORE_UNUSED to aggre1_ufs_axi_hw_ctl_clk flags

### DIFF
--- a/drivers/clk/qcom/gcc-msm8998.c
+++ b/drivers/clk/qcom/gcc-msm8998.c
@@ -1399,7 +1399,7 @@ static struct clk_branch gcc_aggre1_ufs_axi_hw_ctl_clk = {
 				"gcc_aggre1_ufs_axi_clk"
 			},
 			.num_parents = 1,
-			.flags = CLK_SET_RATE_PARENT,
+			.flags = CLK_SET_RATE_PARENT | CLK_IGNORE_UNUSED,
 			.ops = &clk_branch2_hw_ctl_ops,
 		},
 	},


### PR DESCRIPTION
There seems to be a race condition where when clk_disable_unused() is run it sees both the clocks.
This is happening because both gcc_aggre1_ufs_axi_clk and gcc_aggre1_ufs_axi_hw_ctl_clk use the same enable_reg and enable_mask.
Thus they are aliased.
This can be fixed by adding CLK_IGNORE_UNUSED to the hw_ctl_clk flags.

Huge thanks goes to Tootea who reported this bug and also made the idea for this fix.
See: https://github.com/sonyxperiadev/bug_tracker/issues/654