### PR TITLE
Revert "Revert "net: qrtr: Only update pkts with broadcast node ID""

### DIFF
--- a/net/qrtr/qrtr.c
+++ b/net/qrtr/qrtr.c
@@ -555,14 +555,12 @@ static int qrtr_node_enqueue(struct qrtr_node *node, struct sk_buff *skb,
 	hdr->type = cpu_to_le32(type);
 	hdr->src_node_id = cpu_to_le32(from->sq_node);
 	hdr->src_port_id = cpu_to_le32(from->sq_port);
-	if (to->sq_port == QRTR_PORT_CTRL) {
+	if (to->sq_node == QRTR_NODE_BCAST)
 		hdr->dst_node_id = cpu_to_le32(node->nid);
-		hdr->dst_port_id = cpu_to_le32(QRTR_PORT_CTRL);
-	} else {
+	else
 		hdr->dst_node_id = cpu_to_le32(to->sq_node);
-		hdr->dst_port_id = cpu_to_le32(to->sq_port);
-	}
 
+	hdr->dst_port_id = cpu_to_le32(to->sq_port);
 	hdr->size = cpu_to_le32(len);
 	hdr->confirm_rx = !!confirm_rx;
 


### PR DESCRIPTION
This reverts commit 49d71996332a9adcb63de875014391fcfacc5072.

I reverted this as upstream patch would not  apply cleanly as i thought the fix was in upstream already.
This wasnt the case and caused our phones to freeze after few minutes of uptime.