### PR TITLE
[9.14.r1] arm64: dts: qcom: lahaina: Enable 16b ECC

### DIFF
--- a/arch/arm64/boot/dts/qcom/lahaina.dtsi
+++ b/arch/arm64/boot/dts/qcom/lahaina.dtsi
@@ -591,7 +591,7 @@
 		console-size = <0x40000>;
 		ftrace-size = <0x0>;
 		msg-size = <0x20000 0x20000>;
-		cc-size = <0x0>;
+		ecc-size = <16>;
 	};
 
 	cmdline_region: cmdline_region@ffd00000 {


### PR DESCRIPTION
This improves pstore reliability a bit :wink: 