### PR TITLE
Revert "rpmsg: glink_native: bring in 5.4 changes to wake the bus up"

### DIFF
--- a/drivers/rpmsg/qcom_glink_native.c
+++ b/drivers/rpmsg/qcom_glink_native.c
@@ -2158,9 +2158,6 @@ struct qcom_glink *qcom_glink_native_probe(struct device *dev,
 					   bool intentless)
 {
 	struct qcom_glink *glink;
-	u32 *arr;
-	int size;
-	int irq;
 	int ret;
 
 	glink = devm_kzalloc(dev, sizeof(*glink), GFP_KERNEL);
@@ -2215,58 +2212,13 @@ struct qcom_glink *qcom_glink_native_probe(struct device *dev,
 		return ERR_CAST(glink->task);
 	}
 
-	ret = subsys_register_early_notifier(glink->name, XPORT_LAYER_NOTIF,
-					     qcom_glink_notif_reset, glink);
-	if (ret)
-		dev_err(dev, "failed to register early notif %d\n", ret);
-
 	snprintf(glink->irqname, 32, "glink-native-%s", glink->name);
-
-	irq = of_irq_get(dev->of_node, 0);
-	ret = devm_request_irq(dev, irq,
-			       qcom_glink_native_intr,
-			       IRQF_NO_SUSPEND | IRQF_SHARED,
-			       glink->irqname, glink);
-	if (ret) {
-		dev_err(dev, "failed to request IRQ\n");
-		goto unregister;
-	}
-
-	glink->irq = irq;
-
-	size = of_property_count_u32_elems(dev->of_node, "cpu-affinity");
-	if (size > 0) {
-		arr = kmalloc_array(size, sizeof(u32), GFP_KERNEL);
-		if (!arr) {
-			ret = -ENOMEM;
-			goto unregister;
-		}
-		ret = of_property_read_u32_array(dev->of_node, "cpu-affinity",
-						 arr, size);
-		if (!ret)
-			qcom_glink_set_affinity(glink, arr, size);
-		kfree(arr);
-	}
-
-	ret = qcom_glink_send_version(glink);
-	if (ret) {
-		dev_err(dev, "failed to send version %d\n", ret);
-		goto unregister;
-	}
-
-	ret = qcom_glink_create_chrdev(glink);
-	if (ret)
-		dev_err(glink->dev, "failed to register chrdev\n");
 
 	glink->ilc = ipc_log_context_create(GLINK_LOG_PAGE_CNT, glink->name, 0);
 
 	return glink;
-
-unregister:
-	subsys_unregister_early_notifier(glink->name, XPORT_LAYER_NOTIF);
-	return ERR_PTR(ret);
 }
-EXPORT_SYMBOL_GPL(qcom_glink_native_probe);
+EXPORT_SYMBOL(qcom_glink_native_probe);
 
 int qcom_glink_native_start(struct qcom_glink *glink)
 {
@@ -2332,7 +2284,6 @@ void qcom_glink_native_remove(struct qcom_glink *glink)
 	int cid;
 	int ret;
 
-	subsys_unregister_early_notifier(glink->name, XPORT_LAYER_NOTIF);
 	qcom_glink_notif_reset(glink);
 	disable_irq(glink->irq);
 	qcom_glink_cancel_rx_work(glink);


### PR DESCRIPTION
Fixes: [#795](https://github.com/sonyxperiadev/bug_tracker/issues/795)
cc @konradybcio 

Revert https://github.com/sonyxperiadev/kernel/commit/d2fabd8d03f2679dfca23a7f433df9189951ab27 ("rpmsg: glink_native: bring in 5.4 changes to wake the bus up").

The reverted commit was an amalgamation of the code around the original
devm_request_irq prior to
https://github.com/sonyxperiadev/kernel/commit/b21bd352af382264b3d5b7acb2be24e7794a8f17 ("rpmsg: glink: Use threaded interrupts")
and
https://github.com/sonyxperiadev/kernel/commit/f551bd17e4fe7df365799ebaecf2131876537402 ("rpmsg: glink: Request for threaded irq in start phase").
That logic has since been refactored (by those commits), but it is still there.

The reverted commit adds a second request for the same IRQ already requested
by existing code in `qcom_glink_native_start` but it does so via a different API
and using different flags, leading to the pre-existing IRQ request in
`qcom_glink_native_start` failing to complete due to IRQ flags mismatch (on top
of other side effects caused by the duplication of the code creating the
device, sending the version, etc).

The `qcom_glink_native_start` failure causes `adsprpcd` to never complete its init
procedure, which is retried every 25msecs in an endless loop.
```
    genirq  : Flags mismatch irq 407. 00006001 (glink-native-adsp) vs. 00004081 (glink-native-adsp)
    ...
    3000000.remoteproc-adsp: glink-edge: failed to request IRQ with -16
    remoteproc1: failed to probe subdevices for 3000000.remoteproc-adsp: -16
    ...
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/fastrpc_apps_user.c:3426: fastrpc_apps_user_init done
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/adsprpcd.c:41:adsp_default_listener_start called
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/adsp_default_listener.c:67:adsp_default_listener_start started
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/fastrpc_apps_user.c:1437: remote_handle_open: Successfully opened handle 0xffffffff for '":;./\attachguestos on domain 0
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/fastrpc_apps_user.c:3167: Error 0x200: apps_dev_init failed for domain 0, errno No such device, ioErr -1
    ...
    adsprpcd: vendor/qcom/proprietary/adsprpc/src/adsprpcd.c:53:adsp daemon will restart after 25ms...
```
As there is no clarity around whether this change was needed in the first
place, revert it in order to restore the previous behaviour, thus fixing the
flags mismatch and `adsprpcd` init failure loop.

Signed-off-by: Andrea Bernabei <faenil@bernabei.me>