### PR TITLE
[7.1.r1] drm/msm/sde: sde_hw_top: Add SDM630 to legacy platform lookup

### DIFF
--- a/drivers/gpu/drm/msm/sde/sde_hw_top.c
+++ b/drivers/gpu/drm/msm/sde/sde_hw_top.c
@@ -17,7 +17,8 @@
 #include "sde_kms.h"
 
 #if defined(CONFIG_ARCH_MSM8916) || defined(CONFIG_ARCH_MSM8996) || \
-    defined(CONFIG_ARCH_MSM8998) || defined(CONFIG_ARCH_SDM660)
+    defined(CONFIG_ARCH_MSM8998) || defined(CONFIG_ARCH_SDM660) || \
+    defined(CONFIG_ARCH_SDM630)
  #define RUN_ON_LEGACY_PLATFORM
 #endif
 


### PR DESCRIPTION
For some reason it wasn't here already.
Solves the sluggish display issue.