### PR TITLE
[9.12.r1] arm64: dts: SoMC: Tama: Update wled scale current limit for Apollo

### DIFF
--- a/arch/arm64/boot/dts/somc/sdm845-tama-akari_common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-akari_common.dtsi
@@ -61,10 +61,6 @@
 	};
 };
 
-&pmi8998_wled {
-	qcom,string-cfg = <7>;
-};
-
 &qusb_phy0 {
 	qcom,efuse-offset = <0x00000000>;
 	qcom,qusb-phy-init-seq =

--- a/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
@@ -386,6 +386,10 @@
 	status = "okay";
 };
 
+&pmi8998_wled {
+	status = "disabled";
+};
+
 &qusb_phy0 {
 	qcom,efuse-offset = <0x00000000>;
 	qcom,qusb-phy-init-seq =

--- a/arch/arm64/boot/dts/somc/sdm845-tama-apollo_common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-apollo_common.dtsi
@@ -56,11 +56,6 @@
 		    0x22 0x210>; /* PWR_CTRL1 */
 };
 
-&pmi8998_wled {
-	qcom,fs-current-limit = <19500>;
-	qcom,string-cfg = <7>;
-};
-
 #include "dsi-panel-apollo.dtsi"
 #include "somc-tama-display.dtsi"
 #include "somc-tama-display_apollo.dtsi"

--- a/arch/arm64/boot/dts/somc/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-common.dtsi
@@ -690,6 +690,7 @@
 
 &pmi8998_wled {
 	qcom,fs-current-limit = <20000>;
+	qcom,string-cfg = <7>;
 };
 
 &vendor {


### PR DESCRIPTION
The WLED driver found in the current kernel version only supports
setting power values that are predefined in the driver itself in the
wled_fs_current_values array. so let's use 20000 uA for Apollo as well
as Akari. Also move the configuration to Tama common dts and disable the
WLED driver for Akatsuki device because it has an OLED panel.


Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>