### PR TITLE
[9.12.r1] Griffin display fix, SoC SM8150/Trinket VIDC changes

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-sde.dtsi
@@ -100,6 +100,7 @@
 
 		qcom,sde-dsc-off = <0x81000 0x81400 0x81800 0x81c00>;
 		qcom,sde-dsc-size = <0x140>;
+		qcom,sde-dsc-pair-mask = <2 1 4 3>;
 
 		qcom,sde-dither-off = <0x30e0 0x30e0 0x30e0
 							0x30e0 0x30e0 0x30e0>;

--- a/arch/arm64/boot/dts/qcom/sm8150-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-vidc.dtsi
@@ -53,7 +53,7 @@
 			label = "cnoc";
 			qcom,bus-master = <MSM_BUS_MASTER_AMPSS_M0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_VENUS_CFG>;
-			qcom,bus-governor = "performance";
+			qcom,mode = "performance";
 			qcom,bus-range-kbps = <1000 1000>;
 		};
 
@@ -62,23 +62,25 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_LLCC>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "msm-vidc-ddr";
+			qcom,mode = "venus-ddr";
 			qcom,bus-range-kbps = <1000 6533000>;
 		};
+
 		arm9_bus_ddr {
 			compatible = "qcom,msm-vidc,bus";
 			label = "venus-arm9-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "performance";
+			qcom,mode = "performance";
 			qcom,bus-range-kbps = <1000 1000>;
 		};
+
 		venus_bus_llcc {
 			compatible = "qcom,msm-vidc,bus";
 			label = "venus-llcc";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_LLCC>;
-			qcom,bus-governor = "msm-vidc-llcc";
+			qcom,mode = "venus-llcc";
 			qcom,bus-range-kbps = <1000 6533000>;
 		};
 
@@ -117,7 +119,7 @@
 			qcom,iommu-dma-addr-pool = <0x500000 0xdfb00000>;
 			qcom,iommu-faults = "non-fatal";
 			qcom,iommu-pagetable = "LLC";
-			qcom,iommu-vmid = <0xB>; /* VMID_CP_BITSTREAM */
+			qcom,iommu-vmid = <0x9>; /* VMID_CP_BITSTREAM */
 			buffer-types = <0x241>;
 			virtual-addr-pool = <0x500000 0xdfb00000>;
 			qcom,secure-context-bank;

--- a/arch/arm64/boot/dts/qcom/trinket-vidc.dtsi
+++ b/arch/arm64/boot/dts/qcom/trinket-vidc.dtsi
@@ -38,7 +38,7 @@
 			label = "cnoc";
 			qcom,bus-master = <MSM_BUS_MASTER_AMPSS_M0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_VENUS_CFG>;
-			qcom,bus-governor = "performance";
+			qcom,mode = "performance";
 			qcom,bus-range-kbps = <1000 1000>;
 		};
 
@@ -47,7 +47,7 @@
 			label = "venus-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "vidc-ar50-ddr";
+			qcom,mode = "venus-ddr";
 			qcom,bus-range-kbps = <1000 2128000>;
 		};
 
@@ -56,7 +56,7 @@
 			label = "venus-arm9-ddr";
 			qcom,bus-master = <MSM_BUS_MASTER_VIDEO_P0>;
 			qcom,bus-slave = <MSM_BUS_SLAVE_EBI_CH0>;
-			qcom,bus-governor = "performance";
+			qcom,mode = "performance";
 			qcom,bus-range-kbps = <1000 1000>;
 		};
 
@@ -81,7 +81,7 @@
 			qcom,iommu-dma-addr-pool = <0x4b000000 0x25800000>;
 			qcom,iommu-faults = "non-fatal";
 			qcom,iommu-pagetable = "LLC";
-			qcom,iommu-vmid = <0xB>; /* VMID_CP_BITSTREAM */
+			qcom,iommu-vmid = <0x9>; /* VMID_CP_BITSTREAM */
 			buffer-types = <0x241>;
 			virtual-addr-pool = <0x4b000000 0x25800000>;
 			qcom,secure-context-bank;
@@ -92,6 +92,10 @@
 			label = "venus_sec_pixel";
 			iommus =
 				<&apps_smmu 0x843 0x0>;
+			qcom,iommu-dma-addr-pool = <0x25800000 0x25800000>;
+			qcom,iommu-faults = "non-fatal";
+			qcom,iommu-pagetable = "LLC";
+			qcom,iommu-vmid = <0xA>; /* VMID_CP_PIXEL */
 			buffer-types = <0x106>;
 			virtual-addr-pool = <0x25800000 0x25800000>;
 			qcom,secure-context-bank;

--- a/arch/arm64/boot/dts/somc/dsi-panel-griffin.dtsi
+++ b/arch/arm64/boot/dts/somc/dsi-panel-griffin.dtsi
@@ -172,6 +172,7 @@
 				somc,mdss-dsi-flm2-off-command-state = "dsi_lp_mode";
 			};
 			timing@1 {
+				somc,splash-dms-switch-to-this-timing;
 				qcom,mdss-dsi-panel-width = <1644>;
 				qcom,mdss-dsi-panel-height = <3840>;
 				qcom,mdss-dsi-h-back-porch = <8>;

--- a/arch/arm64/boot/dts/somc/kona-edo-common.dtsi
+++ b/arch/arm64/boot/dts/somc/kona-edo-common.dtsi
@@ -3505,6 +3505,7 @@
 	sony_ext_uim_ctrl: sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 47 GPIO_ACTIVE_HIGH>;
+		uim2_detect_legacy;
 	};
 };
 

--- a/arch/arm64/boot/dts/somc/lagoon-lena-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lagoon-lena-common.dtsi
@@ -96,6 +96,7 @@
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 51 GPIO_ACTIVE_HIGH>;
+		uim2_detect_legacy;
 	};
 };
 

--- a/arch/arm64/boot/dts/somc/sdm845-tama-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-common.dtsi
@@ -290,6 +290,7 @@
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 129 GPIO_ACTIVE_HIGH>;
+		uim2_detect_legacy;
 	};
 
 	sim_detect {

--- a/arch/arm64/boot/dts/somc/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sm8150-kumano-common.dtsi
@@ -207,7 +207,7 @@
 
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
-		uim2-gpios = <&tlmm 49 GPIO_ACTIVE_HIGH>;
+		uim2_detect_en_gpio = <&tlmm 49 GPIO_ACTIVE_HIGH>;
 	};
 
 	bu520x1nvx {

--- a/arch/arm64/boot/dts/somc/sm8150-kumano-common.dtsi
+++ b/arch/arm64/boot/dts/somc/sm8150-kumano-common.dtsi
@@ -208,6 +208,7 @@
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 49 GPIO_ACTIVE_HIGH>;
+		uim2_detect_legacy;
 	};
 
 	bu520x1nvx {

--- a/arch/arm64/boot/dts/somc/trinket-seine-common.dtsi
+++ b/arch/arm64/boot/dts/somc/trinket-seine-common.dtsi
@@ -182,6 +182,7 @@
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 101 GPIO_ACTIVE_HIGH>;
+		uim2_detect_legacy;
 	};
 
 	bu520x1nvx {

--- a/arch/arm64/boot/dts/somc/trinket-seine-common.dtsi
+++ b/arch/arm64/boot/dts/somc/trinket-seine-common.dtsi
@@ -181,7 +181,7 @@
 
 	sony_ext_uim_ctrl {
 		compatible = "sony,ext-uim-ctrl";
-		uim2-gpios = <&tlmm 101 GPIO_ACTIVE_HIGH>;
+		uim2_detect_en_gpio = <&tlmm 101 GPIO_ACTIVE_HIGH>;
 	};
 
 	bu520x1nvx {


### PR DESCRIPTION
The patchset includes:
- Griffin display fix;
- VIDC devicetree changes for SoC SM8150 and Trinket;
- Small cleanup for Sony External UIM Control driver (we can definitely avoid adding **uim2_detect_legacy** property since all devices use the same config, but leave it if we need it in the future).