### PR TITLE
[LA.UM.9.12.r1] Revert "selinux: Relocate ss_initialized and selinux_enforcing to sep…

### DIFF
--- a/arch/arm64/kernel/vmlinux.lds.S
+++ b/arch/arm64/kernel/vmlinux.lds.S
@@ -76,10 +76,6 @@ jiffies = jiffies_64;
 #define TRAMP_TEXT
 #endif
 
-#define RTIC_BSS					\
-	. = ALIGN(PAGE_SIZE);				\
-	KEEP(*(.bss.rtic));			\
-	. = ALIGN(PAGE_SIZE);				\
 /*
  * The size of the PE/COFF section that covers the kernel image, which
  * runs from stext to _edata, must be a round multiple of the PE/COFF
@@ -257,10 +253,6 @@ SECTIONS
 	STABS_DEBUG
 
 	HEAD_SYMBOLS
-
-	.bss : {			/* bss segment		*/
-         RTIC_BSS
-	}
 }
 
 /*

--- a/include/linux/init.h
+++ b/include/linux/init.h
@@ -322,8 +322,6 @@ void __init parse_early_options(char *cmdline);
 /* Data marked not to be saved by software suspend */
 #define __nosavedata __section(.data..nosave)
 
-#define __rticdata  __attribute__((section(".bss.rtic")))
-
 #ifdef MODULE
 #define __exit_p(x) x
 #else

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -100,7 +100,7 @@
 #include "audit.h"
 #include "avc_ss.h"
 
-struct selinux_state selinux_state __rticdata;
+struct selinux_state selinux_state;
 
 /* SECMARK reference count */
 static atomic_t selinux_secmark_refcount = ATOMIC_INIT(0);


### PR DESCRIPTION
…arate 4k"

This reverts commit 50240fa8416f5fd183cb147fd3c66aeaeb74a1f8.

That out of tree patch causes the resulting kernel image to be too
large, causing ld.lld to error; since .bss is specified twice.

Fixes the observed error:
ld.lld: error: output file too large: 18446743524330100280 bytes

when using LLD without LTO enabled.

See also: https://github.com/kdrag0n/proton-clang/issues/12
