### PR TITLE
[9.12.r1] leds: qti-tri-led: Remove LED_KEEP_TRIGGER flag

### DIFF
--- a/drivers/leds/leds-qti-tri-led.c
+++ b/drivers/leds/leds-qti-tri-led.c
@@ -411,7 +411,6 @@ static int qpnp_tri_led_register(struct qpnp_tri_led_chip *chip)
 		led->cdev.blink_set = qpnp_tri_led_set_blink;
 		led->cdev.default_trigger = led->default_trigger;
 		led->cdev.brightness = LED_OFF;
-		led->cdev.flags |= LED_KEEP_TRIGGER;
 
 		rc = devm_led_classdev_register(chip->dev, &led->cdev);
 		if (rc < 0) {


### PR DESCRIPTION
Light HAL in the user space resets the "timer" trigger by setting
the "none" trigger to avoid states when the "timer" trigger will
not be cleared automatically, and the LED would be still in working
blink mode.

To allow it to set the "none" trigger LED_KEEP_TRIGGER flag must not
be set.

This change is required for an upcoming Lights HAL update.