### PR TITLE
[LA.UM.9.12.r1] [scripts/dtc: Remove redundant YYLOC global declaration

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
This fix from 4.19.114 is the bare minimum to start building the kernel. Without it we get:

```
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x20): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[3]: *** [scripts/Makefile.host:99: scripts/dtc/dtc] Error 1
make[2]: *** [/repos/SODP/11/kernel/sony/msm-4.19/kernel/scripts/Makefile.build:642: scripts/dtc] Error 2
make[1]: *** [/repos/SODP/11/kernel/sony/msm-4.19/kernel/Makefile:1185: scripts] Error 2
make[1]: *** Waiting for unfinished jobs....
  UPD     include/generated/asm-offsets.h
  CALL    /repos/SODP/11/kernel/sony/msm-4.19/kernel/scripts/checksyscalls.sh
make[1]: Leaving directory '/repos/SODP/11/out/clang.sh/kernel-tmp-pdx203'
make: *** [Makefile:146: sub-make] Error 2

```