### PR TITLE
[LA.UM.7.1.r1] arm: dts: trinket: use qcom,auto-suspend-disable to avoid suspend failures.

### DIFF
--- a/arch/arm64/boot/dts/qcom/trinket-qupv3.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-qupv3.dtsi
@@ -266,6 +266,7 @@
 			<&tlmm 13 0>;
 		qcom,wakeup-byte = <0xFD>;
 		qcom,wrapper-core = <&qupv3_1>;
+		qcom,auto-suspend-disable;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
commit 9a0b2664ae23e6cc54736113789fc82e290fa7f9 made a change to NOT depend
on linux pm runtime, this however fails on (at least) seine.

The failure is as below:
android.system.syspend reads from /sys/power/wakeup_count
android.system.suspend writes to /sys/power/wakeup_count
android.system.suspend writes mem to /sys/power/state

The system tries to suspend as follows:
Feb 14 19:22:33 Xperia10II-DualSIM kernel: PM: PM: suspend entry 2021-02-14 17:22:33.365245561 UTC
Feb 14 19:22:33 Xperia10II-DualSIM kernel: PM: suspend entry (deep)
Feb 14 19:22:33 Xperia10II-DualSIM kernel: PM: Syncing filesystems ... done.
Feb 14 19:22:33 Xperia10II-DualSIM kernel: Freezing user space processes ... (elapsed 0.023 seconds) done.
Feb 14 19:22:33 Xperia10II-DualSIM kernel: OOM killer disabled.
Feb 14 19:22:33 Xperia10II-DualSIM kernel: Freezing remaining freezable tasks ... (elapsed 0.003 seconds) done.
Feb 14 19:22:33 Xperia10II-DualSIM kernel: Suspending console(s) (use no_console_suspend to debug)
Feb 14 19:22:33 Xperia10II-DualSIM kernel: msm_geni_serial 4c90000.qcom,qup_uart: msm_geni_serial_stop_tx.Device is suspended.
^ suspend failure here

Feb 14 19:22:33 Xperia10II-DualSIM kernel: PM: Wakeup pending, aborting suspend
Feb 14 19:22:33 Xperia10II-DualSIM kernel: PM: noirq suspend of devices failed
Feb 14 19:22:33 Xperia10II-DualSIM kernel: OOM killer enabled.
Feb 14 19:22:33 Xperia10II-DualSIM kernel: Restarting tasks ...

At this point the 4c90000.qcom,qup_uart driver is in limbo and future
suspend cycles will fail as below:
android.system.suspend reads from /sys/power/wakeup_count
... and becomes stuck in read().

So after the first suspend cycle the system fails to suspend in future cycles
(and does not even attempt to do so because mem is never written to /sys/power/state anymore).