### PR TITLE
[LA.UM.7.1.r1] cherry-pick: "arm64: fix infinite stacktrace" from upstream.

### DIFF
--- a/arch/arm64/kernel/stacktrace.c
+++ b/arch/arm64/kernel/stacktrace.c
@@ -60,6 +60,9 @@ int notrace unwind_frame(struct task_struct *tsk, struct stackframe *frame)
 	frame->pc = READ_ONCE_NOCHECK(*(unsigned long *)(fp + 8));
 	kasan_enable_current();
 
+	if (frame->fp <= fp)
+		return -EINVAL;
+
 #ifdef CONFIG_FUNCTION_GRAPH_TRACER
 	if (tsk->ret_stack &&
 			(frame->pc == (unsigned long)return_to_handler)) {


### PR DESCRIPTION
Without this, for example:

```perf record -g```

Locks up the device entirely (at least on SailfishOS) and the device reboots soon afterwards due to a kernel panic in the watchdog code.
perf: https://en.wikipedia.org/wiki/Perf_(Linux)
