### PR TITLE
[9.12.r1] staging: android: lowmemorykiller: Port fixes

### DIFF
--- a/drivers/staging/android/lowmemorykiller.c
+++ b/drivers/staging/android/lowmemorykiller.c
@@ -509,7 +509,7 @@ static void lowmem_wakeup_kswapds(struct shrink_control *sc, int minfree)
 	}
 
 	lowmem_print(4, "lowmem_wakeup_kswapds order %d\n", order);
-	_wake_all_kswapds(order, zonelist, high_zoneidx,
+	_wake_all_kswapds(order, gfp_mask, zonelist, high_zoneidx,
 				preferred_zone);
 }
 #endif

--- a/drivers/staging/android/lowmemorykiller.h
+++ b/drivers/staging/android/lowmemorykiller.h
@@ -17,6 +17,8 @@
 
 extern u32 lowmem_debug_level;
 
+extern void wake_oom_reaper(struct task_struct *tsk);
+
 #define lowmem_print(level, x...)			\
 	do {						\
 		if (lowmem_debug_level >= (level))	\

--- a/drivers/staging/android/lowmemorykiller_tng.c
+++ b/drivers/staging/android/lowmemorykiller_tng.c
@@ -63,7 +63,7 @@ ssize_t get_task_rss(struct task_struct *tsk)
 	unsigned long rss = 0;
 	struct mm_struct *mm;
 
-	mm = ACCESS_ONCE(tsk->mm);
+	mm = READ_ONCE(tsk->mm);
 	if (mm)
 		rss = get_mm_rss(mm) << PAGE_SHIFT;
 	if (rss < LMK_ZOMBIE_SIZE)

--- a/drivers/staging/android/lowmemorykiller_tng.c
+++ b/drivers/staging/android/lowmemorykiller_tng.c
@@ -161,8 +161,7 @@ static void calc_params(struct calculated_params *cp, gfp_t mask)
 	int i;
 	int array_size;
 	long free_swap = get_nr_swap_pages();
-	long irp = global_node_page_state(NR_INDIRECTLY_RECLAIMABLE_BYTES)
-	  >> PAGE_SHIFT;
+	long irp = global_node_page_state(NR_KERNEL_MISC_RECLAIMABLE);
 	long usable_free_swap = 0;
 	long tot_usable = 0;
 	int start;
@@ -276,7 +275,7 @@ void print_obituary(struct task_struct *doomed,
 		     "   Slab UnReclaimable is %ldkB\n"
 		     "   Total Slab is %ldkB\n"
 		     "   GFP mask is 0x%x\n"
-		     "   Indirect Reclaimable is %zdkB\n"
+		     "   Kernel Memory Reclaimable is %zdkB\n"
 		     "   Free Swap %ldkB\n"
 		     "   queue len is %d of max %d reason:0x%x margin:%d\n",
 		     doomed->comm, doomed->pid,
@@ -302,8 +301,8 @@ void print_obituary(struct task_struct *doomed,
 		     global_node_page_state(NR_SLAB_UNRECLAIMABLE) *
 		     (long)(PAGE_SIZE / 1024),
 		     gfp_mask,
-		     global_node_page_state(NR_INDIRECTLY_RECLAIMABLE_BYTES)
-		     / 1024,
+		     global_node_page_state(NR_KERNEL_MISC_RECLAIMABLE) *
+		     (long)(PAGE_SIZE / 1024),
 		     get_nr_swap_pages() * (long)(PAGE_SIZE / 1024),
 		     death_pending_len,
 		     cp->dynamic_max_queue_len,

--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -778,6 +778,7 @@ static inline bool pgdat_is_empty(pg_data_t *pgdat)
 void build_all_zonelists(pg_data_t *pgdat);
 #ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
 void _wake_all_kswapds(unsigned int order,
+			     gfp_t gfp_mask,
 			     struct zonelist *zonelist,
 			     enum zone_type high_zoneidx,
 			     struct zone *preferred_zone);

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -4294,6 +4294,7 @@ static void wake_all_kswapds(unsigned int order, gfp_t gfp_mask,
 
 #ifdef CONFIG_ANDROID_LOW_MEMORY_KILLER_CONSIDER_SWAP
 void _wake_all_kswapds(unsigned int order,
+			     gfp_t gfp_mask,
 			     struct zonelist *zonelist,
 			     enum zone_type high_zoneidx,
 			     struct zone *preferred_zone)
@@ -4303,7 +4304,7 @@ void _wake_all_kswapds(unsigned int order,
 
 	for_each_zone_zonelist_nodemask(zone, z, zonelist,
 						high_zoneidx, NULL)
-		wakeup_kswapd(zone, order, zone_idx(preferred_zone));
+		wakeup_kswapd(zone, gfp_mask, order, zone_idx(preferred_zone));
 }
 #endif
 


### PR DESCRIPTION
A few smaller fixes needed to make the Android LowMemoyKiller properly build with 4.19.