### PR TITLE
input: sec_ts: Don't dereference `ts` pointer before it has been allocated

### DIFF
--- a/drivers/input/touchscreen/sec_ts/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/sec_ts.c
@@ -1919,7 +1919,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	int ret = 0;
 	int i = 0;
 
-	input_dbg(ts->debug_flag, &client->dev, "%s: start\n", __func__);
+	input_dbg(true, &client->dev, "%s: start\n", __func__);
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
 		input_err(true, &client->dev, "%s: EIO err!\n", __func__);

--- a/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts_lena/sec_ts.c
@@ -1733,7 +1733,7 @@ static int sec_ts_probe(struct i2c_client *client, const struct i2c_device_id *i
 	unsigned char result = 0;
 	int i = 0;
 
-	input_dbg(ts->debug_flag, &client->dev, "%s\n", __func__);
+	input_dbg(true, &client->dev, "%s\n", __func__);
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
 		input_err(true, &client->dev, "%s: EIO err!\n", __func__);


### PR DESCRIPTION
Cc #2545, @thaodan

Some unreviewed and untested change derferences the `ts` pointer in `_probe` before being allocated and assigned to, causing Seine (and likely also Lena) to fail booting.

Fixes: 27e7bb91f9357 ("input: sec_ts: Convert debug information to input_dbg")
Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
