### PR TITLE
[7.1.r1] usb: gadget: ffs: Remove IPC logging support

### DIFF
--- a/drivers/usb/gadget/function/f_fs.c
+++ b/drivers/usb/gadget/function/f_fs.c
@@ -42,18 +42,6 @@
 
 #define FUNCTIONFS_MAGIC	0xa647361 /* Chosen by a honest dice roll ;) */
 
-#define NUM_PAGES	10 /* # of pages for ipc logging */
-
-#ifdef CONFIG_DYNAMIC_DEBUG
-#define ffs_log(fmt, ...) do { \
-	ipc_log_string(ffs->ipc_log, "%s: " fmt,  __func__, ##__VA_ARGS__); \
-	dynamic_pr_debug("%s: " fmt, __func__, ##__VA_ARGS__); \
-} while (0)
-#else
-#define ffs_log(fmt, ...) \
-	ipc_log_string(ffs->ipc_log, "%s: " fmt,  __func__, ##__VA_ARGS__)
-#endif
-
 /* Reference counter handling */
 static void ffs_data_get(struct ffs_data *ffs);
 static void ffs_data_put(struct ffs_data *ffs);
@@ -292,9 +280,6 @@ static int __ffs_ep0_queue_wait(struct ffs_data *ffs, char *data, size_t len)
 
 	spin_unlock_irq(&ffs->ev.waitq.lock);
 
-	ffs_log("enter: state %d setup_state %d flags %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
 	req->buf      = data;
 	req->length   = len;
 
@@ -319,18 +304,11 @@ static int __ffs_ep0_queue_wait(struct ffs_data *ffs, char *data, size_t len)
 	}
 
 	ffs->setup_state = FFS_NO_SETUP;
-
-	ffs_log("exit: state %d setup_state %d flags %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
 	return req->status ? req->status : req->actual;
 }
 
 static int __ffs_ep0_stall(struct ffs_data *ffs)
 {
-	ffs_log("state %d setup_state %d flags %lu can_stall %d", ffs->state,
-		ffs->setup_state, ffs->flags, ffs->ev.can_stall);
-
 	if (ffs->ev.can_stall) {
 		pr_vdebug("ep0 stall\n");
 		usb_ep_set_halt(ffs->gadget->ep0);
@@ -351,9 +329,6 @@ static ssize_t ffs_ep0_write(struct file *file, const char __user *buf,
 	char *data;
 
 	ENTER();
-
-	ffs_log("enter:len %zu state %d setup_state %d flags %lu", len,
-		ffs->state, ffs->setup_state, ffs->flags);
 
 	/* Fast check if setup was canceled */
 	if (ffs_setup_state_clear_cancelled(ffs) == FFS_SETUP_CANCELLED)
@@ -483,9 +458,6 @@ done_spin:
 		break;
 	}
 
-	ffs_log("exit:ret %zd state %d setup_state %d flags %lu", ret,
-		ffs->state, ffs->setup_state, ffs->flags);
-
 	mutex_unlock(&ffs->mutex);
 	return ret;
 }
@@ -519,10 +491,6 @@ static ssize_t __ffs_ep0_read_events(struct ffs_data *ffs, char __user *buf,
 			ffs->ev.count * sizeof *ffs->ev.types);
 
 	spin_unlock_irq(&ffs->ev.waitq.lock);
-
-	ffs_log("state %d setup_state %d flags %lu #evt %zu", ffs->state,
-		ffs->setup_state, ffs->flags, n);
-
 	mutex_unlock(&ffs->mutex);
 
 	return unlikely(copy_to_user(buf, events, size)) ? -EFAULT : size;
@@ -537,9 +505,6 @@ static ssize_t ffs_ep0_read(struct file *file, char __user *buf,
 	int ret;
 
 	ENTER();
-
-	ffs_log("enter:len %zu state %d setup_state %d flags %lu", len,
-		ffs->state, ffs->setup_state, ffs->flags);
 
 	/* Fast check if setup was canceled */
 	if (ffs_setup_state_clear_cancelled(ffs) == FFS_SETUP_CANCELLED)
@@ -629,12 +594,8 @@ static ssize_t ffs_ep0_read(struct file *file, char __user *buf,
 
 	spin_unlock_irq(&ffs->ev.waitq.lock);
 done_mutex:
-	ffs_log("exit:ret %d state %d setup_state %d flags %lu", ret,
-		ffs->state, ffs->setup_state, ffs->flags);
-
 	mutex_unlock(&ffs->mutex);
 	kfree(data);
-
 	return ret;
 }
 
@@ -643,9 +604,6 @@ static int ffs_ep0_open(struct inode *inode, struct file *file)
 	struct ffs_data *ffs = inode->i_private;
 
 	ENTER();
-
-	ffs_log("state %d setup_state %d flags %lu opened %d", ffs->state,
-		ffs->setup_state, ffs->flags, atomic_read(&ffs->opened));
 
 	if (unlikely(ffs->state == FFS_CLOSING))
 		return -EBUSY;
@@ -662,9 +620,6 @@ static int ffs_ep0_release(struct inode *inode, struct file *file)
 
 	ENTER();
 
-	ffs_log("state %d setup_state %d flags %lu opened %d", ffs->state,
-		ffs->setup_state, ffs->flags, atomic_read(&ffs->opened));
-
 	ffs_data_closed(ffs);
 
 	return 0;
@@ -677,9 +632,6 @@ static long ffs_ep0_ioctl(struct file *file, unsigned code, unsigned long value)
 	long ret;
 
 	ENTER();
-
-	ffs_log("state %d setup_state %d flags %lu opened %d", ffs->state,
-		ffs->setup_state, ffs->flags, atomic_read(&ffs->opened));
 
 	if (code == FUNCTIONFS_INTERFACE_REVMAP) {
 		struct ffs_function *func = ffs->func;
@@ -698,9 +650,6 @@ static unsigned int ffs_ep0_poll(struct file *file, poll_table *wait)
 	struct ffs_data *ffs = file->private_data;
 	unsigned int mask = POLLWRNORM;
 	int ret;
-
-	ffs_log("enter:state %d setup_state %d flags %lu opened %d", ffs->state,
-		ffs->setup_state, ffs->flags, atomic_read(&ffs->opened));
 
 	poll_wait(file, &ffs->ev.waitq, wait);
 
@@ -731,8 +680,6 @@ static unsigned int ffs_ep0_poll(struct file *file, poll_table *wait)
 	case FFS_DEACTIVATED:
 		break;
 	}
-
-	ffs_log("exit: mask %u", mask);
 
 	mutex_unlock(&ffs->mutex);
 
@@ -810,12 +757,9 @@ static void ffs_user_copy_worker(struct work_struct *work)
 {
 	struct ffs_io_data *io_data = container_of(work, struct ffs_io_data,
 						   work);
-	struct ffs_data *ffs = io_data->ffs;
 	int ret = io_data->req->status ? io_data->req->status :
 					 io_data->req->actual;
 	bool kiocb_has_eventfd = io_data->kiocb->ki_flags & IOCB_EVENTFD;
-
-	ffs_log("enter: ret %d for %s", ret, io_data->read ? "read" : "write");
 
 	if (io_data->read && ret > 0) {
 		mm_segment_t oldfs = get_fs();
@@ -838,8 +782,6 @@ static void ffs_user_copy_worker(struct work_struct *work)
 		kfree(io_data->to_free);
 	kfree(io_data->buf);
 	kfree(io_data);
-
-	ffs_log("exit");
 }
 
 static void ffs_epfile_async_io_complete(struct usb_ep *_ep,
@@ -849,8 +791,6 @@ static void ffs_epfile_async_io_complete(struct usb_ep *_ep,
 	struct ffs_data *ffs = io_data->ffs;
 
 	ENTER();
-
-	ffs_log("enter");
 
 	INIT_WORK(&io_data->work, ffs_user_copy_worker);
 	queue_work(ffs->io_completion_wq, &io_data->work);
@@ -941,15 +881,12 @@ static ssize_t __ffs_epfile_read_data(struct ffs_epfile *epfile,
 static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 {
 	struct ffs_epfile *epfile = file->private_data;
-	struct ffs_data *ffs = epfile->ffs;
 	struct usb_request *req;
 	struct ffs_ep *ep;
 	char *data = NULL;
 	ssize_t ret, data_len = -EINVAL;
 	int halt;
 	size_t extra_buf_alloc = 0;
-
-	ffs_log("enter: %s", epfile->name);
 
 	/* Are we still active? */
 	if (WARN_ON(epfile->ffs->state != FFS_ACTIVE))
@@ -1026,7 +963,7 @@ static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 			data_len = usb_ep_align_maybe(gadget, ep->ep, data_len);
 		spin_unlock_irq(&epfile->ffs->eps_lock);
 
-		extra_buf_alloc = ffs->gadget->extra_buf_alloc;
+		extra_buf_alloc = epfile->ffs->gadget->extra_buf_alloc;
 		if (!io_data->read)
 			data = kmalloc(data_len + extra_buf_alloc,
 					GFP_KERNEL);
@@ -1083,8 +1020,6 @@ static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 
 		spin_unlock_irq(&epfile->ffs->eps_lock);
 
-		ffs_log("queued %d bytes on %s", data_len, epfile->name);
-
 		if (unlikely(wait_for_completion_interruptible(&done))) {
 			/*
 			 * To avoid race condition with ffs_epfile_io_complete,
@@ -1118,10 +1053,9 @@ static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 		 * disabled (disconnect) or changed
 		 * (composition switch) ?
 		 */
-		if (epfile->ep == ep) {
+		if (epfile->ep == ep)
 			ret = ep->status;
-			ffs_log("ep status %d for req %pK", ep->status, req);
-		}
+
 		spin_unlock_irq(&epfile->ffs->eps_lock);
 		if (io_data->read && ret > 0)
 			ret = __ffs_epfile_read_data(epfile, data, ep->status,
@@ -1148,8 +1082,6 @@ static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 			goto error_lock;
 		}
 
-		ffs_log("queued %d bytes on %s", data_len, epfile->name);
-
 		ret = -EIOCBQUEUED;
 		/*
 		 * Do not kfree the buffer in this function.  It will be freed
@@ -1164,9 +1096,6 @@ error_mutex:
 	mutex_unlock(&epfile->mutex);
 error:
 	kfree(data);
-
-	ffs_log("exit: %s ret %zd", epfile->name, ret);
-
 	return ret;
 }
 
@@ -1174,13 +1103,8 @@ static int
 ffs_epfile_open(struct inode *inode, struct file *file)
 {
 	struct ffs_epfile *epfile = inode->i_private;
-	struct ffs_data *ffs = epfile->ffs;
 
 	ENTER();
-
-	ffs_log("%s: state %d setup_state %d flag %lu opened %u",
-		epfile->name, epfile->ffs->state, epfile->ffs->setup_state,
-		epfile->ffs->flags, atomic_read(&epfile->opened));
 
 	if (WARN_ON(epfile->ffs->state != FFS_ACTIVE))
 		return -ENODEV;
@@ -1195,15 +1119,11 @@ ffs_epfile_open(struct inode *inode, struct file *file)
 static int ffs_aio_cancel(struct kiocb *kiocb)
 {
 	struct ffs_io_data *io_data = kiocb->private;
-	struct ffs_data *ffs = io_data->ffs;
 	struct ffs_epfile *epfile = kiocb->ki_filp->private_data;
 	unsigned long flags;
 	int value;
 
 	ENTER();
-
-	ffs_log("enter:state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
 
 	spin_lock_irqsave(&epfile->ffs->eps_lock, flags);
 
@@ -1214,21 +1134,15 @@ static int ffs_aio_cancel(struct kiocb *kiocb)
 
 	spin_unlock_irqrestore(&epfile->ffs->eps_lock, flags);
 
-	ffs_log("exit: value %d", value);
-
 	return value;
 }
 
 static ssize_t ffs_epfile_write_iter(struct kiocb *kiocb, struct iov_iter *from)
 {
-	struct ffs_epfile *epfile = kiocb->ki_filp->private_data;
-	struct ffs_data *ffs = epfile->ffs;
 	struct ffs_io_data io_data, *p = &io_data;
 	ssize_t res;
 
 	ENTER();
-
-	ffs_log("enter");
 
 	if (!is_sync_kiocb(kiocb)) {
 		p = kzalloc(sizeof(io_data), GFP_KERNEL);
@@ -1257,22 +1171,15 @@ static ssize_t ffs_epfile_write_iter(struct kiocb *kiocb, struct iov_iter *from)
 		kfree(p);
 	else
 		*from = p->data;
-
-	ffs_log("exit: ret %zd", res);
-
 	return res;
 }
 
 static ssize_t ffs_epfile_read_iter(struct kiocb *kiocb, struct iov_iter *to)
 {
-	struct ffs_epfile *epfile = kiocb->ki_filp->private_data;
-	struct ffs_data *ffs = epfile->ffs;
 	struct ffs_io_data io_data, *p = &io_data;
 	ssize_t res;
 
 	ENTER();
-
-	ffs_log("enter");
 
 	if (!is_sync_kiocb(kiocb)) {
 		p = kzalloc(sizeof(io_data), GFP_KERNEL);
@@ -1313,9 +1220,6 @@ static ssize_t ffs_epfile_read_iter(struct kiocb *kiocb, struct iov_iter *to)
 	} else {
 		*to = p->data;
 	}
-
-	ffs_log("exit: ret %zd", res);
-
 	return res;
 }
 
@@ -1323,18 +1227,13 @@ static int
 ffs_epfile_release(struct inode *inode, struct file *file)
 {
 	struct ffs_epfile *epfile = inode->i_private;
-	struct ffs_data *ffs = epfile->ffs;
 
 	ENTER();
 
 	__ffs_epfile_read_buffer_free(epfile);
-	ffs_log("%s: state %d setup_state %d flag %lu opened %u",
-		epfile->name, epfile->ffs->state, epfile->ffs->setup_state,
-		epfile->ffs->flags, atomic_read(&epfile->opened));
 
 	if (atomic_dec_and_test(&epfile->opened))
 		epfile->invalid = false;
-
 	ffs_data_closed(epfile->ffs);
 
 	return 0;
@@ -1344,15 +1243,10 @@ static long ffs_epfile_ioctl(struct file *file, unsigned code,
 			     unsigned long value)
 {
 	struct ffs_epfile *epfile = file->private_data;
-	struct ffs_data *ffs = epfile->ffs;
 	struct ffs_ep *ep;
 	int ret;
 
 	ENTER();
-
-	ffs_log("%s: code 0x%08x value %#lx state %d setup_state %d flag %lu",
-		epfile->name, code, value, epfile->ffs->state,
-		epfile->ffs->setup_state, epfile->ffs->flags);
 
 	if (WARN_ON(epfile->ffs->state != FFS_ACTIVE))
 		return -ENODEV;
@@ -1426,8 +1320,6 @@ static long ffs_epfile_ioctl(struct file *file, unsigned code,
 	}
 	spin_unlock_irq(&epfile->ffs->eps_lock);
 
-	ffs_log("exit: %s: ret %d\n", epfile->name, ret);
-
 	return ret;
 }
 
@@ -1455,12 +1347,9 @@ ffs_sb_make_inode(struct super_block *sb, void *data,
 		  const struct inode_operations *iops,
 		  struct ffs_file_perms *perms)
 {
-	struct ffs_data	*ffs = sb->s_fs_info;
 	struct inode *inode;
 
 	ENTER();
-
-	ffs_log("enter");
 
 	inode = new_inode(sb);
 
@@ -1495,8 +1384,6 @@ static struct dentry *ffs_sb_create_file(struct super_block *sb,
 
 	ENTER();
 
-	ffs_log("enter");
-
 	dentry = d_alloc_name(sb->s_root, name);
 	if (unlikely(!dentry))
 		return NULL;
@@ -1508,7 +1395,6 @@ static struct dentry *ffs_sb_create_file(struct super_block *sb,
 	}
 
 	d_add(dentry, inode);
-
 	return dentry;
 }
 
@@ -1533,8 +1419,6 @@ static int ffs_sb_fill(struct super_block *sb, void *_data, int silent)
 	struct ffs_data	*ffs = data->ffs_data;
 
 	ENTER();
-
-	ffs_log("enter");
 
 	ffs->sb              = sb;
 	data->ffs_data       = NULL;
@@ -1699,7 +1583,6 @@ ffs_fs_mount(struct file_system_type *t, int flags,
 	rv = mount_nodev(t, flags, &data, ffs_sb_fill);
 	if (IS_ERR(rv) && data.ffs_data)
 		ffs_data_put(data.ffs_data);
-
 	return rv;
 }
 
@@ -1757,18 +1640,12 @@ static void ffs_data_get(struct ffs_data *ffs)
 {
 	ENTER();
 
-	ffs_log("ref %u", refcount_read(&ffs->ref));
-
 	refcount_inc(&ffs->ref);
 }
 
 static void ffs_data_opened(struct ffs_data *ffs)
 {
 	ENTER();
-
-	ffs_log("enter: state %d setup_state %d flag %lu opened %d ref %d",
-		ffs->state, ffs->setup_state, ffs->flags,
-		atomic_read(&ffs->opened), refcount_read(&ffs->ref));
 
 	refcount_inc(&ffs->ref);
 	if (atomic_add_return(1, &ffs->opened) == 1 &&
@@ -1782,8 +1659,6 @@ static void ffs_data_put(struct ffs_data *ffs)
 {
 	ENTER();
 
-	ffs_log("ref %u", refcount_read(&ffs->ref));
-
 	if (unlikely(refcount_dec_and_test(&ffs->ref))) {
 		pr_info("%s(): freeing\n", __func__);
 		ffs_data_clear(ffs);
@@ -1792,7 +1667,6 @@ static void ffs_data_put(struct ffs_data *ffs)
 		       waitqueue_active(&ffs->ep0req_completion.wait) ||
 		       waitqueue_active(&ffs->wait));
 		destroy_workqueue(ffs->io_completion_wq);
-		ipc_log_context_destroy(ffs->ipc_log);
 		kfree(ffs->dev_name);
 		kfree(ffs);
 	}
@@ -1801,9 +1675,6 @@ static void ffs_data_put(struct ffs_data *ffs)
 static void ffs_data_closed(struct ffs_data *ffs)
 {
 	ENTER();
-
-	ffs_log("state %d setup_state %d flag %lu opened %d", ffs->state,
-		ffs->setup_state, ffs->flags, atomic_read(&ffs->opened));
 
 	if (atomic_dec_and_test(&ffs->opened)) {
 		if (ffs->no_disconnect) {
@@ -1830,7 +1701,6 @@ static void ffs_data_closed(struct ffs_data *ffs)
 
 static struct ffs_data *ffs_data_new(const char *dev_name)
 {
-	char ipcname[24] = "usb_ffs_";
 	struct ffs_dev *ffs_dev;
 	struct ffs_data *ffs = kzalloc(sizeof *ffs, GFP_KERNEL);
 	if (unlikely(!ffs))
@@ -1863,11 +1733,6 @@ static struct ffs_data *ffs_data_new(const char *dev_name)
 	/* XXX REVISIT need to update it in some places, or do we? */
 	ffs->ev.can_stall = 1;
 
-	strlcat(ipcname, dev_name, sizeof(ipcname));
-	ffs->ipc_log = ipc_log_context_create(NUM_PAGES, ipcname, 0);
-	if (IS_ERR_OR_NULL(ffs->ipc_log))
-		ffs->ipc_log =  NULL;
-
 	return ffs;
 }
 
@@ -1875,11 +1740,6 @@ static void ffs_data_clear(struct ffs_data *ffs)
 {
 	ENTER();
 
-	ffs_log("enter: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
-	pr_debug("%s: ffs->gadget= %pK, ffs->flags= %lu\n",
-				__func__, ffs->gadget, ffs->flags);
 	ffs_closed(ffs);
 
 	BUG_ON(ffs->gadget);
@@ -1902,9 +1762,6 @@ static void ffs_data_clear(struct ffs_data *ffs)
 static void ffs_data_reset(struct ffs_data *ffs)
 {
 	ENTER();
-
-	ffs_log("enter: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
 
 	ffs_data_clear(ffs);
 
@@ -1941,9 +1798,6 @@ static int functionfs_bind(struct ffs_data *ffs, struct usb_composite_dev *cdev)
 
 	ENTER();
 
-	ffs_log("enter: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
 	if (WARN_ON(ffs->state != FFS_ACTIVE
 		 || test_and_set_bit(FFS_FL_BOUND, &ffs->flags)))
 		return -EBADFD;
@@ -1969,7 +1823,6 @@ static int functionfs_bind(struct ffs_data *ffs, struct usb_composite_dev *cdev)
 	}
 
 	ffs->gadget = cdev->gadget;
-
 	ffs_data_get(ffs);
 	return 0;
 }
@@ -1983,8 +1836,6 @@ static void functionfs_unbind(struct ffs_data *ffs)
 		ffs->ep0req = NULL;
 		ffs->gadget = NULL;
 		clear_bit(FFS_FL_BOUND, &ffs->flags);
-		ffs_log("state %d setup_state %d flag %lu gadget %pK\n",
-			ffs->state, ffs->setup_state, ffs->flags, ffs->gadget);
 		ffs_data_put(ffs);
 	}
 }
@@ -1995,9 +1846,6 @@ static int ffs_epfiles_create(struct ffs_data *ffs)
 	unsigned i, count;
 
 	ENTER();
-
-	ffs_log("enter: eps_count %u state %d setup_state %d flag %lu",
-		ffs->eps_count, ffs->state, ffs->setup_state, ffs->flags);
 
 	count = ffs->eps_count;
 	epfiles = kcalloc(count, sizeof(*epfiles), GFP_KERNEL);
@@ -2024,18 +1872,14 @@ static int ffs_epfiles_create(struct ffs_data *ffs)
 	}
 
 	ffs->epfiles = epfiles;
-
 	return 0;
 }
 
 static void ffs_epfiles_destroy(struct ffs_epfile *epfiles, unsigned count)
 {
 	struct ffs_epfile *epfile = epfiles;
-	struct ffs_data *ffs = epfiles->ffs;
 
 	ENTER();
-
-	ffs_log("enter: count %u", count);
 
 	for (; count; --count, ++epfile) {
 		BUG_ON(mutex_is_locked(&epfile->mutex));
@@ -2052,13 +1896,9 @@ static void ffs_epfiles_destroy(struct ffs_epfile *epfiles, unsigned count)
 static void ffs_func_eps_disable(struct ffs_function *func)
 {
 	struct ffs_ep *ep         = func->eps;
-	struct ffs_data *ffs      = func->ffs;
 	struct ffs_epfile *epfile = func->ffs->epfiles;
 	unsigned count            = func->ffs->eps_count;
 	unsigned long flags;
-
-	ffs_log("enter: state %d setup_state %d flag %lu", func->ffs->state,
-		func->ffs->setup_state, func->ffs->flags);
 
 	spin_lock_irqsave(&func->ffs->eps_lock, flags);
 	while (count--) {
@@ -2086,9 +1926,6 @@ static int ffs_func_eps_enable(struct ffs_function *func)
 	unsigned long flags;
 	int ret = 0;
 
-	ffs_log("enter: state %d setup_state %d flag %lu", func->ffs->state,
-		func->ffs->setup_state, func->ffs->flags);
-
 	spin_lock_irqsave(&func->ffs->eps_lock, flags);
 	while(count--) {
 		ep->ep->driver_data = ep;
@@ -2105,9 +1942,7 @@ static int ffs_func_eps_enable(struct ffs_function *func)
 			epfile->ep = ep;
 			epfile->in = usb_endpoint_dir_in(ep->ep->desc);
 			epfile->isoc = usb_endpoint_xfer_isoc(ep->ep->desc);
-			ffs_log("usb_ep_enable %s", ep->ep->name);
 		} else {
-			ffs_log("usb_ep_enable %s ret %d", ep->ep->name, ret);
 			break;
 		}
 
@@ -2148,8 +1983,7 @@ typedef int (*ffs_os_desc_callback)(enum ffs_os_desc_type entity,
 				    struct usb_os_desc_header *h, void *data,
 				    unsigned len, void *priv);
 
-static int __must_check ffs_do_single_desc(struct ffs_data *ffs,
-					   char *data, unsigned int len,
+static int __must_check ffs_do_single_desc(char *data, unsigned int len,
 					   ffs_entity_callback entity,
 					   void *priv)
 {
@@ -2158,8 +1992,6 @@ static int __must_check ffs_do_single_desc(struct ffs_data *ffs,
 	int ret;
 
 	ENTER();
-
-	ffs_log("enter: len %u", len);
 
 	/* At least two bytes are required: length and type */
 	if (len < 2) {
@@ -2277,21 +2109,16 @@ inv_length:
 #undef __entity_check_STRING
 #undef __entity_check_ENDPOINT
 
-	ffs_log("exit: desc type %d length %d", _ds->bDescriptorType, length);
-
 	return length;
 }
 
-static int __must_check ffs_do_descs(struct ffs_data *ffs, unsigned int count,
-				     char *data, unsigned int len,
+static int __must_check ffs_do_descs(unsigned int count, char *data, unsigned int len,
 				     ffs_entity_callback entity, void *priv)
 {
 	const unsigned _len = len;
 	unsigned long num = 0;
 
 	ENTER();
-
-	ffs_log("enter: len %u", len);
 
 	for (;;) {
 		int ret;
@@ -2310,7 +2137,7 @@ static int __must_check ffs_do_descs(struct ffs_data *ffs, unsigned int count,
 		if (!data)
 			return _len - len;
 
-		ret = ffs_do_single_desc(ffs, data, len, entity, priv);
+		ret = ffs_do_single_desc(data, len, entity, priv);
 		if (unlikely(ret < 0)) {
 			pr_debug("%s returns %d\n", __func__, ret);
 			return ret;
@@ -2327,12 +2154,9 @@ static int __ffs_data_do_entity(enum ffs_entity_type type,
 				void *priv)
 {
 	struct ffs_desc_helper *helper = priv;
-	struct ffs_data *ffs = helper->ffs;
 	struct usb_endpoint_descriptor *d;
 
 	ENTER();
-
-	ffs_log("enter: type %u", type);
 
 	switch (type) {
 	case FFS_DESCRIPTOR:
@@ -2375,14 +2199,11 @@ static int __ffs_data_do_entity(enum ffs_entity_type type,
 	return 0;
 }
 
-static int __ffs_do_os_desc_header(struct ffs_data *ffs,
-				   enum ffs_os_desc_type *next_type,
+static int __ffs_do_os_desc_header(enum ffs_os_desc_type *next_type,
 				   struct usb_os_desc_header *desc)
 {
 	u16 bcd_version = le16_to_cpu(desc->bcdVersion);
 	u16 w_index = le16_to_cpu(desc->wIndex);
-
-	ffs_log("enter: bcd:%x w_index:%d", bcd_version, w_index);
 
 	if (bcd_version != 1) {
 		pr_vdebug("unsupported os descriptors version: %d",
@@ -2408,8 +2229,7 @@ static int __ffs_do_os_desc_header(struct ffs_data *ffs,
  * Process all extended compatibility/extended property descriptors
  * of a feature descriptor
  */
-static int __must_check ffs_do_single_os_desc(struct ffs_data *ffs,
-					      char *data, unsigned int len,
+static int __must_check ffs_do_single_os_desc(char *data, unsigned int len,
 					      enum ffs_os_desc_type type,
 					      u16 feature_count,
 					      ffs_os_desc_callback entity,
@@ -2421,26 +2241,21 @@ static int __must_check ffs_do_single_os_desc(struct ffs_data *ffs,
 
 	ENTER();
 
-	ffs_log("enter: len %u os desc type %d", len, type);
-
 	/* loop over all ext compat/ext prop descriptors */
 	while (feature_count--) {
 		ret = entity(type, h, data, len, priv);
 		if (unlikely(ret < 0)) {
-			ffs_log("bad OS descriptor, type: %d\n", type);
+			pr_debug("bad OS descriptor, type: %d\n", type);
 			return ret;
 		}
 		data += ret;
 		len -= ret;
 	}
-
-
 	return _len - len;
 }
 
 /* Process a number of complete Feature Descriptors (Ext Compat or Ext Prop) */
-static int __must_check ffs_do_os_descs(struct ffs_data *ffs,
-					unsigned int count, char *data,
+static int __must_check ffs_do_os_descs(unsigned int count, char *data,
 					unsigned int len,
 					ffs_os_desc_callback entity, void *priv)
 {
@@ -2448,8 +2263,6 @@ static int __must_check ffs_do_os_descs(struct ffs_data *ffs,
 	unsigned long num = 0;
 
 	ENTER();
-
-	ffs_log("enter: len %u", len);
 
 	for (num = 0; num < count; ++num) {
 		int ret;
@@ -2470,9 +2283,9 @@ static int __must_check ffs_do_os_descs(struct ffs_data *ffs,
 		if (le32_to_cpu(desc->dwLength) > len)
 			return -EINVAL;
 
-		ret = __ffs_do_os_desc_header(ffs, &type, desc);
+		ret = __ffs_do_os_desc_header(&type, desc);
 		if (unlikely(ret < 0)) {
-			ffs_log("entity OS_DESCRIPTOR(%02lx); ret = %d\n",
+			pr_debug("entity OS_DESCRIPTOR(%02lx); ret = %d\n",
 				 num, ret);
 			return ret;
 		}
@@ -2490,17 +2303,16 @@ static int __must_check ffs_do_os_descs(struct ffs_data *ffs,
 		 * Process all function/property descriptors
 		 * of this Feature Descriptor
 		 */
-		ret = ffs_do_single_os_desc(ffs, data, len, type,
+		ret = ffs_do_single_os_desc(data, len, type,
 					    feature_count, entity, priv, desc);
 		if (unlikely(ret < 0)) {
-			ffs_log("%s returns %d\n", __func__, ret);
+			pr_debug("%s returns %d\n", __func__, ret);
 			return ret;
 		}
 
 		len -= ret;
 		data += ret;
 	}
-
 	return _len - len;
 }
 
@@ -2515,8 +2327,6 @@ static int __ffs_data_do_os_desc(enum ffs_os_desc_type type,
 	u8 length;
 
 	ENTER();
-
-	ffs_log("enter: type %d len %u", type, len);
 
 	switch (type) {
 	case FFS_OS_DESC_EXT_COMPAT: {
@@ -2582,7 +2392,6 @@ static int __ffs_data_do_os_desc(enum ffs_os_desc_type type,
 		pr_vdebug("unknown descriptor: %d\n", type);
 		return -EINVAL;
 	}
-
 	return length;
 }
 
@@ -2595,8 +2404,6 @@ static int __ffs_data_got_descs(struct ffs_data *ffs,
 	struct ffs_desc_helper helper;
 
 	ENTER();
-
-	ffs_log("enter: len %zu", len);
 
 	if (get_unaligned_le32(data + 4) != len)
 		goto error;
@@ -2671,7 +2478,7 @@ static int __ffs_data_got_descs(struct ffs_data *ffs,
 			continue;
 		helper.interfaces_count = 0;
 		helper.eps_count = 0;
-		ret = ffs_do_descs(ffs, counts[i], data, len,
+		ret = ffs_do_descs(counts[i], data, len,
 				   __ffs_data_do_entity, &helper);
 		if (ret < 0)
 			goto error;
@@ -2692,7 +2499,7 @@ static int __ffs_data_got_descs(struct ffs_data *ffs,
 		len  -= ret;
 	}
 	if (os_descs_count) {
-		ret = ffs_do_os_descs(ffs, os_descs_count, data, len,
+		ret = ffs_do_os_descs(os_descs_count, data, len,
 				      __ffs_data_do_os_desc, ffs);
 		if (ret < 0)
 			goto error;
@@ -2729,8 +2536,6 @@ static int __ffs_data_got_strings(struct ffs_data *ffs,
 	struct usb_string *s;
 
 	ENTER();
-
-	ffs_log("enter: len %zu", len);
 
 	if (unlikely(len < 16 ||
 		     get_unaligned_le32(data) != FUNCTIONFS_STRINGS_MAGIC ||
@@ -2865,9 +2670,6 @@ static void __ffs_event_add(struct ffs_data *ffs,
 	enum usb_functionfs_event_type rem_type1, rem_type2 = type;
 	int neg = 0;
 
-	ffs_log("enter: type %d state %d setup_state %d flag %lu", type,
-		ffs->state, ffs->setup_state, ffs->flags);
-
 	/*
 	 * Abort any unhandled setup
 	 *
@@ -2956,13 +2758,10 @@ static int __ffs_func_bind_do_descs(enum ffs_entity_type type, u8 *valuep,
 {
 	struct usb_endpoint_descriptor *ds = (void *)desc;
 	struct ffs_function *func = priv;
-	struct ffs_data *ffs = func->ffs;
 	struct ffs_ep *ffs_ep;
 	unsigned ep_desc_id;
 	int idx;
 	static const char *speed_names[] = { "full", "high", "super" };
-
-	ffs_log("enter");
 
 	if (type != FFS_DESCRIPTOR)
 		return 0;
@@ -3047,11 +2846,8 @@ static int __ffs_func_bind_do_nums(enum ffs_entity_type type, u8 *valuep,
 				   void *priv)
 {
 	struct ffs_function *func = priv;
-	struct ffs_data *ffs = func->ffs;
 	unsigned idx;
 	u8 newValue;
-
-	ffs_log("enter: type %d", type);
 
 	switch (type) {
 	default:
@@ -3097,9 +2893,6 @@ static int __ffs_func_bind_do_nums(enum ffs_entity_type type, u8 *valuep,
 
 	pr_vdebug("%02x -> %02x\n", *valuep, newValue);
 	*valuep = newValue;
-
-	ffs_log("exit: newValue %d", newValue);
-
 	return 0;
 }
 
@@ -3108,10 +2901,7 @@ static int __ffs_func_bind_do_os_desc(enum ffs_os_desc_type type,
 				      unsigned len, void *priv)
 {
 	struct ffs_function *func = priv;
-	struct ffs_data *ffs = func->ffs;
 	u8 length = 0;
-
-	ffs_log("enter: type %d", type);
 
 	switch (type) {
 	case FFS_OS_DESC_EXT_COMPAT: {
@@ -3275,9 +3065,6 @@ static int _ffs_func_bind(struct usb_configuration *c,
 
 	ENTER();
 
-	ffs_log("enter: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
 	/* Has descriptors only for speeds gadget does not support */
 	if (unlikely(!(full | high | super)))
 		return -ENOTSUPP;
@@ -3315,7 +3102,7 @@ static int _ffs_func_bind(struct usb_configuration *c,
 	 */
 	if (likely(full)) {
 		func->function.fs_descriptors = vla_ptr(vlabuf, d, fs_descs);
-		fs_len = ffs_do_descs(ffs, ffs->fs_descs_count,
+		fs_len = ffs_do_descs(ffs->fs_descs_count,
 				      vla_ptr(vlabuf, d, raw_descs),
 				      d_raw_descs__sz,
 				      __ffs_func_bind_do_descs, func);
@@ -3329,7 +3116,7 @@ static int _ffs_func_bind(struct usb_configuration *c,
 
 	if (likely(high)) {
 		func->function.hs_descriptors = vla_ptr(vlabuf, d, hs_descs);
-		hs_len = ffs_do_descs(ffs, ffs->hs_descs_count,
+		hs_len = ffs_do_descs(ffs->hs_descs_count,
 				      vla_ptr(vlabuf, d, raw_descs) + fs_len,
 				      d_raw_descs__sz - fs_len,
 				      __ffs_func_bind_do_descs, func);
@@ -3344,7 +3131,7 @@ static int _ffs_func_bind(struct usb_configuration *c,
 	if (likely(super)) {
 		func->function.ss_descriptors = func->function.ssp_descriptors =
 			vla_ptr(vlabuf, d, ss_descs);
-		ss_len = ffs_do_descs(ffs, ffs->ss_descs_count,
+		ss_len = ffs_do_descs(ffs->ss_descs_count,
 				vla_ptr(vlabuf, d, raw_descs) + fs_len + hs_len,
 				d_raw_descs__sz - fs_len - hs_len,
 				__ffs_func_bind_do_descs, func);
@@ -3362,7 +3149,7 @@ static int _ffs_func_bind(struct usb_configuration *c,
 	 * endpoint numbers rewriting.  We can do that in one go
 	 * now.
 	 */
-	ret = ffs_do_descs(ffs, ffs->fs_descs_count +
+	ret = ffs_do_descs(ffs->fs_descs_count +
 			   (high ? ffs->hs_descs_count : 0) +
 			   (super ? ffs->ss_descs_count : 0),
 			   vla_ptr(vlabuf, d, raw_descs), d_raw_descs__sz,
@@ -3382,7 +3169,7 @@ static int _ffs_func_bind(struct usb_configuration *c,
 				vla_ptr(vlabuf, d, ext_compat) + i * 16;
 			INIT_LIST_HEAD(&desc->ext_prop);
 		}
-		ret = ffs_do_os_descs(ffs, ffs->ms_os_descs_count,
+		ret = ffs_do_os_descs(ffs->ms_os_descs_count,
 				      vla_ptr(vlabuf, d, raw_descs) +
 				      fs_len + hs_len + ss_len,
 				      d_raw_descs__sz - fs_len - hs_len -
@@ -3396,12 +3183,10 @@ static int _ffs_func_bind(struct usb_configuration *c,
 
 	/* And we're done */
 	ffs_event_add(ffs, FUNCTIONFS_BIND);
-
 	return 0;
 
 error:
 	/* XXX Do we need to release all claimed endpoints here? */
-	ffs_log("exit: ret %d", ret);
 	return ret;
 }
 
@@ -3410,13 +3195,10 @@ static int ffs_func_bind(struct usb_configuration *c,
 {
 	struct f_fs_opts *ffs_opts = ffs_do_functionfs_bind(f, c);
 	struct ffs_function *func = ffs_func_from_usb(f);
-	struct ffs_data *ffs = func->ffs;
 	int ret;
 
 	if (IS_ERR(ffs_opts))
 		return PTR_ERR(ffs_opts);
-
-	ffs_log("enter");
 
 	ret = _ffs_func_bind(c, f);
 	if (ret && !--ffs_opts->refcnt)
@@ -3432,9 +3214,6 @@ static void ffs_reset_work(struct work_struct *work)
 {
 	struct ffs_data *ffs = container_of(work,
 		struct ffs_data, reset_work);
-
-	ffs_log("enter");
-
 	ffs_data_reset(ffs);
 }
 
@@ -3444,8 +3223,6 @@ static int ffs_func_set_alt(struct usb_function *f,
 	struct ffs_function *func = ffs_func_from_usb(f);
 	struct ffs_data *ffs = func->ffs;
 	int ret = 0, intf;
-
-	ffs_log("enter: alt %d", (int)alt);
 
 	if (alt != (unsigned)-1) {
 		intf = ffs_func_revmap_intf(func, interface);
@@ -3489,10 +3266,6 @@ static int ffs_func_set_alt(struct usb_function *f,
 
 static void ffs_func_disable(struct usb_function *f)
 {
-	struct ffs_function *func = ffs_func_from_usb(f);
-	struct ffs_data *ffs = func->ffs;
-
-	ffs_log("enter");
 	ffs_func_set_alt(f, 0, (unsigned)-1);
 }
 
@@ -3511,11 +3284,6 @@ static int ffs_func_setup(struct usb_function *f,
 	pr_vdebug("creq->wValue       = %04x\n", le16_to_cpu(creq->wValue));
 	pr_vdebug("creq->wIndex       = %04x\n", le16_to_cpu(creq->wIndex));
 	pr_vdebug("creq->wLength      = %04x\n", le16_to_cpu(creq->wLength));
-
-	ffs_log("enter: state %d reqtype=%02x req=%02x wv=%04x wi=%04x wl=%04x",
-			ffs->state, creq->bRequestType, creq->bRequest,
-			le16_to_cpu(creq->wValue), le16_to_cpu(creq->wIndex),
-			le16_to_cpu(creq->wLength));
 
 	/*
 	 * Most requests directed to interface go through here
@@ -3566,12 +3334,9 @@ static bool ffs_func_req_match(struct usb_function *f,
 			       bool config0)
 {
 	struct ffs_function *func = ffs_func_from_usb(f);
-	struct ffs_data *ffs = func->ffs;
 
-	if (!test_bit(FFS_FL_BOUND, &func->ffs->flags)) {
-		ffs_log("ffs function do not bind yet.\n");
+	if (!test_bit(FFS_FL_BOUND, &func->ffs->flags))
 		return false;
-	}
 
 	if (config0 && !(func->ffs->user_flags & FUNCTIONFS_CONFIG0_SETUP))
 		return false;
@@ -3591,23 +3356,13 @@ static bool ffs_func_req_match(struct usb_function *f,
 
 static void ffs_func_suspend(struct usb_function *f)
 {
-	struct ffs_data *ffs = ffs_func_from_usb(f)->ffs;
-
 	ENTER();
-
-	ffs_log("enter");
-
 	ffs_event_add(ffs_func_from_usb(f)->ffs, FUNCTIONFS_SUSPEND);
 }
 
 static void ffs_func_resume(struct usb_function *f)
 {
-	struct ffs_data *ffs = ffs_func_from_usb(f)->ffs;
-
 	ENTER();
-
-	ffs_log("enter");
-
 	ffs_event_add(ffs_func_from_usb(f)->ffs, FUNCTIONFS_RESUME);
 }
 
@@ -3680,9 +3435,7 @@ static struct ffs_dev *_ffs_find_dev(const char *name)
 	if (dev)
 		return dev;
 
-	dev = _ffs_do_find_dev(name);
-
-	return dev;
+	return _ffs_do_find_dev(name);
 }
 
 /* Configfs support *********************************************************/
@@ -3774,10 +3527,6 @@ static void ffs_func_unbind(struct usb_configuration *c,
 	unsigned long flags;
 
 	ENTER();
-
-	ffs_log("enter: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
-
 	if (ffs->func == func) {
 		ffs_func_eps_disable(func);
 		ffs->func = NULL;
@@ -3812,9 +3561,6 @@ static void ffs_func_unbind(struct usb_configuration *c,
 	func->interfaces_nums = NULL;
 
 	ffs_event_add(ffs, FUNCTIONFS_UNBIND);
-
-	ffs_log("exit: state %d setup_state %d flag %lu", ffs->state,
-		ffs->setup_state, ffs->flags);
 }
 
 static struct usb_function *ffs_alloc(struct usb_function_instance *fi)
@@ -3902,7 +3648,6 @@ int ffs_single_dev(struct ffs_dev *dev)
 		dev->single = true;
 
 	ffs_dev_unlock();
-
 	return ret;
 }
 EXPORT_SYMBOL_GPL(ffs_single_dev);
@@ -3925,7 +3670,6 @@ static int ffs_acquire_dev(const char *dev_name, struct ffs_data *ffs_data)
 	struct ffs_dev *ffs_dev;
 
 	ENTER();
-
 	ffs_dev_lock();
 
 	ffs_dev = _ffs_find_dev(dev_name);
@@ -3950,7 +3694,6 @@ static int ffs_acquire_dev(const char *dev_name, struct ffs_data *ffs_data)
 static void ffs_release_dev(struct ffs_dev *ffs_dev)
 {
 	ENTER();
-
 	ffs_dev_lock();
 
 	if (ffs_dev && ffs_dev->mounted) {
@@ -3973,9 +3716,6 @@ static int ffs_ready(struct ffs_data *ffs)
 	int ret = 0;
 
 	ENTER();
-
-	ffs_log("enter");
-
 	ffs_dev_lock();
 
 	ffs_obj = ffs->private_data;
@@ -3999,9 +3739,6 @@ static int ffs_ready(struct ffs_data *ffs)
 	set_bit(FFS_FL_CALL_CLOSED_CALLBACK, &ffs->flags);
 done:
 	ffs_dev_unlock();
-
-	ffs_log("exit: ret %d", ret);
-
 	return ret;
 }
 
@@ -4012,9 +3749,6 @@ static void ffs_closed(struct ffs_data *ffs)
 	struct config_item *ci;
 
 	ENTER();
-
-	ffs_log("enter");
-
 	ffs_dev_lock();
 
 	ffs_obj = ffs->private_data;
@@ -4039,16 +3773,11 @@ static void ffs_closed(struct ffs_data *ffs)
 	ci = opts->func_inst.group.cg_item.ci_parent->ci_parent;
 	ffs_dev_unlock();
 
-	if (test_bit(FFS_FL_BOUND, &ffs->flags)) {
+	if (test_bit(FFS_FL_BOUND, &ffs->flags))
 		unregister_gadget_item(ci);
-		ffs_log("unreg gadget done");
-	}
-
 	return;
 done:
 	ffs_dev_unlock();
-
-	ffs_log("exit error");
 }
 
 /* Misc helper functions ****************************************************/

--- a/drivers/usb/gadget/function/u_fs.h
+++ b/drivers/usb/gadget/function/u_fs.h
@@ -21,7 +21,6 @@
 #include <linux/mutex.h>
 #include <linux/workqueue.h>
 #include <linux/refcount.h>
-#include <linux/ipc_logging.h>
 
 #ifdef VERBOSE_DEBUG
 #ifndef pr_vdebug
@@ -289,8 +288,6 @@ struct ffs_data {
 	 * destroyed by ffs_epfiles_destroy().
 	 */
 	struct ffs_epfile		*epfiles;
-
-	void				*ipc_log;
 };
 
 


### PR DESCRIPTION
It could be useful to get into 9.12.r1 as well, in case somebody wants to
continue merging new LTS releases.
