### PR TITLE
drivers: scsi: ufs-qcom: set auto hibern8 back to 1ms

### DIFF
--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -1849,8 +1849,8 @@ static int ufs_qcom_apply_dev_quirks(struct ufs_hba *hba)
 	spin_lock_irqsave(hba->host->host_lock, flags);
 	/* Set the rpm auto suspend delay to 3s */
 	hba->host->hostt->rpm_autosuspend_delay = UFS_QCOM_AUTO_SUSPEND_DELAY;
-	/* Set the default auto-hiberate idle timer value to 5ms */
-	hba->ahit = FIELD_PREP(UFSHCI_AHIBERN8_TIMER_MASK, 5) |
+	/* Set the default auto-hibernate idle timer value to 1ms */
+	hba->ahit = FIELD_PREP(UFSHCI_AHIBERN8_TIMER_MASK, 1) |
 		    FIELD_PREP(UFSHCI_AHIBERN8_SCALE_MASK, 3);
 	/* Set the clock gating delay to performance mode */
 	hba->clk_gating.delay_ms = UFS_QCOM_CLK_GATING_DELAY_MS_PERF;

--- a/drivers/scsi/ufs/ufshcd.c
+++ b/drivers/scsi/ufs/ufshcd.c
@@ -1972,7 +1972,7 @@ static void ufshcd_init_clk_gating(struct ufs_hba *hba)
 	snprintf(wq_name, ARRAY_SIZE(wq_name), "ufs_clk_gating_%d",
 		 hba->host->host_no);
 	hba->clk_gating.clk_gating_workq = alloc_ordered_workqueue(wq_name,
-							   WQ_MEM_RECLAIM);
+					WQ_MEM_RECLAIM | WQ_HIGHPRI);
 
 	hba->clk_gating.is_enabled = true;
 


### PR DESCRIPTION
Previous generations of qualcomm kernels used a value of 1ms for the auto-hibernate idle timer.
QCOM increased that value initially to 5ms on 5.4 kernels followed by 10ms to improve performance.

5ms:
https://git.codelinaro.org/clo/la/kernel/msm-5.4/-/commit/608ed7596857111c8538b6c7c1be939aa000c006

10ms:
https://git.codelinaro.org/clo/la/kernel/msm-5.4/-/commit/ef3f24dd1cf7252517ab5ba9e8a7c74718370d2e

According to those commits there was only a negligible power impact.
However shortly after the increase to 10ms the same was reverted to 5ms due to power impact:
https://git.codelinaro.org/clo/la/kernel/msm-5.4/-/commit/b16f5839ec0135aed413e86da9f69da25198901d

Since all my 5.4 devices performed worse than their 4.19 predecessors in idle/suspend I found this one of the causes.

Revert this value back to 1ms as it was on previous QCOM generations to improve power consumption during idle/suspend.