### PR TITLE
[LA.UM.9.12.r1] uapi: socket: Define sockaddr_storage for new Android userspace

### DIFF
--- a/include/uapi/linux/socket.h
+++ b/include/uapi/linux/socket.h
@@ -19,4 +19,8 @@ struct __kernel_sockaddr_storage {
 				/* _SS_MAXSIZE value minus size of ss_family */
 } __attribute__ ((aligned(_K_SS_ALIGNSIZE)));	/* force desired alignment */
 
+#ifndef __KERNEL__
+ #define sockaddr_storage __kernel_sockaddr_storage
+#endif
+
 #endif /* _UAPI_LINUX_SOCKET_H */


### PR DESCRIPTION
Starting from at least Pie (9.0), Android is not defining this
struct anymore in Bionic, and it was anyway defined like this
on the previous versions.

Export this to get various components (mainly IPACM) to compile.