### PR TITLE
[LA.UM.9.12.r1] Revert genirq/irqdomain: Don't try to free an interrupt that has no m…

### DIFF
--- a/kernel/irq/irqdomain.c
+++ b/kernel/irq/irqdomain.c
@@ -1249,15 +1249,8 @@ static void irq_domain_free_irqs_hierarchy(struct irq_domain *domain,
 					   unsigned int irq_base,
 					   unsigned int nr_irqs)
 {
-	unsigned int i;
-
-	if (!domain->ops->free)
-		return;
-
-	for (i = 0; i < nr_irqs; i++) {
-		if (irq_domain_get_irq_data(domain, irq_base + i))
-			domain->ops->free(domain, irq_base + i, 1);
-	}
+	if (domain->ops->free)
+            domain->ops->free(domain, irq_base, nr_irqs);
 }
 
 int irq_domain_alloc_irqs_hierarchy(struct irq_domain *domain,


### PR DESCRIPTION
…apping

This reverts commit 4763ddb834462097ff818a8dcae2c545c0d5ba1a added in
treewide: 4.19.164 by 5a2ab32e54e73175cbcd257ac04913e81bf15221.
Reverting the commit fixes crashes the kernel when a soft restarts of
the ecoc is trigged.
Before the kernel would panic when subsystem_restart_wq_func() for
esoc is called.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>