### PR TITLE
[9.12.r1] dts: lena: Fix display brightness control

### DIFF
--- a/arch/arm64/boot/dts/qcom/lagoon-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/lagoon-qrd.dtsi
@@ -140,8 +140,8 @@
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-bl-min-level = <1>;
-	qcom,mdss-dsi-bl-max-level = <4095>;
-	qcom,mdss-brightness-max-level = <4095>;
+	qcom,mdss-dsi-bl-max-level = <1023>;
+	qcom,mdss-brightness-max-level = <1023>;
 	qcom,platform-te-gpio = <&tlmm 23 0>;
 	qcom,platform-reset-gpio = <&pm6150l_gpios 9 0>;
 	somc,disp-err-flag-gpio = <&tlmm 97 0>;


### PR DESCRIPTION
PDX213 panel only regards the first 10 bits of brightness value.

Adjust max brightness to match the workaround mentioned in
https://github.com/sonyxperiadev/kernel/commit/af1ddf3c0940dc3990a764d224fd8be53653e07e

Fixes https://github.com/sonyxperiadev/bug_tracker/issues/764