### PR TITLE
[9.12.r1] misc: sony_ext_uim_ctrl: Add quirks for SoMC Lena

### DIFF
--- a/drivers/misc/sony_ext_uim_ctrl.c
+++ b/drivers/misc/sony_ext_uim_ctrl.c
@@ -32,7 +32,9 @@ struct sony_ext_uim_ctrl_drvdata {
 	struct device *device;
 	struct mutex lock;
 	int uim2_detect_en_gpio;
+#if !defined(CONFIG_ARCH_SONY_LENA)
 	int uim2_select_gpio;
+#endif
 	bool type;
 	bool is_set_once;
 	bool uim2_detect_en_status;
@@ -110,8 +112,10 @@ static ssize_t sony_ext_uim_ctrl_type_store(struct device *dev,
 	if (type) {
 		sony_ext_uim_ctrl_gpio_set_value(
 			drv->uim2_detect_en_gpio, 1);
+#if !defined(CONFIG_ARCH_SONY_LENA)
 		sony_ext_uim_ctrl_gpio_set_value(
 			drv->uim2_select_gpio, 1);
+#endif
 	} else {
 		sony_ext_uim_ctrl_gpio_set_value(
 			drv->uim2_detect_en_gpio,
@@ -179,12 +183,14 @@ static int sony_ext_uim_ctrl_probe(struct platform_device *pdev)
 	pr_info("sony_ext_uim_ctrl: uim2_detect_en_gpio = %d\n",
 		drv->uim2_detect_en_gpio);
 
+#if !defined(CONFIG_ARCH_SONY_LENA)
 	drv->uim2_select_gpio = of_get_named_gpio(np, "uim2_select_gpio", 0);
 	if (!gpio_is_valid(drv->uim2_select_gpio))
 		pr_err("%s: gpio_is_valid(uim2_select_gpio)=%d: invalid\n",
 			__func__, drv->uim2_select_gpio);
 	pr_info("sony_ext_uim_ctrl: uim2_select_gpio = %d\n",
 		drv->uim2_select_gpio);
+#endif
 
 	drv->class = class_create(THIS_MODULE, "sony_ext_uim_ctrl");
 	if (IS_ERR(drv->class)) {
@@ -207,8 +213,12 @@ static int sony_ext_uim_ctrl_probe(struct platform_device *pdev)
 	mutex_init(&drv->lock);
 	_drv = drv;
 
+#if defined(CONFIG_ARCH_SONY_LENA)
+	sony_ext_uim_ctrl_gpio_set_value(drv->uim2_detect_en_gpio, 1);
+#else
 	sony_ext_uim_ctrl_gpio_set_value(drv->uim2_detect_en_gpio, 0);
 	sony_ext_uim_ctrl_gpio_set_value(drv->uim2_select_gpio, 0);
+#endif
 	return 0;
 
 probe_failed:


### PR DESCRIPTION
Lena only uses one of the GPIOs and sets a different value on probe.
Account for this brokennes to make the secondary SIM slot work..
