### PR TITLE
[7.1.r1] arm64: vdso32: Use full path to Clang instead of relying on PATH

### DIFF
--- a/arch/arm64/kernel/vdso32/Makefile
+++ b/arch/arm64/kernel/vdso32/Makefile
@@ -5,7 +5,7 @@
 # A mix between the arm64 and arm vDSO Makefiles.
 
 ifeq ($(cc-name),clang)
-  CC_ARM32 := $(cc-name) $(CLANG_TARGET_ARM32) -no-integrated-as $(CLANG_GCC32_TC) $(CLANG_PREFIX32)
+  CC_ARM32 := $(CC) $(CLANG_TARGET_ARM32) -no-integrated-as $(CLANG_GCC32_TC) $(CLANG_PREFIX32)
 else
   CC_ARM32 := $(CROSS_COMPILE_ARM32)$(cc-name)
 endif


### PR DESCRIPTION
Using (cc-name) directly leads to selection of first (cc-name) in path without respecting (CC) - in practice, this means a fallback to host clang under /usr/bin/clang.

32-bit cross compilers will still be respected.

**EDIT: ** Apparently Nathan already fixed this and it was not ported over: [FROMLIST: arm64: vdso32: Use full path to Clang instead of relying on PATH](https://android.googlesource.com/kernel/msm/+/a01c2fe09643caff8c96b8153de5b1ef488fab20)