### PR TITLE
[9.12.r1]  drivers: staging: wlan-qc: Disable unfixable CAF warnings-as-errors for newer compilers

### DIFF
--- a/drivers/staging/wlan-qc/Makefile
+++ b/drivers/staging/wlan-qc/Makefile
@@ -1,1 +1,7 @@
 obj-$(CONFIG_QCA_CLD_WLAN)	+= qcacld-3.0/
+
+ccflags_no-error_array_parameter := $(call cc-option,-Wno-error=array-parameter)
+ccflags_no-error_maybe_uninitialized := $(call cc-option,-Wno-error=maybe-uninitialized)
+ccflags_no-error_misleading_indentation := $(call cc-option,-Wno-error=misleading-indentation)
+
+subdir-ccflags-y := $(ccflags_no-error_array_parameter) $(ccflags_no-error_maybe_uninitialized) $(ccflags_no-error_misleading_indentation)


### PR DESCRIPTION
Newer compilers detect more and more mistakes in these vast codebases, and they're disallowed with -Werror.  It is infeasible and a waste of our time to fix them all, but we'd still like to use newer GCC.

Fixed for Linux 4.19.