### PR TITLE
[7.1] wlan-qc: Use cc-option to check if -Wno-error excludes are available

### DIFF
--- a/drivers/staging/wlan-qc/Makefile
+++ b/drivers/staging/wlan-qc/Makefile
@@ -1,3 +1,5 @@
 obj-$(CONFIG_QCA_CLD_WLAN)	+= qcacld-3.0/
 
-subdir-ccflags-y += -Wno-error=misleading-indentation -Wno-error=maybe-uninitialized -Wno-error=array-parameter
+subdir-ccflags-y += $(call cc-option,-Wno-error=array-parameter)
+subdir-ccflags-y += $(call cc-option,-Wno-error=maybe-uninitialized)
+subdir-ccflags-y += $(call cc-option,-Wno-error=misleading-indentation)


### PR DESCRIPTION
Unfortunately people are still on ancient compilers that are unaware of these specific warnings (hence why -Werror is not a problem to them) but this also means that the compiler fails on "unknown warning option".  Solve that by running through cc-option, which only passes the option if it's available.

Fixes: 22e47a65f69a ("wlan-qc: Disable unfixable CAF warnings-as-errors for newer compilers")

CC @voidanix
