### PR TITLE
net/wireless/cnss2: Use appropriate pr_ functions instead of printk

### DIFF
--- a/drivers/net/wireless/cnss2/debug.h
+++ b/drivers/net/wireless/cnss2/debug.h
@@ -23,27 +23,27 @@ extern void *cnss_ipc_log_long_context;
 	} while (0)
 
 #define cnss_pr_err(_fmt, ...) do {					\
-		printk("%scnss: " _fmt, KERN_ERR, ##__VA_ARGS__);	\
+		pr_err("cnss: " _fmt, ##__VA_ARGS__);	\
 		cnss_ipc_log_string("%scnss: " _fmt, "", ##__VA_ARGS__);\
 	} while (0)
 
 #define cnss_pr_warn(_fmt, ...) do {					\
-		printk("%scnss: " _fmt, KERN_WARNING, ##__VA_ARGS__);	\
+		pr_warn("cnss: " _fmt, ##__VA_ARGS__);	\
 		cnss_ipc_log_string("%scnss: " _fmt, "", ##__VA_ARGS__);\
 	} while (0)
 
 #define cnss_pr_info(_fmt, ...) do {					\
-		printk("%scnss: " _fmt, KERN_INFO, ##__VA_ARGS__);	\
+		pr_info("cnss: " _fmt, ##__VA_ARGS__);	\
 		cnss_ipc_log_string("%scnss: " _fmt, "", ##__VA_ARGS__);\
 	} while (0)
 
 #define cnss_pr_dbg(_fmt, ...) do {					\
-		printk("%scnss: " _fmt, KERN_DEBUG, ##__VA_ARGS__);	\
+		pr_debug("cnss: " _fmt, ##__VA_ARGS__);	\
 		cnss_ipc_log_string("%scnss: " _fmt, "", ##__VA_ARGS__);\
 	} while (0)
 
 #define cnss_pr_vdbg(_fmt, ...) do {					\
-		printk("%scnss: " _fmt, KERN_DEBUG, ##__VA_ARGS__);	\
+		pr_debug("cnss: " _fmt, ##__VA_ARGS__);	\
 		cnss_ipc_log_long_string("%scnss: " _fmt, "",		\
 					 ##__VA_ARGS__);		\
 	} while (0)


### PR DESCRIPTION
This GREATLY reduces log spam, as originally !!every!! print was piped straight
to dmesg, no matter the build flags (i.e. tons of debug/vdebug info on prod
builds).

Signed-off-by: Konrad Dybcio <konrad.dybcio@somainline.org>