### PR TITLE
[K.P.1.0]Kconfig.platforms: Fix nagara platform typo

### DIFF
--- a/arch/arm64/Kconfig.platforms
+++ b/arch/arm64/Kconfig.platforms
@@ -209,10 +209,10 @@ config ARCH_LAHAINA
 	  runs on this chipset or if you are unsure, say 'N' here.
 
 config ARCH_SONY_NAGARA
-	bool "Sony Mobile Nagaro platform"
+	bool "Sony Mobile Nagara platform"
 	depends on ARCH_WAIPIO
 	help
-	  Support for the SONY Mobile Nagaro platform
+	  Support for the SONY Mobile Nagara platform
 	  which is based on QCOM WAIPIO chipset.
 	  If you enable this config,
 	  please use SONY Mobile device tree.
@@ -222,7 +222,7 @@ config MACH_SONY_PDX223
 	depends on ARCH_SONY_NAGARA
 	help
 	  Support for the SONY Mobile PDX-223 board
-	  which is based on SONY Nagaro platform.
+	  which is based on SONY Nagara platform.
 	  If you enable this config,
 	  please use SONY Mobile device tree.
 


### PR DESCRIPTION
This was missed when fixing the other typos