### PR TITLE
[7.1.r1] input: ts: atmel_mxt640u: Fix misplaced break in drm_notifier_callback

### DIFF
--- a/drivers/input/touchscreen/atmel_mxt640u.c
+++ b/drivers/input/touchscreen/atmel_mxt640u.c
@@ -9441,8 +9441,8 @@ static int drm_notifier_callback(struct notifier_block *self, unsigned long even
 
 				if (mxt_drm_suspend(ts))
 					LOGE("Failed mxt_drm_suspend\n");
-				break;
 			}
+			break;
 		case DRM_BLANK_UNBLANK:
 			if (event == DRM_EXT_EVENT_AFTER_BLANK) {
 				if (!ts->after_work) {


### PR DESCRIPTION
This commit fixes a missing break statement in the switch statement of the DRM notifier callback function. The missing break caused fall-through to the next case, which could lead to unintended behavior.