### PR TITLE
arm64: dts: qcom: pmi8998: enable automatic string configuration

### DIFF
--- a/arch/arm64/boot/dts/qcom/pmi8998.dtsi
+++ b/arch/arm64/boot/dts/qcom/pmi8998.dtsi
@@ -543,6 +543,7 @@
 			qcom,current-boost-limit = <970>;
 			qcom,switching-freq = <800>; /* 800KHz */
 			qcom,enabled-strings = <0 1 2>;
+			qcom,auto-string-detection;
 
 			qcom,pmic-revid = <&pmi8998_revid>;
 			status = "disabled";


### PR DESCRIPTION
This fixes pmi8998 triggering huge amounts of OVP irqs on Apollo,
causing the ovp IRQ handler to take 50+% CPU when the screen is on,
leading to terrible UI performance.

More info:
https://github.com/sonyxperiadev/bug_tracker/issues/757