### PR TITLE
[9.12.r1] Fix continuous splash screen for Nile/Ganges platform devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-camera.dtsi
@@ -293,7 +293,6 @@
 
 	qcom,cam_smmu {
 		compatible = "qcom,msm-cam-smmu";
-		qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 		status = "ok";
 
 		msm_cam_smmu_cb1 {
@@ -303,6 +302,7 @@
 					<&mmss_bimc_smmu 0xc02>,
 					<&mmss_bimc_smmu 0xc03>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x10000000 0x70000000>;
 			label = "vfe";
 			qcom,scratch-buf-support;
 		};
@@ -311,6 +311,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0xa00>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "cpp";
 		};
 
@@ -318,6 +319,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0x800>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "jpeg_enc0";
 		};
 
@@ -325,6 +327,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0x801>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "jpeg_dma";
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -403,9 +403,9 @@
 			linux,cma-default;
 		};
 
-		cont_splash_mem: splash_region@9d400000 {
+		cont_splash_mem: cont_splash_region@9d400000 {
 			reg = <0x0 0x9d400000 0x0 0x23ff000>;
-			label = "cont_splash_mem";
+			label = "cont_splash_region";
 		};
 
 		dfps_data_mem: dfps_data_mem@9f7ff000 {

--- a/arch/arm64/boot/dts/qcom/sdm660-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-camera.dtsi
@@ -289,7 +289,6 @@
 
 	qcom,cam_smmu {
 		compatible = "qcom,msm-cam-smmu";
-		qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 		status = "ok";
 
 		msm_cam_smmu_cb1 {
@@ -299,6 +298,7 @@
 					<&mmss_bimc_smmu 0xc02>,
 					<&mmss_bimc_smmu 0xc03>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x10000000 0x70000000>;
 			label = "vfe";
 			qcom,scratch-buf-support;
 		};
@@ -307,6 +307,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0xa00>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "cpp";
 		};
 
@@ -314,6 +315,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0x800>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "jpeg_enc0";
 		};
 
@@ -321,6 +323,7 @@
 			compatible = "qcom,msm-cam-smmu-cb";
 			iommus = <&mmss_bimc_smmu 0x801>;
 			iommu-cells = <1>;
+			qcom,iommu-dma-addr-pool = <0x00020000 0x78000000>;
 			label = "jpeg_dma";
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -440,9 +440,9 @@
 			linux,cma-default;
 		};
 
-		cont_splash_mem: splash_region@9d400000 {
+		cont_splash_mem: cont_splash_region@9d400000 {
 			reg = <0x0 0x9d400000 0x0 0x2300000>;
-			label = "cont_splash_mem";
+			label = "cont_splash_region";
 		};
 
 		dfps_data_mem: dfps_data_mem@9f700000 {

--- a/arch/arm64/boot/dts/somc/sdm630-ganges-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm630-ganges-common.dtsi
@@ -360,6 +360,14 @@
 	};
 };
 
+&lcdb_ldo_vreg {
+	regulator-boot-on;
+};
+
+&lcdb_ncp_vreg {
+	regulator-boot-on;
+};
+
 &pm660_charger {
 	io-channels = <&pm660_rradc 2>,
 			<&pm660_rradc 3>,

--- a/arch/arm64/boot/dts/somc/sdm630-nile-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm630-nile-common.dtsi
@@ -317,6 +317,7 @@
 		};
 	};
 };
+
 &pm660l_l6 {
 	qcom,regulator-type = <0>;  /* LDO */
 	qcom,init-enable = <0>;
@@ -324,6 +325,14 @@
 	qcom,init-pin-ctrl-enable = <0>;
 	qcom,init-pin-ctrl-mode = <0>;
 	qcom,init-voltage = <3300000>;
+};
+
+&lcdb_ldo_vreg {
+	regulator-boot-on;
+};
+
+&lcdb_ncp_vreg {
+	regulator-boot-on;
 };
 
 /* PM660 */

--- a/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
@@ -241,10 +241,14 @@ static int msm_actuator_bivcm_handle_i2c_ops(
 		reg_setting.size = 1;
 		switch (write_arr[i].reg_write_type) {
 		case MSM_ACTUATOR_WRITE_DAC:
+#ifdef CONFIG_MACH_SONY_KIRIN
+			value = (unsigned short)((0x25 * next_lens_position) + 0xFFFFBC00);
+#else
 			value = (next_lens_position <<
 			write_arr[i].data_shift) |
 			((hw_dword & write_arr[i].hw_mask) >>
 			write_arr[i].hw_shift);
+#endif
 			if (write_arr[i].reg_addr != 0xFFFF) {
 				i2c_byte1 = write_arr[i].reg_addr;
 				i2c_byte2 = value;


### PR DESCRIPTION
This patch set is part of the continuous splash screen fix for Nile/Ganges platform devices.
Also add dma address range for each SMMU context bank for SDM630/660 camera as the driver expects.

This PR depends on: https://github.com/sonyxperiadev/kernel-techpack-display-driver/pull/8

The patch set has been successfully tested on:
- Xperia XA2 (Pioneer)
- Xperia 10+ (Mermaid)
- Xperia 10 (Kirin)