### PR TITLE
input: ts: sec_ts: Remove spam from event buffer empty

### DIFF
--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -680,7 +680,6 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 				read_event_buff[0][6], read_event_buff[0][7]);
 
 	if (read_event_buff[0][0] == 0) {
-		dev_info_ratelimited(&ts->client->dev, "%s: event buffer is empty\n", __func__);
 		return;
 	}
 


### PR DESCRIPTION
On some devices like Xperia 10 II this can happen dozens of times just by touching the screen, remove the message and explain.

Fixes: sonyxperiadev/bug_tracker#738
