### PR TITLE
[9.12.r1] SoMC Tama/Akatsuki stabilization

### DIFF
--- a/arch/arm64/boot/dts/somc/dsi-panel-akatsuki.dtsi
+++ b/arch/arm64/boot/dts/somc/dsi-panel-akatsuki.dtsi
@@ -40,6 +40,7 @@
 		qcom,mdss-dsi-t-clk-post = <0x0E>;
 		qcom,mdss-dsi-t-clk-pre = <0x33>;
 		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-bl-inverted-dbv;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <1023>;
 		qcom,mdss-brightness-max-level = <1023>;

--- a/arch/arm64/boot/dts/somc/dsi-panel-akatsuki_vendor.dtsi
+++ b/arch/arm64/boot/dts/somc/dsi-panel-akatsuki_vendor.dtsi
@@ -39,6 +39,7 @@
 		qcom,mdss-dsi-t-clk-pre = <0x33>;
 		qcom,ulps-enabled;
 		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-bl-inverted-dbv;
 		qcom,mdss-dsi-bl-min-level = <1>;
 		qcom,mdss-dsi-bl-max-level = <1023>;
 		qcom,mdss-brightness-max-level = <1023>;

--- a/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
@@ -452,6 +452,18 @@
 	somc,qusb-phy-init-bias_ctrl2_sp = <0x25>;
 };
 
+&labibb {
+	status = "disabled";
+};
+
+&lab_regulator {
+	status = "disabled";
+};
+
+&ibb_regulator {
+	status = "disabled";
+};
+
 #include "dsi-panel-akatsuki.dtsi"
 #include "somc-tama-display.dtsi"
 #include "somc-tama-display_akatsuki.dtsi"

--- a/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
+++ b/arch/arm64/boot/dts/somc/sdm845-tama-akatsuki_common.dtsi
@@ -390,6 +390,43 @@
 	status = "disabled";
 };
 
+&pmi8998_lsid1 {
+		qcom,leds-xboot@d800 {
+		compatible = "qcom,qpnp-wled";
+		reg = <0xd800 0x100>,
+		      <0xd900 0x100>;
+		reg-names = "qpnp-wled-ctrl-base",
+			    "qpnp-wled-sink-base";
+		interrupts = <0x3 0xd8 0x1 IRQ_TYPE_EDGE_RISING>,
+			     <0x3 0xd8 0x2 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "ovp-irq", "sc-irq";
+		linux,name = "wled";
+		linux,default-trigger = "bkl-trigger";
+		qcom,fdbk-output = "auto";
+		qcom,vref-uv = <127500>;
+		qcom,switch-freq-khz = <800>;
+		qcom,ovp-mv = <29600>;
+		qcom,ilim-ma = <970>;
+		qcom,boost-duty-ns = <26>;
+		qcom,mod-freq-khz = <9600>;
+		qcom,dim-mode = "hybrid";
+		qcom,hyb-thres = <625>;
+		qcom,sync-dly-us = <800>;
+		qcom,fs-curr-ua = <20000>;
+		qcom,cons-sync-write-delay-us = <1000>;
+		qcom,led-strings-list = [00 01 02 03];
+		qcom,en-ext-pfet-sc-pro;
+		qcom,pmic-revid = <&pmi8998_revid>;
+		qcom,loop-auto-gm-en;
+		qcom,auto-calibration-enable;
+		somc,init-br-ua = <10000>;
+		somc-s1,br-power-save-ua = <800>;
+		somc,bl-scale-enabled;
+		somc,area_count_table_size = <0>;
+		status = "okay";
+	};
+};
+
 &qusb_phy0 {
 	qcom,efuse-offset = <0x00000000>;
 	qcom,qusb-phy-init-seq =

--- a/arch/arm64/boot/dts/somc/somc-tama-display_akatsuki.dtsi
+++ b/arch/arm64/boot/dts/somc/somc-tama-display_akatsuki.dtsi
@@ -3,6 +3,11 @@
  * Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
  */
 
+&mdss_mdp {
+	/* Set SDE MAX performance */
+	qcom,sde-perf-default-mode = <3>;
+};
+
 &dsi_default_panel {
 	somc,start-panel-detection;
 	somc,dsi-panel-list = <&dsi_5>;

--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -9478,8 +9478,8 @@ static int drm_notifier_callback(struct notifier_block *self, unsigned long even
 
 				if (mxt_drm_suspend(ts))
 					LOGE("Failed mxt_drm_suspend\n");
-				break;
 			}
+			break;
 		case DRM_PANEL_BLANK_UNBLANK:
 			if (event == DRM_PANEL_EVENT_BLANK) {
 				if (!ts->after_work) {

--- a/drivers/regulator/qpnp-labibb-regulator.c
+++ b/drivers/regulator/qpnp-labibb-regulator.c
@@ -2454,8 +2454,15 @@ static int qpnp_labibb_regulator_disable(struct qpnp_labibb *labibb)
 			pr_err("Error in entering TTW mode rc = %d\n", rc);
 			return rc;
 		}
+#ifdef CONFIG_ARCH_SONY_TAMA
+		if (labibb->lab_vreg.rdev->use_count == 1)
+			labibb->lab_vreg.vreg_enabled = 0;
+		if (labibb->ibb_vreg.rdev->use_count == 1)
+			labibb->ibb_vreg.vreg_enabled = 0;
+#else
 		labibb->lab_vreg.vreg_enabled = 0;
 		labibb->ibb_vreg.vreg_enabled = 0;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 		return 0;
 	}
 
@@ -2498,8 +2505,15 @@ static int qpnp_labibb_regulator_disable(struct qpnp_labibb *labibb)
 		}
 	}
 
+#ifdef CONFIG_ARCH_SONY_TAMA
+	if (labibb->lab_vreg.rdev->use_count == 1)
+		labibb->lab_vreg.vreg_enabled = 0;
+	if (labibb->ibb_vreg.rdev->use_count == 1)
+		labibb->ibb_vreg.vreg_enabled = 0;
+#else
 	labibb->lab_vreg.vreg_enabled = 0;
 	labibb->ibb_vreg.vreg_enabled = 0;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 
 	return 0;
 }
@@ -2559,8 +2573,12 @@ static int qpnp_lab_regulator_disable(struct regulator_dev *rdev)
 				REG_LAB_ENABLE_CTL, rc);
 			return rc;
 		}
-
+#ifdef CONFIG_ARCH_SONY_TAMA
+		if (rdev->use_count == 1)
+			labibb->lab_vreg.vreg_enabled = 0;
+#else
 		labibb->lab_vreg.vreg_enabled = 0;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 	}
 	return 0;
 }
@@ -3223,6 +3241,9 @@ static int register_qpnp_lab_regulator(struct qpnp_labibb *labibb,
 
 			return rc;
 		}
+#ifdef CONFIG_ARCH_SONY_TAMA
+		labibb->lab_vreg.rdev->use_count = 1;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 	} else {
 		dev_err(labibb->dev, "qpnp lab regulator name missing\n");
 		return -EINVAL;
@@ -3756,7 +3777,12 @@ static int qpnp_ibb_regulator_disable(struct regulator_dev *rdev)
 			return rc;
 		}
 
+#ifdef CONFIG_ARCH_SONY_TAMA
+		if (rdev->use_count == 1)
+			labibb->ibb_vreg.vreg_enabled = 0;
+#else
 		labibb->ibb_vreg.vreg_enabled = 0;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 	}
 	return 0;
 }
@@ -4136,6 +4162,9 @@ static int register_qpnp_ibb_regulator(struct qpnp_labibb *labibb,
 
 			return rc;
 		}
+#ifdef CONFIG_ARCH_SONY_TAMA
+		labibb->ibb_vreg.rdev->use_count = 1;
+#endif /* CONFIG_ARCH_SONY_TAMA */
 	} else {
 		dev_err(labibb->dev, "qpnp ibb regulator name missing\n");
 		return -EINVAL;


### PR DESCRIPTION
- Fix Akatsuki display suspend/resume issue.
- Fix "3 fps" behavior until the first cycle of turning the display off/on for all Tama devices.
- Fix Atmel MXT640U unintended behavior during suspend/resume. 