### PR TITLE
[K.P.1.0] random misc fixes for clang/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -973,9 +973,6 @@ NOSTDINC_FLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
 # warn about C99 declaration after statement
 KBUILD_CFLAGS += -Wdeclaration-after-statement
 
-# Variable Length Arrays (VLAs) should not be used anywhere in the kernel
-KBUILD_CFLAGS += -Wvla
-
 # disable pointer signed / unsigned warnings in gcc 4.0
 KBUILD_CFLAGS += -Wno-pointer-sign
 

--- a/drivers/input/touchscreen/of_touchscreen.c
+++ b/drivers/input/touchscreen/of_touchscreen.c
@@ -79,11 +79,11 @@ void touchscreen_parse_properties(struct input_dev *input, bool multitouch,
 
 	data_present = touchscreen_get_prop_u32(dev, "touchscreen-min-x",
 						input_abs_get_min(input, axis_x),
-						&minimum) |
+						&minimum) ||
 		       touchscreen_get_prop_u32(dev, "touchscreen-size-x",
 						input_abs_get_max(input,
 								  axis_x) + 1,
-						&maximum) |
+						&maximum) ||
 		       touchscreen_get_prop_u32(dev, "touchscreen-fuzz-x",
 						input_abs_get_fuzz(input, axis_x),
 						&fuzz);
@@ -92,11 +92,11 @@ void touchscreen_parse_properties(struct input_dev *input, bool multitouch,
 
 	data_present = touchscreen_get_prop_u32(dev, "touchscreen-min-y",
 						input_abs_get_min(input, axis_y),
-						&minimum) |
+						&minimum) ||
 		       touchscreen_get_prop_u32(dev, "touchscreen-size-y",
 						input_abs_get_max(input,
 								  axis_y) + 1,
-						&maximum) |
+						&maximum) ||
 		       touchscreen_get_prop_u32(dev, "touchscreen-fuzz-y",
 						input_abs_get_fuzz(input, axis_y),
 						&fuzz);
@@ -107,7 +107,7 @@ void touchscreen_parse_properties(struct input_dev *input, bool multitouch,
 	data_present = touchscreen_get_prop_u32(dev,
 						"touchscreen-max-pressure",
 						input_abs_get_max(input, axis),
-						&maximum) |
+						&maximum) ||
 		       touchscreen_get_prop_u32(dev,
 						"touchscreen-fuzz-pressure",
 						input_abs_get_fuzz(input, axis),

--- a/drivers/input/touchscreen/sec_ts/sec_cmd.c
+++ b/drivers/input/touchscreen/sec_ts/sec_cmd.c
@@ -426,7 +426,7 @@ static struct attribute_group sec_fac_attr_group = {
 int sec_cmd_init(struct sec_cmd_data *data, struct sec_cmd *cmds,
 			int len, int devt)
 {
-	struct class *sec_class;
+	struct class *sec_class = NULL;
 	struct sec_ts_data *ts = container_of(data, struct sec_ts_data, sec);
 	const char *dev_name;
 	int ret, i;

--- a/drivers/regulator/qpnp-lcdb-regulator.c
+++ b/drivers/regulator/qpnp-lcdb-regulator.c
@@ -2204,7 +2204,7 @@ static int qpnp_lcdb_regulator_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	lcdb->subtype = (u8)of_device_get_match_data(&pdev->dev);
+	lcdb->subtype = (u8)(u64)of_device_get_match_data(&pdev->dev);
 
 	lcdb->dev = &pdev->dev;
 	lcdb->pdev = pdev;

--- a/drivers/remoteproc/esoc-mdm-4x.c
+++ b/drivers/remoteproc/esoc-mdm-4x.c
@@ -155,8 +155,8 @@ static void mdm_update_gpio_configs(struct mdm_ctrl *mdm, enum gpio_update_confi
 
 static void mdm_trigger_dbg(struct mdm_ctrl *mdm)
 {
-	int ret;
 #if 0 /* Apparently unimpl.. and useless for us anyway */
+	int ret;
 	if (mdm->dbg_mode && !mdm->trig_cnt) {
 		ret = coresight_cti_pulse_trig(mdm->cti, MDM_CTI_CH);
 		mdm->trig_cnt++;

--- a/drivers/video/fbdev/earlycon.c
+++ b/drivers/video/fbdev/earlycon.c
@@ -210,7 +210,7 @@ static int __init simplefb_earlycon_setup(struct earlycon_device *device,
 
 	si = &screen_info;
 
-	if (!port->mapbase || !device->options)
+	if (!port->mapbase || !*device->options)
 		return -ENODEV;
 
 	ret = sscanf(device->options, "%u,%u", &xres, &yres);


### PR DESCRIPTION
clang 14.0.6 on arm64 (arch repos) behaves somewhat differently to clang 14.0.6 on x86_64 (also arch repos) and enforces more warnings as errors.. fix (or "fix") enough warnings to make it happy