### PR TITLE
[9.14] lahaina-sagami-common: Adapt Egistec FPC configuration to SODP driver

### DIFF
--- a/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
@@ -66,25 +66,36 @@
 		pinctrl-2 = <>;
 	};
 
-	egistec_fp: egistec_fp {
+	egistec_vcc_pm8350_gpio_6: egistec-vcc-pm8350-gpio-6 {
+		compatible = "regulator-fixed";
+		regulator-name = "egistec-vcc-pm8350-gpio-6";
+		regulator-min-microvolt = <3800000>;
+		regulator-max-microvolt = <3800000>;
+		startup-delay-us = <2000>;
+		enable-active-high;
+		gpio = <&pm8350_gpios 6 0>;
+
+		/*
+		 * Use a "parent" supply just to be able to turn on this VCC gpio and
+		 * the pm8350c BoB (switched on by GPIO 6) regulator */
+		vin-supply = <&pm8350c_bob>;
+	};
+
+	et6xx: et6xx {
+		compatible = "egistec,et580";
+
+		et51x,gpio_irq = <&tlmm 38 0x0>;
+		et51x,no-low-voltage-probe;
+		et51x,vana-voltage = <3800000>;
+		vdd_ana-supply = <&egistec_vcc_pm8350_gpio_6>;
+
+		pinctrl-names = "et51x_reset_reset",
+				"et51x_reset_active",
+				"et51x_irq_active";
+		pinctrl-0 = <&EGIS_RST_sleep>;
+		pinctrl-1 = <&EGIS_RST_active>;
+		pinctrl-2 = <&sm_gpio_38_input_no_pull>;
 		status = "ok";
-		compatible = "fp-egistec";
-		egistec,gpio_reset = <&tlmm 39 0x00>; 		// reset gpio pin num
-		egistec,gpio_irq = <&tlmm 38 0x00>; 		// irq gpio pin num
-		egistec,gpio_vcc_en= <&pm8350_gpios 6 0x00>; 		// vcc enable gpio pin num
-		fp-gpio-vcc-enable; 						// use gpio enable power or not
-		fp-gpio-ext-ldo;
-		pinctrl-names = "egis_rst_active", "egis_rst_sleep", "egis_vcc_high", "egis_vcc_low", "egis_irq_active", "egis_irq_low";
-		pinctrl-0 = <&EGIS_RST_active>;
-		pinctrl-1 = <&EGIS_RST_sleep>;
-		pinctrl-2 = <&EGIS_VCC_active>;
-		pinctrl-3 = <&EGIS_VCC_sleep>;
-		pinctrl-4 = <&sm_gpio_38_input_no_pull>;
-		pinctrl-5 = <&sm_gpio_38>;
-		egis-vcc-supply = <&pm8350c_bob>;
-		egis-fp,vcc-voltage = <3350000 3800000>;
-		egis-fp,vcc-current = <1000000>;
-		egis-fp,vcc-max-voltage = <3960000>;
 	};
 
 	/* Disable extcon_usb1 */
@@ -241,8 +252,8 @@
 	EGIS_VCC_sleep: EGIS_VCC_sleep {
 		pins = "gpio6";
 		function = "normal";
-		bias-disable;
 		output-low;
+		bias-disable;
 		power-source = <0>;
 	};
 };


### PR DESCRIPTION
Based on https://github.com/sonyxperiadev/kernel-copyleft-dts/blob/1038d029de8e528b1acb9e2225027f72915d6f63/somc/lahaina-sagami-common.dtsi#L69-L88 and similar tricks for Lena: https://github.com/sonyxperiadev/kernel/commit/e674fa0eff7e59e815cced02d1419ba330c4a4e2

Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
