### PR TITLE
[9.12.r1] block: vs_block_client: Fix compilation issue

### DIFF
--- a/drivers/block/vs_block_client.c
+++ b/drivers/block/vs_block_client.c
@@ -550,7 +550,7 @@ static int vs_block_client_disk_add(struct block_client *client)
 	client->blkdev = blkdev;
 	vs_service_state_unlock(client->service);
 
-	device_add_disk(&client->service->dev, blkdev->disk);
+	device_add_disk(&client->service->dev, blkdev->disk, NULL);
 	dev_dbg(&client->service->dev, "added block disk '%s'\n",
 			blkdev->disk->disk_name);
 


### PR DESCRIPTION
In commit https://github.com/sonyxperiadev/kernel/commit/8ab86d25b0757efd84b32e296ef2a676157e2ac2 device_add_disk() was updated to take a groups argument so add the missing argument