### PR TITLE
[9.12.r1] arm64: dts: edo: Finish removing Sony camera configuration

### DIFF
--- a/arch/arm64/boot/dts/somc/kona-edo-pdx203_common.dtsi
+++ b/arch/arm64/boot/dts/somc/kona-edo-pdx203_common.dtsi
@@ -15,10 +15,6 @@
 &soc {
 };
 
-&sony_camera_module_4 {
-	status = "okay";
-};
-
 &somc_pinctrl {
 	/* If product common default setting is needed,
 	fill pinctrl-1 value in <product>_common.dtsi */


### PR DESCRIPTION
Almost there... but one (now stale) phandle was left, breaking the
DTBOverlay for PDX203 completely.

Fixes: e5d0a237f6ce ("dts: edo: remove Sony camera configuration")