### PR TITLE
[LA.UM.7.1.r1] driver: staging: Android Low Memory Killer: consider swap free size

### DIFF
--- a/drivers/staging/android/Kconfig
+++ b/drivers/staging/android/Kconfig
@@ -67,6 +67,14 @@ config ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
 	  /sys/module/lowmemorykiller/parameters/adj and convert them
 	  to oom_score_adj values.
 
+config ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	bool "Android Low Memory Killer: consider swap free size"
+	depends on ANDROID_LOW_MEMORY_KILLER && SWAP
+	default n
+	---help---
+	  Use freeswap as otherfile when watermark is grater than
+	  low_watermark. This helps to make use of zram swap.
+
 source "drivers/staging/android/ion/Kconfig"
 
 endif # if ANDROID

--- a/drivers/staging/android/lowmemorykiller.c
+++ b/drivers/staging/android/lowmemorykiller.c
@@ -456,7 +456,61 @@ void tune_lmk_param(int *other_free, int *other_file, struct shrink_control *sc)
 		lowmem_print(4, "lowmem_shrink tunning for others ofree %d, "
 			     "%d\n", *other_free, *other_file);
 	}
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	if (zone_watermark_ok(preferred_zone, 0,
+			  low_wmark_pages(preferred_zone), 0, 0)) {
+		struct sysinfo si;
+		si_swapinfo(&si);
+		*other_free += si.freeswap;
+#ifdef CONFIG_ZRAM
+		/* If swap is actually residing in RAM (e. g. the swap device
+		 * is a ZRAM device), we need to subtract the amount of RAM
+		 * that will be occupied by compressed data. To play on the
+		 * safe side, it's better to subtract too much than too few,
+		 * otherwise LMK may not be triggered when it has to be. ZRAM
+		 * compression ratio is at least 2, so we subtract half of the
+		 * reported freeswap.
+		 */
+		*other_free -= si.freeswap >> 1;
+#endif
+		lowmem_print(4, "lowmem_shrink tunning for swap "
+			     "ofree %d, %d\n", *other_free, *other_file);
+	}
+#endif
 }
+
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+static void lowmem_wakeup_kswapds(struct shrink_control *sc, int minfree)
+{
+	gfp_t gfp_mask;
+	struct zone *preferred_zone;
+	struct zonelist *zonelist;
+	enum zone_type high_zoneidx, classzone_idx;
+	int order = 0;
+	struct zoneref *zref;
+
+	if (likely(current_is_kswapd()))
+		return;
+
+	gfp_mask = sc->gfp_mask;
+	adjust_gfp_mask(&gfp_mask);
+
+	zonelist = node_zonelist(0, gfp_mask);
+	high_zoneidx = gfp_zone(gfp_mask);
+	first_zones_zonelist(zonelist, high_zoneidx, NULL);
+	preferred_zone = zref->zone;
+	classzone_idx = zone_idx(preferred_zone);
+
+	for (minfree >>= 13; order < 7; order++) {
+		if (minfree <= (1 << order))
+			break;
+	}
+
+	lowmem_print(4, "lowmem_wakeup_kswapds order %d\n", order);
+	_wake_all_kswapds(order, zonelist, high_zoneidx,
+				preferred_zone);
+}
+#endif
 
 /*
  * Return the percent of memory which gfp_mask is allowed to allocate from.
@@ -497,6 +551,9 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 	int ret = 0;
 	short min_score_adj = OOM_SCORE_ADJ_MAX + 1;
 	int minfree = 0;
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	int  max_minfree = 0;
+#endif
 	int scale_percent;
 	int selected_tasksize = 0;
 	short selected_oom_score_adj;
@@ -540,6 +597,10 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 		array_size = lowmem_minfree_size;
 	for (i = 0; i < array_size; i++) {
 		minfree = mult_frac(lowmem_minfree[i], scale_percent, 100);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+		if (max_minfree < minfree)
+			max_minfree = minfree;
+#endif
 		if (other_free < minfree && other_file < minfree) {
 			min_score_adj = lowmem_adj[i];
 			break;
@@ -742,6 +803,9 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 		     __func__, sc->nr_to_scan, sc->gfp_mask, rem);
 	if (lock_required)
 		mutex_unlock(&scan_mutex);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+		lowmem_wakeup_kswapds(sc, max_minfree);
+#endif
 #ifdef LMK_TNG_ENABLE_TRACE
 	trace_lmk_remain_scan(rem, sc->nr_to_scan, sc->gfp_mask);
 #endif

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -795,6 +795,12 @@ static inline bool is_dev_zone(const struct zone *zone)
 #include <linux/memory_hotplug.h>
 
 void build_all_zonelists(pg_data_t *pgdat);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+void _wake_all_kswapds(unsigned int order,
+			     struct zonelist *zonelist,
+			     enum zone_type high_zoneidx,
+			     struct zone *preferred_zone);
+#endif
 void wakeup_kswapd(struct zone *zone, int order, enum zone_type classzone_idx);
 bool __zone_watermark_ok(struct zone *z, unsigned int order, unsigned long mark,
 			 int classzone_idx, unsigned int alloc_flags,

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -3784,6 +3784,21 @@ static void wake_all_kswapds(unsigned int order, const struct alloc_context *ac)
 	}
 }
 
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+void _wake_all_kswapds(unsigned int order,
+			     struct zonelist *zonelist,
+			     enum zone_type high_zoneidx,
+			     struct zone *preferred_zone)
+{
+	struct zoneref *z;
+	struct zone *zone;
+
+	for_each_zone_zonelist_nodemask(zone, z, zonelist,
+						high_zoneidx, NULL)
+		wakeup_kswapd(zone, order, zone_idx(preferred_zone));
+}
+#endif
+
 static inline unsigned int
 gfp_to_alloc_flags(gfp_t gfp_mask)
 {


### PR DESCRIPTION
In low memory situations, LMK would no longer detect memory pressure changes and just stop killing apps, letting the device to run out of memory and grind to a halt or otherwise crash/reboot.

This patch greatly alleviates such situations -- with it we have observed LMK to keep killing old apps, and creating enough memory to be able to launch new apps too.

Original commit description:
```
Use freeswap as otherfile when watermark is grater than
low_watermark. This helps to make use of zram swap.
```