### PR TITLE
fw_loader: add /odm/firmware to fw loader lookup

### DIFF
--- a/drivers/base/firmware_loader/main.c
+++ b/drivers/base/firmware_loader/main.c
@@ -283,6 +283,7 @@ static void free_fw_priv(struct fw_priv *fw_priv)
 static char fw_path_para[256];
 static const char * const fw_path[] = {
 	fw_path_para,
+	"/odm/firmware/",
 	"/lib/firmware/updates/" UTS_RELEASE,
 	"/lib/firmware/updates",
 	"/lib/firmware/" UTS_RELEASE,


### PR DESCRIPTION
Qualcomm decided that it would be a good idea to hardcode I2C device
ID for every single DAI device in techpack/audio, essentially making
the codec vendor forcecully set the I2C device ID, which would be fine..
IF WE DIDN'T HAVE TO REQUEST A FIRMWARE FROM USERLAND! By changing the
name halfway through probing, ueventd goes absolutely crazy and does not
know what to do.. There are two solutions:

- Hardcode the device IDs in the techpack/asoc DAI lookup table
(INCLUDING the precise I2C addresses of the codecs for each device using
codec X) AND in the codec driver

- Add a dumb firmware lookup path to fw_loader so that it always finds
the FW first-try

- Rewrite techpack (no, I'd rather write mainline-quality drivers and submit
them there instead of making an even bigger mess in the qualcommCAFland)

All three solutions are horrid, but the second one is the shortest and
least error-prone. Let's stick to it.