### PR TITLE
[9.14.r1] Makefile: Set -Wno-unused-but-set-variable globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ KBUILD_AFLAGS   := -D__ASSEMBLY__ -fno-PIE
 KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE \
 		   -Werror=implicit-function-declaration -Werror=implicit-int \
-		   -Wno-format-security \
+		   -Wno-format-security -Wno-unused-but-set-variable \
 		   -std=gnu89
 KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_AFLAGS_KERNEL :=


### PR DESCRIPTION
Apparently nobody seems to have tested clang 13 before release, as the whole
coding paradigm of calling a function by assigning its return value to a
variable, which is used all throughout the Linux kernel, becomes broken,
as clang seems utterly drunk when it comes to the actual judgement whether
the variable is really used or not..