### PR TITLE
[9.12.r1] psy/qcom/smb5*: Keep Lena-specific quirks strictly to lena

### DIFF
--- a/drivers/power/supply/qcom/qpnp-smb5.c
+++ b/drivers/power/supply/qcom/qpnp-smb5.c
@@ -4382,6 +4382,12 @@ static struct device_attribute smb5_somc_attrs[] = {
 	__ATTR(somc_usb_icl_voter, 0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_usb_icl_voter_effective,
 				0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dc_icl_voter, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dc_icl_voter_effective,
+				0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dc_suspend_voter, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dc_suspend_voter_effective,
+				0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_fcc_voter, 0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_fcc_voter_effective, 0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_chg_disable_voter, 0444, smb5_somc_param_show, NULL),
@@ -4430,8 +4436,23 @@ static struct device_attribute smb5_somc_attrs[] = {
 	__ATTR(somc_reg_usbin_current_limit_cfg,
 				0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_reg_misc_int_rt_sts, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_reg_usbin_adapter_allow_override,
+				0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_reg_usbin_adapter_allow_cfg,
+				0444, smb5_somc_param_show, NULL),
 	__ATTR(somc_reg_usbin_5v_aicl_threshold_cfg,
 				0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dcin_uv_count, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_target_dc_icl, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_settled_dc_icl, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_settled_dc_icl_adjustment, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dcusbex_status, 0444, smb5_somc_param_show, NULL),
+	__ATTR(somc_dc_h_volt_icl_cfg, 0644,
+			smb5_somc_param_show, smb5_somc_param_store),
+	__ATTR(somc_dc_l_volt_icl_cfg, 0644,
+			smb5_somc_param_show, smb5_somc_param_store),
+	__ATTR(somc_dcin_aicl_skip, 0644,
+			smb5_somc_param_show, smb5_somc_param_store),
 };
 
 static ssize_t smb5_somc_param_show(struct device *dev,
@@ -4453,6 +4474,22 @@ static ssize_t smb5_somc_param_show(struct device *dev,
 	case ATTR_USB_ICL_VOTER_EFFECTIVE:
 		size = scnprintf(buf, PAGE_SIZE, "%d\n",
 				get_effective_result(chg->usb_icl_votable));
+		break;
+	case ATTR_DC_ICL_VOTER:
+		size = somc_output_voter_param(chg->dc_icl_votable, buf,
+								PAGE_SIZE);
+		break;
+	case ATTR_DC_ICL_VOTER_EFFECTIVE:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n",
+				get_effective_result(chg->dc_icl_votable));
+		break;
+	case ATTR_DC_SUSPEND_VOTER:
+		size = somc_output_voter_param(chg->dc_suspend_votable, buf,
+								PAGE_SIZE);
+		break;
+	case ATTR_DC_SUSPEND_VOTER_EFFECTIVE:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n",
+				get_effective_result(chg->dc_suspend_votable));
 		break;
 	case ATTR_FCC_VOTER:
 		size = somc_output_voter_param(chg->fcc_votable, buf,
@@ -4731,6 +4768,22 @@ static ssize_t smb5_somc_param_show(struct device *dev,
 		else
 			size = scnprintf(buf, PAGE_SIZE, "0x%02X\n", reg);
 		break;
+	case ATTR_REG_USBIN_ADAPTER_ALLOW_OVERRIDE:
+		ret = smblib_read(chg, USBIN_ADAPTER_ALLOW_OVERRIDE_REG, &reg);
+		if (ret)
+			dev_err(dev, "Can't read USBIN_ADAPTER_ALLOW_OVERRIDE_REG: %d\n",
+									ret);
+		else
+			size = scnprintf(buf, PAGE_SIZE, "0x%02X\n", reg);
+		break;
+	case ATTR_REG_USBIN_ADAPTER_ALLOW_CFG:
+		ret = smblib_read(chg, USBIN_ADAPTER_ALLOW_CFG_REG, &reg);
+		if (ret)
+			dev_err(dev, "Can't read USBIN_ADAPTER_ALLOW_CFG_REG: %d\n",
+									ret);
+		else
+			size = scnprintf(buf, PAGE_SIZE, "0x%02X\n", reg);
+		break;
 	case ATTR_REG_USBIN_5V_AICL_THRESHOLD_CFG:
 		ret = smblib_read(chg, USBIN_5V_AICL_THRESHOLD_CFG_REG, &reg);
 		if (ret)
@@ -4740,6 +4793,30 @@ static ssize_t smb5_somc_param_show(struct device *dev,
 		else
 			size = scnprintf(buf, PAGE_SIZE, "0x%02X\n",
 					reg & USBIN_5V_AICL_THRESHOLD_CFG_MASK);
+		break;
+	case ATTR_DCIN_UV_COUNT:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->somc_dcin_uv_count);
+		break;
+	case ATTR_DCIN_AICL_TARGET:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->somc_target_dc_icl);
+		break;
+	case ATTR_DCIN_AICL_SETTLED:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->somc_settled_dc_icl);
+		break;
+	case ATTR_DCIN_AICL_ADJUSTMENT:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->somc_settled_dc_icl_adjustment);
+		break;
+	case ATTR_DCUSBEX_STATUS:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->dcusbex_status);
+		break;
+	case ATTR_DC_H_VOLT_ICL_CFG:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->dc_h_volt_icl_ua);
+		break;
+	case ATTR_DC_L_VOLT_ICL_CFG:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->dc_l_volt_icl_ua);
+		break;
+	case ATTR_DCIN_AICL_SKIP:
+		size = scnprintf(buf, PAGE_SIZE, "%d\n", chg->debug_dcin_aicl_skip);
 		break;
 	default:
 		size = 0;

--- a/drivers/power/supply/qcom/smb5-lib.c
+++ b/drivers/power/supply/qcom/smb5-lib.c
@@ -2783,7 +2783,7 @@ int smblib_set_prop_system_temp_level(struct smb_charger *chg,
 
 	vote(chg->fcc_votable, THERMAL_DAEMON_VOTER, true,
 			chg->thermal_mitigation[chg->system_temp_level]);
-
+#if defined(CONFIG_ARCH_SONY_LENA)
 	if (screen_state == 0) {
 		vote(chg->usb_icl_votable, THERMAL_DAEMON_VOTER, true,
 			chg->thermal_mitigation[chg->system_temp_level]);
@@ -2795,7 +2795,7 @@ int smblib_set_prop_system_temp_level(struct smb_charger *chg,
 		smblib_dbg(chg, PR_INTERRUPT, "screen_off state=%d,thermal_mitigation_sleep=%d\n",
 			screen_state, chg->thermal_mitigation_sleep[chg->system_temp_level]);
 	}
-
+#endif
 	return 0;
 }
 
@@ -9725,13 +9725,14 @@ int smblib_init(struct smb_charger *chg)
 				"Couldn't register notifier rc=%d\n", rc);
 			return rc;
 		}
-
+#if defined(CONFIG_ARCH_SONY_LENA)
 		rc = screen_on_chg_register_notifier(chg);
 		if (rc < 0) {
 			smblib_err(chg,
 				"Couldn't register screen on notifier rc=%d\n", rc);
 			return rc;
 		}
+#endif
 		break;
 	case PARALLEL_SLAVE:
 		break;
@@ -9773,7 +9774,9 @@ int smblib_deinit(struct smb_charger *chg)
 		cancel_delayed_work_sync(&chg->role_reversal_check);
 		cancel_delayed_work_sync(&chg->pr_swap_detach_work);
 		power_supply_unreg_notifier(&chg->nb);
+#if defined(CONFIG_ARCH_SONY_LENA)
 		power_supply_unreg_notifier(&chg->nbc);
+#endif
 		smblib_destroy_votables(chg);
 		qcom_step_chg_deinit();
 		qcom_batt_deinit();


### PR DESCRIPTION
In the initial porting of psy quirks a bunch of Lena-specific
properties were not put behind a build barrier and a bunch of
actually useful generic properties were removed.. Fix it!