### PR TITLE
[9.12] dts: lagoon: Configure in-house et51x/et580 Egistec fingerprint driver

### DIFF
--- a/arch/arm64/boot/dts/qcom/lagoon-fingerprint.dtsi
+++ b/arch/arm64/boot/dts/qcom/lagoon-fingerprint.dtsi
@@ -1,12 +1,92 @@
 &soc {
-    egistec_fingerprint {
-        status = "ok";
-        compatible = "egistec,et613";
-        interrupt-parent = <&tlmm>;
-        interrupts = <17 0x0>;
-        egistec,gpio_rst= <&tlmm 18 0>;
-        egistec,gpio_irq = <&tlmm 17 0>;
-        egistec,gpio_pwr_en = <&tlmm 70 0 >;
-        egistec,gpio_ldo1p8_en = <&tlmm 87 0 >;
-    };
+	fpc_vana_vreg_87: fpc_vana_vreg_87 {
+		compatible = "regulator-fixed";
+		regulator-name = "fpc_vana_fixed_reg_87";
+		/* Based on egistec,gpio_ldo1p8_en name */
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		startup-delay-us = <2000>;
+		enable-active-high;
+		gpio = <&tlmm 87 0>;
+	};
+
+	fpc_vana_vreg_70: fpc_vana_vreg_70 {
+		compatible = "regulator-fixed";
+		regulator-name = "fpc_vana_fixed_reg_70";
+		/* Actual voltages unknown - just declare
+		   what the driver expects */
+		regulator-min-microvolt = <3350000>;
+		regulator-max-microvolt = <3350000>;
+		startup-delay-us = <2000>;
+		enable-active-high;
+		gpio = <&tlmm 70 0>;
+
+		/* Use a "parent" supply just to be
+		   able to turn on two gpios */
+		vin-supply = <&fpc_vana_vreg_87>;
+	};
+
+	et6xx: et6xx {
+		compatible = "egistec,et580";
+
+		et51x,gpio_irq = <&tlmm 17 0x0>;
+		et51x,no-low-voltage-probe;
+		et51x,vana-voltage = <3350000>;
+		vdd_ana-supply = <&fpc_vana_vreg_70>;
+
+		pinctrl-names = "et51x_reset_reset",
+				"et51x_reset_active",
+				"et51x_irq_active";
+		pinctrl-0 = <&sm_gpio_18>;
+		pinctrl-1 = <&sm_gpio_18_output_high>;
+		pinctrl-2 = <&sm_gpio_17>;
+		status = "ok";
+	};
+};
+
+&tlmm {
+	/* GPIO_74 : FP_RESET_N */
+	sm_gpio_18: sm_gpio_18 {
+		mux {
+			pins = "gpio18";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio18";
+			drive-strength = <2>;
+			bias-disable;
+			output-low;
+		};
+	};
+
+	/* GPIO_18 : FP_RESET_N OUTPUT_HIGH */
+	sm_gpio_18_output_high: sm_gpio_18_output_high {
+		mux {
+			pins = "gpio18";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio18";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	/* GPIO_17 : FP_INT_N */
+	sm_gpio_17: sm_gpio_17 {
+		mux {
+			pins = "gpio17";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio17";
+			drive-strength = <2>;
+			bias-pull-up;
+			input-enable;
+		};
+	};
 };


### PR DESCRIPTION
Use our own Egistec fingerprint device driver as a perfect match to our
fingerprint HAL, with support for fast and efficient wakeup.  This
requires jumping through some hoops to use two gpios as fixed regulators
(without modifying the driver itself).