### PR TITLE
[9.14][TEMP] arm64: dts: qcom: sm5038: Bypass the SM5038 plug detect

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm5038.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm5038.dtsi
@@ -119,5 +119,6 @@
 	};
 };
 &usb0 {
-	extcon = <&sm5038_usbpd>;
+	/* HACK: bypass SM5038 to get usb.. until the driver is ready.. */
+//	extcon = <&sm5038_usbpd>;
 };


### PR DESCRIPTION
The driver is broken as of now, but we can rely on the "built-in" plug recognition to get USB (and by extension, ADB) on 10IV and that makes debugging a whole lot easier..