### PR TITLE
[9.12.r1] MHI Suspend fixes

### DIFF
--- a/drivers/bus/mhi/core/mhi_init.c
+++ b/drivers/bus/mhi/core/mhi_init.c
@@ -1048,7 +1048,16 @@ void mhi_deinit_chan_ctxt(struct mhi_controller *mhi_cntrl,
 	vfree(buf_ring->base);
 
 	buf_ring->base = tre_ring->base = NULL;
+	tre_ring->ctxt_wp = NULL;
 	chan_ctxt->rbase = 0;
+	chan_ctxt->rlen = 0;
+	chan_ctxt->rp = chan_ctxt->wp = chan_ctxt->rbase;
+	tre_ring->rp = tre_ring->wp = tre_ring->base;
+	buf_ring->rp = buf_ring->wp = buf_ring->base;
+
+	/* Update to all cores */
+	smp_wmb();
+
 }
 
 int mhi_init_chan_ctxt(struct mhi_controller *mhi_cntrl,

--- a/drivers/bus/mhi/core/mhi_pm.c
+++ b/drivers/bus/mhi/core/mhi_pm.c
@@ -395,7 +395,8 @@ int mhi_pm_m0_transition(struct mhi_controller *mhi_cntrl)
 
 		read_lock_irq(&mhi_chan->lock);
 		/* only ring DB if ring is not empty */
-		if (tre_ring->base && tre_ring->wp  != tre_ring->rp)
+		if (tre_ring->base && tre_ring->wp  != tre_ring->rp &&
+		    mhi_chan->ch_state == MHI_CH_STATE_ENABLED)
 			mhi_ring_chan_db(mhi_cntrl, mhi_chan);
 		read_unlock_irq(&mhi_chan->lock);
 	}

--- a/drivers/bus/mhi/core/mhi_pm.c
+++ b/drivers/bus/mhi/core/mhi_pm.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-/* Copyright (c) 2018-2020, The Linux Foundation. All rights reserved. */
+/* Copyright (c) 2018-2021, The Linux Foundation. All rights reserved. */
 
 #include <linux/debugfs.h>
 #include <linux/delay.h>
@@ -1061,8 +1061,8 @@ void mhi_control_error(struct mhi_controller *mhi_cntrl)
 				sfr_info->buf_addr);
 	}
 
-	/* link is not down if device is in RDDM */
-	transition_state = (mhi_cntrl->ee == MHI_EE_RDDM) ?
+	/* link is not down if device supports RDDM */
+	transition_state = (mhi_cntrl->rddm_supported) ?
 		MHI_PM_DEVICE_ERR_DETECT : MHI_PM_LD_ERR_FATAL_DETECT;
 
 	write_lock_irq(&mhi_cntrl->pm_lock);

--- a/drivers/bus/mhi/core/mhi_pm.c
+++ b/drivers/bus/mhi/core/mhi_pm.c
@@ -1511,15 +1511,6 @@ int mhi_pm_fast_resume(struct mhi_controller *mhi_cntrl, bool notify_client)
 	}
 
 	if (mhi_cntrl->rddm_supported) {
-
-		/* check EP is in proper state */
-		if (mhi_cntrl->link_status(mhi_cntrl, mhi_cntrl->priv_data)) {
-			MHI_ERR("Unable to access EP Config space\n");
-			write_unlock_irq(&mhi_cntrl->pm_lock);
-			tasklet_enable(&mhi_cntrl->mhi_event->task);
-			return -ETIMEDOUT;
-		}
-
 		if (mhi_get_exec_env(mhi_cntrl) == MHI_EE_RDDM &&
 		    !mhi_cntrl->power_down) {
 			mhi_cntrl->ee = MHI_EE_RDDM;


### PR DESCRIPTION
# Description
Revert 16517fc0bdf1a2810865a9d86b2043212fd15223 which broke Edo/SM8250 and SDX55M suspend and add upstream commits which are missing.

16517fc0bdf1a2810865a9d86b2043212fd15223 is not present in any other tree, LA.UM.9.14.r1 has the same driver without the commit and K.P.1.0 has a reworked mainline version of the driver.

# Issues left after merging

After these changes only sometimes the suspend fails with this:
```
[  457.921240] pci_pm_suspend_noirq(): cnss_pci_suspend_noirq+0x0/0x48 returns -11
[  457.921251] dpm_run_callback(): pci_pm_suspend_noirq+0x0/0x2e4 returns -11
[  457.921258] PM: Device 0000:01:00.0 failed to suspend noirq: error -11
[  457.933364] PM: noirq suspend of devices failed
[  457.968597] OOM killer enabled.
[  457.968599] Restarting tasks ... done.
[  457.976976] thermal thermal_zone91: failed to read out thermal zone (-19)
[  457.977264] PM: suspend exit
```

However this is very similar to the error that stock has sometimes:

```
[  447.292281] Freezing user space processes ... (elapsed 0.019 seconds) done.
[  447.311657] OOM killer disabled.
[  447.311661] Freezing remaining freezable tasks ... (elapsed 0.005 seconds) done.
[  447.316749] Suspending console(s) (use no_console_suspend to debug)
[  447.324180] [kworke][0x2553bfa1b][13:49:17.749991] wlan: [270:I:HDD] hdd_suspend_wlan: 1243: WLAN being suspended by OS
[  447.324336] pci_pm_suspend(): mhi_system_suspend+0x0/0x2c0 returns -16
[  447.324347] dpm_run_callback(): pci_pm_suspend+0x0/0x200 returns -16
[  447.324350] [kworke][0x2553c06f6][13:49:17.750162] wlan: [270:I:PMO] pmo_core_is_wow_applicable: 319: lpass enabled, enabling wow
[  447.324360] PM: Device 0002:01:00.0 failed to suspend async: error -16
[  447.324673] PM: Some devices failed to suspend, or early wake event detected
[  447.324770] [kworke][0x2553c2681][13:49:17.750583] wlan: [270:I:HDD] hdd_resume_wlan: 1301: WLAN being resumed by OS
[  447.324804] [kworke][0x2553c2921][13:49:17.750618] wlan: [270:I:HDD] hdd_disable_host_offloads: 707: vdev is not connected
[  447.324850] [kworke][0x2553c2ca0][13:49:17.750664] wlan: [270:I:HDD] hdd_disable_host_offloads: 702: offload is not supported on this vdev opmode: 7
[  447.330586] OOM killer enabled.
[  447.330590] Restarting tasks ... done.
[  447.340975] thermal thermal_zone99: failed to read out thermal zone (-19)
[  447.340992] thermal thermal_zone101: failed to read out thermal zone (-19)
[  447.340999] thermal thermal_zone102: failed to read out thermal zone (-19)
[  447.341006] thermal thermal_zone103: failed to read out thermal zone (-19)
[  447.341013] thermal thermal_zone104: failed to read out thermal zone (-19)
[  447.341020] thermal thermal_zone105: failed to read out thermal zone (-19)
[  447.341050] Abort: Callback failed on 0002:01:00.0 in pci_pm_suspend+0x0/0x200 returned -16
[  447.341171] PM: suspend exit
[  447.386110] ## sony_ext_uim_ctrl_gpio_set_value: gpio=1147 value=1
[  450.277968] rpmh_rsc_send_data: 30 callbacks suppressed
[  450.277983] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278009] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278026] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278042] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278057] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278073] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278089] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278104] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278120] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  450.278136] qcom_rpmh DRV:apps_rsc TCS Busy, retrying RPMH message send: addr=0x30000
[  453.742669] PM: suspend entry (deep)
[  453.742683] PM: Syncing filesystems ... done.
[  453.766559] Freezing user space processes ... (elapsed 0.016 seconds) done.
[  453.782987] OOM killer disabled.
[  453.782989] Freezing remaining freezable tasks ... (elapsed 0.003 seconds) done.
[  453.786578] Suspending console(s) (use no_console_suspend to debug)
[  453.792454] [kworke][0x25ca2f9ef][13:49:24.218255] wlan: [268:I:HDD] hdd_suspend_wlan: 1243: WLAN being suspended by OS
[  453.792556] [kworke][0x25ca30298][13:49:24.218370] wlan: [268:I:PMO] pmo_core_is_wow_applicable: 319: lpass enabled, enabling wow
[  453.797951] [Binder][0x25ca496fd][13:49:24.223762] wlan: [10444:I:HDD] __wlan_hdd_bus_suspend: 1035: starting bus suspend
[  453.798019] [Binder][0x25ca49c52][13:49:24.223833] wlan: [10444:I:PMO] pmo_core_enable_wow_in_fw: 804: drv wow is enabled
[  453.798060] [Binder][0x25ca49e3e][13:49:24.223859] wlan: [10444:I:WMI] suspend type: WOW_IFACE_PAUSE_ENABLED
[  453.833479] [Binder][0x25caeff2d][13:49:24.259285] wlan: [10444:I:HDD] __wlan_hdd_bus_suspend: 1114: bus suspend succeeded
[  453.833543] cnss: Setting MHI state: SUSPEND(6)
[  453.833576] cnss: Suspending PCI link
[  453.833580] cnss: Use PCIe DRV suspend
[  453.843556] dpm_run_callback(): platform_pm_suspend+0x0/0x58 returns -16
[  453.843568] PM: Device alarmtimer failed to suspend: error -16
[  453.843575] PM: Some devices failed to suspend, or early wake event detected
[  453.859947] pci-msm-rc 0002:00:00.0: Refused to change power state, currently in D3
[  453.859951] pci-msm-rc 0000:00:00.0: Refused to change power state, currently in D3
[  453.860189] cnss: Resuming PCI link
[  453.861441] cnss: Set PCI link status to: 2
[  453.861462] cnss: Setting MHI state: RESUME(7)
[  453.865023] [Binder][0x25cb83d6d][13:49:24.290835] wlan: [10444:I:HDD] wlan_hdd_bus_resume: 1252: starting bus resume
[  453.865289] [Binder][0x25cb8517f][13:49:24.291102] wlan: [10444:I:PMO] pmo_core_psoc_send_host_wakeup_ind_to_fw: 1201: Host wakeup indication sent to fw
[  453.879294] [soft_i][0x25cbc663a][13:49:24.305034] wlan: [0:F:WMA] Non-WLAN triggered wakeup: UNSPECIFIED (-1)
[  453.879768] [Binder][0x25cbc8f65][13:49:24.305581] wlan: [10444:I:HDD] wlan_hdd_bus_resume: 1317: bus resume succeeded
[  453.880027] [kworke][0x25cbca2c1][13:49:24.305839] wlan: [383:I:HDD] hdd_resume_wlan: 1301: WLAN being resumed by OS
[  453.880072] [kworke][0x25cbca63f][13:49:24.305886] wlan: [383:I:HDD] hdd_disable_host_offloads: 707: vdev is not connected
[  453.880139] [kworke][0x25cbcaa38][13:49:24.305939] wlan: [383:I:HDD] hdd_disable_host_offloads: 702: offload is not supported on this vdev opmode: 7
[  453.892295] OOM killer enabled.
[  453.892298] Restarting tasks ... done.
```

