### PR TITLE
[LA.UM.9.12.r1] arm64: dts: qcom: kona: Fix up the pstore node

### DIFF
--- a/arch/arm64/boot/dts/qcom/kona.dtsi
+++ b/arch/arm64/boot/dts/qcom/kona.dtsi
@@ -632,7 +632,7 @@
 			console-size = <0x40000>;
 			ftrace-size = <0x0>;
 			msg-size = <0x20000 0x20000>;
-			cc-size = <0x0>;
+			ecc-size = <16>;
 		};
 
 		cmdline_region: cmdline_region@ffd00000 {


### PR DESCRIPTION
Fix a typo ("cc" -> "ecc") and enable 16-bit ECC.