### PR TITLE
[LA.UM.9.12.r1] ARM64: dts: qcom: Fix IPA load uC property

### DIFF
--- a/arch/arm64/boot/dts/qcom/lagoon.dtsi
+++ b/arch/arm64/boot/dts/qcom/lagoon.dtsi
@@ -3599,7 +3599,7 @@
 	qcom,rmnet-ipa {
 		compatible = "qcom,rmnet-ipa3";
 		qcom,rmnet-ipa-ssr;
-		qcom,ipa-platform-type-msm;
+		qcom,ipa-loaduC;
 		qcom,ipa-advertise-sg-support;
 		qcom,ipa-napi-enable;
 	};

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1328,7 +1328,7 @@
 	qcom,rmnet-ipa {
 		compatible = "qcom,rmnet-ipa";
 		qcom,rmnet-ipa-ssr;
-		qcom,ipa-platform-type-msm;
+		qcom,ipa-loaduC;
 		qcom,ipa-advertise-sg-support;
 		qcom,ipa-napi-enable;
 	};

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -1502,7 +1502,7 @@
 	qcom,rmnet-ipa {
 		compatible = "qcom,rmnet-ipa";
 		qcom,rmnet-ipa-ssr;
-		qcom,ipa-platform-type-msm;
+		qcom,ipa-loaduC;
 		qcom,ipa-advertise-sg-support;
 		qcom,ipa-napi-enable;
 	};


### PR DESCRIPTION
CAF changed this property back in msm-4.14, but the
ipa_v2 driver it's still reading qcom,ipa-loaduC.