### PR TITLE
[9.12.r1] Fix modem audio errors on Sony Edo

### DIFF
--- a/arch/arm64/boot/dts/qcom/kona-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/kona-audio-overlay.dtsi
@@ -312,7 +312,6 @@
 	qcom,msm-mbhc-gnd-swh = <1>;
 	qcom,cdc-dmic01-gpios = <&cdc_dmic01_gpios>;
 	qcom,cdc-dmic23-gpios = <&cdc_dmic23_gpios>;
-	qcom,cdc-dmic45-gpios = <&cdc_dmic45_gpios>;
 	asoc-codec  = <&stub_codec>, <&bolero>, <&ext_disp_audio_codec>;
 	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
 			   "msm-ext-disp-audio-codec-rx";

--- a/arch/arm64/boot/dts/somc/kona-edo-common.dtsi
+++ b/arch/arm64/boot/dts/somc/kona-edo-common.dtsi
@@ -531,6 +531,10 @@
 	};
 };
 
+&cdc_dmic45_gpios {
+	status = "disabled";
+};
+
 &lpi_tlmm {
 	somc_cdc_dmic01_clk_active: somc_dmic01_clk_active {
 		mux {


### PR DESCRIPTION
When starting a voice call the dmic4-5 gpios are accessed, but Sony Edo has no DMIC4 nor DMIC5.
Also these GPIOs are being used for the Senary MI2S on that platform.

