### PR TITLE
[7.1.r1] Avoid suspend failures on sm8150

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm845-tama-common.dtsi
@@ -286,6 +286,7 @@
 	qcom,qup_uart@898000 {
 		clock-frequency = <4000000>;
 		status = "okay";
+		qcom,auto-suspend-disable = <1>;
 	};
 
 	/* SPI: QUP8 */

--- a/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-kumano-common.dtsi
@@ -566,6 +566,7 @@
 	/* UART: QUP13 */
 	qcom,qup_uart@c8c000 {
 		status = "okay";
+		qcom,auto-suspend-disable = <1>;
 	};
 
 	qcom,wdt@17c10000 {


### PR DESCRIPTION
Just like with tama, seine and lena, kumano does not go to sleep without this.

FWIW this patch would probably also have to be applied on 4.19
