### PR TITLE
ssusb-redriver-nb7vpq904m.c: Remove leftover #endif

### DIFF
--- a/drivers/usb/misc/ssusb-redriver-nb7vpq904m.c
+++ b/drivers/usb/misc/ssusb-redriver-nb7vpq904m.c
@@ -26,7 +26,7 @@
 /* Registers Address */
 #define GEN_DEV_SET_REG			0x00
 #define AUX_CH_CTRL_REG			0x09
-#endif
+
 #define CHIP_VERSION_REG		0x17
 
 #define REDRIVER_REG_MAX		0x1f


### PR DESCRIPTION
In commit f7d0ae632da4d51033e413137e13266d506b7ab6
#ifdef that used this #endif was removed but endif was left over

Remove it