### PR TITLE
[7.1.r1] MSM8998/Yoshino/Lilac: Force ICC_SRE_EL1.SRE to be enabled

### DIFF
--- a/drivers/irqchip/irq-gic-v3.c
+++ b/drivers/irqchip/irq-gic-v3.c
@@ -1076,6 +1076,7 @@ static void gic_send_sgi(u64 cluster_id, u16 tlist, unsigned int irq)
 
 static void gic_raise_softirq(const struct cpumask *mask, unsigned int irq)
 {
+	gic_cpu_sys_reg_init();
 	int cpu;
 
 	if (WARN_ON(irq >= 16))


### PR DESCRIPTION
When building the latest 4.14 kernel for MSM8998/Yoshino/Lilac, the kernel will start, then get rebooted by the watchdog after about 16 seconds. Lots of debugging revealed that the cause of this is an undefined instruction error; kernel function gic_send_sgi() tries to write to system register ICC_SGI1R_EL1, but the flag that enables this (ICC_SRE_EL1.SRE) is not 1, causing a die(). 

In each processing unit of the ARMv8 SOC, there is an internal register ICC_SRE_EL1 which is used to enable software-generated interrupts, wrapped by kernel function gic_enable_sre(). What I think is _meant_ to happen is that this register gets flipped on for all PUs at the very start of the boot sequence, then this value doesn't have to be touched again. 

```
Places gic_enable_sre gets called:
[    0.000000] GICv3: gic_enable_sre: orig 1
[    0.000000] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 4.14.254-gf956fbd9a234-dirty #7
[    0.000000] Hardware name: SoMC Lilac-ROW(MSM8998 v2.1) (DT)
[    0.000000] Call trace:
[    0.000000]  dump_backtrace+0x0/0x188
[    0.000000]  show_stack+0x14/0x1c
[    0.000000]  dump_stack+0xcc/0x10c
[    0.000000]  gic_cpu_sys_reg_init+0x24/0xb4
[    0.000000]  gic_cpu_init+0x224/0x26c
[    0.000000]  gic_of_init+0x5bc/0x98c
[    0.000000]  of_irq_init+0x1dc/0x2f4
[    0.000000]  irqchip_init+0x14/0x1c
[    0.000000]  init_IRQ+0x78/0xa4
[    0.000000]  start_kernel+0x2c0/0x444

(x8 times)
[    0.033170] GICv3: gic_enable_sre: orig 0
[    0.033175] CPU: 1 PID: 0 Comm: swapper/1 Not tainted 4.14.254-gf956fbd9a234-dirty #7
[    0.033177] Hardware name: SoMC Lilac-ROW(MSM8998 v2.1) (DT)
[    0.033179] Call trace:
[    0.033190]  dump_backtrace+0x0/0x188
[    0.033193]  show_stack+0x14/0x1c
[    0.033199]  dump_stack+0xcc/0x10c
[    0.033206]  gic_cpu_sys_reg_init+0x24/0xb4
[    0.033209]  gic_cpu_init+0x224/0x26c
[    0.033212]  gic_starting_cpu+0xc/0x18
[    0.033218]  cpuhp_invoke_callback+0x310/0x7a0
[    0.033221]  notify_cpu_starting+0x80/0xa4
[    0.033226]  secondary_start_kernel+0xd4/0x120

[    0.106070] CPU features: gic_enable_sre: orig 1
[    0.106076] CPU: 0 PID: 1 Comm: swapper/0 Tainted: G S              4.14.254-gf956fbd9a234-dirty #7
[    0.106079] Hardware name: SoMC Lilac-ROW(MSM8998 v2.1) (DT)
[    0.106082] Call trace:
[    0.106087]  dump_backtrace+0x0/0x188
[    0.106092]  show_stack+0x14/0x1c
[    0.106097]  dump_stack+0xcc/0x10c
[    0.106101]  has_useable_gicv3_cpuif+0x30/0x98
[    0.106106]  __update_cpu_capabilities+0x60/0xf0
[    0.106113]  setup_cpu_features+0x4c/0x2a4
[    0.106120]  smp_cpus_done+0x28/0x8c
[    0.106126]  smp_init+0x134/0x154
[    0.106133]  kernel_init_freeable+0xa8/0x1f8
[    0.106140]  kernel_init+0x10/0x20c
```

What seems to be happening afterward is that _something_ in the power management firmware (?) flips the flag off again; I can't find any kernel mechanism that does this explicitly. Even more confusing is that there appears to be a race condition inside cpu_pm_exit(): it will first call rcu_irq_enter_irqson() which eventually raises a software interrupt, triggering the crash. But afterwards (asynchronously?) it will call gic_cpu_pm_notifier(), which fixes the registers with gic_cpu_sys_reg_init().

```
[   15.987468] Internal error: undefined instruction: 0 [#1]  PREEMPT SMP CurrentEL 4 ICC_SRE_EL1.SRE 0

[   15.992831] Call trace:
[   15.992879]  gic_raise_softirq+0xe8/0x134
[   15.992965]  smp_cross_call_common+0x120/0x13c
[   15.993013]  arch_irq_work_raise+0x4c/0x54
[   15.993099]  irq_work_queue+0xd0/0x108
[   15.993148]  update_util_handler+0x68/0x74
[   15.993197]  enqueue_task_fair+0xa74/0x2670
[   15.993283]  ttwu_do_activate+0xc0/0x244
[   15.993330]  try_to_wake_up+0x430/0x610
[   15.993378]  wake_up_process+0x18/0x20
[   15.993464]  raise_softirq+0x48/0x58
[   15.993512]  rcu_irq_enter+0x114/0x118
[   15.993559]  rcu_irq_enter_irqson+0x18/0x28
[   15.993645]  cpu_pm_exit+0x10/0x54     # in cpu_unprepare
[   15.993694]  lpm_cpuidle_enter+0x1bc/0x538
[   15.993740]  cpuidle_enter_state+0x1c0/0x338
[   15.993824]  cpuidle_enter+0x18/0x20
[   15.993871]  do_idle+0x194/0x264
[   15.993917]  cpu_startup_entry+0x20/0x34
[   15.994002]  secondary_start_kernel+0x114/0x120

[   15.987675] GICv3: gic_enable_sre: orig 0
[   15.987699] CPU: 2 PID: 0 Comm: swapper/2 Tainted: G S      W       4.14.254-gf956fbd9a234-dirty #7
[   15.987748] CPU: 7 PID: 0 Comm: swapper/7 Tainted: G S      W       4.14.254-gf956fbd9a234-dirty #7
[   15.987831] Hardware name: SoMC Lilac-ROW(MSM8998 v2.1) (DT)
[   15.987919] Hardware name: SoMC Lilac-ROW(MSM8998 v2.1) (DT)
[   15.987964] task: ffffffc0f9525700 task.stack: ffffffc0f9548000
[   15.988052] Call trace:
[   15.988151]  dump_backtrace+0x0/0x188
[   15.988279]  show_stack+0x14/0x1c
[   15.988411]  dump_stack+0xcc/0x10c
[   15.988541]  gic_cpu_sys_reg_init+0x24/0xb4
[   15.988590]  gic_cpu_pm_notifier+0xb8/0x154
[   15.988594]  __atomic_notifier_call_chain+0x60/0xa0
[   15.988725]  cpu_pm_exit+0x2c/0x54
[   15.988816]  lpm_cpuidle_enter+0x1bc/0x538
[   15.988944]  cpuidle_enter_state+0x1c0/0x338
[   15.989074]  cpuidle_enter+0x18/0x20
[   15.989164]  do_idle+0x194/0x264
[   15.989254]  cpu_startup_entry+0x20/0x34
[   15.989258]  secondary_start_kernel+0x114/0x120
```

So in short I don't know how to confirm if the root cause is firmware, or whether or not this issue is just a timing bug that got exposed, or what the ideal way to fix it is. But I do know that plonking a call to gic_cpu_sys_reg_init() at the start of gic_raise_softirq() stops the crashes.