### PR TITLE
{LA.UM.7.1.r1] Revert "selinux: Relocate ss_initialized and selinux_enforcing to sep…

### DIFF
--- a/arch/arm64/kernel/vmlinux.lds.S
+++ b/arch/arm64/kernel/vmlinux.lds.S
@@ -76,12 +76,6 @@ jiffies = jiffies_64;
 #define TRAMP_TEXT
 #endif
 
-#define RTIC_BSS					\
-	. = ALIGN(PAGE_SIZE);				\
-	VMLINUX_SYMBOL(__bss_rtic_start) = .;	\
-	KEEP(*(.bss.rtic))			\
-	. = ALIGN(PAGE_SIZE);				\
-	VMLINUX_SYMBOL(__bss_rtic_end) = .;
 /*
  * The size of the PE/COFF section that covers the kernel image, which
  * runs from stext to _edata, must be a round multiple of the PE/COFF
@@ -253,10 +247,6 @@ SECTIONS
 	STABS_DEBUG
 
 	HEAD_SYMBOLS
-
-	.bss : {			/* bss segment		*/
-         RTIC_BSS
-	}
 }
 
 PROVIDE(__efistub_stext_offset = stext - _text);

--- a/include/linux/init.h
+++ b/include/linux/init.h
@@ -289,8 +289,6 @@ void __init parse_early_options(char *cmdline);
 /* Data marked not to be saved by software suspend */
 #define __nosavedata __section(.data..nosave)
 
-#define __rticdata  __attribute__((section(".bss.rtic")))
-
 #ifdef MODULE
 #define __exit_p(x) x
 #else

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -102,7 +102,7 @@
 static atomic_t selinux_secmark_refcount = ATOMIC_INIT(0);
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-int selinux_enforcing __rticdata;
+int selinux_enforcing;
 
 static int __init enforcing_setup(char *str)
 {

--- a/security/selinux/ss/services.c
+++ b/security/selinux/ss/services.c
@@ -91,7 +91,7 @@ static DEFINE_RWLOCK(policy_rwlock);
 
 static struct sidtab sidtab;
 struct policydb policydb;
-int ss_initialized __rticdata;
+int ss_initialized;
 
 /*
  * The largest sequence number that has been used when


### PR DESCRIPTION
…arate 4k"

This reverts commit d4807bd60dc166a6445c3b13684f1d1afb722bc5.

That out of tree patch causes the resulting kernel image to be too
large, causing ld.lld to error; likely due to the additional section and
alignment requirements.  Android and floral don't host virtual targets
and thus do not run at EL2 on arm64.

Bug: 63740206
Change-Id: I357bf4d5c7e29230746eacd51fef413acec06067
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>

See also: https://github.com/kdrag0n/proton-clang/issues/12
I discovered while building for kumano against GCC 11.2.