### PR TITLE
[9.12.r1] input: sec_ts: Convert debug information to input_dbg

### DIFF
--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -56,13 +56,13 @@ void sec_ts_set_irq(struct sec_ts_data *ts, bool enable)
 		if (enable && !ts->irq_status) {
 			enable_irq(ts->client->irq);
 			ts->irq_status = true;
-			input_info(true, &ts->client->dev, "Change irq enabled\n");
+			input_dbg(ts->debug_flag, &ts->client->dev, "Change irq enabled\n");
 		} else if (!enable && ts->irq_status) {
 			disable_irq_nosync(ts->client->irq);
 			ts->irq_status = false;
-			input_info(true, &ts->client->dev, "Change irq was disable\n");
+			input_dbg(ts->debug_flag, &ts->client->dev, "Change irq was disable\n");
 		} else {
-			input_info(true, &ts->client->dev, "no irq change [%s]\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "no irq change [%s]\n",
 				ts->irq_status ? "enable" : "disable");
 		}
 
@@ -84,7 +84,7 @@ void sec_ts_free_irq(struct sec_ts_data *ts)
 	if (ts->client->irq) {
 		free_irq(ts->client->irq, ts);
 		ts->client->irq = 0;
-		input_info(true, &ts->client->dev, "irq release done [%s]\n", ts->client->irq);
+		input_dbg(ts->debug_flag, &ts->client->dev, "irq release done [%s]\n", ts->client->irq);
 	}
 	return;
 }
@@ -100,7 +100,7 @@ void sec_ts_irq_wake(struct sec_ts_data *ts, bool enable)
 		disable_irq_wake(ts->client->irq);
 		ts->irq_wake_mask = false;
 	} else {
-		input_info(true, &ts->client->dev, "no irq wake change [%s]\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "no irq wake change [%s]\n",
 		     ts->irq_wake_mask ? "enable" : "disable");
 	}
 	mutex_unlock(&ts->irq_mutex);
@@ -420,7 +420,7 @@ int sec_ts_wait_for_ready(struct sec_ts_data *ts, unsigned int ack)
 		sec_ts_delay(20);
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: %02X, %02X, %02X, %02X, %02X, %02X, %02X, %02X [%d]\n",
 			__func__, tBuff[0], tBuff[1], tBuff[2], tBuff[3],
 			tBuff[4], tBuff[5], tBuff[6], tBuff[7], retry);
@@ -441,7 +441,7 @@ int sec_ts_read_calibration_report(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev, "%s: count:%d, pass count:%d, fail count:%d, status:0x%X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: count:%d, pass count:%d, fail count:%d, status:0x%X\n",
 			__func__, buf[1], buf[2], buf[3], buf[4]);
 
 	return buf[4];
@@ -452,7 +452,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 	u8 w_data[2] = {0x00, 0x00};
 	int ret = 0;
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s : charger=0x%x, touch_functions=0x%x, Power mode=0x%x, noise_mode=%d\n",
 			__func__, ts->charger_mode, ts->touch_functions,
 			ts->power_status, ts->touch_noise_status);
@@ -507,7 +507,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		sec_ts_set_grip_type(ts, ONLY_EDGE_HANDLER);
 
 		if (ts->dex_mode) {
-			input_info(true, &ts->client->dev, "%s: set dex mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set dex mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_DEX_MODE, &ts->dex_mode, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -515,7 +515,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		}
 
 		if (ts->brush_mode) {
-			input_info(true, &ts->client->dev, "%s: set brush mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set brush mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_BRUSH_MODE, &ts->brush_mode, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -523,7 +523,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		}
 
 		if (ts->touchable_area) {
-			input_info(true, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_TOUCHABLE_AREA, &ts->touchable_area, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -681,7 +681,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 				read_event_buff[0][6], read_event_buff[0][7]);
 
 	if (read_event_buff[0][0] == 0) {
-		input_info(true, &ts->client->dev, "%s: event buffer is empty\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: event buffer is empty\n", __func__);
 		return;
 	}
 
@@ -1044,7 +1044,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 				ts->scrub_x = (tdata[0] << 4) | (tdata[2] >> 4 & 0xF);
 				ts->scrub_y = (tdata[1] << 4) | (tdata[2] >> 0 & 0xF);
 
-				input_info(true, &ts->client->dev, "%s: double tap x:%d, y:%d\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: double tap x:%d, y:%d\n",
 						__func__, ts->scrub_x, ts->scrub_y);
 				for (i = 0; i < AOD_MODE_DOUBLE_TAP; i++) {
 					/* Touch the panel */
@@ -1145,7 +1145,7 @@ int sec_ts_glove_mode_enables(struct sec_ts_data *ts, int mode)
 		goto glove_enable_err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: glove:%d, status:%x\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: glove:%d, status:%x\n", __func__,
 			mode, ts->touch_functions);
 
 	return 0;
@@ -1159,7 +1159,7 @@ int sec_ts_set_cover_type(struct sec_ts_data *ts, bool enable)
 {
 	int ret;
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, ts->flip_enable);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, ts->flip_enable);
 
 	if (enable)
 		ts->touch_functions = (ts->touch_functions | SEC_TS_BIT_SETFUNC_COVER | SEC_TS_DEFAULT_ENABLE_BIT_SETFUNC);
@@ -1186,7 +1186,7 @@ int sec_ts_set_cover_type(struct sec_ts_data *ts, bool enable)
 		goto cover_enable_err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: close:%d, status:%x\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: close:%d, status:%x\n", __func__,
 			enable, ts->touch_functions);
 
 	return 0;
@@ -1202,7 +1202,7 @@ void sec_ts_set_grip_type(struct sec_ts_data *ts, u8 set_type)
 {
 	u8 mode = G_NONE;
 
-	input_info(true, &ts->client->dev, "%s: re-init grip(%d), edh:%d, edg:%d, lan:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: re-init grip(%d), edh:%d, edg:%d, lan:%d\n", __func__,
 			set_type, ts->grip_edgehandler_direction, ts->grip_edge_range, ts->grip_landscape_mode);
 
 	/* edge handler */
@@ -1277,7 +1277,7 @@ static int sec_ts_parse_dt(struct i2c_client *client)
 		input_err(true, dev, "%s: Failed to get irq_type property\n", __func__);
 		pdata->irq_type = IRQF_TRIGGER_LOW | IRQF_ONESHOT;
 	} else {
-		input_info(true, dev, "%s: irq_type property:%X, %d\n", __func__,
+		input_dbg(ts->debug_flag, dev, "%s: irq_type property:%X, %d\n", __func__,
 				pdata->irq_type, pdata->irq_type);
 	}
 
@@ -1365,7 +1365,7 @@ ts_rst_found:
 		pdata->expected_device_id[2] = 0x71;
 	}
 
-	input_info(true, &client->dev, "%s: i2c buffer limit: %d, lcd_id:%06X, bringup:%d, FW:%s(%d), id:%d,%d, mis_cal:%d dex:%d, gesture:%d\n",
+	input_dbg(ts->debug_flag, &client->dev, "%s: i2c buffer limit: %d, lcd_id:%06X, bringup:%d, FW:%s(%d), id:%d,%d, mis_cal:%d dex:%d, gesture:%d\n",
 		__func__, pdata->i2c_burstmax, lcdtype, pdata->bringup, pdata->firmware_name,
 			count, pdata->tsp_id, pdata->tsp_icid, pdata->mis_cal_check,
 			pdata->support_dex);
@@ -1400,7 +1400,7 @@ static int sec_ts_parse_dt_feature(struct i2c_client *client)
 			pdata->watchdog.supported = false;
 		} else {
 			pdata->watchdog.delay_ms = tmp_value;
-			input_info(true, &client->dev, "watchdog_delay_ms: %d\n",
+			input_dbg(ts->debug_flag, &client->dev, "watchdog_delay_ms: %d\n",
 				pdata->watchdog.delay_ms);
 		}
 	}
@@ -1506,7 +1506,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: %X, %X, %X\n",
 			__func__, data[0], data[1], data[2]);
 	memset(data, 0x0, 11);
@@ -1518,7 +1518,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: nTX:%X, nRX:%X, rY:%d, rX:%d\n",
 			__func__, data[8], data[9],
 			(data[2] << 8) | data[3], (data[0] << 8) | data[1]);
@@ -1542,7 +1542,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: STATUS : %X\n",
 			__func__, data[0]);
 
@@ -1784,10 +1784,10 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 	unsigned char deviceID[5] = { 0 };
 	unsigned char result = 0;
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 	ts->power_status = SEC_TS_STATE_POWER_ON;
-	input_info(true, &ts->client->dev, "%s: request_irq = %d\n", __func__, ts->client->irq);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: request_irq = %d\n", __func__, ts->client->irq);
 	if (!ts->irq_req) {
 		ret = request_threaded_irq(ts->client->irq, NULL, sec_ts_irq_thread,
 				ts->plat_data->irq_type, SEC_TS_I2C_NAME, ts);
@@ -1804,7 +1804,7 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 	sec_ts_set_irq(ts, false);
 
 	if (ts->plat_data->ack_wait_time) {
-		input_info(true, &ts->client->dev, "%s: wait [%d]\n", __func__, ts->plat_data->ack_wait_time);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: wait [%d]\n", __func__, ts->plat_data->ack_wait_time);
 		sec_ts_delay(ts->plat_data->ack_wait_time);
 	}
 
@@ -1812,7 +1812,7 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 	if (ret < 0)
 		input_err(true, &ts->client->dev, "%s: failed to read device ID(%d)\n", __func__, ret);
 	else
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: TOUCH DEVICE ID : %02X, %02X, %02X, %02X, %02X\n", __func__,
 				deviceID[0], deviceID[1], deviceID[2], deviceID[3], deviceID[4]);
 
@@ -1844,7 +1844,7 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 					__func__, ret);
 		}
 	}
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: TOUCH STATUS : %02X || %02X, %02X, %02X, %02X\n",
 			__func__, data[0], data[1], data[2], data[3], data[4]);
 
@@ -1863,7 +1863,7 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 		input_err(true, &ts->client->dev, "%s: fail firmware update on probe\n", __func__);
 	}
 #else
-	input_info(true, &ts->client->dev, "%s: fw update on probe disabled!\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: fw update on probe disabled!\n", __func__);
 #endif
 
 	ret = sec_ts_read_information(ts);
@@ -1904,7 +1904,7 @@ static int sec_ts_after_init(struct sec_ts_data *ts)
 
 	ts->report_rejected_event_flag = report_rejected_event;
 
-	input_info(true, &ts->client->dev, "%s: success\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: success\n", __func__);
 	return ret;
 err:
 	ts->power_status = SEC_TS_STATE_POWER_OFF;
@@ -1919,7 +1919,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	int ret = 0;
 	int i = 0;
 
-	input_info(true, &client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s: start\n", __func__);
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
 		input_err(true, &client->dev, "%s: EIO err!\n", __func__);
@@ -2042,13 +2042,13 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 
 	atomic_set(&ts->lock_cnt, 0);
 
-	input_info(true, &client->dev, "%s: init resource\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s: init resource\n", __func__);
 
 	if (!pdata->regulator_boot_on)
 		sec_ts_delay(70);
 	ts->external_factory = false;
 
-	input_info(true, &client->dev, "%s: power enable\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s: power enable\n", __func__);
 
 	/* init notification callbacks */
 	ts->drm_notif.notifier_call = drm_notifier_callback;
@@ -2106,7 +2106,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	ts_dup = ts;
 	ts->probe_done = true;
 
-	input_info(true, &ts->client->dev, "%s: done\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: done\n", __func__);
 	input_log_fix();
 
 	ts->after_work.err = true;
@@ -2224,7 +2224,7 @@ static int sec_ts_feature_settings(struct sec_ts_data *ts)
 	int ret = 0;
 	u8 tBuff[3] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 	/* cover */
 	if (ts->flip_enable) {
@@ -2233,12 +2233,12 @@ static int sec_ts_feature_settings(struct sec_ts_data *ts)
 			goto err;
 
 		ts->touch_functions = ts->touch_functions | SEC_TS_BIT_SETFUNC_COVER;
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover cmd write type:%d, mode:%x, ret:%d\n",
 				__func__, ts->touch_functions, ts->cover_type, ret);
 	} else {
 		ts->touch_functions = (ts->touch_functions & (~SEC_TS_BIT_SETFUNC_COVER));
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover open, not send cmd\n", __func__);
 	}
 
@@ -2291,7 +2291,7 @@ static int sec_ts_feature_settings(struct sec_ts_data *ts)
 	input_info(true, &ts->client->dev, "%s: cover:%d, glove:%d, side:%d, stamina:%d, doze timeout:%d\n",
 			__func__, ts->cover_type, ts->touch_functions, ts->side_enable, ts->stamina_enable, ts->doze_timeout);
 
-	input_info(true, &ts->client->dev, "%s: success\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: success\n", __func__);
 
 err:
 	return ret;
@@ -2373,7 +2373,7 @@ static void sec_ts_reset_work(struct work_struct *work)
 	pm_relax(&ts->client->dev);
 
 	ts->reset_is_on_going = true;
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_ts_stop_device(ts);
 
@@ -2406,14 +2406,14 @@ static void sec_ts_read_info_work(struct work_struct *work)
 	char para = TO_TOUCH_MODE;
 	int ret;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	/* run self-test */
 	sec_ts_set_irq(ts, false);
 	execute_selftest(ts, false);
 	sec_ts_set_irq(ts, true);
 
-	input_info(true, &ts->client->dev, "%s: %02X %02X %02X %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X %02X %02X %02X\n",
 		__func__, ts->ito_test[0], ts->ito_test[1]
 		, ts->ito_test[2], ts->ito_test[3]);
 
@@ -2442,14 +2442,14 @@ static void sec_ts_after_init_work(struct work_struct *work)
 
 
 	if (ts->after_work.done) {
-		input_info(true, &ts->client->dev, "already after_init_work\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "already after_init_work\n");
 			goto out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: session_work start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: session_work start\n", __func__);
 
 	if (sec_ts_get_pw_status()) {
-		input_info(true, &ts->client->dev, "params update, will update feature on resume\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "params update, will update feature on resume\n");
 		goto after_work_fail;
 	}
 
@@ -2458,7 +2458,7 @@ static void sec_ts_after_init_work(struct work_struct *work)
 		if (request_firmware(&fw_entry,
 				     ts->plat_data->firmware_name,
 				     &ts->client->dev) !=  0) {
-			input_info(true, &ts->client->dev,
+			input_dbg(ts->debug_flag, &ts->client->dev,
 			   "Userspace is not ready. Delaying TS init...\n");
 			goto userspace_not_ready;
 		} else {
@@ -2474,11 +2474,11 @@ static void sec_ts_after_init_work(struct work_struct *work)
 	sec_ts_pw_lock(ts, INCELL_DISPLAY_POWER_UNLOCK);
 
 	if (ret) {
-		input_info(true, &ts->client->dev, "stop session_work\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "stop session_work\n");
 			goto after_work_fail;
 	}
 
-	input_info(true, &ts->client->dev, "after_init_work done\n");
+	input_dbg(ts->debug_flag, &ts->client->dev, "after_init_work done\n");
 	ts->after_work.done = true;
 
 	if (is_first_ts_kickstart) {
@@ -2496,7 +2496,7 @@ after_work_fail:
 		goto out;
 	}
 userspace_not_ready:
-	input_info(true, &ts->client->dev, "retry after_work [%d]\n", ts->after_work.retry);
+	input_dbg(ts->debug_flag, &ts->client->dev, "retry after_work [%d]\n", ts->after_work.retry);
 	schedule_delayed_work(&ts->after_work.start, 3 * HZ);
 out:
 	return;
@@ -2506,10 +2506,10 @@ int sec_ts_suspend(struct sec_ts_data *ts)
 {
 	int ret = 0;
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 	if (ts->power_status == SEC_TS_STATE_POWER_OFF) {
-		input_info(true, &ts->client->dev, "%s: already power off\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: already power off\n", __func__);
 		goto out;
 	}
 #ifdef USE_POWER_RESET_WORK
@@ -2523,7 +2523,7 @@ int sec_ts_suspend(struct sec_ts_data *ts)
 	if (ret)
 		input_err(true, &ts->client->dev, "%s: failed sec_ts_stop_device\n", __func__);
 out:
-	input_info(true, &ts->client->dev, "%s: end\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end\n", __func__);
 	return 0;
 }
 
@@ -2531,10 +2531,10 @@ int sec_ts_resume(struct sec_ts_data *ts)
 {
 	int ret = 0;
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 	if (ts->power_status == SEC_TS_STATE_POWER_ON) {
-		input_info(true, &ts->client->dev, "%s: already power on\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: already power on\n", __func__);
 		goto out;
 	}
 
@@ -2546,7 +2546,7 @@ int sec_ts_resume(struct sec_ts_data *ts)
 	if (ret < 0)
 		input_err(true, &ts->client->dev, "%s: failed sec_ts_start_device\n", __func__);
 out:
-	input_info(true, &ts->client->dev, "%s: end\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end\n", __func__);
 	return 0;
 }
 
@@ -2556,7 +2556,7 @@ int sec_ts_set_lowpowermode(struct sec_ts_data *ts, u8 mode)
 	int retrycnt = 0;
 	char para = 0;
 
-	input_info(true, &ts->client->dev, "%s: %s(%X)\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s(%X)\n", __func__,
 			mode == TO_LOWPOWER_MODE ? "ENTER" : "EXIT", ts->lowpower_mode);
 
 retry_pmode:
@@ -2573,7 +2573,7 @@ retry_pmode:
 		input_err(true, &ts->client->dev, "%s: read power mode failed!\n", __func__);
 		goto i2c_error;
 	} else {
-		input_info(true, &ts->client->dev, "%s: power mode - write(%d) read(%d)\n", __func__, mode, para);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: power mode - write(%d) read(%d)\n", __func__, mode, para);
 	}
 
 	if (mode != para) {
@@ -2605,7 +2605,7 @@ retry_pmode:
 		ts->power_status = SEC_TS_STATE_POWER_ON;
 
 i2c_error:
-	input_info(true, &ts->client->dev, "%s: end %d\n", __func__, ret);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end %d\n", __func__, ret);
 
 	return ret;
 }
@@ -2626,7 +2626,7 @@ static int sec_ts_input_open(struct input_dev *dev)
 
 	ts->input_closed = false;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	mutex_unlock(&ts->modechange);
 	
@@ -2648,7 +2648,7 @@ static void sec_ts_input_close(struct input_dev *dev)
 
 	ts->input_closed = true;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 #ifdef USE_POWER_RESET_WORK
 	cancel_delayed_work(&ts->reset_work);
@@ -2663,7 +2663,7 @@ static int sec_ts_remove(struct i2c_client *client)
 {
 	struct sec_ts_data *ts = i2c_get_clientdata(client);
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 #ifdef USE_SELF_TEST_WORK
 	cancel_delayed_work_sync(&ts->work_read_info);
@@ -2672,13 +2672,13 @@ static int sec_ts_remove(struct i2c_client *client)
 
 	sec_ts_set_irq(ts, false);
 	sec_ts_free_irq(ts);
-	input_info(true, &ts->client->dev, "%s: irq disabled\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: irq disabled\n", __func__);
 
 #ifdef USE_POWER_RESET_WORK
 	cancel_delayed_work_sync(&ts->reset_work);
 	flush_delayed_work(&ts->reset_work);
 
-	input_info(true, &ts->client->dev, "%s: flush queue\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: flush queue\n", __func__);
 
 #endif
 
@@ -2729,7 +2729,7 @@ static void sec_ts_shutdown(struct i2c_client *client)
 {
 	struct sec_ts_data *ts = i2c_get_clientdata(client);
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_ts_remove(client);
 }
@@ -2740,7 +2740,7 @@ int sec_ts_stop_device(struct sec_ts_data *ts)
 	int display_sod_mode;
 #endif
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 #ifndef TOUCH_DRIVER_NOT_SOD_PROXIMITY
 	if (ts->plat_data->sod_mode.status) {
@@ -2774,7 +2774,7 @@ int sec_ts_stop_device(struct sec_ts_data *ts)
 	if (ts->plat_data->enable_sync)
 		ts->plat_data->enable_sync(false);
 
-	input_info(true, &ts->client->dev, "%s: end\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end\n", __func__);
 	mutex_unlock(&ts->device_mutex);
 	return 0;
 }
@@ -2785,7 +2785,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	u8 cmd_ena = 0x01;
 	u8 cmd_dis = 0;
 
-	input_info(true, &ts->client->dev, "%s: start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start\n", __func__);
 
 	if (ts->plat_data->sod_mode.status && ts->power_status == SEC_TS_STATE_LPM) {
 		sec_ts_set_lowpowermode(ts, TO_TOUCH_MODE);
@@ -2849,7 +2849,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	sec_ts_set_grip_type(ts, ONLY_EDGE_HANDLER);
 
 	if (ts->dex_mode) {
-		input_info(true, &ts->client->dev, "%s: set dex mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set dex mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_DEX_MODE, &ts->dex_mode, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,
@@ -2859,7 +2859,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	}
 
 	if (ts->brush_mode) {
-		input_info(true, &ts->client->dev, "%s: set brush mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set brush mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_BRUSH_MODE, &ts->brush_mode, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,
@@ -2869,7 +2869,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	}
 
 	if (ts->touchable_area) {
-		input_info(true, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_TOUCHABLE_AREA, &ts->touchable_area, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,
@@ -2895,7 +2895,7 @@ init_err:
 		mutex_unlock(&ts->device_mutex);
 		return lock_ret;
 	}
-	input_info(true, &ts->client->dev, "%s: end\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end\n", __func__);
 	mutex_unlock(&ts->device_mutex);
 	return ret;
 }
@@ -2952,24 +2952,24 @@ int drm_notifier_callback(struct notifier_block *self, unsigned long event, void
 	if (evdata && evdata->data && ts) {
 		if (event == DRM_PANEL_EARLY_EVENT_BLANK) {
 			blank = *(int *)evdata->data;
-			input_info(true, &ts->client->dev, "Before: %s\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "Before: %s\n",
 				(blank == DRM_PANEL_BLANK_POWERDOWN) ? "Powerdown" :
 				(blank == DRM_PANEL_BLANK_UNBLANK) ? "Unblank" :
 				 "???");
 			switch (blank) {
 			case DRM_PANEL_BLANK_POWERDOWN:
 				if (!ts->after_work.done) {
-					input_info(true, &ts->client->dev, "not already sleep out\n");
+					input_dbg(ts->debug_flag, &ts->client->dev, "not already sleep out\n");
 					mutex_unlock(&ts->aod_mutex);
 					return 0;
 				}
 
 				get_monotonic_boottime(&time);
-				input_info(true, &ts->client->dev, "start@%ld.%06ld\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "start@%ld.%06ld\n",
 					time.tv_sec, time.tv_nsec);
 				sec_ts_suspend(ts);
 				get_monotonic_boottime(&time);
-				input_info(true, &ts->client->dev, "end@%ld.%06ld\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "end@%ld.%06ld\n",
 					time.tv_sec, time.tv_nsec);
 				break;
 			case DRM_PANEL_BLANK_UNBLANK:
@@ -2979,7 +2979,7 @@ int drm_notifier_callback(struct notifier_block *self, unsigned long event, void
 			}
 		} else if (event == DRM_PANEL_EVENT_BLANK) {
 			blank = *(int *)evdata->data;
-			input_info(true, &ts->client->dev, "After: %s\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "After: %s\n",
 				(blank == DRM_PANEL_BLANK_POWERDOWN) ? "Powerdown" :
 				(blank == DRM_PANEL_BLANK_UNBLANK) ? "Unblank" :
 				 "???");
@@ -2988,12 +2988,12 @@ int drm_notifier_callback(struct notifier_block *self, unsigned long event, void
 				break;
 			case DRM_PANEL_BLANK_UNBLANK:
 				if (!ts->after_work.done && !ts->after_work.err) {
-					input_info(true, &ts->client->dev, "not already sleep out\n");
+					input_dbg(ts->debug_flag, &ts->client->dev, "not already sleep out\n");
 					mutex_unlock(&ts->aod_mutex);
 					return 0;
 				}
 				if (is_first_ts_kickstart) {
-					input_info(true, &ts->client->dev,
+					input_dbg(ts->debug_flag, &ts->client->dev,
 						   "First TS kickstart, wait "
 						   "for worker sleep-out\n");
 					mutex_unlock(&ts->aod_mutex);
@@ -3002,12 +3002,12 @@ int drm_notifier_callback(struct notifier_block *self, unsigned long event, void
 
 				if (ts->after_work.done || ts->after_work.err) {
 					get_monotonic_boottime(&time);
-					input_info(true, &ts->client->dev, "start@%ld.%06ld\n",
+					input_dbg(ts->debug_flag, &ts->client->dev, "start@%ld.%06ld\n",
 						time.tv_sec, time.tv_nsec);
 
 					sec_ts_resume(ts);
 					get_monotonic_boottime(&time);
-					input_info(true, &ts->client->dev, "end@%ld.%06ld\n",
+					input_dbg(ts->debug_flag, &ts->client->dev, "end@%ld.%06ld\n",
 						time.tv_sec, time.tv_nsec);
 				}
 				break;
@@ -3016,7 +3016,7 @@ int drm_notifier_callback(struct notifier_block *self, unsigned long event, void
 			}
 
 			if (ts->aod_pending) {
-				input_info(true, &ts->client->dev,
+				input_dbg(ts->debug_flag, &ts->client->dev,
 					"Applying aod_pending_lowpower_mode: %d\n",
 					ts->aod_pending_lowpower_mode);
 				ts->aod_pending = false;

--- a/drivers/input/touchscreen/sec_ts/sec_ts_fn.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts_fn.c
@@ -181,10 +181,10 @@ static ssize_t scrub_position_show(struct device *dev,
 	char buff[256] = { 0 };
 
 #ifdef CONFIG_SAMSUNG_PRODUCT_SHIP
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: scrub_id: %d\n", __func__, ts->scrub_id);
 #else
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: scrub_id: %d, X:%d, Y:%d\n", __func__,
 			ts->scrub_id, ts->scrub_x, ts->scrub_y);
 #endif
@@ -205,7 +205,7 @@ static ssize_t read_ito_check_show(struct device *dev,
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 	char buff[256] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: %02X%02X%02X%02X\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X%02X%02X%02X\n", __func__,
 			ts->ito_test[0], ts->ito_test[1],
 			ts->ito_test[2], ts->ito_test[3]);
 
@@ -253,7 +253,7 @@ static ssize_t read_multi_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->multi_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->multi_count);
@@ -268,7 +268,7 @@ static ssize_t clear_multi_count_store(struct device *dev,
 
 	ts->multi_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -279,7 +279,7 @@ static ssize_t read_wet_mode_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d, %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d, %d\n", __func__,
 			ts->wet_count, ts->dive_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->wet_count);
@@ -295,7 +295,7 @@ static ssize_t clear_wet_mode_store(struct device *dev,
 	ts->wet_count = 0;
 	ts->dive_count= 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -306,7 +306,7 @@ static ssize_t read_noise_mode_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, ts->noise_count);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, ts->noise_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->noise_count);
 }
@@ -320,7 +320,7 @@ static ssize_t clear_noise_mode_store(struct device *dev,
 
 	ts->noise_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -331,7 +331,7 @@ static ssize_t read_comm_err_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->multi_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->comm_err_count);
@@ -346,7 +346,7 @@ static ssize_t clear_comm_err_count_store(struct device *dev,
 
 	ts->comm_err_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -362,7 +362,7 @@ static ssize_t read_module_id_show(struct device *dev,
 		ts->plat_data->panel_revision, ts->plat_data->img_version_of_ic[2],
 		ts->plat_data->img_version_of_ic[3]);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%s", buff);
 }
@@ -388,7 +388,7 @@ static ssize_t clear_checksum_store(struct device *dev,
 
 	ts->checksum_result = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -399,7 +399,7 @@ static ssize_t read_checksum_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->checksum_result);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->checksum_result);
@@ -414,7 +414,7 @@ static ssize_t clear_holding_time_store(struct device *dev,
 
 	ts->time_longest = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -425,7 +425,7 @@ static ssize_t read_holding_time_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %ld\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %ld\n", __func__,
 			ts->time_longest);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%ld", ts->time_longest);
@@ -437,7 +437,7 @@ static ssize_t read_all_touch_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: touch:%d, force:%d, aod:%d, spay:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: touch:%d, force:%d, aod:%d, spay:%d\n", __func__,
 			ts->all_finger_count, ts->all_force_count,
 			ts->all_aod_tap_count, ts->all_spay_count);
 
@@ -458,7 +458,7 @@ static ssize_t clear_all_touch_count_store(struct device *dev,
 	ts->all_aod_tap_count = 0;
 	ts->all_spay_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -469,7 +469,7 @@ static ssize_t read_z_value_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: max:%d, min:%d, avg:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: max:%d, min:%d, avg:%d\n", __func__,
 			ts->max_z_value, ts->min_z_value,
 			ts->sum_z_value);
 
@@ -497,7 +497,7 @@ static ssize_t clear_z_value_store(struct device *dev,
 	ts->sum_z_value= 0;
 	ts->all_finger_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -543,12 +543,12 @@ static ssize_t after_init_work_start_store(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: - start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: - start\n", __func__);
 
 	if (ts->after_work.done) {
-		input_info(true, &ts->client->dev, "already post probed, need reboot\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "already post probed, need reboot\n");
 	} else {
-		input_info(true, &ts->client->dev, "start after_init_work\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "start after_init_work\n", __func__);
 		schedule_delayed_work(&ts->after_work.start, 0);
 	}
 
@@ -646,7 +646,7 @@ static ssize_t ic_status_show(struct device *dev,
 	snprintf(temp, sizeof(temp), "artcanvas,%d,", data[0]);
 	strncat(buff, temp, sizeof(temp) - strlen(temp) - 1 );
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%s\n", buff);
 }
@@ -703,13 +703,13 @@ static int sec_ts_check_index(struct sec_ts_data *ts)
 		snprintf(buff, sizeof(buff), "%s", "NG");
 		sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
-		input_info(true, &ts->client->dev, "%s: parameter error: %u, %u\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: parameter error: %u, %u\n",
 				__func__, sec->cmd_param[0], sec->cmd_param[0]);
 		node = -1;
 		return node;
 	}
 	node = sec->cmd_param[1] * ts->tx_count + sec->cmd_param[0];
-	input_info(true, &ts->client->dev, "%s: node = %d\n", __func__, node);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: node = %d\n", __func__, node);
 	return node;
 }
 static void fw_update(void *device_data)
@@ -720,7 +720,7 @@ static void fw_update(void *device_data)
 	int retval = 0;
 
 	if (sec_ts_get_pw_status()) {
-		input_info(true, &ts->client->dev, "cannot fw_update, panel power off\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "cannot fw_update, panel power off\n");
 		return;
 	}
 	sec_cmd_set_default_result(sec);
@@ -743,7 +743,7 @@ static void fw_update(void *device_data)
 		snprintf(buff, sizeof(buff), "%s", "OK");
 		sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 		sec->cmd_state = SEC_CMD_STATUS_OK;
-		input_info(true, &ts->client->dev, "%s: success [%d]\n", __func__, retval);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: success [%d]\n", __func__, retval);
 	}
 }
 
@@ -753,7 +753,7 @@ int sec_ts_fix_tmode(struct sec_ts_data *ts, u8 mode, u8 state)
 	u8 onoff[1] = {STATE_MANAGE_OFF};
 	u8 tBuff[2] = { mode, state };
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_STATEMANAGE_ON, onoff, 1);
 	sec_ts_delay(20);
@@ -769,7 +769,7 @@ int sec_ts_p2p_tmode(struct sec_ts_data *ts)
 	int ret;
 	u8 mode[1] = {0x0C};
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_CLEAR_EVENT_STACK, NULL, 0);
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_P2P_MODE, mode, sizeof(mode));
@@ -800,7 +800,7 @@ static int execute_p2ptest(struct sec_ts_data *ts)
 		}
 
 		if ((tBuff[7] & 0x3F) == 0x00) {
-			input_info(true, &ts->client->dev, "%s: left event is 0\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: left event is 0\n", __func__);
 			ret = 0;
 			break;
 		}
@@ -819,7 +819,7 @@ int sec_ts_release_tmode(struct sec_ts_data *ts)
 	int ret;
 	u8 onoff[1] = {STATE_MANAGE_ON};
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_STATEMANAGE_ON, onoff, 1);
 	sec_ts_delay(20);
@@ -835,7 +835,7 @@ static void sec_ts_print_frame(struct sec_ts_data *ts, short *min, short *max)
 	unsigned char pTmp[16] = { 0 };
 	int lsize = 7 * (ts->tx_count + 1);
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	pStr = kzalloc(lsize, GFP_KERNEL);
 	if (pStr == NULL)
@@ -850,7 +850,7 @@ static void sec_ts_print_frame(struct sec_ts_data *ts, short *min, short *max)
 		strncat(pStr, pTmp, lsize);
 	}
 
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 	memset(pStr, 0x0, lsize);
 	snprintf(pTmp, sizeof(pTmp), " +");
 	strncat(pStr, pTmp, lsize);
@@ -860,7 +860,7 @@ static void sec_ts_print_frame(struct sec_ts_data *ts, short *min, short *max)
 		strncat(pStr, pTmp, lsize);
 	}
 
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 	for (i = 0; i < ts->rx_count; i++) {
 		memset(pStr, 0x0, lsize);
@@ -878,7 +878,7 @@ static void sec_ts_print_frame(struct sec_ts_data *ts, short *min, short *max)
 
 			strncat(pStr, pTmp, lsize);
 		}
-		input_info(true, &ts->client->dev, "%s\n", pStr);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 	}
 	kfree(pStr);
 }
@@ -894,7 +894,7 @@ static int sec_ts_read_frame(struct sec_ts_data *ts, u8 type, short *min,
 	int j = 0;
 	short *temp = NULL;
 
-	input_info(true, &ts->client->dev, "%s: type %d\n", __func__, type);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: type %d\n", __func__, type);
 
 	/* set data length, allocation buffer memory */
 	readbytes = ts->rx_count * ts->tx_count * 2;
@@ -950,7 +950,7 @@ static int sec_ts_read_frame(struct sec_ts_data *ts, u8 type, short *min,
 	*min = *max = ts->pFrame[0];
 
 #ifdef DEBUG_MSG
-	input_info(true, &ts->client->dev, "%s: 02X%02X%02X readbytes=%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: 02X%02X%02X readbytes=%d\n", __func__,
 			pRead[0], pRead[1], pRead[2], readbytes);
 #endif
 	sec_ts_print_frame(ts, min, max);
@@ -1002,7 +1002,7 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 		snprintf(pTmp, sizeof(pTmp), "    %02d", k);
 		strncat(pStr, pTmp, 7 * ts->tx_count);
 	}
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 	memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 	snprintf(pTmp, sizeof(pTmp), " +");
@@ -1012,7 +1012,7 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 		snprintf(pTmp, sizeof(pTmp), "------");
 		strncat(pStr, pTmp, 7 * ts->tx_count);
 	}
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 	memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 	snprintf(pTmp, sizeof(pTmp), " | ");
@@ -1020,8 +1020,8 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 
 	for (i = 0; i < (ts->tx_count + ts->rx_count) * 2; i += 2) {
 		if (j == ts->tx_count) {
-			input_info(true, &ts->client->dev, "%s\n", pStr);
-			input_info(true, &ts->client->dev, "\n");
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "\n");
 			memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 			snprintf(pTmp, sizeof(pTmp), " RX");
 			strncat(pStr, pTmp, 7 * ts->tx_count);
@@ -1031,7 +1031,7 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 				strncat(pStr, pTmp, 7 * ts->tx_count);
 			}
 
-			input_info(true, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 			memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 			snprintf(pTmp, sizeof(pTmp), " +");
@@ -1041,13 +1041,13 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 				snprintf(pTmp, sizeof(pTmp), "------");
 				strncat(pStr, pTmp, 7 * ts->tx_count);
 			}
-			input_info(true, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 			memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 			snprintf(pTmp, sizeof(pTmp), " | ");
 			strncat(pStr, pTmp, 7 * ts->tx_count);
 		} else if (j && !(j % ts->tx_count)) {
-			input_info(true, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 			memset(pStr, 0x0, 7 * (ts->tx_count + 1));
 			snprintf(pTmp, sizeof(pTmp), " | ");
 			strncat(pStr, pTmp, 7 * ts->tx_count);
@@ -1058,7 +1058,7 @@ static void sec_ts_print_channel(struct sec_ts_data *ts)
 
 		j++;
 	}
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 	vfree(pStr);
 }
 
@@ -1073,7 +1073,7 @@ static int sec_ts_read_channel(struct sec_ts_data *ts, u8 type,
 	unsigned int data_length = (ts->tx_count + ts->rx_count) * 2;
 	u8 w_data;
 
-	input_info(true, &ts->client->dev, "%s: type %d\n", __func__, type);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: type %d\n", __func__, type);
 
 	pRead = kzalloc(data_length, GFP_KERNEL);
 	if (!pRead)
@@ -1154,11 +1154,11 @@ static void sec_ts_get_cm_gap(struct sec_ts_data *ts, short *gap, bool gap_dir)
 	int gapx, gapy, pos1, pos2;
 	short dpos1, dpos2;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	/* Get x-direction cm gap */
 	if (gap_dir == X_DIR) {
-		input_info(true, &ts->client->dev, "gapX\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "gapX\n");
 
 		for (i = 0; i < ts->rx_count; i++) {
 			for (j = 0; j < ts->tx_count - 1; j++) {
@@ -1183,7 +1183,7 @@ static void sec_ts_get_cm_gap(struct sec_ts_data *ts, short *gap, bool gap_dir)
 
 	/* get y-direction cm gap */
 	else {
-		input_info(true, &ts->client->dev, "gapY\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "gapY\n");
 
 		for (i = 0; i < ts->rx_count - 1; i++) {
 			for (j = 0; j < ts->tx_count; j++) {
@@ -1348,7 +1348,7 @@ static int sec_ts_read_raw_data(struct sec_ts_data *ts,
 		goto error_power_state;
 	}
 
-	input_info(true, &ts->client->dev, "%s: %d, %s\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d, %s\n",
 			__func__, mode->type, mode->allnode ? "ALL" : "");
 
 	ret = sec_ts_fix_tmode(ts, TOUCH_SYSTEM_MODE_TOUCH, TOUCH_MODE_STATE_TOUCH);
@@ -1447,7 +1447,7 @@ static int sec_ts_read_rawp2p_data(struct sec_ts_data *ts,
 	if (!buff)
 		goto error_alloc_mem;
 
-	input_info(true, &ts->client->dev, "%s: %d, %s\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d, %s\n",
 			__func__, mode->type, mode->allnode ? "ALL" : "");
 
 	sec_ts_set_irq(ts, false);
@@ -1587,7 +1587,7 @@ static void get_fw_ver_bin(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_fw_ver_ic(void *device_data)
@@ -1623,7 +1623,7 @@ static void get_fw_ver_ic(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_config_ver(void *device_data)
@@ -1640,7 +1640,7 @@ static void get_config_ver(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_threshold(void *device_data)
@@ -1673,14 +1673,14 @@ static void get_threshold(void *device_data)
 		goto err;
 	}
 
-	input_info(true, &ts->client->dev, "0x%02X, 0x%02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "0x%02X, 0x%02X\n",
 			threshold[0], threshold[1]);
 
 	snprintf(buff, sizeof(buff), "%d", (threshold[0] << 8) | threshold[1]);
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return;
 err:
@@ -1709,7 +1709,7 @@ static void module_off_master(void *device_data)
 		sec->cmd_state = SEC_CMD_STATUS_OK;
 	else
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void module_on_master(void *device_data)
@@ -1733,7 +1733,7 @@ static void module_on_master(void *device_data)
 	else
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_chip_vendor(void *device_data)
@@ -1746,7 +1746,7 @@ static void get_chip_vendor(void *device_data)
 	sec_cmd_set_default_result(sec);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_chip_name(void *device_data)
@@ -1771,7 +1771,7 @@ static void get_chip_name(void *device_data)
 	sec_cmd_set_default_result(sec);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void set_mis_cal_spec(void *device_data)
@@ -1806,7 +1806,7 @@ static void set_mis_cal_spec(void *device_data)
 				input_err(true, &ts->client->dev, "%s: Misscal spec write failed. ret: %d\n", __func__, ret);
 				goto NG;
 			} else {
-				input_info(true, &ts->client->dev, "%s: tx gap=%d, rx gap=%d, peak=%d\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: tx gap=%d, rx gap=%d, peak=%d\n",
 								__func__, wreg[0], wreg[1], wreg[2]);
 				sec_ts_delay(20);
 			}
@@ -1869,7 +1869,7 @@ static void get_mis_cal_info(void *device_data)
 			mis_cal_data = 0xF3;
 			goto NG;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
 		}
 
 		ret = ts->sec_ts_i2c_read(ts, SEC_TS_CMD_MIS_CAL_SPEC, wreg, 4);
@@ -1878,7 +1878,7 @@ static void get_mis_cal_info(void *device_data)
 			mis_cal_data = 0xF4;
 			goto NG;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal spec : %d,%d,%d,%d\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal spec : %d,%d,%d,%d\n",
 						__func__, wreg[0], wreg[1], wreg[2], wreg[3]);
 		}
 	}
@@ -1888,7 +1888,7 @@ static void get_mis_cal_info(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff_all);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff_all);
 	return;
 
 NG:
@@ -1896,7 +1896,7 @@ NG:
 	snprintf(buff_all, sizeof(buff_all), "%d,%d,%d,%d", mis_cal_data, 0, 0, 0);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff_all);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff_all);
 }
 
 static void get_wet_mode(void *device_data)
@@ -1918,14 +1918,14 @@ static void get_wet_mode(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", wet_mode_info);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 	return;
 
 NG:
 	snprintf(buff, sizeof(buff), "NG");
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -1939,7 +1939,7 @@ static void get_x_num(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", ts->tx_count);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_y_num(void *device_data)
@@ -1952,7 +1952,7 @@ static void get_y_num(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", ts->rx_count);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static u32 checksum_sum(struct sec_ts_data *ts, u8 *chunk_data, u32 size)
@@ -1970,7 +1970,7 @@ static u32 checksum_sum(struct sec_ts_data *ts, u8 *chunk_data, u32 size)
 
 	checksum &= 0xFFFFFFFF;
 
-	input_info(true, &ts->client->dev, "%s: checksum = [%x]\n", __func__, checksum);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: checksum = [%x]\n", __func__, checksum);
 
 	return checksum;
 }
@@ -2001,7 +2001,7 @@ static u32 get_bin_checksum(struct sec_ts_data *ts, const u8 *data, size_t size)
 		checksum += data_32;
 	}
 
-	input_info(true, &ts->client->dev, "%s: fw_hd->totalsize = [%d] checksum = [%x]\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: fw_hd->totalsize = [%d] checksum = [%x]\n",
 				__func__, fw_hd->totalsize, checksum);
 
 	checksum &= 0xFFFFFFFF;
@@ -2013,7 +2013,7 @@ static u32 get_bin_checksum(struct sec_ts_data *ts, const u8 *data, size_t size)
 	for (i = 0; i < fw_hd->num_chunk; i++) {
 		fw_ch = (fw_chunk *)fd;
 
-		input_info(true, &ts->client->dev, "%s: [%d] 0x%08X, 0x%08X, 0x%08X, 0x%08X\n", __func__, i,
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: [%d] 0x%08X, 0x%08X, 0x%08X, 0x%08X\n", __func__, i,
 				fw_ch->signature, fw_ch->addr, fw_ch->size, fw_ch->reserved);
 
 		if (fw_ch->signature != SEC_TS_FW_CHUNK_SIGN) {
@@ -2167,7 +2167,7 @@ static void get_checksum_data(void *device_data)
 
 		release_firmware(fw_entry);
 
-		input_info(true, &ts->client->dev, "%s: img_checksum=[0x%X], ic_checksum=[0x%X]\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: img_checksum=[0x%X], ic_checksum=[0x%X]\n",
 						__func__, img_checksum, ic_checksum);
 
 		if (img_checksum != ic_checksum) {
@@ -2179,7 +2179,7 @@ static void get_checksum_data(void *device_data)
 	}
 out:
 
-	input_info(true, &ts->client->dev, "%s: checksum = %02X\n", __func__, csum);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: checksum = %02X\n", __func__, csum);
 	snprintf(buff, sizeof(buff), "%02X", csum);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
@@ -2198,13 +2198,13 @@ static void check_io_sync(void *device_data)
 	char buff[16] = { 0 };
 	int ret;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_cmd_set_default_result(sec);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SYNC_STATUS, &para, 1);
 	if (ret < 0) {
-		input_info(true, &ts->client->dev, "%s: Sync check cmd write fail\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Sync check cmd write fail\n", __func__);
 		goto err_out;
 	}
 
@@ -2212,14 +2212,14 @@ static void check_io_sync(void *device_data)
 
 	ts->sec_ts_i2c_read(ts, SEC_TS_CMD_SYNC_STATUS, &para, 1);
 	if (ret < 0) {
-		input_info(true, &ts->client->dev, "%s: Sync check result read fail\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Sync check result read fail\n", __func__);
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: sync check result is %02X\n", __func__, para);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: sync check result is %02X\n", __func__, para);
 
 	if ((para & BIT_VSYNC) && (para & BIT_HSYNC)) {
-		input_info(true, &ts->client->dev, "%s: Vsync & Hsync detected!\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Vsync & Hsync detected!\n", __func__);
 
 		snprintf(buff, sizeof(buff), "%d", 1);
 		sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
@@ -2228,13 +2228,13 @@ static void check_io_sync(void *device_data)
 		return;
 
 	} else if ((para & BIT_VSYNC) && !(para & BIT_HSYNC)) {
-		input_info(true, &ts->client->dev, "%s: Hsync Not detected!\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Hsync Not detected!\n", __func__);
 		goto err_out;
 	} else if (!(para & BIT_VSYNC) && (para & BIT_HSYNC)) {
-		input_info(true, &ts->client->dev, "%s: Vsync not detected!\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Vsync not detected!\n", __func__);
 		goto err_out;
 	} else {
-		input_info(true, &ts->client->dev, "%s: Both Vsync & Hsync not detected!\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Both Vsync & Hsync not detected!\n", __func__);
 		goto err_out;
 	}
 
@@ -2253,7 +2253,7 @@ static void check_io_intx(void *device_data)
 	u8 para[4] = {0x12, 0x34, 0x56, 0x78};
 	u8 tBuff[8];
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_cmd_set_default_result(sec);
 
@@ -2281,7 +2281,7 @@ static void check_io_intx(void *device_data)
 			}
 			if ((tBuff[2] == para[0]) && (tBuff[3] == para[1]) &&
 				(tBuff[4] == para[2]) && (tBuff[5] == para[3])) {
-				input_info(true, &ts->client->dev, "%s: INT pin low checked!\n", __func__);
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: INT pin low checked!\n", __func__);
 				break;
 			}
 		}
@@ -2316,7 +2316,7 @@ static void check_io_resetb(void *device_data)
 
 	sec_cmd_set_default_result(sec);
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	mutex_lock(&ts->device_mutex);
 
@@ -2334,12 +2334,12 @@ static void check_io_resetb(void *device_data)
 	/* make resetb signal toggle (high->low->high) */
 	if (gpio_is_valid(ts->plat_data->resetb_gpio)) {
 
-		input_info(true, &ts->client->dev, "%s: drive RESETB signal to low\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: drive RESETB signal to low\n", __func__);
 		gpio_set_value(ts->plat_data->resetb_gpio, 0);
 
 		sec_ts_delay(1);
 
-		input_info(true, &ts->client->dev, "%s: drive RESETB signal to high\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: drive RESETB signal to high\n", __func__);
 		gpio_set_value(ts->plat_data->resetb_gpio, 1);
 	}
 #endif
@@ -2359,12 +2359,12 @@ static void check_io_resetb(void *device_data)
 			goto err_out;
 
 		ts->touch_functions = ts->touch_functions | SEC_TS_BIT_SETFUNC_COVER;
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover cmd write type:%d, mode:%x, ret:%d\n",
 				__func__, ts->touch_functions, ts->cover_type, ret);
 	} else {
 		ts->touch_functions = (ts->touch_functions & (~SEC_TS_BIT_SETFUNC_COVER));
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover open, not send cmd\n", __func__);
 	}
 
@@ -2452,7 +2452,7 @@ static void get_reference(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_rawcap_read(void *device_data)
@@ -2510,7 +2510,7 @@ static void get_rawcap(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_delta_read(void *device_data)
@@ -2569,7 +2569,7 @@ static void get_delta(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_raw_p2p_read(void *device_data)
@@ -2757,7 +2757,7 @@ void sec_ts_run_rawdata_all(struct sec_ts_data *ts, bool full_read)
 	u8 test_type[5] = {TYPE_AMBIENT_DATA, TYPE_DECODED_DATA,
 		TYPE_SIGNAL_DATA, TYPE_OFFSET_DATA_SET, TYPE_OFFSET_DATA_SDC};
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: start (noise:%d, wet:%d)##\n",
 			__func__, ts->touch_noise_status, ts->wet_mode);
 
@@ -2778,12 +2778,12 @@ void sec_ts_run_rawdata_all(struct sec_ts_data *ts, bool full_read)
 	for (i = 0; i < read_num; i++) {
 		ret = sec_ts_read_frame(ts, test_type[i], &min, &max, false);
 		if (ret < 0) {
-			input_info(true, &ts->client->dev,
+			input_dbg(ts->debug_flag, &ts->client->dev,
 					"%s: mutual %d : error ## ret:%d\n",
 					__func__, test_type[i], ret);
 			goto out;
 		} else {
-			input_info(true, &ts->client->dev,
+			input_dbg(ts->debug_flag, &ts->client->dev,
 					"%s: mutual %d : Max/Min %d,%d ##\n",
 					__func__, test_type[i], max, min);
 		}
@@ -2792,12 +2792,12 @@ void sec_ts_run_rawdata_all(struct sec_ts_data *ts, bool full_read)
 		if (full_read) {
 			ret = sec_ts_read_channel(ts, test_type[i], &min, &max, false);
 			if (ret < 0) {
-				input_info(true, &ts->client->dev,
+				input_dbg(ts->debug_flag, &ts->client->dev,
 						"%s: self %d : error ## ret:%d\n",
 						__func__, test_type[i], ret);
 				goto out;
 			} else {
-				input_info(true, &ts->client->dev,
+				input_dbg(ts->debug_flag, &ts->client->dev,
 						"%s: self %d : Max/Min %d,%d ##\n",
 						__func__, test_type[i], max, min);
 			}
@@ -2808,11 +2808,11 @@ void sec_ts_run_rawdata_all(struct sec_ts_data *ts, bool full_read)
 	sec_ts_release_tmode(ts);
 
 out:
-	input_info(true, &ts->client->dev, "%s: ito : %02X %02X %02X %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: ito : %02X %02X %02X %02X\n",
 			__func__, ts->ito_test[0], ts->ito_test[1]
 			, ts->ito_test[2], ts->ito_test[3]);
 
-	input_info(true, &ts->client->dev, "%s: done (noise:%d, wet:%d)##\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: done (noise:%d, wet:%d)##\n",
 			__func__, ts->touch_noise_status, ts->wet_mode);
 
 	sec_ts_locked_release_all_finger(ts);
@@ -2839,7 +2839,7 @@ static void run_rawdata_read_all(void *device_data)
 	sec->cmd_state = SEC_CMD_STATUS_OK;
 out:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 /* Use TSP NV area
@@ -2916,7 +2916,7 @@ int get_tsp_nvm_data(struct sec_ts_data *ts, u8 offset)
 		goto out_nvm;
 	}
 
-	input_info(true, &ts->client->dev, "%s: offset:%u  data:%02X\n", __func__, offset, buff[0]);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: offset:%u  data:%02X\n", __func__, offset, buff[0]);
 
 out_nvm:
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SENSE_ON, NULL, 0);
@@ -2939,7 +2939,7 @@ int get_tsp_nvm_data_by_size(struct sec_ts_data *ts, u8 offset, int length, u8 *
 	if (!buff)
 		return -ENOMEM;
 
-	input_info(true, &ts->client->dev, "%s: offset:%u, length:%d, size:%d\n", __func__, offset, length, sizeof(data));
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: offset:%u, length:%d, size:%d\n", __func__, offset, length, sizeof(data));
 
 	/* SENSE OFF -> CELAR EVENT STACK -> READ NV -> SENSE ON */
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SENSE_OFF, NULL, 0);
@@ -3036,7 +3036,7 @@ static void glove_mode(void *device_data)
 
 		ts->plat_data->glove_mode.status = glove_mode_enables;
 		if (sec_ts_get_pw_status() || !ts->after_work.done) {
-			input_info(true, &ts->client->dev, "%s: update skip\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: update skip\n", __func__);
 			goto update_skip;
 		}
 
@@ -3064,10 +3064,10 @@ static void cover_mode_enable(void *device_data)
 	char buff[SEC_CMD_STR_LEN] = { 0 };
 
 	if (!ts->plat_data->cover_mode.supported) {
-		input_info(true, &ts->client->dev, "cover_mode is not supported.\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "cover_mode is not supported.\n");
 		return;
 	}
-	input_info(true, &ts->client->dev, "%s: start cover_set %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start cover_set %s\n", __func__, buff);
 	sec_cmd_set_default_result(sec);
 
 	if (sec->cmd_param[0] < 0 || sec->cmd_param[0] > 1) {
@@ -3086,7 +3086,7 @@ static void cover_mode_enable(void *device_data)
 	snprintf(buff, sizeof(buff), "%s", "OK");
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 	return;
 }
 
@@ -3097,10 +3097,10 @@ static void cover_set(void *device_data)
 	char buff[SEC_CMD_STR_LEN] = { 0 };
 
 	if (!ts->plat_data->cover_mode.supported) {
-		input_info(true, &ts->client->dev, "cover_mode is not supported.\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "cover_mode is not supported.\n");
 		return;
 	}
-	input_info(true, &ts->client->dev, "%s: start cover_mode %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start cover_mode %s\n", __func__, buff);
 	sec_cmd_set_default_result(sec);
 
 	if (sec->cmd_param[0] < 0 || sec->cmd_param[0] > 1) {
@@ -3122,7 +3122,7 @@ static void cover_set(void *device_data)
 					sec_ts_set_cover_type(ts, false);
 			}
 		} else {
-			input_info(true, &ts->client->dev, "%s: update skip\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: update skip\n", __func__);
 			goto update_skip;
 		}
 		snprintf(buff, sizeof(buff), "%s", "OK");
@@ -3168,7 +3168,7 @@ err_set_dead_zone:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 };
 
 static void drawing_test_enable(void *device_data)
@@ -3190,7 +3190,7 @@ static void drawing_test_enable(void *device_data)
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 };
 
 static void sec_ts_swap(u8 *a, u8 *b)
@@ -3233,7 +3233,7 @@ int execute_selftest(struct sec_ts_data *ts, bool save_result)
 	if (!rBuff)
 		return -ENOMEM;
 
-	input_info(true, &ts->client->dev, "%s: Self test start!\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Self test start!\n", __func__);
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SELFTEST, tpara, 2);
 	if (rc < 0) {
 		input_err(true, &ts->client->dev, "%s: Send selftest cmd failed!\n", __func__);
@@ -3248,7 +3248,7 @@ int execute_selftest(struct sec_ts_data *ts, bool save_result)
 		goto err_exit;
 	}
 
-	input_info(true, &ts->client->dev, "%s: Self test done!\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Self test done!\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, result_size);
 	if (rc < 0) {
@@ -3316,7 +3316,7 @@ int execute_selftest(struct sec_ts_data *ts, bool save_result)
 			ts->ito_test[3] = rBuff[i + 3];
 		}
 		if (i % 8 == 4) {
-			input_info(true, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 			memset(pStr, 0x00, sizeof(pStr));
 		} else {
 			strncat(pStr, "  ", 3);
@@ -3364,7 +3364,7 @@ static void run_trx_short_test(void *device_data)
 
 	sec_ts_set_irq(ts, false);
 
-	input_info(true, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
 
 	data[0] = 0x02;
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_POWER_MODE, data, 1);
@@ -3373,14 +3373,14 @@ static void run_trx_short_test(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: clear event stack\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear event stack\n", __func__);
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_CLEAR_EVENT_STACK, NULL, 0);
 	if (rc < 0) {
 		input_err(true, &ts->client->dev, "%s: clear event stack failed\n", __func__);
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test start\n", __func__);
 	
 	data[0] = 0x04;
 	
@@ -3398,7 +3398,7 @@ static void run_trx_short_test(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test done\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test done\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, size);
 	if (rc < 0) {
@@ -3416,7 +3416,7 @@ static void run_trx_short_test(void *device_data)
 
 	sec_ts_reinit(ts);
 
-	input_info(true, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
 			__func__, rBuff[16], rBuff[17], rBuff[18], rBuff[19]);
 
 	sec_ts_set_irq(ts, true);
@@ -3453,7 +3453,7 @@ static void run_trx_short_test(void *device_data)
 			data[ii], data[ii + 1], data[ii + 2], data[ii + 3]);
 		strncat(pStr, pTmp, strnlen(pTmp, sizeof(pTmp)));
 		if (ii % 8 == 4) {
-			input_info(true, &ts->client->dev, "%s\n", pStr);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 			memset(pStr, 0x00, sizeof(pStr));
 		} else {
 			strncat(pStr, "  ", 3);
@@ -3525,7 +3525,7 @@ static void run_trx_short_test_all(void *device_data)
 	memset(rBuff, 0x00, size);
 	memset(data, 0x00, 24);
 
-	input_info(true, &ts->client->dev, "%s: Read self test result\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Read self test result\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, size);
 	if (rc < 0) {
@@ -3535,7 +3535,7 @@ static void run_trx_short_test_all(void *device_data)
 
 	rearrange_sft_result(rBuff, SEC_TS_SELFTEST_REPORT_SIZE);
 
-	input_info(true, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
 			__func__, rBuff[16], rBuff[17], rBuff[18], rBuff[19]);
 
 	memcpy(data, &rBuff[56], 24);
@@ -3560,7 +3560,7 @@ static void run_trx_short_test_all(void *device_data)
 			memset(pTmp, 0x00, sizeof(pTmp));
 		}
 		strncat(pStr, "\n", 1);
-		input_info(true, &ts->client->dev, "%s", pStr);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s", pStr);
 		strncat(buff, pStr, sizeof(pStr) - strlen(pStr) - 1);
 		memset(pStr, 0x00, sizeof(pStr));
 	}
@@ -3615,7 +3615,7 @@ static void run_trx_open_test(void *device_data)
 
 	sec_ts_set_irq(ts, false);
 
-	input_info(true, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
 
 	data[0] = 0x02;
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_POWER_MODE, data, 1);
@@ -3624,14 +3624,14 @@ static void run_trx_open_test(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: clear event stack\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear event stack\n", __func__);
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_CLEAR_EVENT_STACK, NULL, 0);
 	if (rc < 0) {
 		input_err(true, &ts->client->dev, "%s: clear event stack failed\n", __func__);
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test start\n", __func__);
 
 	data[0] = 0x03;
 
@@ -3649,7 +3649,7 @@ static void run_trx_open_test(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test done\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test done\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, size);
 	if (rc < 0) {
@@ -3667,7 +3667,7 @@ static void run_trx_open_test(void *device_data)
 
 	sec_ts_reinit(ts);
 
-	input_info(true, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
 			__func__, rBuff[16], rBuff[17], rBuff[18], rBuff[19]);
 
 	sec_ts_set_irq(ts, true);
@@ -3689,7 +3689,7 @@ static void run_trx_open_test(void *device_data)
 		if (ii < 4)
 			strncat(pStr, "  ", 3);
 	}
-	input_info(true, &ts->client->dev, "%s\n", pStr);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", pStr);
 
 	if (!sum) {
 		sec_cmd_set_cmd_result(sec, "1", 1);
@@ -3744,7 +3744,7 @@ static void run_trx_open_test_all(void *device_data)
 	memset(rBuff, 0x00, size);
 	memset(data, 0x00, 8);
 
-	input_info(true, &ts->client->dev, "%s: Read self test result\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Read self test result\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, size);
 	if (rc < 0) {
@@ -3754,7 +3754,7 @@ static void run_trx_open_test_all(void *device_data)
 
 	rearrange_sft_result(rBuff, SEC_TS_SELFTEST_REPORT_SIZE);
 
-	input_info(true, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
 			__func__, rBuff[16], rBuff[17], rBuff[18], rBuff[19]);
 
 	memcpy(data, &rBuff[48], 8);
@@ -3771,7 +3771,7 @@ static void run_trx_open_test_all(void *device_data)
 			memset(pTmp, 0x00, sizeof(pTmp));
 		}
 		strncat(pStr, "\n", 1);
-		input_info(true, &ts->client->dev, "%s", pStr);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s", pStr);
 		strncat(buff, pStr, sizeof(pStr)- strlen(pStr) - 1);
 		memset(pStr, 0x00, sizeof(pStr));
 	}
@@ -3795,7 +3795,7 @@ int sec_ts_execute_force_calibration(struct sec_ts_data *ts, int cal_mode)
 	int rc = -1;
 	u8 cmd;
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, cal_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, cal_mode);
 
 	if (cal_mode == OFFSET_CAL_SET)
 		cmd = SEC_TS_CMD_FACTORY_PANELCALIBRATION;
@@ -3884,7 +3884,7 @@ static void run_force_calibration(void *device_data)
 			input_err(true, &ts->client->dev, "%s: i2c fail!, %d\n", __func__, rc);
 			mis_cal_data = 0xF3;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
 		}
 
 		buff[0] = 1;
@@ -3916,7 +3916,7 @@ out_force_cal:
 out_force_cal_before_irq_ctrl:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -3951,7 +3951,7 @@ static void get_force_calibration(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -3981,7 +3981,7 @@ static void set_lowpower_mode(void *device_data)
 	if (sec_ts_get_pw_status() || !ts->after_work.done || (ts->power_status == SEC_TS_STATE_POWER_OFF)) {
 		ts->aod_pending = true;
 		ts->aod_pending_lowpower_mode = sec->cmd_param[0];
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 			"Postponing lowpower_mode: %d\n",
 			ts->aod_pending_lowpower_mode);
 	} else {
@@ -4071,7 +4071,7 @@ static void spay_enable(void *device_data)
 	if (sec->cmd_param[0] < 0 || sec->cmd_param[0] > 1)
 		goto NG;
 
-	input_info(true, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
 
 	snprintf(buff, sizeof(buff), "%s", "OK");
 	sec->cmd_state = SEC_CMD_STATUS_OK;
@@ -4101,7 +4101,7 @@ static void aod_enable(void *device_data)
 	if (sec->cmd_param[0] < 0 || sec->cmd_param[0] > 1)
 		goto NG;
 
-	input_info(true, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
 
 	snprintf(buff, sizeof(buff), "%s", "OK");
 	sec->cmd_state = SEC_CMD_STATUS_OK;
@@ -4123,7 +4123,7 @@ static void sod_enable(void *device_data)
 	char buff[SEC_CMD_STR_LEN] = { 0 };
 
 	if (!ts->plat_data->sod_mode.supported) {
-		input_info(true, &ts->client->dev, "sod_mode is not supported.\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "sod_mode is not supported.\n");
 		return;
 	}
 	sec_cmd_set_default_result(sec);
@@ -4133,9 +4133,9 @@ static void sod_enable(void *device_data)
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
 	} else {
 		if (sec->cmd_param[0])
-			input_info(true, &ts->client->dev, "sod_mode ON\n");
+			input_dbg(ts->debug_flag, &ts->client->dev, "sod_mode ON\n");
 		else
-			input_info(true, &ts->client->dev, "sod_mode OFF\n");
+			input_dbg(ts->debug_flag, &ts->client->dev, "sod_mode OFF\n");
 
 		ts->plat_data->sod_mode.status = sec->cmd_param[0];
 
@@ -4144,7 +4144,7 @@ static void sod_enable(void *device_data)
 	}
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 	return;
 }
 
@@ -4158,14 +4158,14 @@ static void touch_enable_irq(void *device_data)
 	sec_cmd_set_default_result(sec);
 
 	irq_judge = sec->cmd_param[0];
-	input_info(true, &ts->client->dev, "%s: change irq status to %d through sysfs\n", __func__, irq_judge);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: change irq status to %d through sysfs\n", __func__, irq_judge);
 
 	if (!irq_judge) {
 		sec_ts_set_irq(ts, false);
 		input_dbg(ts->debug_flag, &ts->client->dev, "irq disabled\n");
 	} else {
 		if (sec_ts_get_pw_status() || ts->power_status == SEC_TS_STATE_POWER_OFF || !ts->after_work.done) {
-			input_info(true, &ts->client->dev, "%s: update skip\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: update skip\n", __func__);
 			goto NG;
 		}
 		sec_ts_set_irq(ts, true);
@@ -4207,7 +4207,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 {
 	u8 data[8] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: flag: %02X (clr,lan,nor,edg,han)\n", __func__, flag);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: flag: %02X (clr,lan,nor,edg,han)\n", __func__, flag);
 
 	if (flag & G_SET_EDGE_HANDLER) {
 		if (ts->grip_edgehandler_direction == 0) {
@@ -4222,7 +4222,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 			data[3] = ts->grip_edgehandler_direction & 0x3;
 		}
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_EDGE_HANDLER, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_EDGE_HANDLER, data[0], data[1], data[2], data[3]);
 	}
 
@@ -4230,7 +4230,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[0] = (ts->grip_edge_range >> 8) & 0xFF;
 		data[1] = ts->grip_edge_range  & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_EDGE_AREA, data, 2);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X\n",
 				__func__, SEC_TS_CMD_EDGE_AREA, data[0], data[1]);
 	}
 
@@ -4240,7 +4240,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[2] = (ts->grip_deadzone_y >> 8) & 0xFF;
 		data[3] = ts->grip_deadzone_y & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_DEAD_ZONE, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_DEAD_ZONE, data[0], data[1], data[2], data[3]);
 	}
 
@@ -4250,14 +4250,14 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[2] = (ts->grip_landscape_edge << 4 & 0xF0) | ((ts->grip_landscape_deadzone >> 8) & 0xF);
 		data[3] = ts->grip_landscape_deadzone & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_LANDSCAPE_MODE, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_LANDSCAPE_MODE, data[0], data[1], data[2], data[3]);
 	}
 
 	if (flag & G_CLR_LANDSCAPE_MODE) {
 		data[0] = ts->grip_landscape_mode;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_LANDSCAPE_MODE, data, 1);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X\n",
 				__func__, SEC_TS_CMD_LANDSCAPE_MODE, data[0]);
 	}
 }
@@ -4459,7 +4459,7 @@ static void brush_enable(void *device_data)
 		goto out;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: set brush mode %s\n", __func__, ts->brush_mode ? "enable" : "disable");
 
 	/*	- 0: Disable Artcanvas min phi mode
@@ -4480,7 +4480,7 @@ out:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void set_touchable_area(void *device_data)
@@ -4507,7 +4507,7 @@ static void set_touchable_area(void *device_data)
 		goto out;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: set 16:9 mode %s\n", __func__, ts->touchable_area ? "enable" : "disable");
 
 	/*  - 0: Disable 16:9 mode
@@ -4528,7 +4528,7 @@ out:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void set_log_level(void *device_data)
@@ -4572,7 +4572,7 @@ static void set_log_level(void *device_data)
 		goto err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: STATUS_EVENT enable = 0x%02X, 0x%02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: STATUS_EVENT enable = 0x%02X, 0x%02X\n",
 			__func__, tBuff[0], tBuff[1]);
 
 	tBuff[0] = BIT_STATUS_EVENT_VENDOR_INFO(sec->cmd_param[6]);
@@ -4608,7 +4608,7 @@ static void set_log_level(void *device_data)
 		}
 	}
 
-	input_info(true, &ts->client->dev, "%s: ERROR : %d, INFO : %d, USER_INPUT : %d, INFO_CUSTOMLIB : %d, VENDOR_INFO : %d, VENDOR_EVENT_LEVEL : %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: ERROR : %d, INFO : %d, USER_INPUT : %d, INFO_CUSTOMLIB : %d, VENDOR_INFO : %d, VENDOR_EVENT_LEVEL : %d\n",
 			__func__, sec->cmd_param[0], sec->cmd_param[1], sec->cmd_param[2], sec->cmd_param[5], sec->cmd_param[6], w_data[0]);
 
 	snprintf(buff, sizeof(buff), "%s", "OK");
@@ -4657,7 +4657,7 @@ static void get_touch_mode(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: read status = %d, %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: read status = %d, %d\n",
 			__func__, para[1], para[3]);
 
 	switch (para[1]) {
@@ -4712,22 +4712,22 @@ static void set_touch_mode(void *device_data)
 
 	switch(sec->cmd_param[0]) {
 	case 0:
-		input_info(true, &ts->client->dev, "%s: param = %d, set ACTIVE mode\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: param = %d, set ACTIVE mode\n",
 				__func__, sec->cmd_param[0]);
 		sec_ts_fix_tmode(ts, TOUCH_SYSTEM_MODE_TOUCH, TOUCH_MODE_STATE_TOUCH);
 		break;
 	case 1:
-		input_info(true, &ts->client->dev, "%s: param = %d, set DOZE mode\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: param = %d, set DOZE mode\n",
 				__func__, sec->cmd_param[0]);
 		sec_ts_fix_tmode(ts, TOUCH_SYSTEM_MODE_TOUCH, TOUCH_MODE_STATE_IDLE);
 		break;
 	case 2:
-		input_info(true, &ts->client->dev, "%s: param = %d, set SLEEP mode\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: param = %d, set SLEEP mode\n",
 				__func__, sec->cmd_param[0]);
 		sec_ts_fix_tmode(ts, 0x6, 0x1);
 		break;
 	default:
-		input_info(true, &ts->client->dev, "%s: param error! param = %d\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: param error! param = %d\n",
 				__func__, sec->cmd_param[0]);
 		goto err_out;
 	}
@@ -4790,7 +4790,7 @@ static void set_doze_timeout(void *device_data)
 		input_err(true, &ts->client->dev, "%s: param out of range\n", __func__);
 		goto err_out;
 	} else {
-		input_info(true, &ts->client->dev, "%s: doze timeout change from %d to %d ms\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: doze timeout change from %d to %d ms\n",
 				__func__, ts->doze_timeout, sec->cmd_param[0]);
 
 		ts->doze_timeout = sec->cmd_param[0];
@@ -4798,11 +4798,11 @@ static void set_doze_timeout(void *device_data)
 		tBuff[0] = 0x01;
 		tBuff[1] = (ts->doze_timeout & 0xFF00) >> 8;
 		tBuff[2] = (ts->doze_timeout & 0x00FF) >> 0;
-		input_info(true, &ts->client->dev, "%s: doze_timeout = %d, writing 0x%X 0x%X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: doze_timeout = %d, writing 0x%X 0x%X\n",
 				__func__, ts->doze_timeout, tBuff[1], tBuff[2]);
 
 		if (sec_ts_get_pw_status() || !ts->after_work.done) {
-			input_info(true, &ts->client->dev, "%s: update skip\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: update skip\n", __func__);
 			goto update_skip;
 		}
 
@@ -4821,7 +4821,7 @@ static void set_doze_timeout(void *device_data)
 		}
 
 		delay_digit = ((tBuff[0] << 8) & 0xFF00) + (tBuff[1] & 0x00FF);
-		input_info(true, &ts->client->dev, "%s: read result = %d frame(120Hz)\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: read result = %d frame(120Hz)\n",
 				__func__, delay_digit);
 	}
 	snprintf(buff, sizeof(buff), "%s", "OK");
@@ -4891,7 +4891,7 @@ static int set_sidetouch(void *device_data, int status)
 			goto err_out;
 		}
 		side_current = CONVERT_SIDE_ENABLE_MODE_FOR_READ(side_current);
-		input_info(true, &ts->client->dev, "%s: sidetouch is now %s\n", __func__,
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: sidetouch is now %s\n", __func__,
 				side_current == 0 ? "BOTH_ON" : (side_current == 1 ? "RIGHT_ON" :
 				(side_current == 2 ? "LEFT_ON" : "OFF")));
 	}
@@ -4928,7 +4928,7 @@ static void sidetouch_enable(void *device_data)
 		input_err(true, &ts->client->dev, "%s: param out of range\n", __func__);
 		goto err_out;
 	} else {
-		input_info(true, &ts->client->dev, "%s: sidetouch %d -> %d\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: sidetouch %d -> %d\n",
 				__func__, ts->side_enable, sec->cmd_param[0]);
 
 		ts->side_enable = sec->cmd_param[0];
@@ -4972,7 +4972,7 @@ static void stamina_enable(void *device_data)
 		input_err(true, &ts->client->dev, "%s: param out of range\n", __func__);
 		goto err_out;
 	} else {
-		input_info(true, &ts->client->dev, "%s: stamina %d -> %d\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: stamina %d -> %d\n",
 				__func__, ts->stamina_enable, sec->cmd_param[0]);
 
 		if (ts->stamina_enable == sec->cmd_param[0])
@@ -4981,7 +4981,7 @@ static void stamina_enable(void *device_data)
 		ts->stamina_enable = sec->cmd_param[0];
 
 		if (sec_ts_get_pw_status() || !ts->after_work.done) {
-			input_info(true, &ts->client->dev, "%s: update skip\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: update skip\n", __func__);
 			goto update_skip;
 		}
 
@@ -4999,7 +4999,7 @@ static void stamina_enable(void *device_data)
 			goto err_out;
 		}
 
-		input_info(true, &ts->client->dev, "%s: stamina is now %d\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: stamina is now %d\n",
 				__func__, tRead);
 	}
 	snprintf(buff, sizeof(buff), "%s", "OK");
@@ -5111,7 +5111,7 @@ static void orientation_change(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: Grip Rejection is now %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Grip Rejection is now %d\n",
 			__func__, tRead);
 
 	sec_cmd_set_default_result(sec);
@@ -5166,7 +5166,7 @@ static void doze_mode_change(void *device_data)
 		goto err_out;
 	}
 
-	input_info(true, &ts->client->dev, "%s: Doze mode is now %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Doze mode is now %d\n",
 			__func__, tRead);
 
 	if (sec->cmd_param[0] == 1) {
@@ -5213,7 +5213,7 @@ static void wireless_charging(void *device_data)
 		goto err_out;
 	}
 	ts->plat_data->wireless_charging.status = sec->cmd_param[0];
-	input_info(true, &ts->client->dev, "%s: wireless charging status: %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: wireless charging status: %d\n",
 			__func__, ts->plat_data->wireless_charging.status);
 
 	if (ts->plat_data->wireless_charging.status)

--- a/drivers/input/touchscreen/sec_ts/sec_ts_only_vendor.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts_only_vendor.c
@@ -80,14 +80,14 @@ static ssize_t sec_ts_reg_store(struct device *dev, struct device_attribute *att
 	struct sec_ts_data *ts = dev_get_drvdata(dev);
 
 	if (ts->power_status == SEC_TS_STATE_POWER_OFF) {
-		input_info(true, &ts->client->dev, "%s: Power off state\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: Power off state\n", __func__);
 		return -EIO;
 	}
 
 	if (size > 0)
 		ts->sec_ts_i2c_write_burst(ts, (u8 *)buf, size);
 
-	input_info(true, &ts->client->dev, "%s: 0x%x, 0x%x, size %d\n", __func__, buf[0], buf[1], (int)size);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%x, 0x%x, size %d\n", __func__, buf[0], buf[1], (int)size);
 	return size;
 }
 
@@ -134,7 +134,7 @@ static ssize_t sec_ts_regread_show(struct device *dev, struct device_attribute *
 		offset += length;
 	} while (remain > 0);
 
-	input_info(true, &ts->client->dev, "%s: lv1_readsize = %d\n", __func__, lv1_readsize);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: lv1_readsize = %d\n", __func__, lv1_readsize);
 	memcpy(buf, read_lv1_buff + lv1_readoffset, lv1_readsize);
 
 i2c_err:
@@ -153,7 +153,7 @@ static ssize_t sec_ts_gesture_status_show(struct device *dev, struct device_attr
 
 	mutex_lock(&ts->device_mutex);
 	memcpy(buf, ts->gesture_status, sizeof(ts->gesture_status));
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: GESTURE STATUS %x %x %x %x %x %x\n", __func__,
 				ts->gesture_status[0], ts->gesture_status[1], ts->gesture_status[2],
 				ts->gesture_status[3], ts->gesture_status[4], ts->gesture_status[5]);
@@ -197,10 +197,10 @@ static ssize_t sec_ts_enter_recovery_store(struct device *dev, struct device_att
 		sec_ts_set_irq(ts, false);
 		gpio_free(pdata->irq_gpio);
 
-		input_info(true, &ts->client->dev, "%s: gpio free\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: gpio free\n", __func__);
 		if (gpio_is_valid(pdata->irq_gpio)) {
 			ret = gpio_request_one(pdata->irq_gpio, GPIOF_OUT_INIT_LOW, "sec,tsp_int");
-			input_info(true, &ts->client->dev, "%s: gpio request one\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: gpio request one\n", __func__);
 			if (ret < 0)
 				input_err(true, &ts->client->dev, "%s: Unable to request tsp_int [%d]: %d\n", __func__, pdata->irq_gpio, ret);
 		} else {

--- a/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
@@ -1311,7 +1311,7 @@ int sec_ts_power(void *data, bool on)
 	enabled = on;
 
 out:
-	input_err(true, &ts->client->dev, "%s: %s: avdd:%s, dvdd:%s\n", __func__, on ? "on" : "off",
+	input_dbg(ts->dbg_flag, &ts->client->dev, "%s: %s: avdd:%s, dvdd:%s\n", __func__, on ? "on" : "off",
 			regulator_is_enabled(regulator_avdd) ? "on" : "off",
 			regulator_is_enabled(regulator_dvdd) ? "on" : "off");
 
@@ -2181,7 +2181,7 @@ static void sec_ts_reset_work(struct work_struct *work)
 			reset_work.work);
 	int ret;
 
-	input_err(true, &ts->client->dev, "%s: reset work\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: reset work\n", __func__);
 
 	if (ts->reset_is_on_going) {
 		input_err(true, &ts->client->dev, "%s: reset is ongoing\n", __func__);
@@ -2532,7 +2532,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 {
 	int ret = -1;
 
-	input_err(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_ts_pinctrl_configure(ts, true);
 
@@ -2650,7 +2650,7 @@ static int sec_ts_dsi_panel_notifier_cb(struct notifier_block *self, unsigned lo
 		if (event == DRM_PANEL_EARLY_EVENT_BLANK) {
 			transition = *(int *)evdata->data;
 			if (transition == DRM_PANEL_BLANK_POWERDOWN) {
-				input_err(true, &ts->client->dev, "%s: power down\n",  __func__);
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: power down\n",  __func__);
 				sec_ts_stop_device(ts);
 			}
 		}
@@ -2660,7 +2660,7 @@ static int sec_ts_dsi_panel_notifier_cb(struct notifier_block *self, unsigned lo
 		if (event == DRM_PANEL_EVENT_BLANK) {
 			transition = *(int *)evdata->data;
 			if (transition == DRM_PANEL_BLANK_UNBLANK) {
-				input_err(true, &ts->client->dev,  "%s: power up\n", __func__);
+				input_dbg(ts->debug_flag, &ts->client->dev,  "%s: power up\n", __func__);
 				sec_ts_start_device(ts);
 			}
 		}

--- a/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
@@ -354,11 +354,11 @@ static void sec_ts_check_rawdata(struct work_struct *work)
 		return;
 	}
 
-	input_info(true, &ts->client->dev, "%s: start ##\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start ##\n", __func__);
 	sec_ts_run_rawdata_all(ts, true);
 	msleep(100);
 
-	input_info(true, &ts->client->dev, "%s: done ##\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: done ##\n", __func__);
 }
 
 static void dump_tsp_log(void)
@@ -415,7 +415,7 @@ int sec_ts_wait_for_ready(struct sec_ts_data *ts, unsigned int ack)
 		sec_ts_delay(20);
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: %02X, %02X, %02X, %02X, %02X, %02X, %02X, %02X [%d]\n",
 			__func__, tBuff[0], tBuff[1], tBuff[2], tBuff[3],
 			tBuff[4], tBuff[5], tBuff[6], tBuff[7], retry);
@@ -436,7 +436,7 @@ int sec_ts_read_calibration_report(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev, "%s: count:%d, pass count:%d, fail count:%d, status:0x%X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: count:%d, pass count:%d, fail count:%d, status:0x%X\n",
 			__func__, buf[1], buf[2], buf[3], buf[4]);
 
 	return buf[4];
@@ -447,7 +447,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 	u8 w_data[2] = {0x00, 0x00};
 	int ret = 0;
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s : charger=0x%x, touch_functions=0x%x, Power mode=0x%x, noise_mode=%d\n",
 			__func__, ts->charger_mode, ts->touch_functions,
 			ts->power_status, ts->touch_noise_status);
@@ -520,7 +520,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		sec_ts_set_grip_type(ts, ONLY_EDGE_HANDLER);
 
 		if (ts->dex_mode) {
-			input_info(true, &ts->client->dev, "%s: set dex mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set dex mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_DEX_MODE, &ts->dex_mode, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -528,7 +528,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		}
 
 		if (ts->brush_mode) {
-			input_info(true, &ts->client->dev, "%s: set brush mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set brush mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_BRUSH_MODE, &ts->brush_mode, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -536,7 +536,7 @@ void sec_ts_reinit(struct sec_ts_data *ts)
 		}
 
 		if (ts->touchable_area) {
-			input_info(true, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
 			ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_TOUCHABLE_AREA, &ts->touchable_area, 1);
 			if (ret < 0)
 				input_err(true, &ts->client->dev,
@@ -666,7 +666,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 			return;
 		}
 
-		input_info(true, &ts->client->dev, "%s: run LPM interrupt handler, %d\n", __func__, ret);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: run LPM interrupt handler, %d\n", __func__, ret);
 		/* run lpm interrupt handler */
 	}
 
@@ -679,14 +679,14 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 	}
 
 	if (ts->debug_flag & SEC_TS_DEBUG_PRINT_ONEEVENT)
-		input_info(true, &ts->client->dev, "ONE: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "ONE: %02X %02X %02X %02X %02X %02X %02X %02X\n",
 				read_event_buff[0][0], read_event_buff[0][1],
 				read_event_buff[0][2], read_event_buff[0][3],
 				read_event_buff[0][4], read_event_buff[0][5],
 				read_event_buff[0][6], read_event_buff[0][7]);
 
 	if (read_event_buff[0][0] == 0) {
-		input_info(true, &ts->client->dev, "%s: event buffer is empty\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: event buffer is empty\n", __func__);
 		return;
 	}
 
@@ -720,7 +720,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 		event_id = event_buff[0] & 0x3;
 
 		if (ts->debug_flag & SEC_TS_DEBUG_PRINT_ALLEVENT)
-			input_info(true, &ts->client->dev, "ALL: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "ALL: %02X %02X %02X %02X %02X %02X %02X %02X\n",
 					event_buff[0], event_buff[1], event_buff[2], event_buff[3],
 					event_buff[4], event_buff[5], event_buff[6], event_buff[7]);
 
@@ -730,7 +730,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 
 			/* tchsta == 0 && ttype == 0 && eid == 0 : buffer empty */
 			if (p_event_status->stype > 0)
-				input_info(true, &ts->client->dev, "%s: STATUS %x %x %x %x %x %x %x %x\n", __func__,
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: STATUS %x %x %x %x %x %x %x %x\n", __func__,
 						event_buff[0], event_buff[1], event_buff[2],
 						event_buff[3], event_buff[4], event_buff[5],
 						event_buff[6], event_buff[7]);
@@ -767,7 +767,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 			if ((p_event_status->stype == TYPE_STATUS_EVENT_INFO) &&
 				(p_event_status->status_id == SEC_TS_ACK_WET_MODE)) {
 				ts->wet_mode = p_event_status->status_data_1;
-				input_info(true, &ts->client->dev, "%s: water wet mode %d\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: water wet mode %d\n",
 						__func__, ts->wet_mode);
 				if (ts->wet_mode)
 					ts->wet_count++;
@@ -777,7 +777,7 @@ static void sec_ts_read_event(struct sec_ts_data *ts)
 					(p_event_status->status_id == SEC_TS_VENDOR_ACK_NOISE_STATUS_NOTI)) {
 
 				ts->touch_noise_status = !!p_event_status->status_data_1;
-				input_info(true, &ts->client->dev, "%s: TSP NOISE MODE %s[%d]\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: TSP NOISE MODE %s[%d]\n",
 						__func__, ts->touch_noise_status == 0 ? "OFF" : "ON",
 						p_event_status->status_data_1);
 
@@ -1089,12 +1089,12 @@ void sec_ts_set_charger(bool enable)
 	u8 noise_mode_off[] = {0x00};
 
 	if (enable) {
-		input_info(true, &ts->client->dev, "sec_ts_set_charger : charger CONNECTED!!\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "sec_ts_set_charger : charger CONNECTED!!\n");
 		ret = sec_ts_i2c_write(ts, SEC_TS_CMD_NOISE_MODE, noise_mode_on, sizeof(noise_mode_on));
 		if (ret < 0)
 			input_err(true, &ts->client->dev, "sec_ts_set_charger: fail to write NOISE_ON\n");
 	} else {
-		input_info(true, &ts->client->dev, "sec_ts_set_charger : charger DISCONNECTED!!\n");
+		input_dbg(ts->debug_flag, &ts->client->dev, "sec_ts_set_charger : charger DISCONNECTED!!\n");
 		ret = sec_ts_i2c_write(ts, SEC_TS_CMD_NOISE_MODE, noise_mode_off, sizeof(noise_mode_off));
 		if (ret < 0)
 			input_err(true, &ts->client->dev, "sec_ts_set_charger: fail to write NOISE_OFF\n");
@@ -1124,7 +1124,7 @@ int sec_ts_glove_mode_enables(struct sec_ts_data *ts, int mode)
 		goto glove_enable_err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: glove:%d, status:%x\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: glove:%d, status:%x\n", __func__,
 			mode, ts->touch_functions);
 
 	return 0;
@@ -1138,7 +1138,7 @@ int sec_ts_set_cover_type(struct sec_ts_data *ts, bool enable)
 {
 	int ret;
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, ts->cover_type);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, ts->cover_type);
 
 
 	switch (ts->cover_type) {
@@ -1188,7 +1188,7 @@ int sec_ts_set_cover_type(struct sec_ts_data *ts, bool enable)
 		goto cover_enable_err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: close:%d, status:%x\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: close:%d, status:%x\n", __func__,
 			enable, ts->touch_functions);
 
 	return 0;
@@ -1204,7 +1204,7 @@ void sec_ts_set_grip_type(struct sec_ts_data *ts, u8 set_type)
 {
 	u8 mode = G_NONE;
 
-	input_info(true, &ts->client->dev, "%s: re-init grip(%d), edh:%d, edg:%d, lan:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: re-init grip(%d), edh:%d, edg:%d, lan:%d\n", __func__,
 			set_type, ts->grip_edgehandler_direction, ts->grip_edge_range, ts->grip_landscape_mode);
 
 	/* edge handler */
@@ -1234,7 +1234,7 @@ static int sec_ts_pinctrl_configure(struct sec_ts_data *ts, bool enable)
 {
 	struct pinctrl_state *state;
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, enable ? "ACTIVE" : "SUSPEND");
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, enable ? "ACTIVE" : "SUSPEND");
 
 	if (enable) {
 		state = pinctrl_lookup_state(ts->plat_data->pinctrl, "on_state");
@@ -1360,7 +1360,7 @@ static int sec_ts_get_active_panel(struct device_node *np)
 
 		pdata->tsp_icid = of_get_named_gpio(np, "sec,tsp-icid_gpio", 0);
 		if (gpio_is_valid(pdata->tsp_icid)) {
-			input_info(true, dev, "%s: TSP_ICID : %d\n", __func__, gpio_get_value(pdata->tsp_icid));
+			input_dbg(ts->debug_flag, dev, "%s: TSP_ICID : %d\n", __func__, gpio_get_value(pdata->tsp_icid));
 			if (of_property_read_u32(np, "sec,icid_match_value", &ic_match_value)) {
 				input_err( true, dev, "%s: Failed to get icid match value\n", __func__);
 				return -EINVAL;
@@ -1377,7 +1377,7 @@ static int sec_ts_get_active_panel(struct device_node *np)
 		pdata->tsp_vsync =
 			of_get_named_gpio(np, "sec,tsp_vsync_gpio", 0);
 		if (gpio_is_valid(pdata->tsp_vsync))
-			input_info(true, &client->dev, "%s: vsync %s\n", __func__, gpio_get_value(pdata->tsp_vsync) ? "disable" :  "enable");
+			input_dbg(ts->debug_flag, &client->dev, "%s: vsync %s\n", __func__, gpio_get_value(pdata->tsp_vsync) ? "disable" :  "enable");
 
 		pdata->irq_gpio = of_get_named_gpio(np, "sec,irq-gpio", 0);
 		if (gpio_is_valid(pdata->irq_gpio)) {
@@ -1397,7 +1397,7 @@ static int sec_ts_get_active_panel(struct device_node *np)
 			input_err(true, dev, "%s: Failed to get irq_type property\n", __func__);
 			pdata->irq_type = IRQF_TRIGGER_LOW | IRQF_ONESHOT;
 		} else {
-			input_info(true, dev, "%s: irq_type property:%X, %d\n",  __func__, pdata->irq_type, pdata->irq_type);
+			input_dbg(ts->debug_flag, dev, "%s: irq_type property:%X, %d\n",  __func__, pdata->irq_type, pdata->irq_type);
 		}
 
 		pdata->reset_gpio = of_get_named_gpio(np, "sec,reset-gpio", 0);
@@ -1440,7 +1440,7 @@ static int sec_ts_get_active_panel(struct device_node *np)
 
 	pdata->tsp_id = of_get_named_gpio(np, "sec,tsp-id_gpio", 0);
 	if (gpio_is_valid(pdata->tsp_id))
-		input_info(true, dev, "%s: TSP_ID : %d\n", __func__, gpio_get_value(pdata->tsp_id));
+		input_dbg(ts->debug_flag, dev, "%s: TSP_ID : %d\n", __func__, gpio_get_value(pdata->tsp_id));
 	else
 		input_err(true, dev, "%s: Failed to get tsp-id gpio\n", __func__);
 
@@ -1531,7 +1531,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: %X, %X, %X\n",
 			__func__, data[0], data[1], data[2]);
 	memset(data, 0x0, 11);
@@ -1543,7 +1543,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: nTX:%X, nRX:%X, rY:%d, rX:%d\n",
 			__func__, data[8], data[9],
 			(data[2] << 8) | data[3], (data[0] << 8) | data[1]);
@@ -1567,7 +1567,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: STATUS : %X\n",
 			__func__, data[0]);
 
@@ -1580,7 +1580,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: TOUCH STATUS : %02X, %02X, %02X, %02X\n",
 			__func__, data[0], data[1], data[2], data[3]);
 
@@ -1593,7 +1593,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: TOUCH STATUS : %02X, %02X, %02X, %02X\n",
 			__func__, data[0], data[1], data[2], data[3]);
 
@@ -1610,7 +1610,7 @@ int sec_ts_read_information(struct sec_ts_data *ts)
 		return ret;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: Functions : %02X\n",
 			__func__, ts->touch_functions);
 
@@ -1646,7 +1646,7 @@ int sec_ts_check_custom_library(struct sec_ts_data *ts)
 
 	ret = ts->sec_ts_i2c_read(ts, SEC_TS_CMD_CUSTOMLIB_GET_INFO, &data[0], 10);
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: (%d) %c%c%c%c, || %02X, %02X, %02X, %02X, || %02X, %02X\n",
 				__func__, ret, data[0], data[1], data[2], data[3], data[4],
 				data[5], data[6], data[7], data[8], data[9]);
@@ -1733,7 +1733,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	unsigned char result = 0;
 	int i = 0;
 
-	input_info(true, &client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s\n", __func__);
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
 		input_err(true, &client->dev, "%s: EIO err!\n", __func__);
@@ -1849,7 +1849,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	else
 		ts->lowpower_mode &= ~SEC_TS_MODE_CUSTOMLIB_FORCE_KEY;
 
-	input_info(true, &client->dev, "%s: init resource\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s: init resource\n", __func__);
 
 	sec_ts_pinctrl_configure(ts, true);
 
@@ -1862,13 +1862,13 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 
 	sec_ts_wait_for_ready(ts, SEC_TS_ACK_BOOT_COMPLETE);
 
-	input_info(true, &client->dev, "%s: power enable\n", __func__);
+	input_dbg(ts->debug_flag, &client->dev, "%s: power enable\n", __func__);
 
 	ret = sec_ts_i2c_read(ts, SEC_TS_READ_DEVICE_ID, deviceID, 5);
 	if (ret < 0)
 		input_err(true, &ts->client->dev, "%s: failed to read device ID(%d)\n", __func__, ret);
 	else
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: TOUCH DEVICE ID : %02X, %02X, %02X, %02X, %02X\n", __func__,
 				deviceID[0], deviceID[1], deviceID[2], deviceID[3], deviceID[4]);
 
@@ -1900,7 +1900,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 					__func__, ret);
 		}
 	}
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: TOUCH STATUS : %02X || %02X, %02X, %02X, %02X\n",
 			__func__, data[0], data[1], data[2], data[3], data[4]);
 
@@ -1922,7 +1922,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 #ifdef SEC_TS_FW_UPDATE_ON_PROBE
 	schedule_delayed_work(&ts->fw_update_work, msecs_to_jiffies(TOUCH_FW_UPDATE_TIME));
 #else
-	input_info(true, &ts->client->dev, "%s: fw update on probe disabled!\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: fw update on probe disabled!\n", __func__);
 #endif
 
 	ts->fb_notifier.notifier_call = sec_ts_dsi_panel_notifier_cb;
@@ -1978,7 +1978,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 		}
 	}
 
-	input_info(true, &ts->client->dev, "%s: request_irq = %d\n", __func__, client->irq);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: request_irq = %d\n", __func__, client->irq);
 
 	ret = request_threaded_irq(client->irq, NULL, sec_ts_irq_thread,
 			ts->plat_data->irq_type, SEC_TS_I2C_NAME, ts);
@@ -2192,7 +2192,7 @@ static void sec_ts_reset_work(struct work_struct *work)
 	__pm_stay_awake(ts->wakelock);
 
 	ts->reset_is_on_going = true;
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	sec_ts_stop_device(ts);
 
@@ -2263,14 +2263,14 @@ static void sec_ts_read_info_work(struct work_struct *work)
 	char para = TO_TOUCH_MODE;
 	int ret;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	/* run self-test */
 	disable_irq(ts->client->irq);
 	execute_selftest(ts, false);
 	enable_irq(ts->client->irq);
 
-	input_info(true, &ts->client->dev, "%s: %02X %02X %02X %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X %02X %02X %02X\n",
 		__func__, ts->ito_test[0], ts->ito_test[1]
 		, ts->ito_test[2], ts->ito_test[3]);
 
@@ -2328,7 +2328,7 @@ retry_pmode:
 		input_err(true, &ts->client->dev, "%s: read power mode failed!\n", __func__);
 		goto i2c_error;
 	} else {
-		input_info(true, &ts->client->dev, "%s: power mode - write(%d) read(%d)\n", __func__, mode, para);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: power mode - write(%d) read(%d)\n", __func__, mode, para);
 	}
 
 	if (mode != para) {
@@ -2360,7 +2360,7 @@ retry_pmode:
 		ts->power_status = SEC_TS_STATE_POWER_ON;
 
 i2c_error:
-	input_info(true, &ts->client->dev, "%s: end %d\n", __func__, ret);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: end %d\n", __func__, ret);
 
 	return ret;
 }
@@ -2380,7 +2380,7 @@ static int sec_ts_input_open(struct input_dev *dev)
 
 	ts->input_closed = false;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	if (ts->power_status == SEC_TS_STATE_LPM) {
 #ifdef USE_RESET_EXIT_LPM
@@ -2415,7 +2415,7 @@ static void sec_ts_input_close(struct input_dev *dev)
 
 	ts->input_closed = true;
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 #ifdef USE_POWER_RESET_WORK
 	cancel_delayed_work(&ts->reset_work);
@@ -2438,20 +2438,20 @@ static int sec_ts_remove(struct i2c_client *client)
 {
 	struct sec_ts_data *ts = i2c_get_clientdata(client);
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	cancel_delayed_work_sync(&ts->work_read_info);
 	flush_delayed_work(&ts->work_read_info);
 
 	disable_irq_nosync(ts->client->irq);
 	free_irq(ts->client->irq, ts);
-	input_info(true, &ts->client->dev, "%s: irq disabled\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: irq disabled\n", __func__);
 
 #ifdef USE_POWER_RESET_WORK
 	cancel_delayed_work_sync(&ts->reset_work);
 	flush_delayed_work(&ts->reset_work);
 
-	input_info(true, &ts->client->dev, "%s: flush queue\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: flush queue\n", __func__);
 
 #endif
 
@@ -2566,12 +2566,12 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 			goto err;
 
 		ts->touch_functions = ts->touch_functions | SEC_TS_BIT_SETFUNC_COVER;
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover cmd write type:%d, mode:%x, ret:%d\n",
 				__func__, ts->touch_functions, ts->cover_cmd, ret);
 	} else {
 		ts->touch_functions = (ts->touch_functions & (~SEC_TS_BIT_SETFUNC_COVER));
-		input_info(true, &ts->client->dev,
+		input_dbg(ts->debug_flag, &ts->client->dev,
 				"%s: cover open, not send cmd\n", __func__);
 	}
 
@@ -2594,7 +2594,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	sec_ts_set_grip_type(ts, ONLY_EDGE_HANDLER);
 
 	if (ts->dex_mode) {
-		input_info(true, &ts->client->dev, "%s: set dex mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set dex mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_DEX_MODE, &ts->dex_mode, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,
@@ -2604,7 +2604,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	}
 
 	if (ts->brush_mode) {
-		input_info(true, &ts->client->dev, "%s: set brush mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set brush mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_BRUSH_MODE, &ts->brush_mode, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,
@@ -2614,7 +2614,7 @@ int sec_ts_start_device(struct sec_ts_data *ts)
 	}
 
 	if (ts->touchable_area) {
-		input_info(true, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: set 16:9 mode\n", __func__);
 		ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_TOUCHABLE_AREA, &ts->touchable_area, 1);
 		if (ret < 0) {
 			input_err(true, &ts->client->dev,

--- a/drivers/input/touchscreen/sec_ts_lena/sec_ts_fn.c
+++ b/drivers/input/touchscreen/sec_ts_lena/sec_ts_fn.c
@@ -143,10 +143,10 @@ static ssize_t scrub_position_show(struct device *dev,
 	char buff[256] = { 0 };
 
 #ifdef CONFIG_SAMSUNG_PRODUCT_SHIP
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: scrub_id: %d\n", __func__, ts->scrub_id);
 #else
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: scrub_id: %d, X:%d, Y:%d\n", __func__,
 			ts->scrub_id, ts->scrub_x, ts->scrub_y);
 #endif
@@ -167,7 +167,7 @@ static ssize_t read_ito_check_show(struct device *dev,
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 	char buff[256] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: %02X%02X%02X%02X\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X%02X%02X%02X\n", __func__,
 			ts->ito_test[0], ts->ito_test[1],
 			ts->ito_test[2], ts->ito_test[3]);
 
@@ -215,7 +215,7 @@ static ssize_t read_multi_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->multi_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->multi_count);
@@ -230,7 +230,7 @@ static ssize_t clear_multi_count_store(struct device *dev,
 
 	ts->multi_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -241,7 +241,7 @@ static ssize_t read_wet_mode_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d, %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d, %d\n", __func__,
 			ts->wet_count, ts->dive_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->wet_count);
@@ -257,7 +257,7 @@ static ssize_t clear_wet_mode_store(struct device *dev,
 	ts->wet_count = 0;
 	ts->dive_count= 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -268,7 +268,7 @@ static ssize_t read_noise_mode_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, ts->noise_count);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, ts->noise_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->noise_count);
 }
@@ -282,7 +282,7 @@ static ssize_t clear_noise_mode_store(struct device *dev,
 
 	ts->noise_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -293,7 +293,7 @@ static ssize_t read_comm_err_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->multi_count);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->comm_err_count);
@@ -308,7 +308,7 @@ static ssize_t clear_comm_err_count_store(struct device *dev,
 
 	ts->comm_err_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -324,7 +324,7 @@ static ssize_t read_module_id_show(struct device *dev,
 		ts->plat_data->panel_revision, ts->plat_data->img_version_of_bin[2],
 		ts->plat_data->img_version_of_bin[3]);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%s", buff);
 }
@@ -356,7 +356,7 @@ static ssize_t clear_checksum_store(struct device *dev,
 
 	ts->checksum_result = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -367,7 +367,7 @@ static ssize_t read_checksum_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__,
 			ts->checksum_result);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%d", ts->checksum_result);
@@ -382,7 +382,7 @@ static ssize_t clear_holding_time_store(struct device *dev,
 
 	ts->time_longest = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -393,7 +393,7 @@ static ssize_t read_holding_time_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: %ld\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %ld\n", __func__,
 			ts->time_longest);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%ld", ts->time_longest);
@@ -405,7 +405,7 @@ static ssize_t read_all_touch_count_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: touch:%d, force:%d, aod:%d, spay:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: touch:%d, force:%d, aod:%d, spay:%d\n", __func__,
 			ts->all_finger_count, ts->all_force_count,
 			ts->all_aod_tap_count, ts->all_spay_count);
 
@@ -426,7 +426,7 @@ static ssize_t clear_all_touch_count_store(struct device *dev,
 	ts->all_aod_tap_count = 0;
 	ts->all_spay_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -437,7 +437,7 @@ static ssize_t read_z_value_show(struct device *dev,
 	struct sec_cmd_data *sec = dev_get_drvdata(dev);
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 
-	input_info(true, &ts->client->dev, "%s: max:%d, min:%d, avg:%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: max:%d, min:%d, avg:%d\n", __func__,
 			ts->max_z_value, ts->min_z_value,
 			ts->sum_z_value);
 
@@ -465,7 +465,7 @@ static ssize_t clear_z_value_store(struct device *dev,
 	ts->sum_z_value= 0;
 	ts->all_finger_count = 0;
 
-	input_info(true, &ts->client->dev, "%s: clear\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear\n", __func__);
 
 	return count;
 }
@@ -575,7 +575,7 @@ static ssize_t ic_status_show(struct device *dev,
 
 	count += snprintf(buff + count, PAGE_SIZE, "artcanvas,%d,", data[0]);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return snprintf(buf, SEC_CMD_BUF_SIZE, "%s\n", buff);
 }
@@ -630,13 +630,13 @@ static int sec_ts_check_index(struct sec_ts_data *ts)
 		snprintf(buff, sizeof(buff), "%s", "NG");
 		sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
-		input_info(true, &ts->client->dev, "%s: parameter error: %u, %u\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: parameter error: %u, %u\n",
 				__func__, sec->cmd_param[0], sec->cmd_param[0]);
 		node = -1;
 		return node;
 	}
 	node = sec->cmd_param[1] * ts->tx_count + sec->cmd_param[0];
-	input_info(true, &ts->client->dev, "%s: node = %d\n", __func__, node);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: node = %d\n", __func__, node);
 	return node;
 }
 static void fw_update(void *device_data)
@@ -666,7 +666,7 @@ static void fw_update(void *device_data)
 		snprintf(buff, sizeof(buff), "%s", "OK");
 		sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 		sec->cmd_state = SEC_CMD_STATUS_OK;
-		input_info(true, &ts->client->dev, "%s: success [%d]\n", __func__, retval);
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: success [%d]\n", __func__, retval);
 	}
 }
 
@@ -676,7 +676,7 @@ int sec_ts_fix_tmode(struct sec_ts_data *ts, u8 mode, u8 state)
 	u8 onoff[1] = {STATE_MANAGE_OFF};
 	u8 tBuff[2] = { mode, state };
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_STATEMANAGE_ON, onoff, 1);
 	sec_ts_delay(20);
@@ -692,7 +692,7 @@ int sec_ts_p2p_tmode(struct sec_ts_data *ts)
 	int ret;
 	u8 mode[1] = {0x0C};
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_CLEAR_EVENT_STACK, NULL, 0);
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_P2P_MODE, mode, sizeof(mode));
@@ -723,7 +723,7 @@ static int execute_p2ptest(struct sec_ts_data *ts)
 		}
 
 		if ((tBuff[7] & 0x3F) == 0x00) {
-			input_info(true, &ts->client->dev, "%s: left event is 0\n", __func__);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: left event is 0\n", __func__);
 			ret = 0;
 			break;
 		}
@@ -742,7 +742,7 @@ int sec_ts_release_tmode(struct sec_ts_data *ts)
 	int ret;
 	u8 onoff[1] = {STATE_MANAGE_ON};
 
-	input_info(true, &ts->client->dev, "%s\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s\n", __func__);
 
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_STATEMANAGE_ON, onoff, 1);
 	sec_ts_delay(20);
@@ -873,7 +873,7 @@ static int sec_ts_read_frame(struct sec_ts_data *ts, u8 type, short *min,
 	*min = *max = ts->pFrame[0];
 
 #ifdef DEBUG_MSG
-	input_info(true, &ts->client->dev, "%s: 02X%02X%02X readbytes=%d\n", __func__,
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: 02X%02X%02X readbytes=%d\n", __func__,
 			pRead[0], pRead[1], pRead[2], readbytes);
 #endif
 	sec_ts_print_frame(ts, min, max);
@@ -1248,7 +1248,7 @@ static int sec_ts_read_rawp2p_data(struct sec_ts_data *ts,
 	if (!buff)
 		goto error_alloc_mem;
 
-	input_info(true, &ts->client->dev, "%s: %d, %s\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d, %s\n",
 			__func__, mode->type, mode->allnode ? "ALL" : "");
 
 	disable_irq(ts->client->irq);
@@ -1431,14 +1431,14 @@ static void get_threshold(void *device_data)
 		goto err;
 	}
 
-	input_info(true, &ts->client->dev, "0x%02X, 0x%02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "0x%02X, 0x%02X\n",
 			threshold[0], threshold[1]);
 
 	snprintf(buff, sizeof(buff), "%d", (threshold[0] << 8) | threshold[1]);
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	return;
 err:
@@ -1467,7 +1467,7 @@ static void module_off_master(void *device_data)
 		sec->cmd_state = SEC_CMD_STATUS_OK;
 	else
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void module_on_master(void *device_data)
@@ -1496,7 +1496,7 @@ static void module_on_master(void *device_data)
 	else
 		sec->cmd_state = SEC_CMD_STATUS_FAIL;
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_chip_vendor(void *device_data)
@@ -1569,7 +1569,7 @@ static void set_mis_cal_spec(void *device_data)
 				input_err(true, &ts->client->dev, "%s: Misscal spec write failed. ret: %d\n", __func__, ret);
 				goto NG;
 			} else {
-				input_info(true, &ts->client->dev, "%s: tx gap=%d, rx gap=%d, peak=%d\n",
+				input_dbg(ts->debug_flag, &ts->client->dev, "%s: tx gap=%d, rx gap=%d, peak=%d\n",
 								__func__, wreg[0], wreg[1], wreg[2]);
 				sec_ts_delay(20);
 			}
@@ -1632,7 +1632,7 @@ static void get_mis_cal_info(void *device_data)
 			mis_cal_data = 0xF3;
 			goto NG;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
 		}
 
 		ret = ts->sec_ts_i2c_read(ts, SEC_TS_CMD_MIS_CAL_SPEC, wreg, 4);
@@ -1641,7 +1641,7 @@ static void get_mis_cal_info(void *device_data)
 			mis_cal_data = 0xF4;
 			goto NG;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal spec : %d,%d,%d,%d\n",
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal spec : %d,%d,%d,%d\n",
 						__func__, wreg[0], wreg[1], wreg[2], wreg[3]);
 		}
 	}
@@ -1651,7 +1651,7 @@ static void get_mis_cal_info(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff_all);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff_all);
 	return;
 
 NG:
@@ -1659,7 +1659,7 @@ NG:
 	snprintf(buff_all, sizeof(buff_all), "%d,%d,%d,%d", mis_cal_data, 0, 0, 0);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff_all);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff_all);
 }
 
 static void get_wet_mode(void *device_data)
@@ -1681,14 +1681,14 @@ static void get_wet_mode(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", wet_mode_info);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 	return;
 
 NG:
 	snprintf(buff, sizeof(buff), "NG");
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -1702,7 +1702,7 @@ static void get_x_num(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", ts->tx_count);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void get_y_num(void *device_data)
@@ -1715,7 +1715,7 @@ static void get_y_num(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", ts->rx_count);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static u32 checksum_sum(struct sec_ts_data *ts, u8 *chunk_data, u32 size)
@@ -1733,7 +1733,7 @@ static u32 checksum_sum(struct sec_ts_data *ts, u8 *chunk_data, u32 size)
 
 	checksum &= 0xFFFFFFFF;
 
-	input_info(true, &ts->client->dev, "%s: checksum = [%x]\n", __func__, checksum);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: checksum = [%x]\n", __func__, checksum);
 
 	return checksum;
 }
@@ -1764,7 +1764,7 @@ static u32 get_bin_checksum(struct sec_ts_data *ts, const u8 *data, size_t size)
 		checksum += data_32;
 	}
 
-	input_info(true, &ts->client->dev, "%s: fw_hd->totalsize = [%d] checksum = [%x]\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: fw_hd->totalsize = [%d] checksum = [%x]\n",
 				__func__, fw_hd->totalsize, checksum);
 
 	checksum &= 0xFFFFFFFF;
@@ -1776,7 +1776,7 @@ static u32 get_bin_checksum(struct sec_ts_data *ts, const u8 *data, size_t size)
 	for (i = 0; i < fw_hd->num_chunk; i++) {
 		fw_ch = (fw_chunk *)fd;
 
-		input_info(true, &ts->client->dev, "%s: [%d] 0x%08X, 0x%08X, 0x%08X, 0x%08X\n", __func__, i,
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: [%d] 0x%08X, 0x%08X, 0x%08X, 0x%08X\n", __func__, i,
 				fw_ch->signature, fw_ch->addr, fw_ch->size, fw_ch->reserved);
 
 		if (fw_ch->signature != SEC_TS_FW_CHUNK_SIGN) {
@@ -1930,7 +1930,7 @@ static void get_checksum_data(void *device_data)
 
 		release_firmware(fw_entry);
 
-		input_info(true, &ts->client->dev, "%s: img_checksum=[0x%X], ic_checksum=[0x%X]\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: img_checksum=[0x%X], ic_checksum=[0x%X]\n",
 						__func__, img_checksum, ic_checksum);
 
 		if (img_checksum != ic_checksum) {
@@ -1942,7 +1942,7 @@ static void get_checksum_data(void *device_data)
 	}
 out:
 
-	input_info(true, &ts->client->dev, "%s: checksum = %02X\n", __func__, csum);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: checksum = %02X\n", __func__, csum);
 	snprintf(buff, sizeof(buff), "%02X", csum);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
@@ -2008,7 +2008,7 @@ static void get_reference(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_rawcap_read(void *device_data)
@@ -2066,7 +2066,7 @@ static void get_rawcap(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_delta_read(void *device_data)
@@ -2125,7 +2125,7 @@ static void get_delta(void *device_data)
 	snprintf(buff, sizeof(buff), "%d", val);
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void run_raw_p2p_min_read_all(void *device_data)
@@ -2363,7 +2363,7 @@ static void run_rawdata_read_all(void *device_data)
 out:
 #endif
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 /* Use TSP NV area
@@ -2440,7 +2440,7 @@ int get_tsp_nvm_data(struct sec_ts_data *ts, u8 offset)
 		goto out_nvm;
 	}
 
-	input_info(true, &ts->client->dev, "%s: offset:%u  data:%02X\n", __func__, offset, buff[0]);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: offset:%u  data:%02X\n", __func__, offset, buff[0]);
 
 out_nvm:
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SENSE_ON, NULL, 0);
@@ -2463,7 +2463,7 @@ int get_tsp_nvm_data_by_size(struct sec_ts_data *ts, u8 offset, int length, u8 *
 	if (!buff)
 		return -ENOMEM;
 
-	input_info(true, &ts->client->dev, "%s: offset:%u, length:%d, size:%d\n", __func__, offset, length, sizeof(data));
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: offset:%u, length:%d, size:%d\n", __func__, offset, length, sizeof(data));
 
 	/* SENSE OFF -> CELAR EVENT STACK -> READ NV -> SENSE ON */
 	ret = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SENSE_OFF, NULL, 0);
@@ -2576,7 +2576,7 @@ static void clear_cover_mode(void *device_data)
 	struct sec_ts_data *ts = container_of(sec, struct sec_ts_data, sec);
 	char buff[SEC_CMD_STR_LEN] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: start clear_cover_mode %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: start clear_cover_mode %s\n", __func__, buff);
 	sec_cmd_set_default_result(sec);
 
 	if (sec->cmd_param[0] < 0 || sec->cmd_param[0] > 3) {
@@ -2605,7 +2605,7 @@ static void clear_cover_mode(void *device_data)
 	sec->cmd_state = SEC_CMD_STATUS_OK;
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 };
 
 static void dead_zone_enable(void *device_data)
@@ -2641,7 +2641,7 @@ err_set_dead_zone:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 };
 
 static void drawing_test_enable(void *device_data)
@@ -2684,7 +2684,7 @@ static void drawing_test_enable(void *device_data)
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 };
 
 static void sec_ts_swap(u8 *a, u8 *b)
@@ -2727,7 +2727,7 @@ int execute_selftest(struct sec_ts_data *ts, bool save_result)
 	if (!rBuff)
 		return -ENOMEM;
 
-	input_info(true, &ts->client->dev, "%s: Self test start!\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Self test start!\n", __func__);
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SELFTEST, tpara, 2);
 	if (rc < 0) {
 		input_err(true, &ts->client->dev, "%s: Send selftest cmd failed!\n", __func__);
@@ -2860,7 +2860,7 @@ static void run_trx_short_test(void *device_data)
 
 	disable_irq(ts->client->irq);
 
-	input_info(true, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: set power mode to test mode\n", __func__);
 	data[0] = 0x02;
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_SET_POWER_MODE, data, 1);
 	if (rc < 0) {
@@ -2868,14 +2868,14 @@ static void run_trx_short_test(void *device_data)
 		goto err_trx_short;
 	}
 
-	input_info(true, &ts->client->dev, "%s: clear event stack\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: clear event stack\n", __func__);
 	rc = ts->sec_ts_i2c_write(ts, SEC_TS_CMD_CLEAR_EVENT_STACK, NULL, 0);
 	if (rc < 0) {
 		input_err(true, &ts->client->dev, "%s: clear event stack failed\n", __func__);
 		goto err_trx_short;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test start\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test start\n", __func__);
 	
 	data[0] = 0x04;
 	
@@ -2893,7 +2893,7 @@ static void run_trx_short_test(void *device_data)
 		goto err_trx_short;
 	}
 
-	input_info(true, &ts->client->dev, "%s: self test done\n", __func__);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: self test done\n", __func__);
 
 	rc = ts->sec_ts_i2c_read(ts, SEC_TS_READ_SELFTEST_RESULT, rBuff, size);
 	if (rc < 0) {
@@ -2909,7 +2909,7 @@ static void run_trx_short_test(void *device_data)
 
 	sec_ts_reinit(ts);
 
-	input_info(true, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: Test Result %02X, %02X, %02X, %02X\n",
 			__func__, rBuff[16], rBuff[17], rBuff[18], rBuff[19]);
 
 	enable_irq(ts->client->irq);
@@ -2955,7 +2955,7 @@ static void run_trx_short_test(void *device_data)
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	kfree(rBuff);
 	return;
@@ -2965,7 +2965,7 @@ test_ok:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec->cmd_state = SEC_CMD_STATUS_OK;
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 	kfree(rBuff);
 	return;
@@ -2980,7 +2980,7 @@ err_trx_short:
 	sec->cmd_state = SEC_CMD_STATUS_FAIL;
 
 	kfree(rBuff);
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 	return;
 }
 
@@ -2989,7 +2989,7 @@ int sec_ts_execute_force_calibration(struct sec_ts_data *ts, int cal_mode)
 	int rc = -1;
 	u8 cmd;
 
-	input_info(true, &ts->client->dev, "%s: %d\n", __func__, cal_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %d\n", __func__, cal_mode);
 
 	if (cal_mode == OFFSET_CAL_SET)
 		cmd = SEC_TS_CMD_FACTORY_PANELCALIBRATION;
@@ -3078,7 +3078,7 @@ static void run_force_calibration(void *device_data)
 			input_err(true, &ts->client->dev, "%s: i2c fail!, %d\n", __func__, rc);
 			mis_cal_data = 0xF3;
 		} else {
-			input_info(true, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
+			input_dbg(ts->debug_flag, &ts->client->dev, "%s: miss cal data : %d\n", __func__, mis_cal_data);
 		}
 
 		buff[0] = 1;
@@ -3110,7 +3110,7 @@ out_force_cal:
 out_force_cal_before_irq_ctrl:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -3145,7 +3145,7 @@ static void get_force_calibration(void *device_data)
 
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 
 }
 
@@ -3256,7 +3256,7 @@ static void spay_enable(void *device_data)
 			ts->lowpower_mode &= ~SEC_TS_MODE_CUSTOMLIB_SPAY;
 	}
 
-	input_info(true, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
 
 	#ifdef SEC_TS_SUPPORT_CUSTOMLIB
 	if (ts->use_customlib)
@@ -3295,7 +3295,7 @@ static void aod_enable(void *device_data)
 			ts->lowpower_mode &= ~SEC_TS_MODE_CUSTOMLIB_AOD;
 	}
 
-	input_info(true, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %02X\n", __func__, ts->lowpower_mode);
 
 	#ifdef SEC_TS_SUPPORT_CUSTOMLIB
 	if (ts->use_customlib)
@@ -3339,7 +3339,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 {
 	u8 data[8] = { 0 };
 
-	input_info(true, &ts->client->dev, "%s: flag: %02X (clr,lan,nor,edg,han)\n", __func__, flag);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: flag: %02X (clr,lan,nor,edg,han)\n", __func__, flag);
 
 	if (flag & G_SET_EDGE_HANDLER) {
 		if (ts->grip_edgehandler_direction == 0) {
@@ -3354,7 +3354,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 			data[3] = ts->grip_edgehandler_direction & 0x3;
 		}
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_EDGE_HANDLER, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_EDGE_HANDLER, data[0], data[1], data[2], data[3]);
 	}
 
@@ -3362,7 +3362,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[0] = (ts->grip_edge_range >> 8) & 0xFF;
 		data[1] = ts->grip_edge_range  & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_EDGE_AREA, data, 2);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X\n",
 				__func__, SEC_TS_CMD_EDGE_AREA, data[0], data[1]);
 	}
 
@@ -3372,7 +3372,7 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[2] = (ts->grip_deadzone_y >> 8) & 0xFF;
 		data[3] = ts->grip_deadzone_y & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_DEAD_ZONE, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_DEAD_ZONE, data[0], data[1], data[2], data[3]);
 	}
 
@@ -3382,14 +3382,14 @@ void set_grip_data_to_ic(struct sec_ts_data *ts, u8 flag)
 		data[2] = (ts->grip_landscape_edge << 4 & 0xF0) | ((ts->grip_landscape_deadzone >> 8) & 0xF);
 		data[3] = ts->grip_landscape_deadzone & 0xFF;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_LANDSCAPE_MODE, data, 4);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X,%02X,%02X,%02X\n",
 				__func__, SEC_TS_CMD_LANDSCAPE_MODE, data[0], data[1], data[2], data[3]);
 	}
 
 	if (flag & G_CLR_LANDSCAPE_MODE) {
 		data[0] = ts->grip_landscape_mode;
 		ts->sec_ts_i2c_write(ts, SEC_TS_CMD_LANDSCAPE_MODE, data, 1);
-		input_info(true, &ts->client->dev, "%s: 0x%02X %02X\n",
+		input_dbg(ts->debug_flag, &ts->client->dev, "%s: 0x%02X %02X\n",
 				__func__, SEC_TS_CMD_LANDSCAPE_MODE, data[0]);
 	}
 }
@@ -3612,7 +3612,7 @@ out:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void set_touchable_area(void *device_data)
@@ -3639,7 +3639,7 @@ static void set_touchable_area(void *device_data)
 		goto out;
 	}
 
-	input_info(true, &ts->client->dev,
+	input_dbg(ts->debug_flag, &ts->client->dev,
 			"%s: set 16:9 mode %s\n", __func__, ts->touchable_area ? "enable" : "disable");
 
 	/*  - 0: Disable 16:9 mode
@@ -3660,7 +3660,7 @@ out:
 	sec_cmd_set_cmd_result(sec, buff, strnlen(buff, sizeof(buff)));
 	sec_cmd_set_cmd_exit(sec);
 
-	input_info(true, &ts->client->dev, "%s: %s\n", __func__, buff);
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: %s\n", __func__, buff);
 }
 
 static void set_log_level(void *device_data)
@@ -3704,7 +3704,7 @@ static void set_log_level(void *device_data)
 		goto err;
 	}
 
-	input_info(true, &ts->client->dev, "%s: STATUS_EVENT enable = 0x%02X, 0x%02X\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: STATUS_EVENT enable = 0x%02X, 0x%02X\n",
 			__func__, tBuff[0], tBuff[1]);
 
 	tBuff[0] = BIT_STATUS_EVENT_VENDOR_INFO(sec->cmd_param[6]);
@@ -3740,7 +3740,7 @@ static void set_log_level(void *device_data)
 		}
 	}
 
-	input_info(true, &ts->client->dev, "%s: ERROR : %d, INFO : %d, USER_INPUT : %d, INFO_CUSTOMLIB : %d, VENDOR_INFO : %d, VENDOR_EVENT_LEVEL : %d\n",
+	input_dbg(ts->debug_flag, &ts->client->dev, "%s: ERROR : %d, INFO : %d, USER_INPUT : %d, INFO_CUSTOMLIB : %d, VENDOR_INFO : %d, VENDOR_EVENT_LEVEL : %d\n",
 			__func__, sec->cmd_param[0], sec->cmd_param[1], sec->cmd_param[2], sec->cmd_param[5], sec->cmd_param[6], w_data[0]);
 
 	snprintf(buff, sizeof(buff), "%s", "OK");


### PR DESCRIPTION
Convert all debug information that falsely used input_dbg. The driver doesn't really differentiate between debug or diagnostic information that is helpful for the user such as firmware version or supported features. In quite many cases the  are mixed in between debug information with messages such as start foo and end foo.

I changed all debug information to input_dbg except those regarding firmware, config versions and supported features.

Messages such as screen of and on should be gone unless ts->debug_flags is true.