### PR TITLE
[LE.UM.2.3.2.r1.4] [TESTING IN PROGRESS] rqbalance: avoid calling cpufreq_notify_transition with irqs_disabled.

### DIFF
--- a/drivers/cpuquiet/governors/rqbalance.c
+++ b/drivers/cpuquiet/governors/rqbalance.c
@@ -1049,7 +1049,7 @@ static void rqbalance_stop(void)
 	cpufreq_unregister_notifier(&frequency_limits_nb,
 		CPUFREQ_POLICY_NOTIFIER);
 
-	cpuhp_remove_state_nocalls(CPUHP_AP_ONLINE);
+	cpuhp_remove_state_nocalls(CPUHP_AP_ONLINE_IDLE);
 
 	unregister_pm_notifier(&pm_notifier_block);
 
@@ -1072,7 +1072,7 @@ static int rqbalance_cfl_start(void)
 	cpufreq_register_notifier(&frequency_limits_nb,
 		CPUFREQ_POLICY_NOTIFIER);
 	
-	rc = cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE,
+	rc = cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE_IDLE,
 		"rqbalance_cpuhp", cfl_hotplug_notify, NULL);
 	if (rc < 0)
 		goto end;


### PR DESCRIPTION
Commit cfaa29a8cb3cfe66a3756b048b415e33613f8165 changed the cluster
voting mechanism in such a way that a if a cluster is unabvailable
the cluster policy will be updated at the next upcore event using a
CPUHP_AP_ONLINE callback called cfl_hotplug_notify.

When a cpu is starting the notify_cpu_starting function, called from
arch/arm64/kernel/smp.c, will take care of calling the CPUHP_AP_ONLINE
callbacks, see kernel/cpu.c. However at this point irqs are disabled
and in cpufreq_notify_transition (which is in the callchain of the
cfl_hotplug_notify function) there is a BUG_ON(irqs_disabled());.

This results in a relatively rare crash.

Backtrace:
6>[96457.930238] ------------[ cut here ]------------
<2>[96457.930264] Kernel BUG at ffffff9624c0a840 [verbose debug info unavailable]
<6>[96457.930470] ------------[ cut here ]------------
<2>[96457.930699] Kernel BUG at ffffff9624c0a840 [verbose debug info unavailable]
<0>[96457.930823] Internal error: Oops - BUG: 0 [#1] PREEMPT SMP
<6>[96457.931034] Modules linked in:
<6>[96457.931296] CPU: 5 PID: 0 Comm: swapper/5 Tainted: G        W       4.9.194 #1
<6>[96457.931508] Hardware name: Sony Mobile Communications. kirin(sdm630) (DT)
<6>[96457.931630] task: ffffffe1faff0000 task.stack: ffffffe1fafec000
<6>[96457.931892] PC is at cpufreq_notify_transition+0x134/0x210
<6>[96457.932018] LR is at cpufreq_notify_transition+0x68/0x210
...
<6>[96457.956130] [<ffffff9624c0a840>] cpufreq_notify_transition+0x134/0x210
<6>[96457.956351] [<ffffff9624c0aaf8>] cpufreq_freq_transition_begin+0x1dc/0x268
<6>[96457.956485] [<ffffff9624c19e40>] set_cpu_freq.isra.11+0x58/0x1f8
<6>[96457.956696] [<ffffff9624c1a14c>] msm_cpufreq_target+0x16c/0x450
<6>[96457.956817] [<ffffff9624c0aee8>] __cpufreq_driver_target+0x8c/0x5a4
<6>[96457.957050] [<ffffff9624c17754>] cpufreq_interactive_limits+0x60/0xc0
<6>[96457.957280] [<ffffff9624c0dd2c>] cpufreq_set_policy+0x33c/0x3ac
<6>[96457.957416] [<ffffff9624c0de68>] cpufreq_update_policy+0xcc/0x108
<6>[96457.957641] [<ffffff9624c266a4>] cfl_hotplug_notify+0x54/0x64
<6>[96457.957774] [<ffffff9623eb86e8>] cpuhp_invoke_callback+0x9c/0x594
<6>[96457.957997] [<ffffff9623ebb150>] notify_cpu_starting+0x7c/0x9c
<6>[96457.958122] [<ffffff9623e93ad8>] secondary_start_kernel+0xc4/0x140
<6>[96457.958335] [<00000000816ab1d4>] 0x816ab1d4

The change proposed in this commit will change it so that the callbacks
will be called only when the CPUHP_AP_ONLINE_IDLE state is entered.
CPUHP_AP_ONLINE_IDLE is entered in arch/arm64/kernel/smp.c soon after
a call to local_irq_enable().

Tagging @kholk as he is the author of the mentioned commit. Sorry if that is inappropriate.
Please let us know whether this change is correct or not.

We are still testing whether we can reproduce the crash still with this change, so far it doesn't look like it, but given the rarity of the crash it might take a while to be sure. I marked the bug with [TESTING IN PROGRESS] because of that.

We should probably also merge these to other branches which are affected if this change makes sense.