### PR TITLE
[9.12.r1] drivers: staging: Port lowmemorykiller to 4.19

### DIFF
--- a/arch/arm64/include/asm/thread_info.h
+++ b/arch/arm64/include/asm/thread_info.h
@@ -94,6 +94,7 @@ void arch_release_task_struct(struct task_struct *tsk);
 #define TIF_SVE_VL_INHERIT	24	/* Inherit sve_vl_onexec across exec */
 #define TIF_SSBD		25	/* Wants SSB mitigation */
 #define TIF_TAGGED_ADDR		26	/* Allow tagged user addresses */
+#define TIF_MM_RELEASED		27
 
 #define _TIF_SIGPENDING		(1 << TIF_SIGPENDING)
 #define _TIF_NEED_RESCHED	(1 << TIF_NEED_RESCHED)

--- a/drivers/staging/android/Kconfig
+++ b/drivers/staging/android/Kconfig
@@ -23,6 +23,25 @@ config ANDROID_VSOC
 	  a 'cuttlefish' Android image inside QEmu. The driver interacts with
 	  a QEmu ivshmem device. If built as a module, it will be called vsoc.
 
+config ANDROID_LOW_MEMORY_KILLER
+	bool "Android Low Memory Killer"
+	select HAVE_LOW_MEMORY_KILLER
+	---help---
+	  Registers processes to be killed when low memory conditions, this is useful
+	  as there is no particular swap space on android.
+	  The registered process will kill according to the priorities in android init
+	  scripts (/init.rc), and it defines priority values with minimum free memory size
+	  for each priority.
+
+config ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
+	bool "Android Low Memory Killer: detect oom_adj values"
+	depends on ANDROID_LOW_MEMORY_KILLER
+	default y
+	---help---
+	  Detect oom_adj values written to
+	  /sys/module/lowmemorykiller/parameters/adj and convert them
+	  to oom_score_adj values.
+
 source "drivers/staging/android/ion/Kconfig"
 
 endif # if ANDROID

--- a/drivers/staging/android/Kconfig
+++ b/drivers/staging/android/Kconfig
@@ -66,6 +66,14 @@ config ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
 	  /sys/module/lowmemorykiller/parameters/adj and convert them
 	  to oom_score_adj values.
 
+config ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	bool "Android Low Memory Killer: consider swap free size"
+	depends on ANDROID_LOW_MEMORY_KILLER && SWAP
+	default n
+	---help---
+	  Use freeswap as otherfile when watermark is grater than
+	  low_watermark. This helps to make use of zram swap.
+
 source "drivers/staging/android/ion/Kconfig"
 
 endif # if ANDROID

--- a/drivers/staging/android/Kconfig
+++ b/drivers/staging/android/Kconfig
@@ -33,6 +33,30 @@ config ANDROID_LOW_MEMORY_KILLER
 	  scripts (/init.rc), and it defines priority values with minimum free memory size
 	  for each priority.
 
+config ANDROID_LOW_MEMORY_KILLER_TNG
+	bool "Android Low Memory Killer TNG"
+	depends on ANDROID_LOW_MEMORY_KILLER
+	select OOM_SCORE_NOTIFIER
+	---help---
+	  The NEXT generation (TNG) lowmemorykiller.
+	  Registers processes to be killed when low memory conditions, this is useful
+	  as there is no particular swap space on android.
+
+	  The registered process will kills according to the priorities in android init
+	  scripts (/init.rc), and it defines priority values with minimum free memory size
+	  for each priority.
+
+config ANDROID_LOW_MEMORY_KILLER_STATS
+	bool "Android Low Memory Killer: collect statistics"
+	depends on ANDROID_LOW_MEMORY_KILLER_TNG
+	default n
+	help
+	  Create a file in /proc/lmkstats that includes
+	  collected statistics about kills, scans and counts
+	  and  interaction with the shrinker. Its content
+	  will be different depending on lmk implementation used
+	  in TNG lowmemorykiller.
+
 config ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
 	bool "Android Low Memory Killer: detect oom_adj values"
 	depends on ANDROID_LOW_MEMORY_KILLER

--- a/drivers/staging/android/Makefile
+++ b/drivers/staging/android/Makefile
@@ -4,3 +4,4 @@ obj-y					+= ion/
 
 obj-$(CONFIG_ASHMEM)			+= ashmem.o
 obj-$(CONFIG_ANDROID_VSOC)		+= vsoc.o
+obj-$(CONFIG_ANDROID_LOW_MEMORY_KILLER)	+= lowmemorykiller.o

--- a/drivers/staging/android/Makefile
+++ b/drivers/staging/android/Makefile
@@ -5,3 +5,7 @@ obj-y					+= ion/
 obj-$(CONFIG_ASHMEM)			+= ashmem.o
 obj-$(CONFIG_ANDROID_VSOC)		+= vsoc.o
 obj-$(CONFIG_ANDROID_LOW_MEMORY_KILLER)	+= lowmemorykiller.o
+lmk_tng-y := lowmemorykiller_tng.o lowmemorykiller_tasks.o \
+             lowmemorykiller_oom.o lowmemorykiller_vmpressure.o
+obj-$(CONFIG_ANDROID_LOW_MEMORY_KILLER_TNG) += lmk_tng.o
+obj-$(CONFIG_ANDROID_LOW_MEMORY_KILLER_STATS) += lowmemorykiller_stats.o

--- a/drivers/staging/android/lowmemorykiller.c
+++ b/drivers/staging/android/lowmemorykiller.c
@@ -1,0 +1,791 @@
+/* drivers/misc/lowmemorykiller.c
+ *
+ * The lowmemorykiller driver lets user-space specify a set of memory thresholds
+ * where processes with a range of oom_score_adj values will get killed. Specify
+ * the minimum oom_score_adj values in
+ * /sys/module/lowmemorykiller/parameters/adj and the number of free pages in
+ * /sys/module/lowmemorykiller/parameters/minfree. Both files take a comma
+ * separated list of numbers in ascending order.
+ *
+ * For example, write "0,8" to /sys/module/lowmemorykiller/parameters/adj and
+ * "1024,4096" to /sys/module/lowmemorykiller/parameters/minfree to kill
+ * processes with a oom_score_adj value of 8 or higher when the free memory
+ * drops below 4096 pages and kill processes with a oom_score_adj value of 0 or
+ * higher when the free memory drops below 1024 pages.
+ *
+ * The driver considers memory used for caches to be free, but if a large
+ * percentage of the cached memory is locked this can be very inaccurate
+ * and processes may not get killed until the normal oom killer is triggered.
+ *
+ * Copyright (C) 2007-2008 Google, Inc.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/init.h>
+#include <linux/moduleparam.h>
+#include <linux/kernel.h>
+#include <linux/mm.h>
+#include <linux/oom.h>
+#include <linux/sched/signal.h>
+#include <linux/swap.h>
+#include <linux/rcupdate.h>
+#include <linux/profile.h>
+#include <linux/notifier.h>
+#include <linux/mutex.h>
+#include <linux/delay.h>
+#include <linux/swap.h>
+#include <linux/fs.h>
+#include <linux/cpuset.h>
+#include <linux/vmpressure.h>
+#include <linux/freezer.h>
+
+#define CREATE_TRACE_POINTS
+#include <trace/events/almk.h>
+#include <linux/show_mem_notifier.h>
+
+#ifdef CONFIG_HIGHMEM
+#define _ZONE ZONE_HIGHMEM
+#else
+#define _ZONE ZONE_NORMAL
+#endif
+
+#define CREATE_TRACE_POINTS
+#include "trace/lowmemorykiller.h"
+
+/* to enable lowmemorykiller */
+static int enable_lmk = 1;
+module_param_named(enable_lmk, enable_lmk, int, 0644);
+
+static u32 lowmem_debug_level = 1;
+static short lowmem_adj[6] = {
+	0,
+	1,
+	6,
+	12,
+};
+
+static int lowmem_adj_size = 4;
+static int lowmem_minfree[6] = {
+	3 * 512,	/* 6MB */
+	2 * 1024,	/* 8MB */
+	4 * 1024,	/* 16MB */
+	16 * 1024,	/* 64MB */
+};
+
+static int lowmem_minfree_size = 4;
+static int lmk_fast_run = 1;
+
+static unsigned long lowmem_deathpending_timeout;
+
+extern void wake_oom_reaper(struct task_struct *tsk);
+
+#define lowmem_print(level, x...)			\
+	do {						\
+		if (lowmem_debug_level >= (level))	\
+			pr_info(x);			\
+	} while (0)
+
+static unsigned long lowmem_count(struct shrinker *s,
+				  struct shrink_control *sc)
+{
+	if (!enable_lmk)
+		return 0;
+
+	return global_node_page_state(NR_ACTIVE_ANON) +
+		global_node_page_state(NR_ACTIVE_FILE) +
+		global_node_page_state(NR_INACTIVE_ANON) +
+		global_node_page_state(NR_INACTIVE_FILE);
+}
+
+bool lmk_kill_possible(void);
+static atomic_t shift_adj = ATOMIC_INIT(0);
+static short adj_max_shift = 353;
+module_param_named(adj_max_shift, adj_max_shift, short, 0644);
+
+/* User knob to enable/disable adaptive lmk feature */
+static int enable_adaptive_lmk;
+module_param_named(enable_adaptive_lmk, enable_adaptive_lmk, int, 0644);
+
+/*
+ * This parameter controls the behaviour of LMK when vmpressure is in
+ * the range of 90-94. Adaptive lmk triggers based on number of file
+ * pages wrt vmpressure_file_min, when vmpressure is in the range of
+ * 90-94. Usually this is a pseudo minfree value, higher than the
+ * highest configured value in minfree array.
+ */
+static int vmpressure_file_min;
+module_param_named(vmpressure_file_min, vmpressure_file_min, int, 0644);
+
+/* User knob to enable/disable oom reaping feature */
+static int oom_reaper = 1;
+module_param_named(oom_reaper, oom_reaper, int, 0644);
+
+/* Variable that helps in feed to the reclaim path  */
+static atomic64_t lmk_feed = ATOMIC64_INIT(0);
+
+/*
+ * This function can be called whether to include the anon LRU pages
+ * for accounting in the page reclaim.
+ */
+bool lmk_kill_possible(void)
+{
+	unsigned long val = atomic64_read(&lmk_feed);
+
+	return !val || time_after_eq(jiffies, val);
+}
+
+enum {
+	VMPRESSURE_NO_ADJUST = 0,
+	VMPRESSURE_ADJUST_ENCROACH,
+	VMPRESSURE_ADJUST_NORMAL,
+};
+
+static int adjust_minadj(short *min_score_adj)
+{
+	int ret = VMPRESSURE_NO_ADJUST;
+
+	if (!enable_adaptive_lmk)
+		return 0;
+
+	if (atomic_read(&shift_adj) &&
+	    (*min_score_adj > adj_max_shift)) {
+		if (*min_score_adj == OOM_SCORE_ADJ_MAX + 1)
+			ret = VMPRESSURE_ADJUST_ENCROACH;
+		else
+			ret = VMPRESSURE_ADJUST_NORMAL;
+		*min_score_adj = adj_max_shift;
+	}
+	atomic_set(&shift_adj, 0);
+
+	return ret;
+}
+
+static int lmk_vmpressure_notifier(struct notifier_block *nb,
+				   unsigned long action, void *data)
+{
+	int other_free, other_file;
+	unsigned long pressure = action;
+	int array_size = ARRAY_SIZE(lowmem_adj);
+
+	if (!enable_adaptive_lmk)
+		return 0;
+
+	if (pressure >= 95) {
+		other_file = global_node_page_state(NR_FILE_PAGES) -
+			global_node_page_state(NR_SHMEM) -
+			total_swapcache_pages();
+		other_free = global_zone_page_state(NR_FREE_PAGES);
+
+		atomic_set(&shift_adj, 1);
+		trace_almk_vmpressure(pressure, other_free, other_file);
+	} else if (pressure >= 90) {
+		if (lowmem_adj_size < array_size)
+			array_size = lowmem_adj_size;
+		if (lowmem_minfree_size < array_size)
+			array_size = lowmem_minfree_size;
+
+		other_file = global_node_page_state(NR_FILE_PAGES) -
+			global_node_page_state(NR_SHMEM) -
+			total_swapcache_pages();
+
+		other_free = global_zone_page_state(NR_FREE_PAGES);
+
+		if (other_free < lowmem_minfree[array_size - 1] &&
+		    other_file < vmpressure_file_min) {
+			atomic_set(&shift_adj, 1);
+			trace_almk_vmpressure(pressure, other_free, other_file);
+		}
+	} else if (atomic_read(&shift_adj)) {
+		other_file = global_node_page_state(NR_FILE_PAGES) -
+			global_node_page_state(NR_SHMEM) -
+			total_swapcache_pages();
+
+		other_free = global_zone_page_state(NR_FREE_PAGES);
+		/*
+		 * shift_adj would have been set by a previous invocation
+		 * of notifier, which is not followed by a lowmem_shrink yet.
+		 * Since vmpressure has improved, reset shift_adj to avoid
+		 * false adaptive LMK trigger.
+		 */
+		trace_almk_vmpressure(pressure, other_free, other_file);
+		atomic_set(&shift_adj, 0);
+	}
+
+	return 0;
+}
+
+static struct notifier_block lmk_vmpr_nb = {
+	.notifier_call = lmk_vmpressure_notifier,
+};
+
+static int test_task_flag(struct task_struct *p, int flag)
+{
+	struct task_struct *t;
+
+	for_each_thread(p, t) {
+		task_lock(t);
+		if (test_tsk_thread_flag(t, flag)) {
+			task_unlock(t);
+			return 1;
+		}
+		task_unlock(t);
+	}
+
+	return 0;
+}
+
+static int test_task_state(struct task_struct *p, int state)
+{
+	struct task_struct *t;
+
+	for_each_thread(p, t) {
+		task_lock(t);
+		if (t->state & state) {
+			task_unlock(t);
+			return 1;
+		}
+		task_unlock(t);
+	}
+
+	return 0;
+}
+
+static int test_task_lmk_waiting(struct task_struct *p)
+{
+	struct task_struct *t;
+
+	for_each_thread(p, t) {
+		task_lock(t);
+		if (task_lmk_waiting(t)) {
+			task_unlock(t);
+			return 1;
+		}
+		task_unlock(t);
+	}
+
+	return 0;
+}
+
+static DEFINE_MUTEX(scan_mutex);
+
+static int can_use_cma_pages(gfp_t gfp_mask)
+{
+	if (gfpflags_to_migratetype(gfp_mask) == MIGRATE_MOVABLE &&
+	    (gfp_mask & __GFP_CMA))
+		return 1;
+
+	return 0;
+}
+
+void tune_lmk_zone_param(struct zonelist *zonelist, int classzone_idx,
+					int *other_free, int *other_file,
+					int use_cma_pages)
+{
+	struct zone *zone;
+	struct zoneref *zoneref;
+	int zone_idx;
+
+	for_each_zone_zonelist(zone, zoneref, zonelist, MAX_NR_ZONES) {
+		zone_idx = zonelist_zone_idx(zoneref);
+
+		if (zone_idx > classzone_idx) {
+			if (other_free != NULL)
+				*other_free -= zone_page_state(zone,
+							       NR_FREE_PAGES);
+			if (other_file != NULL)
+				*other_file -= zone_page_state(zone,
+					NR_ZONE_INACTIVE_FILE) +
+					zone_page_state(zone,
+					NR_ZONE_ACTIVE_FILE);
+		} else if (zone_idx < classzone_idx) {
+			if (zone_watermark_ok(zone, 0, 0, classzone_idx, 0) &&
+			    other_free) {
+				if (!use_cma_pages) {
+					*other_free -= min(
+					  zone->lowmem_reserve[classzone_idx] +
+					  zone_page_state(
+					    zone, NR_FREE_CMA_PAGES),
+					  zone_page_state(
+					    zone, NR_FREE_PAGES));
+				} else {
+					*other_free -=
+					  zone->lowmem_reserve[classzone_idx];
+				}
+			} else {
+				if (other_free)
+					*other_free -=
+					  zone_page_state(zone, NR_FREE_PAGES);
+			}
+		}
+	}
+}
+
+#ifdef CONFIG_HIGHMEM
+static void adjust_gfp_mask(gfp_t *gfp_mask)
+{
+	struct zone *preferred_zone;
+	struct zoneref *zref;
+	struct zonelist *zonelist;
+	enum zone_type high_zoneidx;
+
+	if (current_is_kswapd()) {
+		zonelist = node_zonelist(0, *gfp_mask);
+		high_zoneidx = gfp_zone(*gfp_mask);
+		zref = first_zones_zonelist(zonelist, high_zoneidx, NULL);
+		preferred_zone = zref->zone;
+
+		if (high_zoneidx == ZONE_NORMAL) {
+			if (zone_watermark_ok_safe(
+					preferred_zone, 0,
+					high_wmark_pages(preferred_zone), 0))
+				*gfp_mask |= __GFP_HIGHMEM;
+		} else if (high_zoneidx == ZONE_HIGHMEM) {
+			*gfp_mask |= __GFP_HIGHMEM;
+		}
+	}
+}
+#else
+static void adjust_gfp_mask(gfp_t *unused)
+{
+}
+#endif
+
+void tune_lmk_param(int *other_free, int *other_file, struct shrink_control *sc)
+{
+	gfp_t gfp_mask;
+	struct zone *preferred_zone;
+	struct zoneref *zref;
+	struct zonelist *zonelist;
+	enum zone_type high_zoneidx, classzone_idx;
+	unsigned long balance_gap;
+	int use_cma_pages;
+
+	gfp_mask = sc->gfp_mask;
+	adjust_gfp_mask(&gfp_mask);
+
+	zonelist = node_zonelist(0, gfp_mask);
+	high_zoneidx = gfp_zone(gfp_mask);
+	zref = first_zones_zonelist(zonelist, high_zoneidx, NULL);
+	preferred_zone = zref->zone;
+	classzone_idx = zone_idx(preferred_zone);
+	use_cma_pages = can_use_cma_pages(gfp_mask);
+
+	balance_gap = min(low_wmark_pages(preferred_zone),
+			  (preferred_zone->present_pages +
+			   100-1) /
+			   100);
+
+	if (likely(current_is_kswapd() && zone_watermark_ok(preferred_zone, 0,
+			  high_wmark_pages(preferred_zone) + SWAP_CLUSTER_MAX +
+			  balance_gap, 0, 0))) {
+		if (lmk_fast_run)
+			tune_lmk_zone_param(zonelist, classzone_idx, other_free,
+				       other_file, use_cma_pages);
+		else
+			tune_lmk_zone_param(zonelist, classzone_idx, other_free,
+				       NULL, use_cma_pages);
+
+		if (zone_watermark_ok(preferred_zone, 0, 0, _ZONE, 0)) {
+			if (!use_cma_pages) {
+				*other_free -= min(
+				  preferred_zone->lowmem_reserve[_ZONE]
+				  + zone_page_state(
+				    preferred_zone, NR_FREE_CMA_PAGES),
+				  zone_page_state(
+				    preferred_zone, NR_FREE_PAGES));
+			} else {
+				*other_free -=
+				  preferred_zone->lowmem_reserve[_ZONE];
+			}
+		} else {
+			*other_free -= zone_page_state(preferred_zone,
+						      NR_FREE_PAGES);
+		}
+
+		lowmem_print(4, "lowmem_shrink of kswapd tunning for highmem "
+			     "ofree %d, %d\n", *other_free, *other_file);
+	} else {
+		tune_lmk_zone_param(zonelist, classzone_idx, other_free,
+			       other_file, use_cma_pages);
+
+		if (!use_cma_pages) {
+			*other_free -=
+			  zone_page_state(preferred_zone, NR_FREE_CMA_PAGES);
+		}
+
+		lowmem_print(4, "lowmem_shrink tunning for others ofree %d, "
+			     "%d\n", *other_free, *other_file);
+	}
+}
+
+/*
+ * Return the percent of memory which gfp_mask is allowed to allocate from.
+ * CMA memory is assumed to be a small percent and is not considered.
+ * The goal is to apply a margin of minfree over all zones, rather than to
+ * each zone individually.
+ */
+static int get_minfree_scalefactor(gfp_t gfp_mask)
+{
+	struct zonelist *zonelist = node_zonelist(0, gfp_mask);
+	struct zoneref *z;
+	struct zone *zone;
+	unsigned long nr_usable = 0;
+
+	for_each_zone_zonelist(zone, z, zonelist, gfp_zone(gfp_mask))
+		nr_usable += zone->managed_pages;
+
+	return max_t(int, 1, mult_frac(100, nr_usable, totalram_pages));
+}
+
+static void mark_lmk_victim(struct task_struct *tsk)
+{
+	struct mm_struct *mm = tsk->mm;
+
+	if (!cmpxchg(&tsk->signal->oom_mm, NULL, mm)) {
+		atomic_inc(&tsk->signal->oom_mm->mm_count);
+		set_bit(MMF_OOM_VICTIM, &mm->flags);
+	}
+}
+
+static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
+{
+	struct task_struct *tsk;
+	struct task_struct *selected = NULL;
+	unsigned long rem = 0;
+	int tasksize;
+	int i;
+	int ret = 0;
+	short min_score_adj = OOM_SCORE_ADJ_MAX + 1;
+	int minfree = 0;
+	int scale_percent;
+	int selected_tasksize = 0;
+	short selected_oom_score_adj;
+	int array_size = ARRAY_SIZE(lowmem_adj);
+	int other_free;
+	int other_file;
+	bool lock_required = true;
+
+	other_free = global_zone_page_state(NR_FREE_PAGES) - totalreserve_pages;
+
+	if (global_node_page_state(NR_SHMEM) + total_swapcache_pages() +
+			global_node_page_state(NR_UNEVICTABLE) <
+			global_node_page_state(NR_FILE_PAGES))
+		other_file = global_node_page_state(NR_FILE_PAGES) -
+					global_node_page_state(NR_SHMEM) -
+					global_node_page_state(NR_UNEVICTABLE) -
+					total_swapcache_pages();
+	else
+		other_file = 0;
+
+	if (!get_nr_swap_pages() && (other_free <= lowmem_minfree[0] >> 1) &&
+	    (other_file <= lowmem_minfree[0] >> 1))
+		lock_required = false;
+
+	if (likely(lock_required) && !mutex_trylock(&scan_mutex))
+		return 0;
+
+	tune_lmk_param(&other_free, &other_file, sc);
+
+	scale_percent = get_minfree_scalefactor(sc->gfp_mask);
+	if (lowmem_adj_size < array_size)
+		array_size = lowmem_adj_size;
+	if (lowmem_minfree_size < array_size)
+		array_size = lowmem_minfree_size;
+	for (i = 0; i < array_size; i++) {
+		minfree = mult_frac(lowmem_minfree[i], scale_percent, 100);
+		if (other_free < minfree && other_file < minfree) {
+			min_score_adj = lowmem_adj[i];
+			break;
+		}
+	}
+
+	ret = adjust_minadj(&min_score_adj);
+
+	lowmem_print(3, "%s %lu, %x, ofree %d %d, ma %hd\n",
+		     __func__, sc->nr_to_scan, sc->gfp_mask, other_free,
+		     other_file, min_score_adj);
+
+	if (min_score_adj == OOM_SCORE_ADJ_MAX + 1) {
+		trace_almk_shrink(0, ret, other_free, other_file, 0);
+		lowmem_print(5, "%s %lu, %x, return 0\n",
+			     __func__, sc->nr_to_scan, sc->gfp_mask);
+		if (lock_required)
+			mutex_unlock(&scan_mutex);
+		return 0;
+	}
+
+	selected_oom_score_adj = min_score_adj;
+
+	rcu_read_lock();
+	for_each_process(tsk) {
+		struct task_struct *p;
+		short oom_score_adj;
+
+		if (tsk->flags & PF_KTHREAD)
+			continue;
+
+		/* if task no longer has any memory ignore it */
+		if (test_task_flag(tsk, TIF_MM_RELEASED))
+			continue;
+
+		if (oom_reaper) {
+			p = find_lock_task_mm(tsk);
+			if (!p)
+				continue;
+
+			if (test_bit(MMF_OOM_VICTIM, &p->mm->flags)) {
+				if (test_bit(MMF_OOM_SKIP, &p->mm->flags)) {
+					task_unlock(p);
+					continue;
+				} else if (time_before_eq(jiffies,
+						lowmem_deathpending_timeout)) {
+					task_unlock(p);
+					rcu_read_unlock();
+					if (lock_required)
+						mutex_unlock(&scan_mutex);
+					return 0;
+				}
+			}
+		} else {
+			if (time_before_eq(jiffies,
+					   lowmem_deathpending_timeout))
+				if (test_task_lmk_waiting(tsk)) {
+					rcu_read_unlock();
+					if (lock_required)
+						mutex_unlock(&scan_mutex);
+					return 0;
+				}
+
+			p = find_lock_task_mm(tsk);
+			if (!p)
+				continue;
+		}
+
+		oom_score_adj = p->signal->oom_score_adj;
+		if (oom_score_adj < min_score_adj) {
+			task_unlock(p);
+			continue;
+		}
+		tasksize = get_mm_rss(p->mm);
+		task_unlock(p);
+		if (tasksize <= 0)
+			continue;
+		if (selected) {
+			if (oom_score_adj < selected_oom_score_adj)
+				continue;
+			if (oom_score_adj == selected_oom_score_adj &&
+			    tasksize <= selected_tasksize)
+				continue;
+		}
+		selected = p;
+		selected_tasksize = tasksize;
+		selected_oom_score_adj = oom_score_adj;
+		lowmem_print(3, "select '%s' (%d), adj %hd, size %d, to kill\n",
+			     p->comm, p->pid, oom_score_adj, tasksize);
+	}
+	if (selected) {
+		long cache_size = other_file * (long)(PAGE_SIZE / 1024);
+		long cache_limit = minfree * (long)(PAGE_SIZE / 1024);
+		long free = other_free * (long)(PAGE_SIZE / 1024);
+
+		atomic64_set(&lmk_feed, 0);
+		if (test_task_lmk_waiting(selected) &&
+		    (test_task_state(selected, TASK_UNINTERRUPTIBLE))) {
+			lowmem_print(2, "'%s' (%d) is already killed\n",
+				     selected->comm,
+				     selected->pid);
+			rcu_read_unlock();
+			if (lock_required)
+				mutex_unlock(&scan_mutex);
+			return 0;
+		}
+
+		task_lock(selected);
+		send_sig(SIGKILL, selected, 0);
+		if (selected->mm) {
+			task_set_lmk_waiting(selected);
+			if (!test_bit(MMF_OOM_SKIP, &selected->mm->flags) &&
+			    oom_reaper) {
+				mark_lmk_victim(selected);
+				wake_oom_reaper(selected);
+			}
+		}
+		task_unlock(selected);
+		trace_lowmemory_kill(selected, cache_size, cache_limit, free);
+		lowmem_print(1, "Killing '%s' (%d) (tgid %d), adj %hd,\n"
+			"to free %ldkB on behalf of '%s' (%d) because\n"
+			"cache %ldkB is below limit %ldkB for oom score %hd\n"
+			"Free memory is %ldkB above reserved.\n"
+			"Free CMA is %ldkB\n"
+			"Total reserve is %ldkB\n"
+			"Total free pages is %ldkB\n"
+			"Total file cache is %ldkB\n"
+			"GFP mask is 0x%x\n",
+			selected->comm, selected->pid, selected->tgid,
+			selected_oom_score_adj,
+			selected_tasksize * (long)(PAGE_SIZE / 1024),
+			current->comm, current->pid,
+			cache_size, cache_limit,
+			min_score_adj,
+			free,
+			global_zone_page_state(NR_FREE_CMA_PAGES) *
+			(long)(PAGE_SIZE / 1024),
+			totalreserve_pages * (long)(PAGE_SIZE / 1024),
+			global_zone_page_state(NR_FREE_PAGES) *
+			(long)(PAGE_SIZE / 1024),
+			global_node_page_state(NR_FILE_PAGES) *
+			(long)(PAGE_SIZE / 1024),
+			sc->gfp_mask);
+
+		if (lowmem_debug_level >= 2 && selected_oom_score_adj == 0) {
+			show_mem(SHOW_MEM_FILTER_NODES, NULL);
+			show_mem_call_notifiers();
+			dump_tasks(NULL, NULL);
+		}
+
+		lowmem_deathpending_timeout = jiffies + HZ;
+		rem += selected_tasksize;
+		rcu_read_unlock();
+		/* give the system time to free up the memory */
+		msleep_interruptible(20);
+		trace_almk_shrink(selected_tasksize, ret,
+				  other_free, other_file,
+				  selected_oom_score_adj);
+	} else {
+		trace_almk_shrink(1, ret, other_free, other_file, 0);
+		rcu_read_unlock();
+		if (other_free < lowmem_minfree[0] &&
+		    other_file < lowmem_minfree[0])
+			atomic64_set(&lmk_feed, jiffies + HZ);
+		else
+			atomic64_set(&lmk_feed, 0);
+
+	}
+
+	lowmem_print(4, "%s %lu, %x, return %lu\n",
+		     __func__, sc->nr_to_scan, sc->gfp_mask, rem);
+	if (lock_required)
+		mutex_unlock(&scan_mutex);
+	return rem;
+}
+
+static struct shrinker lowmem_shrinker = {
+	.scan_objects = lowmem_scan,
+	.count_objects = lowmem_count,
+	.seeks = DEFAULT_SEEKS * 16
+};
+
+static int __init lowmem_init(void)
+{
+	register_shrinker(&lowmem_shrinker);
+	vmpressure_notifier_register(&lmk_vmpr_nb);
+	return 0;
+}
+device_initcall(lowmem_init);
+
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
+static short lowmem_oom_adj_to_oom_score_adj(short oom_adj)
+{
+	if (oom_adj == OOM_ADJUST_MAX)
+		return OOM_SCORE_ADJ_MAX;
+	else
+		return (oom_adj * OOM_SCORE_ADJ_MAX) / -OOM_DISABLE;
+}
+
+static void lowmem_autodetect_oom_adj_values(void)
+{
+	int i;
+	short oom_adj;
+	short oom_score_adj;
+	int array_size = ARRAY_SIZE(lowmem_adj);
+
+	if (lowmem_adj_size < array_size)
+		array_size = lowmem_adj_size;
+
+	if (array_size <= 0)
+		return;
+
+	oom_adj = lowmem_adj[array_size - 1];
+	if (oom_adj > OOM_ADJUST_MAX)
+		return;
+
+	oom_score_adj = lowmem_oom_adj_to_oom_score_adj(oom_adj);
+	if (oom_score_adj <= OOM_ADJUST_MAX)
+		return;
+
+	lowmem_print(1, "lowmem_shrink: convert oom_adj to oom_score_adj:\n");
+	for (i = 0; i < array_size; i++) {
+		oom_adj = lowmem_adj[i];
+		oom_score_adj = lowmem_oom_adj_to_oom_score_adj(oom_adj);
+		lowmem_adj[i] = oom_score_adj;
+		lowmem_print(1, "oom_adj %d => oom_score_adj %d\n",
+			     oom_adj, oom_score_adj);
+	}
+}
+
+static int lowmem_adj_array_set(const char *val, const struct kernel_param *kp)
+{
+	int ret;
+
+	ret = param_array_ops.set(val, kp);
+
+	/* HACK: Autodetect oom_adj values in lowmem_adj array */
+	lowmem_autodetect_oom_adj_values();
+
+	return ret;
+}
+
+static int lowmem_adj_array_get(char *buffer, const struct kernel_param *kp)
+{
+	return param_array_ops.get(buffer, kp);
+}
+
+static void lowmem_adj_array_free(void *arg)
+{
+	param_array_ops.free(arg);
+}
+
+static struct kernel_param_ops lowmem_adj_array_ops = {
+	.set = lowmem_adj_array_set,
+	.get = lowmem_adj_array_get,
+	.free = lowmem_adj_array_free,
+};
+
+static const struct kparam_array __param_arr_adj = {
+	.max = ARRAY_SIZE(lowmem_adj),
+	.num = &lowmem_adj_size,
+	.ops = &param_ops_short,
+	.elemsize = sizeof(lowmem_adj[0]),
+	.elem = lowmem_adj,
+};
+#endif
+
+/*
+ * not really modular, but the easiest way to keep compat with existing
+ * bootargs behaviour is to continue using module_param here.
+ */
+module_param_named(cost, lowmem_shrinker.seeks, int, 0644);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_AUTODETECT_OOM_ADJ_VALUES
+module_param_cb(adj, &lowmem_adj_array_ops,
+		.arr = &__param_arr_adj,
+		0644);
+__MODULE_PARM_TYPE(adj, "array of short");
+#else
+module_param_array_named(adj, lowmem_adj, short, &lowmem_adj_size, 0644);
+#endif
+module_param_array_named(minfree, lowmem_minfree, uint, &lowmem_minfree_size,
+			 S_IRUGO | S_IWUSR);
+module_param_named(debug_level, lowmem_debug_level, uint, S_IRUGO | S_IWUSR);
+module_param_named(lmk_fast_run, lmk_fast_run, int, S_IRUGO | S_IWUSR);
+

--- a/drivers/staging/android/lowmemorykiller.c
+++ b/drivers/staging/android/lowmemorykiller.c
@@ -458,7 +458,61 @@ void tune_lmk_param(int *other_free, int *other_file, struct shrink_control *sc)
 		lowmem_print(4, "lowmem_shrink tunning for others ofree %d, "
 			     "%d\n", *other_free, *other_file);
 	}
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	if (zone_watermark_ok(preferred_zone, 0,
+			  low_wmark_pages(preferred_zone), 0, 0)) {
+		struct sysinfo si;
+		si_swapinfo(&si);
+		*other_free += si.freeswap;
+#ifdef CONFIG_ZRAM
+		/* If swap is actually residing in RAM (e. g. the swap device
+		 * is a ZRAM device), we need to subtract the amount of RAM
+		 * that will be occupied by compressed data. To play on the
+		 * safe side, it's better to subtract too much than too few,
+		 * otherwise LMK may not be triggered when it has to be. ZRAM
+		 * compression ratio is at least 2, so we subtract half of the
+		 * reported freeswap.
+		 */
+		*other_free -= si.freeswap >> 1;
+#endif
+		lowmem_print(4, "lowmem_shrink tunning for swap "
+			     "ofree %d, %d\n", *other_free, *other_file);
+	}
+#endif
 }
+
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+static void lowmem_wakeup_kswapds(struct shrink_control *sc, int minfree)
+{
+	gfp_t gfp_mask;
+	struct zone *preferred_zone;
+	struct zonelist *zonelist;
+	enum zone_type high_zoneidx, classzone_idx;
+	int order = 0;
+	struct zoneref *zref;
+
+	if (likely(current_is_kswapd()))
+		return;
+
+	gfp_mask = sc->gfp_mask;
+	adjust_gfp_mask(&gfp_mask);
+
+	zonelist = node_zonelist(0, gfp_mask);
+	high_zoneidx = gfp_zone(gfp_mask);
+	first_zones_zonelist(zonelist, high_zoneidx, NULL);
+	preferred_zone = zref->zone;
+	classzone_idx = zone_idx(preferred_zone);
+
+	for (minfree >>= 13; order < 7; order++) {
+		if (minfree <= (1 << order))
+			break;
+	}
+
+	lowmem_print(4, "lowmem_wakeup_kswapds order %d\n", order);
+	_wake_all_kswapds(order, zonelist, high_zoneidx,
+				preferred_zone);
+}
+#endif
 
 /*
  * Return the percent of memory which gfp_mask is allowed to allocate from.
@@ -499,6 +553,9 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 	int ret = 0;
 	short min_score_adj = OOM_SCORE_ADJ_MAX + 1;
 	int minfree = 0;
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+	int  max_minfree = 0;
+#endif
 	int scale_percent;
 	int selected_tasksize = 0;
 	short selected_oom_score_adj;
@@ -542,6 +599,10 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 		array_size = lowmem_minfree_size;
 	for (i = 0; i < array_size; i++) {
 		minfree = mult_frac(lowmem_minfree[i], scale_percent, 100);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+		if (max_minfree < minfree)
+			max_minfree = minfree;
+#endif
 		if (other_free < minfree && other_file < minfree) {
 			min_score_adj = lowmem_adj[i];
 			break;
@@ -744,6 +805,9 @@ static unsigned long lowmem_scan(struct shrinker *s, struct shrink_control *sc)
 		     __func__, sc->nr_to_scan, sc->gfp_mask, rem);
 	if (lock_required)
 		mutex_unlock(&scan_mutex);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+		lowmem_wakeup_kswapds(sc, max_minfree);
+#endif
 #ifdef LMK_TNG_ENABLE_TRACE
 	trace_lmk_remain_scan(rem, sc->nr_to_scan, sc->gfp_mask);
 #endif

--- a/drivers/staging/android/lowmemorykiller.h
+++ b/drivers/staging/android/lowmemorykiller.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+#ifndef __LOWMEMORYKILLER_H
+#define __LOWMEMORYKILLER_H
+
+#include <linux/version.h>
+
+/* The lowest score LMK is using */
+#define LMK_SCORE_THRESHOLD 0
+#define LMK_TRACE_OOMKILL (-1)
+#define LMK_TRACE_MEMERROR (-2)
+
+extern u32 lowmem_debug_level;
+
+#define lowmem_print(level, x...)			\
+	do {						\
+		if (lowmem_debug_level >= (level))	\
+			pr_info(x);			\
+	} while (0)
+
+int __init lowmemorykiller_register_oom_notifier(void);
+struct calculated_params {
+	long selected_tasksize;
+	long minfree;
+	int other_file;
+	int other_free;
+	int margin;
+	int dynamic_max_queue_len;
+	short selected_oom_score_adj;
+	short min_score_adj;
+	int kill_reason;
+};
+
+int kill_needed(int level, gfp_t mask,
+		struct calculated_params *cp);
+void print_obituary(struct task_struct *doomed,
+		    struct calculated_params *cp,
+		    gfp_t gfp_mask);
+
+ssize_t get_task_rss(struct task_struct *tsk);
+
+/* kernel does not have a task_trylock and
+ * to make it more obvious what the code do
+ * we create a help function for it.
+ * see sched.h for task_lock and task_unlock
+ */
+static inline int task_trylock_lmk(struct task_struct *p)
+{
+	return spin_trylock(&p->alloc_lock);
+}
+
+/* maybe not exact version, we need something betwwen 3.18 and 4.4.
+ * using LINUX_VERSION_CODE like this will give a warning.
+ * it it not OK for mainline but for multiple kernel version patches
+ * I think it is OK.
+ */
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 0, 0)
+#define LMK_TAG_TASK_DIE(x) set_tsk_thread_flag(x, TIF_MEMDIE)
+#elseif LINUX_VERSION_CODE <= KERNEL_VERSION(4, 5, 0)
+#define LMK_TAG_TASK_DIE(x) mark_oom_victim(x)
+#else
+#define LMK_TAG_TASK_DIE(x)			\
+	do {					\
+		task_set_lmk_waiting(x);	\
+		if (x->mm) {			\
+			if (!test_bit(MMF_OOM_SKIP, &x->mm->flags) && \
+			    oom_reaper) { \
+				mark_lmk_victim(x); \
+				wake_oom_reaper(x);\
+			} \
+		} \
+	} while (0)
+
+#endif
+
+#endif

--- a/drivers/staging/android/lowmemorykiller_oom.c
+++ b/drivers/staging/android/lowmemorykiller_oom.c
@@ -1,0 +1,114 @@
+/*
+ *  lowmemorykiller_oom
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+/* add fake print format with original module name */
+#define pr_fmt(fmt) "lowmemorykiller: " fmt
+
+#include <linux/mm.h>
+#include <linux/slab.h>
+#include <linux/oom.h>
+
+#ifdef LMK_TNG_ENABLE_TRACE
+#include <trace/events/lmk.h>
+#endif
+
+#include "lowmemorykiller.h"
+#include "lowmemorykiller_tng.h"
+#include "lowmemorykiller_stats.h"
+#include "lowmemorykiller_tasks.h"
+
+/**
+ * lowmemorykiller_oom_notify - OOM notifier
+ * @self:	notifier block struct
+ * @notused:	not used
+ * @parm:	returned - number of pages freed
+ *
+ * Return value:
+ *	NOTIFY_OK
+ **/
+
+static int lowmemorykiller_oom_notify(struct notifier_block *self,
+				      unsigned long notused, void *param)
+{
+	struct lmk_rb_watch *lrw;
+	unsigned long *nfreed = param;
+
+	lowmem_print(2, "oom notify event\n");
+	*nfreed = 0;
+	lmk_inc_stats(LMK_OOM_COUNT);
+	spin_lock_bh(&lmk_task_lock);
+	lrw = __lmk_task_first();
+	if (lrw) {
+		struct task_struct *selected = lrw->tsk;
+		struct lmk_death_pending_entry *ldpt;
+
+		if (!task_trylock_lmk(selected)) {
+			lmk_inc_stats(LMK_ERROR);
+			lowmem_print(1, "Failed to lock task.\n");
+			lmk_inc_stats(LMK_BUSY);
+			goto unlock_out;
+		}
+
+		get_task_struct(selected);
+		/* move to kill pending set */
+		ldpt = kmem_cache_alloc(lmk_dp_cache, GFP_ATOMIC);
+		/* if we fail to alloc we ignore the death pending list */
+		if (ldpt) {
+			ldpt->tsk = selected;
+			__lmk_death_pending_add(ldpt);
+		} else {
+			WARN_ON(1);
+			lmk_inc_stats(LMK_MEM_ERROR);
+#ifdef LMK_TNG_ENABLE_TRACE
+			trace_lmk_sigkill(selected->pid, selected->comm,
+					  LMK_TRACE_MEMERROR, *nfreed, 0);
+#endif
+		}
+		if (!__lmk_task_remove(selected, lrw->key))
+			WARN_ON(1);
+
+		spin_unlock_bh(&lmk_task_lock);
+		*nfreed = get_task_rss(selected);
+		send_sig(SIGKILL, selected, 0);
+
+		LMK_TAG_TASK_DIE(selected);
+#ifdef LMK_TNG_ENABLE_TRACE
+		trace_lmk_sigkill(selected->pid, selected->comm,
+				  LMK_TRACE_OOMKILL, *nfreed,
+				  0);
+#endif
+
+		task_unlock(selected);
+		put_task_struct(selected);
+		lmk_inc_stats(LMK_OOM_KILL_COUNT);
+		goto out;
+	}
+unlock_out:
+	spin_unlock_bh(&lmk_task_lock);
+out:
+	return NOTIFY_OK;
+}
+
+static struct notifier_block lowmemorykiller_oom_nb = {
+	.notifier_call = lowmemorykiller_oom_notify
+};
+
+int __init lowmemorykiller_register_oom_notifier(void)
+{
+	register_oom_notifier(&lowmemorykiller_oom_nb);
+	return 0;
+}

--- a/drivers/staging/android/lowmemorykiller_oom.h
+++ b/drivers/staging/android/lowmemorykiller_oom.h
@@ -1,0 +1,25 @@
+/*
+ *  lowmemorykiller_oom interface
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#include <linux/mm.h>
+#include <linux/slab.h>
+#include <linux/oom.h>
+#include "lowmemorykiller.h"
+#include "lowmemorykiller_stats.h"
+#include "lowmemorykiller_tasks.h"
+
+int __init lowmemorykiller_register_oom_notifier(void);

--- a/drivers/staging/android/lowmemorykiller_stats.c
+++ b/drivers/staging/android/lowmemorykiller_stats.c
@@ -1,0 +1,150 @@
+/*
+ *  lowmemorykiller_stats
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+/* This code is bookkeeping of statistical information
+ * from lowmemorykiller and provide a node in proc "/proc/lmkstats".
+ */
+
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include "lowmemorykiller_stats.h"
+
+struct lmk_stats {
+	atomic_long_t scans; /* counter as in shrinker scans */
+	atomic_long_t kills; /* the number of sigkills sent */
+	atomic_long_t waste; /* the number of expensive calls that did
+			      * not lead to anything
+			      */
+	atomic_long_t timeout; /* counter for shrinker calls that needed
+				* to be cancelled due to pending kills
+				*/
+	atomic_long_t count; /* number of shrinker count calls */
+	atomic_long_t scan_busy; /* mutex held */
+	atomic_long_t no_kill; /* mutex held */
+	atomic_long_t busy;
+	atomic_long_t error;
+	atomic_long_t zero_count;
+	atomic_long_t oom_count;
+	atomic_long_t oom_kill_count;
+	atomic_long_t morgue_count;
+	atomic_long_t balance_kill;
+	atomic_long_t balance_waste;
+	atomic_long_t mem_error;
+
+	atomic_long_t unknown; /* internal */
+} st;
+
+void lmk_inc_stats(int key)
+{
+	switch (key) {
+	case LMK_SCAN:
+		atomic_long_inc(&st.scans);
+		break;
+	case LMK_KILL:
+		atomic_long_inc(&st.kills);
+		break;
+	case LMK_WASTE:
+		atomic_long_inc(&st.waste);
+		break;
+	case LMK_TIMEOUT:
+		atomic_long_inc(&st.timeout);
+		break;
+	case LMK_COUNT:
+		atomic_long_inc(&st.count);
+		break;
+	case LMK_BUSY:
+		atomic_long_inc(&st.busy);
+		break;
+	case LMK_ERROR:
+		atomic_long_inc(&st.error);
+		break;
+	case LMK_NO_KILL:
+		atomic_long_inc(&st.no_kill);
+		break;
+	case LMK_ZERO_COUNT:
+		atomic_long_inc(&st.zero_count);
+		break;
+	case LMK_OOM_COUNT:
+		atomic_long_inc(&st.oom_count);
+		break;
+	case LMK_OOM_KILL_COUNT:
+		atomic_long_inc(&st.oom_kill_count);
+		break;
+	case LMK_MORGUE_COUNT:
+		atomic_long_inc(&st.morgue_count);
+		break;
+	case LMK_BALANCE_KILL:
+		atomic_long_inc(&st.balance_kill);
+		break;
+	case LMK_BALANCE_WASTE:
+		atomic_long_inc(&st.balance_waste);
+		break;
+	case LMK_MEM_ERROR:
+		atomic_long_inc(&st.mem_error);
+		break;
+	default:
+		atomic_long_inc(&st.unknown);
+		break;
+	}
+}
+
+static int lmk_proc_show(struct seq_file *m, void *v)
+{
+	seq_printf(m, "kill: %ld\n", atomic_long_read(&st.kills));
+	seq_printf(m, "scan: %ld\n", atomic_long_read(&st.scans));
+	seq_printf(m, "waste: %ld\n", atomic_long_read(&st.waste));
+	seq_printf(m, "timeout: %ld\n", atomic_long_read(&st.timeout));
+	seq_printf(m, "count: %ld\n", atomic_long_read(&st.count));
+	seq_printf(m, "busy: %ld\n", atomic_long_read(&st.busy));
+	seq_printf(m, "error: %ld\n", atomic_long_read(&st.error));
+	seq_printf(m, "no kill: %ld\n", atomic_long_read(&st.no_kill));
+	seq_printf(m, "zero: %ld\n", atomic_long_read(&st.zero_count));
+	seq_printf(m, "oom: %ld\n", atomic_long_read(&st.oom_count));
+	seq_printf(m, "oom kill: %ld\n", atomic_long_read(&st.oom_kill_count));
+	seq_printf(m, "morgue: %ld\n", atomic_long_read(&st.morgue_count));
+	seq_printf(m, "balance kill: %ld\n",
+		   atomic_long_read(&st.balance_kill));
+	seq_printf(m, "balance waste: %ld\n",
+		   atomic_long_read(&st.balance_waste));
+	seq_printf(m, "mem error: %ld\n",
+		   atomic_long_read(&st.mem_error));
+	seq_printf(m, "unknown: %ld (internal)\n",
+		   atomic_long_read(&st.unknown));
+
+	return 0;
+}
+
+static int lmk_proc_open(struct inode *inode, struct file *file)
+{
+	return single_open(file, lmk_proc_show, PDE_DATA(inode));
+}
+
+static const struct file_operations lmk_proc_fops = {
+	.open		= lmk_proc_open,
+	.read		= seq_read,
+	.release	= single_release
+};
+
+int __init init_procfs_lmk(void)
+{
+	proc_create_data(LMK_PROCFS_NAME, 0444, NULL, &lmk_proc_fops, NULL);
+	return 0;
+}
+
+void exit_procfs_lmk(void)
+{
+	remove_proc_entry(LMK_PROCFS_NAME, NULL);
+}

--- a/drivers/staging/android/lowmemorykiller_stats.h
+++ b/drivers/staging/android/lowmemorykiller_stats.h
@@ -1,0 +1,52 @@
+/*
+ *  lowmemorykiller_stats interface
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef __LOWMEMORYKILLER_STATS_H
+#define __LOWMEMORYKILLER_STATS_H
+
+enum  lmk_kill_stats {
+	LMK_SCAN = 1,
+	LMK_KILL = 2,
+	LMK_WASTE = 3,
+	LMK_TIMEOUT = 4,
+	LMK_COUNT = 5,
+	LMK_SCAN_BUSY = 6,
+	LMK_NO_KILL = 7,
+	LMK_BUSY = 8,
+	LMK_ERROR = 9,
+	LMK_ZERO_COUNT = 10,
+	LMK_OOM_COUNT = 11,
+	LMK_OOM_KILL_COUNT = 12,
+	LMK_BALANCE_KILL = 13,
+	LMK_BALANCE_WASTE = 14,
+	LMK_MORGUE_COUNT = 15,
+	LMK_MEM_ERROR = 16,
+};
+
+#define LMK_PROCFS_NAME "lmkstats"
+
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_STATS
+void lmk_inc_stats(int key);
+int __init init_procfs_lmk(void);
+void exit_procfs_lmk(void);
+#else
+static inline void lmk_inc_stats(int key) { return; };
+static inline int __init init_procfs_lmk(void) { return 0; };
+static inline void exit_procfs_lmk(void) { return; };
+#endif
+
+#endif

--- a/drivers/staging/android/lowmemorykiller_tasks.c
+++ b/drivers/staging/android/lowmemorykiller_tasks.c
@@ -1,0 +1,285 @@
+/*
+ *  lowmemorykiller_tasks
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+/* this files contains help functions for handling tasks within the
+ * lowmemorykiller. It track tasks that are in it's score range,
+ * and it track tasks that signaled to be killed
+ */
+
+/* add fake print format with original module name */
+#define pr_fmt(fmt) "lowmemorykiller: " fmt
+
+#include <linux/kernel.h>
+#include <linux/mm.h>
+#include <linux/oom.h>
+#include <linux/slab.h>
+#include <linux/oom_score_notifier.h>
+
+#include "lowmemorykiller.h"
+#include "lowmemorykiller_tasks.h"
+#include "lowmemorykiller_stats.h"
+
+static struct rb_root watch_tree = RB_ROOT;
+struct list_head lmk_death_pending;
+struct kmem_cache *lmk_dp_cache;
+struct kmem_cache *lmk_task_cache;
+
+/* We need a well defined order for our tree, score is the major order
+ * and we use pid to get a unique order.
+ * return -1 on smaller, 0 on equal and 1 on bigger
+ */
+
+enum {
+	LMK_OFR_LESS = -1,
+	LMK_OFR_EQUAL = 0,
+	LMK_OFR_GREATER = 1
+};
+
+/* to protect lmk task storage data structures */
+DEFINE_SPINLOCK(lmk_task_lock);
+LIST_HEAD(lmk_death_pending);
+
+int death_pending_len;
+
+static inline int lmk_task_orderfunc(int lkey, uintptr_t lpid,
+				     int rkey, uintptr_t rpid)
+{
+	if (lkey > rkey)
+		return LMK_OFR_GREATER;
+	if (lkey < rkey)
+		return LMK_OFR_LESS;
+	if (lpid > rpid)
+		return LMK_OFR_GREATER;
+	if (lpid < rpid)
+		return LMK_OFR_LESS;
+	return LMK_OFR_EQUAL;
+}
+
+static inline int __lmk_task_insert(struct task_struct *tsk)
+{
+	struct rb_node **new = &watch_tree.rb_node, *parent = NULL;
+	struct lmk_rb_watch *t;
+
+	t = kmem_cache_alloc(lmk_task_cache, GFP_ATOMIC);
+	t->key = tsk->signal->oom_score_adj;
+	t->tsk = tsk;
+
+	/* Figure out where to put new node */
+	while (*new) {
+		struct lmk_rb_watch *this = rb_entry(*new,
+						     struct lmk_rb_watch,
+						     rb_node);
+		int result;
+
+		result = lmk_task_orderfunc(t->key,
+					    (uintptr_t)t->tsk,
+					    this->key,
+					    (uintptr_t)this->tsk);
+
+		if (result == LMK_OFR_EQUAL) {
+			lowmem_print(1, "Dupe key %d:%d:%p - key %d:%d:%p\n",
+				     t->key, t->tsk->pid, t->tsk,
+				     this->key, this->tsk->pid, this->tsk);
+			WARN_ON(1);
+			return 0;
+		}
+		parent = *new;
+		if (result > 0)
+			new = &((*new)->rb_left);
+		else
+			new = &((*new)->rb_right);
+	}
+
+	/* Add new node and rebalance tree. */
+	rb_link_node(&t->rb_node, parent, new);
+	rb_insert_color(&t->rb_node, &watch_tree);
+	get_task_struct(tsk);
+	return 1;
+}
+
+static struct lmk_rb_watch *__lmk_task_search(struct task_struct *tsk,
+					      int score)
+{
+	struct rb_node *node = watch_tree.rb_node;
+	struct lmk_rb_watch *data = NULL;
+
+	while (node) {
+		int result;
+
+		data = rb_entry(node, struct lmk_rb_watch, rb_node);
+
+		result = lmk_task_orderfunc(data->key, (uintptr_t)data->tsk,
+					    score, (uintptr_t)tsk);
+		switch (result) {
+		case LMK_OFR_LESS:
+			node = node->rb_left;
+			break;
+		case LMK_OFR_GREATER:
+			node = node->rb_right;
+			break;
+		case LMK_OFR_EQUAL:
+			if (data->tsk == tsk)
+				return data;
+			WARN(1, "tsk not equal %p %p", data->tsk, tsk);
+			/* Oh shit, hope for the best :-( */
+			return NULL;
+		default:
+			WARN(1, "Unknown result %d", result);
+			break;
+		}
+	}
+	return NULL;
+}
+
+int __lmk_task_remove(struct task_struct *tsk,
+		      int score)
+{
+	struct lmk_rb_watch *lrw;
+
+	lrw = __lmk_task_search(tsk, score);
+	if (lrw) {
+		rb_erase(&lrw->rb_node, &watch_tree);
+		kmem_cache_free(lmk_task_cache, lrw);
+		put_task_struct(tsk);
+		return 1;
+	}
+
+	return 0;
+}
+
+static void lmk_task_watch(struct task_struct *tsk, int old_oom_score_adj)
+{
+	if (thread_group_leader(tsk) &&
+	    (tsk->signal->oom_score_adj >= LMK_SCORE_THRESHOLD ||
+	     old_oom_score_adj >= LMK_SCORE_THRESHOLD) &&
+	    !(tsk->flags & PF_KTHREAD)) {
+		spin_lock(&lmk_task_lock);
+		__lmk_task_remove(tsk, old_oom_score_adj);
+		if (tsk->signal->oom_score_adj >= LMK_SCORE_THRESHOLD) {
+			struct mm_struct *mm = tsk->mm;
+
+			if (mm) {
+				if (!test_tsk_thread_flag(tsk, TIF_MEMDIE) &&
+				    !test_bit(MMF_OOM_SKIP, &mm->flags) &&
+				    !test_bit(MMF_OOM_VICTIM, &mm->flags))
+					__lmk_task_insert(tsk);
+			} else {
+				if (!test_tsk_thread_flag(tsk, TIF_MEMDIE) &&
+				    !test_tsk_thread_flag(tsk, TIF_MM_RELEASED) &&
+				    !task_lmk_waiting(tsk))
+					__lmk_task_insert(tsk);
+			}
+		}
+		spin_unlock(&lmk_task_lock);
+	}
+}
+
+bool __lmk_death_pending_morgue(void)
+{
+	bool changed = false;
+	struct lmk_death_pending_entry *dp_iterator, *tmp;
+
+	list_for_each_entry_safe(dp_iterator, tmp,
+				 &lmk_death_pending, lmk_dp_list) {
+		if (!dp_iterator->tsk->mm) {
+			put_task_struct(dp_iterator->tsk);
+			list_del(&dp_iterator->lmk_dp_list);
+			kmem_cache_free(lmk_dp_cache, dp_iterator);
+			death_pending_len--;
+			lmk_inc_stats(LMK_MORGUE_COUNT);
+			changed = true;
+		}
+	}
+	return changed;
+}
+
+bool lmk_death_pending_morgue(void)
+{
+	bool changed;
+
+	spin_lock(&lmk_task_lock);
+	changed = __lmk_death_pending_morgue();
+	spin_unlock(&lmk_task_lock);
+	return changed;
+}
+
+static void lmk_task_free(struct task_struct *tsk)
+{
+	if (thread_group_leader(tsk) &&
+	    !(tsk->flags & PF_KTHREAD)) {
+		struct lmk_death_pending_entry *dp_iterator;
+		int clear = 1;
+
+		spin_lock(&lmk_task_lock);
+		if (__lmk_task_remove(tsk, tsk->signal->oom_score_adj))
+			clear = 0;
+
+		/* check our kill queue */
+		list_for_each_entry(dp_iterator,
+				    &lmk_death_pending, lmk_dp_list) {
+			if (dp_iterator->tsk == tsk) {
+				list_del(&dp_iterator->lmk_dp_list);
+				kmem_cache_free(lmk_dp_cache, dp_iterator);
+				death_pending_len--;
+				put_task_struct(tsk);
+				clear = 0;
+				break;
+			}
+		}
+		spin_unlock(&lmk_task_lock);
+		if (clear) {
+			lowmem_print(2, "Pid not in list %d %d\n",
+				     tsk->pid, tsk->signal->oom_score_adj);
+		}
+	}
+}
+
+static int lmk_oom_score_notifier(struct notifier_block *nb,
+				  unsigned long action, void *data)
+{
+	struct oom_score_notifier_struct *osns = data;
+
+	switch (action) {
+	case OSN_NEW:
+		lmk_task_watch(osns->tsk, LMK_SCORE_THRESHOLD - 1);
+		break;
+	case OSN_FREE:
+		lmk_task_free(osns->tsk);
+		break;
+	case OSN_UPDATE:
+		lmk_task_watch(osns->tsk, osns->old_score);
+		break;
+	}
+	return 0;
+}
+
+int __lmk_death_pending_add(struct lmk_death_pending_entry *lwp)
+{
+	list_add(&lwp->lmk_dp_list, &lmk_death_pending);
+	get_task_struct(lwp->tsk);
+	death_pending_len++;
+	return 0;
+}
+
+struct lmk_rb_watch *__lmk_task_first(void)
+{
+	return rb_entry(rb_first(&watch_tree), struct lmk_rb_watch, rb_node);
+}
+
+struct notifier_block lmk_oom_score_nb = {
+	.notifier_call = lmk_oom_score_notifier,
+};

--- a/drivers/staging/android/lowmemorykiller_tasks.h
+++ b/drivers/staging/android/lowmemorykiller_tasks.h
@@ -1,0 +1,44 @@
+/*
+ *  lowmemorykiller_tasks interface
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef __LOWMEMORYKILLER_TASKS_H
+#define __LOWMEMORYKILLER_TASKS_H
+
+struct lmk_death_pending_entry {
+	struct list_head lmk_dp_list;
+	struct task_struct *tsk;
+};
+
+struct lmk_rb_watch {
+	struct rb_node rb_node;
+	struct task_struct *tsk;
+	int key;
+};
+
+extern int death_pending_len;
+extern struct kmem_cache *lmk_dp_cache;
+extern struct kmem_cache *lmk_task_cache;
+extern spinlock_t lmk_task_lock;
+extern struct notifier_block lmk_oom_score_nb;
+
+int __lmk_task_remove(struct task_struct *tsk, int score);
+int __lmk_death_pending_add(struct lmk_death_pending_entry *lwp);
+bool lmk_death_pending_morgue(void);
+bool __lmk_death_pending_morgue(void);
+struct lmk_rb_watch *__lmk_task_first(void);
+
+#endif

--- a/drivers/staging/android/lowmemorykiller_tng.c
+++ b/drivers/staging/android/lowmemorykiller_tng.c
@@ -1,0 +1,459 @@
+/*
+ *  lowmemorykiller_tng
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *  co Author: Snild Dolkow
+ *  co Author: Björn Davidsson
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+/* This file contain the logic for new lowmemorykiller (TNG). Parts
+ * of the calculations is taken from the original lowmemorykiller
+ */
+
+/* add fake print format with original module name */
+#define pr_fmt(fmt) "lowmemorykiller: " fmt
+
+#include <linux/slab.h>
+#include <linux/swap.h>
+#include <linux/mm.h>
+
+#include <linux/oom_score_notifier.h>
+#include "lowmemorykiller_tasks.h"
+#include "lowmemorykiller_oom.h"
+#include "lowmemorykiller_tng.h"
+
+#ifdef LMK_TNG_ENABLE_TRACE
+#include <trace/events/lmk.h>
+#endif
+#ifdef CONFIG_ZCACHE
+#include <linux/zcache.h>
+#else
+/*zcache.h has incorrect definition here.*/
+static inline u64 zcache_pages(void) { return 0; }
+#endif
+#define LMK_ZOMBIE_SIZE (PAGE_SIZE)
+static int seek_count;
+static unsigned long lowmem_count_tng(struct shrinker *s,
+				      struct shrink_control *sc);
+static unsigned long lowmem_scan_tng(struct shrinker *s,
+				     struct shrink_control *sc);
+
+void __init lowmem_init_tng(struct shrinker *shrinker)
+{
+	lmk_dp_cache = KMEM_CACHE(lmk_death_pending_entry, 0);
+	lmk_task_cache = KMEM_CACHE(lmk_rb_watch, 0);
+	oom_score_notifier_register(&lmk_oom_score_nb);
+	lowmemorykiller_register_oom_notifier();
+	shrinker->count_objects = lowmem_count_tng;
+	shrinker->scan_objects = lowmem_scan_tng;
+}
+
+ssize_t get_task_rss(struct task_struct *tsk)
+{
+	unsigned long rss = 0;
+	struct mm_struct *mm;
+
+	mm = ACCESS_ONCE(tsk->mm);
+	if (mm)
+		rss = get_mm_rss(mm) << PAGE_SHIFT;
+	if (rss < LMK_ZOMBIE_SIZE)
+		rss = LMK_ZOMBIE_SIZE;
+	return rss;
+}
+
+static inline long zone_threshold_check(struct zone *zone, int zone_type,
+					int threshold)
+{
+	int order;
+	unsigned long flags;
+	unsigned long tot = 0;
+
+	spin_lock_irqsave(&zone->lock, flags);
+	for (order = 0; order < MAX_ORDER; ++order) {
+		struct free_area *area;
+		struct list_head *curr;
+
+		area = &zone->free_area[order];
+		list_for_each(curr, &area->free_list[zone_type]) {
+			tot += 1 << order;
+			if (tot >= threshold)
+				goto out;
+		}
+	}
+out:
+	spin_unlock_irqrestore(&zone->lock, flags);
+	return tot;
+}
+
+/* can_swap check if we have memory resources to be able to swap.
+ * When we have a pressure to get more atomic or movable pages
+ * it is sent through the shrinker as gfp. We can not trace it back
+ * to who the consumer is.
+ */
+static int can_swap(gfp_t mask, int atomic_threshold, int movable_threshold)
+{
+	struct zonelist *zonelist;
+	enum zone_type high_zoneidx;
+	struct zone *zone;
+	struct zoneref *zoneref;
+	int zone_idx;
+	struct zone *preferred_zone;
+	struct zoneref *zref;
+	int sum_atomic = 0;
+	int sum_movable = 0;
+
+	/* if there is no need for movable or atomic we are safe */
+
+	if (atomic_threshold == 0 && movable_threshold == 0)
+		return 1;
+
+	zonelist = node_zonelist(0, 0);
+
+	high_zoneidx = gfp_zone(mask);
+	zref = first_zones_zonelist(zonelist, high_zoneidx, NULL);
+	preferred_zone = zref->zone;
+
+	/* Watermark for the zone can handle 64 pages of order 0
+	 * we assume we are safe.
+	 */
+	if (zone_watermark_ok(preferred_zone, 0, 64, high_zoneidx, mask))
+		return 1;
+
+	/* this is scan is heuristic based on qualcomm hardware. */
+	/* we can swap if there is movable pages */
+	for_each_zone_zonelist(zone, zoneref, zonelist, MAX_NR_ZONES) {
+		zone_idx = zonelist_zone_idx(zoneref);
+		if (zone_idx == ZONE_NORMAL) {
+			sum_atomic +=
+				zone_threshold_check(zone,
+						     MIGRATE_HIGHATOMIC,
+						     atomic_threshold);
+
+			if (sum_movable >= movable_threshold &&
+			    sum_atomic >= atomic_threshold)
+				return 1;
+
+			sum_movable +=
+				zone_threshold_check(zone,
+						     MIGRATE_MOVABLE,
+						     movable_threshold);
+
+			if (sum_movable >= movable_threshold &&
+			    sum_atomic >= atomic_threshold)
+				return 1;
+		}
+	}
+	return 0;
+}
+
+static void calc_params(struct calculated_params *cp, gfp_t mask)
+{
+	int i;
+	int array_size;
+	long free_swap = get_nr_swap_pages();
+	long irp = global_node_page_state(NR_INDIRECTLY_RECLAIMABLE_BYTES)
+	  >> PAGE_SHIFT;
+	long usable_free_swap = 0;
+	long tot_usable = 0;
+	int start;
+	int cs = 1; /* we can swap unless the checks says no */
+	int movc = 0;
+	int atomicc = 0;
+
+	if (free_swap > 64) {
+		if (mask & __GFP_MOVABLE)
+			movc = (1 << (PAGE_ALLOC_COSTLY_ORDER + 2));
+
+		if (mask & __GFP_ATOMIC)
+			atomicc = (1 << PAGE_ALLOC_COSTLY_ORDER);
+
+		cs = can_swap(mask, atomicc, movc);
+		if (cs) {
+			if (free_swap > 0x800)
+				usable_free_swap = free_swap;
+			else
+				usable_free_swap = free_swap / 2;
+
+		} else {
+			cp->kill_reason |= LMK_CANT_SWAP;
+		}
+	}
+
+	tot_usable = usable_free_swap + irp;
+	/* Free CMA is part of NR_FREE_PAGES, but sometimes not usable. */
+	cp->margin = global_zone_page_state(NR_FREE_PAGES) - totalreserve_pages
+	  - global_zone_page_state(NR_FREE_CMA_PAGES);
+	cp->other_free = cp->margin + tot_usable;
+
+	if (global_node_page_state(NR_SHMEM) + total_swapcache_pages() +
+	    global_node_page_state(NR_UNEVICTABLE) <
+	    global_node_page_state(NR_FILE_PAGES))
+		cp->other_file = global_node_page_state(NR_FILE_PAGES) -
+		  global_node_page_state(NR_SHMEM) -
+		  global_node_page_state(NR_UNEVICTABLE) -
+		  total_swapcache_pages();
+	else
+		cp->other_file = 0;
+
+	cp->min_score_adj = SHRT_MAX;
+	array_size = lowmem_min_param_size();
+	start = 0;
+
+	/* be extra careful with vmpressure to kill perceptible stuff */
+	if (tot_usable > 128 && cp->kill_reason == LMK_VMPRESSURE)
+		start = 3;
+
+	for (i = start; i < array_size; i++) {
+		cp->minfree = lowmem_minfree[i];
+		if (cp->other_free < cp->minfree &&
+		    cp->other_file < cp->minfree) {
+			cp->min_score_adj = lowmem_adj[i];
+			break;
+		}
+	}
+	cp->dynamic_max_queue_len = (array_size - i) / 2 + 1;
+
+	/* If there is a lot of reclaimable we dont kill more
+	 *  than one at the time.
+	 */
+	if (tot_usable > 128)
+		cp->dynamic_max_queue_len = 1;
+
+	if (cp->margin <= 0) {
+		/* If have used more 5/6 our total reserve
+		 * we need to take a action and kill something even if
+		 * we have reclaimable memory and lot of free swap
+		 * but can not swap.
+		 */
+		if (cp->kill_reason & LMK_CANT_SWAP) {
+			if (-6 * (cp->margin) > 5 * totalreserve_pages) {
+				cp->kill_reason |= LMK_LOW_RESERVE;
+				cp->dynamic_max_queue_len = 1;
+				cp->min_score_adj = 0;
+			}
+		}
+	}
+}
+
+int kill_needed(int level, gfp_t mask,
+		struct calculated_params *cp)
+{
+	calc_params(cp, mask);
+	cp->selected_oom_score_adj = level;
+
+	if (level >= cp->min_score_adj)
+		return 1;
+	return 0;
+}
+
+void print_obituary(struct task_struct *doomed,
+		    struct calculated_params *cp,
+		    gfp_t gfp_mask)
+{
+	long cache_size = cp->other_file * (long)(PAGE_SIZE / 1024);
+	long cache_limit = cp->minfree * (long)(PAGE_SIZE / 1024);
+	long free = cp->other_free * (long)(PAGE_SIZE / 1024);
+
+	lowmem_print(1, "Killing '%s' (%d), adj %hd,\n"
+		     "   to free %ldkB on behalf of '%s' (%d) because\n"
+		     "   cache %ldkB is below limit %ldkB for oom_score_adj %hd\n"
+		     "   Free memory is %ldkB above reserved.\n"
+		     "   Free CMA is %ldkB\n"
+		     "   Total reserve is %ldkB\n"
+		     "   Total free pages is %ldkB\n"
+		     "   Total file cache is %ldkB\n"
+		     "   Slab Reclaimable is %ldkB\n"
+		     "   Slab UnReclaimable is %ldkB\n"
+		     "   Total Slab is %ldkB\n"
+		     "   GFP mask is 0x%x\n"
+		     "   Indirect Reclaimable is %zdkB\n"
+		     "   Free Swap %ldkB\n"
+		     "   queue len is %d of max %d reason:0x%x margin:%d\n",
+		     doomed->comm, doomed->pid,
+		     cp->selected_oom_score_adj,
+		     cp->selected_tasksize / 1024,
+		     current->comm, current->pid,
+		     cache_size, cache_limit,
+		     cp->min_score_adj,
+		     free,
+		     global_zone_page_state(NR_FREE_CMA_PAGES) *
+		     (long)(PAGE_SIZE / 1024),
+		     totalreserve_pages * (long)(PAGE_SIZE / 1024),
+		     global_zone_page_state(NR_FREE_PAGES) *
+		     (long)(PAGE_SIZE / 1024),
+		     global_node_page_state(NR_FILE_PAGES) *
+		     (long)(PAGE_SIZE / 1024),
+		     global_node_page_state(NR_SLAB_RECLAIMABLE) *
+		     (long)(PAGE_SIZE / 1024),
+		     global_node_page_state(NR_SLAB_UNRECLAIMABLE) *
+		     (long)(PAGE_SIZE / 1024),
+		     global_node_page_state(NR_SLAB_RECLAIMABLE) *
+		     (long)(PAGE_SIZE / 1024) +
+		     global_node_page_state(NR_SLAB_UNRECLAIMABLE) *
+		     (long)(PAGE_SIZE / 1024),
+		     gfp_mask,
+		     global_node_page_state(NR_INDIRECTLY_RECLAIMABLE_BYTES)
+		     / 1024,
+		     get_nr_swap_pages() * (long)(PAGE_SIZE / 1024),
+		     death_pending_len,
+		     cp->dynamic_max_queue_len,
+		     cp->kill_reason, cp->margin);
+}
+
+static unsigned long lowmem_count_tng(struct shrinker *s,
+				      struct shrink_control *sc)
+{
+	struct lmk_rb_watch *lrw;
+	struct calculated_params cp;
+	short score;
+
+	if (!(sc->gfp_mask & __GFP_MOVABLE)) {
+		if (current_is_kswapd()) {
+			if (seek_count++ < (s->seeks * 4))
+				return 0;
+			seek_count = 0;
+		}
+	}
+
+	lmk_inc_stats(LMK_COUNT);
+	cp.selected_tasksize = 0;
+	cp.kill_reason = LMK_SHRINKER_COUNT;
+	spin_lock(&lmk_task_lock);
+	lrw = __lmk_task_first();
+	if (lrw) {
+		ssize_t rss = get_task_rss(lrw->tsk);
+
+		score = lrw->tsk->signal->oom_score_adj;
+		spin_unlock(&lmk_task_lock);
+		if (kill_needed(score, sc->gfp_mask, &cp)) {
+			if (death_pending_len < cp.dynamic_max_queue_len)
+				cp.selected_tasksize = rss;
+			else if (lmk_death_pending_morgue())
+				if (death_pending_len <
+				    cp.dynamic_max_queue_len)
+					cp.selected_tasksize = rss;
+		}
+	} else {
+		spin_unlock(&lmk_task_lock);
+		lowmem_print(2, "Empty task list in count");
+	}
+	if (cp.selected_tasksize == 0)
+		lmk_inc_stats(LMK_ZERO_COUNT);
+
+	return cp.selected_tasksize;
+}
+
+static unsigned long lowmem_scan_tng(struct shrinker *s,
+				     struct shrink_control *sc)
+{
+	struct task_struct *selected = NULL;
+	unsigned long nr_to_scan = sc->nr_to_scan;
+	struct lmk_rb_watch *lrw;
+	int do_kill;
+	struct calculated_params cp;
+
+	lmk_inc_stats(LMK_SCAN);
+
+	cp.selected_tasksize = 0;
+	cp.kill_reason = LMK_SHRINKER_SCAN;
+	spin_lock(&lmk_task_lock);
+
+	lrw = __lmk_task_first();
+	if (lrw) {
+		cp.selected_tasksize = get_task_rss(lrw->tsk);
+		do_kill = kill_needed(lrw->key, sc->gfp_mask, &cp);
+		if (death_pending_len >= cp.dynamic_max_queue_len) {
+			lmk_inc_stats(LMK_BUSY);
+			cp.selected_tasksize = SHRINK_STOP;
+			goto unlock_out;
+		}
+
+		if (do_kill) {
+			struct lmk_death_pending_entry *ldpt;
+
+			selected = lrw->tsk;
+
+			/* there is a chance that task is locked,
+			 * and the case where it locked in oom_score_adj_write
+			 * we might have deadlock.
+			 */
+			if (!task_trylock_lmk(selected)) {
+				lmk_inc_stats(LMK_ERROR);
+				lowmem_print(2, "Failed to lock task.\n");
+				lmk_inc_stats(LMK_BUSY);
+				cp.selected_tasksize = SHRINK_STOP;
+				goto unlock_out;
+			}
+
+			/* move to kill pending set */
+			ldpt = kmem_cache_alloc(lmk_dp_cache, GFP_ATOMIC);
+			if (!ldpt) {
+				WARN_ON(1);
+				lmk_inc_stats(LMK_MEM_ERROR);
+				cp.selected_tasksize = SHRINK_STOP;
+#ifdef LMK_TNG_ENABLE_TRACE
+				trace_lmk_sigkill(selected->pid, selected->comm,
+						  LMK_TRACE_MEMERROR,
+						  cp.selected_tasksize,
+						  sc->gfp_mask);
+#endif
+
+				goto unlock_out;
+			}
+			ldpt->tsk = selected;
+
+			__lmk_death_pending_add(ldpt);
+			if (!__lmk_task_remove(selected, lrw->key))
+				WARN_ON(1);
+
+			spin_unlock(&lmk_task_lock);
+
+			send_sig(SIGKILL, selected, 0);
+			LMK_TAG_TASK_DIE(selected);
+#ifdef LMK_TNG_ENABLE_TRACE
+			trace_lmk_sigkill(selected->pid, selected->comm,
+					  cp.selected_oom_score_adj,
+					  cp.selected_tasksize,
+					  sc->gfp_mask);
+#endif
+			print_obituary(selected, &cp, sc->gfp_mask);
+
+			task_unlock(selected);
+
+			lmk_inc_stats(LMK_KILL);
+			goto out;
+		} else {
+			lmk_inc_stats(LMK_WASTE);
+		}
+	} else {
+		lmk_inc_stats(LMK_NO_KILL);
+	}
+
+unlock_out:
+	spin_unlock(&lmk_task_lock);
+out:
+	if (cp.selected_tasksize == 0)
+		lowmem_print(2, "list empty nothing to free\n");
+	lowmem_print(4, "lowmem_shrink %lu, %x, return %ld\n",
+		     nr_to_scan, sc->gfp_mask, cp.selected_tasksize);
+
+	return cp.selected_tasksize;
+}
+
+void tune_lmk_param_mask(int *other_free, int *other_file, gfp_t mask)
+{
+	struct shrink_control fake_shrink_control;
+
+	fake_shrink_control.gfp_mask = mask;
+	tune_lmk_param(other_free, other_file, &fake_shrink_control);
+}

--- a/drivers/staging/android/lowmemorykiller_tng.h
+++ b/drivers/staging/android/lowmemorykiller_tng.h
@@ -1,0 +1,41 @@
+/*
+ *  lowmemorykiller_tng interface
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+#ifndef __LOWMEMORYKILLER_TNG_H
+#define __LOWMEMORYKILLER_TNG_H
+extern short lowmem_adj[];
+extern int lowmem_minfree[];
+extern int oom_reaper;
+
+/* basic kill reason */
+#define LMK_VMPRESSURE		(0x1)
+#define LMK_SHRINKER_SCAN	(0x2)
+#define LMK_OOM			(0x4)
+#define LMK_SHRINKER_COUNT	(0x8)
+/* calc option reason */
+#define LMK_LOW_RESERVE		(0x0100)
+#define LMK_CANT_SWAP		(0x0200)
+
+/* function in lowmemorykiller.c */
+int lowmem_min_param_size(void);
+int adjust_minadj(short *min_score_adj);
+/* please dont use tune_lmk_param directly without good reason */
+void tune_lmk_param(int *other_free, int *other_file,
+		    struct shrink_control *sc);
+void tune_lmk_param_mask(int *other_free, int *other_file, gfp_t mask);
+void __init lowmem_init_tng(struct shrinker *shrinker);
+void balance_cache(unsigned long vmpressure);
+void mark_lmk_victim(struct task_struct *tsk);
+#endif

--- a/drivers/staging/android/lowmemorykiller_vmpressure.c
+++ b/drivers/staging/android/lowmemorykiller_vmpressure.c
@@ -1,0 +1,160 @@
+/*
+ *  lowmemorykiller_vmpressure
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+/* todo: Handle vmpressure notifier directly.
+ * It is there on this version since it us hooking
+ * into qualcomm vmpressure extension.
+ */
+
+/* add fake print format with original module name */
+#define pr_fmt(fmt) "lowmemorykiller: " fmt
+
+#include <linux/kernel.h>
+#include <linux/mm.h>
+#include <linux/oom.h>
+#include <linux/slab.h>
+#include <linux/vmpressure.h>
+
+#ifdef LMK_TNG_ENABLE_TRACE
+#include <trace/events/lmk.h>
+#endif
+
+#include "lowmemorykiller.h"
+#include "lowmemorykiller_tng.h"
+#include "lowmemorykiller_stats.h"
+#include "lowmemorykiller_tasks.h"
+
+static unsigned long oldvmp;
+
+void balance_cache(unsigned long vmpressure)
+{
+	struct task_struct *selected = NULL;
+	struct lmk_rb_watch *lrw;
+	int do_kill;
+	struct calculated_params cp;
+	gfp_t mask = ___GFP_KSWAPD_RECLAIM |
+	  ___GFP_DIRECT_RECLAIM | __GFP_FS | __GFP_IO;
+
+	if (vmpressure < 50) {
+		oldvmp = vmpressure;
+		return;
+	}
+
+	if (vmpressure < oldvmp && vmpressure < 95) {
+		oldvmp = vmpressure;
+		return;
+	}
+
+	oldvmp = vmpressure;
+	cp.selected_tasksize = 0;
+	cp.dynamic_max_queue_len = 1;
+	cp.kill_reason = LMK_VMPRESSURE;
+	spin_lock_bh(&lmk_task_lock);
+
+	lrw = __lmk_task_first();
+
+	if (lrw) {
+		if (lrw->tsk->mm) {
+			cp.selected_tasksize = get_mm_rss(lrw->tsk->mm);
+		} else {
+			lowmem_print(3, "pid:%d no mem\n", lrw->tsk->pid);
+			lmk_inc_stats(LMK_ERROR);
+			goto unlock_out;
+		}
+
+		do_kill = kill_needed(lrw->key, mask, &cp);
+
+		if (death_pending_len >= cp.dynamic_max_queue_len)
+			__lmk_death_pending_morgue();
+		if (death_pending_len >= cp.dynamic_max_queue_len) {
+			lmk_inc_stats(LMK_BUSY);
+			cp.selected_tasksize = SHRINK_STOP;
+			lowmem_print(3, "Queue %d >= %d",
+				     death_pending_len,
+				     cp.dynamic_max_queue_len);
+			goto unlock_out;
+		}
+
+		if (do_kill) {
+			struct lmk_death_pending_entry *ldpt;
+
+			selected = lrw->tsk;
+
+			/* there is a chance that task is locked,
+			 * and the case where it locked in oom_score_adj_write
+			 * we might have deadlock. There is no macro for it
+			 *  and this is the only place there is a try on
+			 * the task_lock.
+			 */
+			if (!spin_trylock(&selected->alloc_lock)) {
+				lowmem_print(2, "Failed to lock task.\n");
+				lmk_inc_stats(LMK_BUSY);
+				cp.selected_tasksize = SHRINK_STOP;
+				goto unlock_out;
+			}
+
+			/* move to kill pending set */
+			ldpt = kmem_cache_alloc(lmk_dp_cache, GFP_ATOMIC);
+			if (!ldpt) {
+				WARN_ON(1);
+				lmk_inc_stats(LMK_MEM_ERROR);
+				cp.selected_tasksize = SHRINK_STOP;
+#ifdef LMK_TNG_ENABLE_TRACE
+				trace_lmk_sigkill(selected->pid, selected->comm,
+						  LMK_TRACE_MEMERROR,
+						  cp.selected_tasksize,
+						  0);
+#endif
+				goto unlock_out;
+			}
+
+			ldpt->tsk = selected;
+
+			__lmk_death_pending_add(ldpt);
+			if (!__lmk_task_remove(selected, lrw->key))
+				WARN_ON(1);
+
+			spin_unlock_bh(&lmk_task_lock);
+
+			send_sig(SIGKILL, selected, 0);
+			LMK_TAG_TASK_DIE(selected);
+			print_obituary(selected, &cp, 0);
+#ifdef LMK_TNG_ENABLE_TRACE
+			trace_lmk_sigkill(selected->pid, selected->comm,
+					  cp.selected_oom_score_adj,
+					  cp.selected_tasksize,
+					  0);
+#endif
+
+			task_unlock(selected);
+
+			lmk_inc_stats(LMK_BALANCE_KILL);
+			goto out;
+		} else {
+			lowmem_print(3, "No kill");
+			lmk_inc_stats(LMK_BALANCE_WASTE);
+		}
+	} else {
+		lowmem_print(2, "Nothing to kill");
+		lmk_inc_stats(LMK_NO_KILL);
+	}
+unlock_out:
+	spin_unlock_bh(&lmk_task_lock);
+out:
+	if (cp.selected_tasksize == 0)
+		lowmem_print(2, "list empty nothing to free\n");
+}

--- a/drivers/staging/android/trace/lowmemorykiller.h
+++ b/drivers/staging/android/trace/lowmemorykiller.h
@@ -1,0 +1,42 @@
+#undef TRACE_SYSTEM
+#define TRACE_INCLUDE_PATH ../../drivers/staging/android/trace
+#define TRACE_SYSTEM lowmemorykiller
+
+#if !defined(_TRACE_LOWMEMORYKILLER_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _TRACE_LOWMEMORYKILLER_H
+
+#include <linux/tracepoint.h>
+
+TRACE_EVENT(lowmemory_kill,
+        TP_PROTO(struct task_struct *killed_task, long cache_size, \
+                 long cache_limit, long free),
+
+        TP_ARGS(killed_task, cache_size, cache_limit, free),
+
+        TP_STRUCT__entry(
+                        __array(char, comm, TASK_COMM_LEN)
+                        __field(pid_t, pid)
+                        __field(long, pagecache_size)
+                        __field(long, pagecache_limit)
+                        __field(long, free)
+        ),
+
+        TP_fast_assign( 
+                        memcpy(__entry->comm, killed_task->comm, TASK_COMM_LEN);
+                        __entry->pid = killed_task->pid;
+                        __entry->pagecache_size = cache_size;
+                        __entry->pagecache_limit = cache_limit;
+                        __entry->free = free;
+        ),
+
+        TP_printk("%s (%d), page cache %ldkB (limit %ldkB), free %ldKb",
+                __entry->comm, __entry->pid, __entry->pagecache_size,
+                __entry->pagecache_limit, __entry->free)
+);
+
+
+#endif /* if !defined(_TRACE_LOWMEMORYKILLER_H) || defined(TRACE_HEADER_MULTI_READ) */
+
+/* This part must be outside protection */
+#include <trace/define_trace.h>
+

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -776,6 +776,12 @@ static inline bool pgdat_is_empty(pg_data_t *pgdat)
 #include <linux/memory_hotplug.h>
 
 void build_all_zonelists(pg_data_t *pgdat);
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+void _wake_all_kswapds(unsigned int order,
+			     struct zonelist *zonelist,
+			     enum zone_type high_zoneidx,
+			     struct zone *preferred_zone);
+#endif
 void wakeup_kswapd(struct zone *zone, gfp_t gfp_mask, int order,
 		   enum zone_type classzone_idx);
 bool __zone_watermark_ok(struct zone *z, unsigned int order, unsigned long mark,

--- a/include/linux/oom_score_notifier.h
+++ b/include/linux/oom_score_notifier.h
@@ -1,0 +1,56 @@
+/*
+ *  oom_score_notifier interface
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+#ifndef _LINUX_OOM_SCORE_NOTIFIER_H
+#define _LINUX_OOM_SCORE_NOTIFIER_H
+
+#ifdef CONFIG_OOM_SCORE_NOTIFIER
+
+#include <linux/kernel.h>
+#include <linux/list.h>
+#include <linux/spinlock.h>
+
+enum osn_msg_type {
+	OSN_NEW,
+	OSN_FREE,
+	OSN_UPDATE
+};
+
+extern struct atomic_notifier_head oom_score_notifier;
+extern int oom_score_notifier_register(struct notifier_block *n);
+extern int oom_score_notifier_unregister(struct notifier_block *n);
+extern int oom_score_notify_free(struct task_struct *tsk);
+extern int oom_score_notify_new(struct task_struct *tsk);
+extern int oom_score_notify_update(struct task_struct *tsk, int old_score);
+
+struct oom_score_notifier_struct {
+	struct task_struct *tsk;
+	int old_score;
+};
+
+#else
+static inline int oom_score_notify_free(struct task_struct *tsk) { return 0; };
+static inline int oom_score_notify_new(struct task_struct *tsk) { return 0; };
+static inline int oom_score_notify_update(struct task_struct *tsk,
+					  int old_score)
+{
+	return 0;
+};
+
+#endif /* CONFIG_OOM_SCORE_NOTIFIER */
+
+#endif /* _LINUX_OOM_SCORE_NOTIFIER_H */

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -1724,6 +1724,7 @@ static inline bool is_percpu_thread(void)
 #define PFA_SPEC_SSB_FORCE_DISABLE	4	/* Speculative Store Bypass force disabled*/
 #define PFA_SPEC_IB_DISABLE		5	/* Indirect branch speculation restricted */
 #define PFA_SPEC_IB_FORCE_DISABLE	6	/* Indirect branch speculation permanently restricted */
+#define PFA_LMK_WAITING			7	/* Lowmemorykiller is waiting */
 
 #define TASK_PFA_TEST(name, func)					\
 	static inline bool task_##func(struct task_struct *p)		\
@@ -1761,6 +1762,9 @@ TASK_PFA_CLEAR(SPEC_IB_DISABLE, spec_ib_disable)
 
 TASK_PFA_TEST(SPEC_IB_FORCE_DISABLE, spec_ib_force_disable)
 TASK_PFA_SET(SPEC_IB_FORCE_DISABLE, spec_ib_force_disable)
+
+TASK_PFA_TEST(LMK_WAITING, lmk_waiting)
+TASK_PFA_SET(LMK_WAITING, lmk_waiting)
 
 static inline void
 current_restore_flags(unsigned long orig_flags, unsigned long flags)

--- a/include/trace/events/almk.h
+++ b/include/trace/events/almk.h
@@ -1,0 +1,84 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM almk
+
+#if !defined(_TRACE_EVENT_ALMK_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _TRACE_EVENT_ALMK_H
+
+#include <linux/tracepoint.h>
+#include <linux/types.h>
+
+TRACE_EVENT(almk_vmpressure,
+
+        TP_PROTO(unsigned long pressure,
+                int other_free,
+                int other_file),
+
+        TP_ARGS(pressure, other_free, other_file),
+
+        TP_STRUCT__entry(
+                __field(unsigned long, pressure)
+                __field(int, other_free)
+                __field(int, other_file)
+        ),
+
+        TP_fast_assign(
+                __entry->pressure       = pressure;
+                __entry->other_free     = other_free;
+                __entry->other_file     = other_file;
+        ),
+
+        TP_printk("%lu, %d, %d",
+                        __entry->pressure, __entry->other_free,
+                        __entry->other_file)
+);
+
+TRACE_EVENT(almk_shrink,
+
+        TP_PROTO(int tsize,
+                 int vmp,
+                 int other_free,
+                 int other_file,
+                 short adj),
+
+        TP_ARGS(tsize, vmp, other_free, other_file, adj),
+
+        TP_STRUCT__entry(
+                __field(int, tsize)
+                __field(int, vmp)
+                __field(int, other_free)
+                __field(int, other_file)
+                __field(short, adj)
+        ),
+
+        TP_fast_assign(
+                __entry->tsize          = tsize;
+                __entry->vmp            = vmp;
+                __entry->other_free     = other_free;
+                __entry->other_file     = other_file;
+                __entry->adj            = adj;
+        ),
+
+        TP_printk("%d, %d, %d, %d, %d",
+                __entry->tsize,
+                __entry->vmp,
+                __entry->other_free,
+                __entry->other_file,
+                __entry->adj)
+);
+
+#endif
+
+#include <trace/define_trace.h>
+

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -56,6 +56,7 @@
 #include <trace/events/sched.h>
 #include <linux/hw_breakpoint.h>
 #include <linux/oom.h>
+#include <linux/oom_score_notifier.h>
 #include <linux/writeback.h>
 #include <linux/shm.h>
 #include <linux/kcov.h>
@@ -113,6 +114,9 @@ static void __exit_signal(struct task_struct *tsk)
 		if (unlikely(has_group_leader_pid(tsk)))
 			posix_cpu_timers_exit_group(tsk);
 	}
+#endif
+#ifdef CONFIG_OOM_SCORE_NOTIFIER
+	oom_score_notify_free(tsk);
 #endif
 
 	if (group_dead) {

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -96,6 +96,8 @@
 #include <linux/cpufreq_times.h>
 #include <linux/scs.h>
 
+#include <linux/oom_score_notifier.h>
+
 #include <asm/pgtable.h>
 #include <asm/pgalloc.h>
 #include <linux/uaccess.h>
@@ -2217,6 +2219,11 @@ static __latent_entropy struct task_struct *copy_process(
 
 		init_task_pid(p, PIDTYPE_PID, pid);
 		if (thread_group_leader(p)) {
+#ifdef CONFIG_OOM_SCORE_NOTIFIER
+			retval = oom_score_notify_new(p);
+			if (retval)
+				goto bad_fork_cancel_cgroup;
+#endif
 			init_task_pid(p, PIDTYPE_TGID, pid);
 			init_task_pid(p, PIDTYPE_PGID, task_pgrp(current));
 			init_task_pid(p, PIDTYPE_SID, task_session(current));

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -314,6 +314,15 @@ config MMU_NOTIFIER
 	bool
 	select SRCU
 
+config OOM_SCORE_NOTIFIER
+	bool "OOM score notifier"
+	default n
+	help
+	  This creates a notifier for process oom_score_adj status.
+	  It create events for new, updated or freed tasks and
+	  are used to build a mirrored task list in
+	  lowmemorykiller.
+
 config KSM
 	bool "Enable KSM for page merging"
 	depends on MMU

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -106,3 +106,4 @@ obj-$(CONFIG_PERCPU_STATS) += percpu-stats.o
 obj-$(CONFIG_HMM) += hmm.o
 obj-$(CONFIG_MEMFD_CREATE) += memfd.o
 obj-$(CONFIG_PROCESS_RECLAIM)	+= process_reclaim.o
+obj-$(CONFIG_OOM_SCORE_NOTIFIER) += oom_score_notifier.o

--- a/mm/oom_kill.c
+++ b/mm/oom_kill.c
@@ -818,7 +818,7 @@ static int oom_reaper(void *unused)
 	return 0;
 }
 
-static void wake_oom_reaper(struct task_struct *tsk)
+void wake_oom_reaper(struct task_struct *tsk)
 {
 	/*
 	 * Move the lock here to avoid scenario of queuing
@@ -849,7 +849,7 @@ static int __init oom_init(void)
 }
 subsys_initcall(oom_init)
 #else
-static inline void wake_oom_reaper(struct task_struct *tsk)
+inline void wake_oom_reaper(struct task_struct *tsk)
 {
 }
 #endif /* CONFIG_MMU */

--- a/mm/oom_score_notifier.c
+++ b/mm/oom_score_notifier.c
@@ -1,0 +1,67 @@
+/*
+ *  oom_score_notifier interface
+ *
+ *  Author: Peter Enderborg <peter.enderborg@sonymobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+/*
+ * Copyright (C) 2018 Sony Mobile Communications Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2, as
+ * published by the Free Software Foundation.
+ */
+
+
+#include <linux/notifier.h>
+#include <linux/oom_score_notifier.h>
+
+#ifdef CONFIG_OOM_SCORE_NOTIFIER
+ATOMIC_NOTIFIER_HEAD(oom_score_notifier);
+
+int oom_score_notifier_register(struct notifier_block *n)
+{
+	return atomic_notifier_chain_register(&oom_score_notifier, n);
+}
+EXPORT_SYMBOL_GPL(oom_score_notifier_register);
+
+int oom_score_notifier_unregister(struct notifier_block *n)
+{
+	return atomic_notifier_chain_unregister(&oom_score_notifier, n);
+}
+EXPORT_SYMBOL_GPL(oom_score_notifier_unregister);
+
+int oom_score_notify_free(struct task_struct *tsk)
+{
+	struct oom_score_notifier_struct osns;
+
+	osns.tsk = tsk;
+	return notifier_to_errno(atomic_notifier_call_chain(
+		&oom_score_notifier, OSN_FREE, &osns));
+}
+EXPORT_SYMBOL_GPL(oom_score_notify_free);
+
+int oom_score_notify_new(struct task_struct *tsk)
+{
+	struct oom_score_notifier_struct osns;
+
+	osns.tsk = tsk;
+	return notifier_to_errno(atomic_notifier_call_chain(
+		&oom_score_notifier, OSN_NEW, &osns));
+}
+EXPORT_SYMBOL_GPL(oom_score_notify_new);
+
+int oom_score_notify_update(struct task_struct *tsk, int old_score)
+{
+	struct oom_score_notifier_struct osns;
+
+	osns.tsk = tsk;
+	osns.old_score = old_score;
+	return notifier_to_errno(atomic_notifier_call_chain(&oom_score_notifier,
+							    OSN_UPDATE, &osns));
+}
+EXPORT_SYMBOL_GPL(oom_score_notify_update);
+#endif

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -4292,6 +4292,21 @@ static void wake_all_kswapds(unsigned int order, gfp_t gfp_mask,
 	}
 }
 
+#ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
+void _wake_all_kswapds(unsigned int order,
+			     struct zonelist *zonelist,
+			     enum zone_type high_zoneidx,
+			     struct zone *preferred_zone)
+{
+	struct zoneref *z;
+	struct zone *zone;
+
+	for_each_zone_zonelist_nodemask(zone, z, zonelist,
+						high_zoneidx, NULL)
+		wakeup_kswapd(zone, order, zone_idx(preferred_zone));
+}
+#endif
+
 static inline unsigned int
 gfp_to_alloc_flags(gfp_t gfp_mask)
 {


### PR DESCRIPTION
This is useful for environments where a userspace low memory killer daemon is not available.

Also added Sony's TNG patches (#2106), as well as zram consideration (#2498).