### PR TITLE
[K.P.1.0.r1] msm_eva_private.h: Fix a broken symlink

### DIFF
--- a/include/media/msm_eva_private.h
+++ b/include/media/msm_eva_private.h
@@ -1,1 +1,1 @@
-../../usr/include/eva/media/msm_eva_private.h
+../../techpack/eva/include/uapi/eva/media/msm_eva_private.h


### PR DESCRIPTION
This symlink is trying to point to root structure and find the file there
where its ofc not.

Fix this path.

Signed-off-by: Martin Botka <martin.botka@somainline.org>