### PR TITLE
[9.12.r1] arm64: dts: qcom: sdm845-audio: Update wsa_spk_wcd label names

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm-wsa881x.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-wsa881x.dtsi
@@ -4,7 +4,7 @@
  */
 
 &slim_aud {
-	pahu_codec {
+	pahu_codec: pahu_codec {
 		swr_master {
 			compatible = "qcom,swr-wcd";
 			#address-cells = <2>;
@@ -36,7 +36,7 @@
 		};
 	};
 
-	tavil_codec {
+	tavil_codec: tavil_codec {
 		swr_master {
 			compatible = "qcom,swr-wcd";
 			#address-cells = <2>;

--- a/arch/arm64/boot/dts/qcom/sdm845-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-audio-overlay.dtsi
@@ -7,6 +7,8 @@
 #include "msm-wsa881x.dtsi"
 #include <dt-bindings/clock/qcom,audio-ext-clk.h>
 
+/delete-node/ &pahu_codec;
+
 &snd_934x {
 	qcom,audio-routing =
 		"AIF4 VI", "MCLK",

--- a/arch/arm64/boot/dts/qcom/sdm845-wcd.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-wcd.dtsi
@@ -122,14 +122,14 @@
 			};
 		};
 
-		wsa_spkr_wcd_sd1: msm_cdc_pinctrll {
+		wsa_spk_wcd_sd1: msm_cdc_pinctrll {
 		      compatible = "qcom,msm-cdc-pinctrl";
 		      pinctrl-names = "aud_active", "aud_sleep";
 		      pinctrl-0 = <&spkr_1_wcd_en_active>;
 		      pinctrl-1 = <&spkr_1_wcd_en_sleep>;
 		};
 
-		wsa_spkr_wcd_sd2: msm_cdc_pinctrlr {
+		wsa_spk_wcd_sd2: msm_cdc_pinctrlr {
 		      compatible = "qcom,msm-cdc-pinctrl";
 		      pinctrl-names = "aud_active", "aud_sleep";
 		      pinctrl-0 = <&spkr_2_wcd_en_active>;


### PR DESCRIPTION
Due to recent wsa881x changes, label names have been changed to
prevent conflict with sm8150. Update them accordingly. Also disable
pahu codec on sdm845 because it doesn't exist on this platform.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>