### PR TITLE
[7.1] wlan-qc: Disable unfixable CAF warnings-as-errors for newer compilers

### DIFF
--- a/drivers/staging/wlan-qc/Makefile
+++ b/drivers/staging/wlan-qc/Makefile
@@ -1,1 +1,3 @@
 obj-$(CONFIG_QCA_CLD_WLAN)	+= qcacld-3.0/
+
+subdir-ccflags-y += -Wno-error=misleading-indentation -Wno-error=maybe-uninitialized -Wno-error=array-parameter


### PR DESCRIPTION
Newer compilers detect more and more mistakes in these vast codebases, and they're disallowed with -Werror.  It is infeasible and a waste of our time to fix them all, but we'd still like to use newer GCC.
