### PR TITLE
[9.16.r1] Compilation fixes for Сlang 14.0.6 (clang-r450784d)

### DIFF
--- a/arch/arm64/boot/dts/qcom/blair-camera-sensor-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-camera-sensor-qrd.dtsi
@@ -14,6 +14,9 @@
 };
 
 &cam_cci0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	actuator_rear: qcom,actuator0 {
 		cell-index = <0>;
 		compatible = "qcom,actuator";
@@ -129,29 +132,29 @@
 		status = "ok";
 	};
 
-        ois_rear: qcom,ois@0 {
-            cell-index = <0>;
-            reg = <0xe0>;
-            compatible = "qcom,ois";
-            cci-master = <0>;
-            //cam_vaf-supply = <&actuator_rear>;
-            regulator-names = "cam_wl2868c_vio","cam_wl2868c_vaf";
-            rgltr-cntrl-support;
-            pwm-switch;
-            rgltr-min-voltage = <1800000 2800000>;
-            rgltr-max-voltage = <1800000 2800000>;
-            rgltr-load-current = <0 0>;
-            gpio-no-mux = <0>;
-            gpio-ois = <0>;
-            pinctrl-names = "cam_default", "cam_suspend";
-            pinctrl-0 = <&cam_ois_vdd_active>;
-            pinctrl-1 = <&cam_ois_vdd_suspend>;
-            gpios = <&tlmm 33 0>;
-            gpio-req-tbl-num = <0>;
-            gpio-req-tbl-flags = <0>;
-            gpio-req-tbl-label = "OIS_VDD";
-            status = "ok";
-        };
+	ois_rear: qcom,ois@0 {
+		cell-index = <0>;
+		reg = <0xe0>;
+		compatible = "qcom,ois";
+		cci-master = <0>;
+		//cam_vaf-supply = <&actuator_rear>;
+		regulator-names = "cam_wl2868c_vio","cam_wl2868c_vaf";
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000 2800000>;
+		rgltr-max-voltage = <1800000 2800000>;
+		rgltr-load-current = <0 0>;
+		gpio-no-mux = <0>;
+		gpio-ois = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_ois_vdd_active>;
+		pinctrl-1 = <&cam_ois_vdd_suspend>;
+		gpios = <&tlmm 33 0>;
+		gpio-req-tbl-num = <0>;
+		gpio-req-tbl-flags = <0>;
+		gpio-req-tbl-label = "OIS_VDD";
+		status = "ok";
+	};
 
 	/* Rear*/
 	qcom,cam-sensor0 {

--- a/arch/arm64/boot/dts/qcom/blair-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-qrd.dtsi
@@ -269,6 +269,8 @@
 	};
 };*/
 &qupv3_se8_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
 	qcom,i2c-touch-active="sec,sec_ts";
 
@@ -318,6 +320,8 @@
 };
 
 &qupv3_se10_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	awinic@64 {
 		compatible = "awinic,aw2016_led";
 		reg = <0x64>;

--- a/arch/arm64/boot/dts/qcom/haptic_nv.dtsi
+++ b/arch/arm64/boot/dts/qcom/haptic_nv.dtsi
@@ -1,5 +1,7 @@
 /* AWINIC AW862XX Haptic */
 &qupv3_se10_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "ok";
 	awinic_haptic@58{
 		compatible = "awinic,haptic_nv";

--- a/arch/arm64/boot/dts/qcom/haptic_ti.dtsi
+++ b/arch/arm64/boot/dts/qcom/haptic_ti.dtsi
@@ -1,4 +1,6 @@
 &qupv3_se10_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "ok";
 	ti_haptic@5A{
 		compatible = "ti,haptic";

--- a/arch/arm64/boot/dts/qcom/holi-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-audio-overlay.dtsi
@@ -97,6 +97,8 @@
 		qcom,rx_mclk_mode_muxsel = <0xA5640D8>;
 		qcom,rx-bcl-pmic-params = /bits/ 8 <0x00 0x03 0x48>;
 		qcom,default-clk-id = <TX_CORE_CLK>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
 		swr1: rx_swr_master {
 			compatible = "qcom,swr-mstr";
 			#address-cells = <2>;
@@ -301,6 +303,8 @@
 };
 
 &qupv3_se10_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	aw882xx_smartpa@34 {
 		compatible = "awinic,aw882xx_smartpa";
 		reg = <0x34>;

--- a/arch/arm64/boot/dts/qcom/holi-coresight.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-coresight.dtsi
@@ -1171,6 +1171,8 @@
 		clock-names = "apb_pclk";
 
 		out-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
 			port@0 {
 				reg = <0>;
 				funnel_turing_out_tpda_center11: endpoint {
@@ -1456,6 +1458,8 @@
 		clock-names = "apb_pclk";
 
 		out-ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
 			port@0 {
 				reg = <0>;
 				funnel_ddr_out_tpda_center14: endpoint {
@@ -1478,7 +1482,7 @@
 		in-ports {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			port@ {
+			port@0 {
 				reg = <0>;
 				funnel_ddr_in_tpdm_ddr0: endpoint {
 					remote-endpoint =
@@ -1545,7 +1549,7 @@
 				};
 			};
 
-			port@11 {
+			port@b {
 				reg = <11>;
 				tpda_center11_in_funnel_turing: endpoint {
 					remote-endpoint =
@@ -1553,7 +1557,7 @@
 				};
 			};
 
-			port@12 {
+			port@c {
 				reg = <12>;
 				tpda_center12_in_funnel_turing: endpoint {
 					remote-endpoint =
@@ -1561,7 +1565,7 @@
 				};
 			};
 
-			port@14 {
+			port@e {
 				reg = <14>;
 				tpda_center14_in_funnel_ddr: endpoint {
 					remote-endpoint =
@@ -1569,7 +1573,7 @@
 				};
 			};
 
-			port@15 {
+			port@f {
 				reg = <15>;
 				tpda_center15_in_funnel_ddr: endpoint {
 					remote-endpoint =
@@ -1577,7 +1581,7 @@
 				};
 			};
 
-			port@27 {
+			port@1b {
 				reg = <27>;
 				tpda_center27_in_tpdm_center: endpoint {
 					remote-endpoint =
@@ -1585,15 +1589,13 @@
 				};
 			};
 
-			port@28 {
+			port@1c {
 				reg = <28>;
 				tpda_center28_in_tpdm_ipcc: endpoint {
 					remote-endpoint =
 					<&tpdm_ipcc_out_tpda_center28>;
 				};
 			};
-
-
 		};
 	};
 
@@ -1676,7 +1678,7 @@
 		in-ports {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			port@23 {
+			port@17 {
 				reg = <23>;
 				tpda_qdss23_in_tpdm_vsense: endpoint {
 					remote-endpoint =
@@ -1684,7 +1686,7 @@
 				};
 			};
 
-			port@24 {
+			port@18 {
 				reg = <24>;
 				tpda_qdss24_in_tpdm_dcc: endpoint {
 					remote-endpoint =
@@ -1692,7 +1694,7 @@
 				};
 			};
 
-			port@25 {
+			port@19 {
 				reg = <25>;
 				tpda_qdss25_in_tpdm_prng: endpoint {
 					remote-endpoint =
@@ -1700,7 +1702,7 @@
 				};
 			};
 
-			port@26 {
+			port@1a {
 				reg = <26>;
 				tpda_qdss26_in_tpdm_qm: endpoint {
 					remote-endpoint =
@@ -1708,7 +1710,7 @@
 				};
 			};
 
-			port@27 {
+			port@1b {
 				reg = <27>;
 				tpda_qdss27_in_tpdm_north: endpoint {
 					remote-endpoint =
@@ -1716,7 +1718,7 @@
 				};
 			};
 
-			port@28 {
+			port@1c {
 				reg = <28>;
 				tpda_qdss28_in_tpdm_spdm: endpoint {
 					remote-endpoint =
@@ -1724,7 +1726,7 @@
 				};
 			};
 
-			port@29 {
+			port@1d {
 				reg = <29>;
 				tpda_qdss29_in_tpdm_sdcc0: endpoint {
 					remote-endpoint =
@@ -1732,7 +1734,7 @@
 				};
 			};
 
-			port@30 {
+			port@1e {
 				reg = <30>;
 				tpda_qdss30_in_tpdm_sdcc1: endpoint {
 					remote-endpoint =
@@ -1740,7 +1742,7 @@
 				};
 			};
 
-			port@31 {
+			port@1f {
 				reg = <31>;
 				tpda_qdss31_in_tpdm_pimem: endpoint {
 					remote-endpoint =
@@ -2008,8 +2010,7 @@
 		};
 
 		out-ports {
-			port@0 {
-				reg = <0>;
+			port {
 				replicator_qdss_out_tmc_etr: endpoint {
 					remote-endpoint =
 					<&tmc_etr_in_replicator_qdss>;

--- a/arch/arm64/boot/dts/qcom/holi-pmic-overlay-pm6125.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-pmic-overlay-pm6125.dtsi
@@ -27,7 +27,12 @@
 };
 
 &spmi_bus {
+	interrupt-controller;
+	#interrupt-cells = <4>;
+
 	qcom,pmr735a@4 {
+		#address-cells = <1>;
+		#size-cells = <0>;
 		/* Example configuration to enable PMR735A VADC in standalone mode */
 		pmr735a_vadc: vadc@3600 {
 			compatible = "qcom,spmi-adc7-sw-calib";
@@ -203,6 +208,8 @@
 
 &spmi_bus {
 	qcom,pm6125@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
 		pm6125_adc_tm_iio: adc_tm@3400 {
 			compatible = "qcom,adc-tm5-iio";
 			reg = <0x3400>;

--- a/arch/arm64/boot/dts/qcom/lahaina-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/lahaina-audio-overlay.dtsi
@@ -132,6 +132,8 @@
 		qcom,rx_mclk_mode_muxsel = <0x033240D8>;
 		qcom,rx-bcl-pmic-params = /bits/ 8 <0x00 0x03 0x48>;
 		qcom,default-clk-id = <TX_CORE_CLK>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
 		swr1: rx_swr_master {
 			compatible = "qcom,swr-mstr";
 			#address-cells = <2>;
@@ -176,6 +178,8 @@
 		qcom,wsa-swr-gpios = <&wsa_swr_gpios>;
 		qcom,wsa-bcl-pmic-params = /bits/ 8 <0x00 0x03 0x48>;
 		qcom,default-clk-id = <TX_CORE_CLK>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
 		swr0: wsa_swr_master {
 			compatible = "qcom,swr-mstr";
 			#address-cells = <2>;

--- a/arch/arm64/boot/dts/somc/Makefile
+++ b/arch/arm64/boot/dts/somc/Makefile
@@ -1,30 +1,26 @@
 ifeq ($(CONFIG_BUILD_ARM64_DT_OVERLAY),y)
 
-ifeq ($(CONFIG_MACH_SONY_PDX214),y)
-dtbo-$(CONFIG_ARCH_SONY_SAGAMI) += lahaina-sagami-pdx214_generic-overlay.dtbo
-endif
-ifeq ($(CONFIG_MACH_SONY_PDX215),y)
-dtbo-$(CONFIG_ARCH_SONY_SAGAMI) += lahaina-sagami-pdx215_generic-overlay.dtbo
-endif
-ifeq ($(CONFIG_MACH_SONY_PDX225),y)
-dtbo-$(CONFIG_MACH_SONY_PDX225) += blair-murray-pdx225_sm5038_generic-overlay.dtbo
-endif
+# SoMC Sagami
+dtbo-$(CONFIG_MACH_SONY_PDX214) += lahaina-sagami-pdx214_generic-overlay.dtbo
+dtbo-$(CONFIG_MACH_SONY_PDX215) += lahaina-sagami-pdx215_generic-overlay.dtbo
 
-ifeq ($(CONFIG_MACH_SONY_PDX214),y)
 lahaina-sagami-pdx214_generic-overlay.dtbo-base := ../qcom/lahaina.dtb ../qcom/lahaina-v2.dtb ../qcom/lahaina-v2.1.dtb
-endif
-ifeq ($(CONFIG_MACH_SONY_PDX215),y)
 lahaina-sagami-pdx215_generic-overlay.dtbo-base := ../qcom/lahaina.dtb ../qcom/lahaina-v2.dtb ../qcom/lahaina-v2.1.dtb
-endif
-ifeq ($(CONFIG_MACH_SONY_PDX225),y)
+
+# SoMC Murray
+dtbo-$(CONFIG_MACH_SONY_PDX225) += blair-murray-pdx225_sm5038_generic-overlay.dtbo
+
 blair-murray-pdx225_sm5038_generic-overlay.dtbo-base := ../qcom/blair.dtb
-endif
 
 else
+
+# SoMC Sagami
 dtb-$(CONFIG_MACH_SONY_PDX214) += \
 	lahaina-v2-sagami-pdx214_generic.dtb
 dtb-$(CONFIG_MACH_SONY_PDX215) += \
 	lahaina-v2-sagami-pdx215_generic.dtb
+
+# SoMC Murray
 dtb-$(CONFIG_MACH_SONY_PDX225) += \
 	blair-murray-pdx225_sm5038_generic.dtb
 endif

--- a/arch/arm64/boot/dts/somc/lahaina-sagami-camera.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-camera.dtsi
@@ -63,6 +63,9 @@
 };
 
 &qupv3_se13_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	cam4_pmic: slg51000@75 {
 		compatible = "dlg,slg51000";
 		reg = <0x75>;
@@ -118,6 +121,9 @@
 };
 
 &qupv3_se1_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	pinctrl-0 = <&sm_gpio_8 &sm_gpio_9>;
 	pinctrl-1 = <&sm_gpio_8_suspend &sm_gpio_9_suspend>;
 	qcom,clk-freq-out = <1000000>;
@@ -139,6 +145,9 @@
 };
 
 &cam_cci0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	// wide camera
 	actuator0: qcom,actuator@0 {
 		cell-index = <0>;
@@ -310,6 +319,9 @@
 };
 
 &cam_cci1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	// front camera
 	eeprom2: qcom,eeprom@2 {
 		cell-index = <2>;

--- a/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
@@ -263,6 +263,8 @@
 };
 
 &qupv3_se2_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	pinctrl-0 = <&sm_gpio_12 &sm_gpio_13>;
 	pinctrl-1 = <&sm_gpio_12_suspend &sm_gpio_13_suspend>;
 	status = "okay";
@@ -287,6 +289,8 @@
 };
 
 &qupv3_se11_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	pinctrl-0 = <&sm_gpio_48 &sm_gpio_49>;
 	pinctrl-1 = <&sm_gpio_48_suspend &sm_gpio_49_suspend>;
 	qcom,clk-freq-out = <1000000>;
@@ -716,6 +720,8 @@
 
 
 &qupv3_se12_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	pinctrl-0 = <&sm_gpio_52 &sm_gpio_53>;
 	pinctrl-1 = <&sm_gpio_52_suspend &sm_gpio_53_suspend>;
 	status = "okay";
@@ -786,6 +792,8 @@
 };
 
 &qupv3_se17_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	pinctrl-0 = <&sm_gpio_72 &sm_gpio_73>;
 	pinctrl-1 = <&sm_gpio_72_suspend &sm_gpio_73_suspend>;
 	qcom,clk-freq-out = <1000000>;

--- a/arch/arm64/boot/dts/somc/sec_touchscreen.dtsi
+++ b/arch/arm64/boot/dts/somc/sec_touchscreen.dtsi
@@ -11,6 +11,8 @@
  */
 
 &qupv3_se4_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "ok";
 	touchscreen@48 {
 		compatible = "sec,sec_ts";

--- a/arch/arm64/boot/dts/somc/somc-sagami-nfc.dtsi
+++ b/arch/arm64/boot/dts/somc/somc-sagami-nfc.dtsi
@@ -11,6 +11,8 @@
  */
 
 &qupv3_se15_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	/* I2C */
 	nfc@28 {
 		compatible = "nxp,sn1x0-i2c";
@@ -25,6 +27,8 @@
 };
 
 &qupv3_se14_spi {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	/* sm_gpio_56: SPI MISO */
 	/* sm_gpio_57: SPI MOSI */
 	/* sm_gpio_58: SPI CLK */

--- a/arch/mips/Makefile
+++ b/arch/mips/Makefile
@@ -320,7 +320,7 @@ KBUILD_LDFLAGS		+= -m $(ld-emul)
 
 ifdef CONFIG_MIPS
 CHECKFLAGS += $(shell $(CC) $(KBUILD_CFLAGS) -dM -E -x c /dev/null | \
-	egrep -vw '__GNUC_(MINOR_|PATCHLEVEL_)?_' | \
+	grep -E -vw '__GNUC_(MINOR_|PATCHLEVEL_)?_' | \
 	sed -e "s/^\#define /-D'/" -e "s/ /'='/" -e "s/$$/'/" -e 's/\$$/&&/g')
 endif
 

--- a/drivers/input/touchscreen/sec_ts/sec_cmd.c
+++ b/drivers/input/touchscreen/sec_ts/sec_cmd.c
@@ -390,19 +390,18 @@ static ssize_t sec_cmd_list_show(struct device *dev,
 {
 	struct sec_cmd_data *data = dev_get_drvdata(dev);
 	struct sec_cmd *sec_cmd_ptr = NULL;
-	char buffer[data->cmd_buffer_size + 30];
-	char buffer_name[SEC_CMD_STR_LEN];
 
-	snprintf(buffer, 30, "++factory command list++\n");
+	int len = snprintf(buf, 30, "++factory command list++\n");
 
 	list_for_each_entry(sec_cmd_ptr, &data->cmd_list_head, list) {
 		if (strncmp(sec_cmd_ptr->cmd_name, "not_support_cmd", 15)) {
-			snprintf(buffer_name, SEC_CMD_STR_LEN, "%s\n", sec_cmd_ptr->cmd_name);
-			strncat(buffer, buffer_name, SEC_CMD_STR_LEN);
+			len += snprintf(buf + len, PAGE_SIZE - len, "%s\n", sec_cmd_ptr->cmd_name);
+			if (len >= PAGE_SIZE)
+				break;
 		}
 	}
 
-	return snprintf(buf, SEC_CMD_BUF_SIZE, "%s\n", buffer);
+	return strnlen(buf, PAGE_SIZE);
 }
 
 static DEVICE_ATTR(cmd, S_IWUSR | S_IWGRP, NULL, sec_cmd_store);
@@ -426,8 +425,8 @@ static struct attribute_group sec_fac_attr_group = {
 int sec_cmd_init(struct sec_cmd_data *data, struct sec_cmd *cmds,
 			int len, int devt)
 {
-	struct class *sec_class;
 	struct sec_ts_data *ts = container_of(data, struct sec_ts_data, sec);
+	struct class *sec_class = ts->sec_class;
 	const char *dev_name;
 	int ret, i;
 

--- a/drivers/leds/leds-qti-flash.c
+++ b/drivers/leds/leds-qti-flash.c
@@ -1784,7 +1784,7 @@ static int qti_flash_led_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	led->max_channels = (u8)of_device_get_match_data(&pdev->dev);
+	led->max_channels = (uintptr_t)of_device_get_match_data(&pdev->dev);
 	if (!led->max_channels) {
 		pr_err("Failed to get max supported led channels\n");
 		return -EINVAL;

--- a/drivers/media/platform/msm/cvp/hfi_response_handler.c
+++ b/drivers/media/platform/msm/cvp/hfi_response_handler.c
@@ -504,7 +504,7 @@ static int hfi_process_session_cvp_msg(u32 device_id,
 	}
 	session_id = (void *)(uintptr_t)get_msg_session_id(pkt);
 	core = list_first_entry(&cvp_driver->cores, struct msm_cvp_core, list);
-	inst = cvp_get_inst_from_id(core, (unsigned int)session_id);
+	inst = cvp_get_inst_from_id(core, (uintptr_t)session_id);
 
 	if (!inst) {
 		dprintk(CVP_ERR, "%s: invalid session\n", __func__);

--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -3753,8 +3753,8 @@ static int __qseecom_send_cmd(struct qseecom_dev_handle *data,
 				(uint32_t)(__qseecom_uvirt_to_kphys(
 				data, (uintptr_t)req->resp_buf));
 		} else {
-			send_data_req.req_ptr = (uint32_t)req->cmd_req_buf;
-			send_data_req.rsp_ptr = (uint32_t)req->resp_buf;
+			send_data_req.req_ptr = (uintptr_t)req->cmd_req_buf;
+			send_data_req.rsp_ptr = (uintptr_t)req->resp_buf;
 		}
 
 		send_data_req.req_len = req->cmd_req_len;

--- a/drivers/power/supply/sm5038_fg.c
+++ b/drivers/power/supply/sm5038_fg.c
@@ -2562,9 +2562,6 @@ int sm5038_fuelgauge_probe(struct platform_device *pdev)
 
 err_supply_unreg:
 err_data_free:
-#if defined(CONFIG_OF)
-#endif
-err_pdata_free:
 	kfree(fuelgauge_data);
 	mutex_destroy(&fuelgauge->fg_lock);
 err_free:
@@ -2595,18 +2592,11 @@ static int sm5038_fuelgauge_suspend(struct device *dev)
 
 static int sm5038_fuelgauge_resume(struct device *dev)
 {
-	struct sm5038_fg_data *fuelgauge = dev_get_drvdata(dev);
-
 	return 0;
 }
 
 static void sm5038_fuelgauge_shutdown(struct platform_device *pdev)
 {
-	struct sm5038_fg_data *fuelgauge = platform_get_drvdata(pdev);
-
-	pr_info("%s: ++\n", __func__);
-
-	pr_info("%s: --\n", __func__);
 }
 
 static SIMPLE_DEV_PM_OPS(sm5038_fuelgauge_pm_ops, sm5038_fuelgauge_suspend,

--- a/drivers/thermal/tsens-mtc.c
+++ b/drivers/thermal/tsens-mtc.c
@@ -23,7 +23,7 @@ struct tsens_device *tsens_controller_is_present(void)
 }
 EXPORT_SYMBOL(tsens_controller_is_present);
 
-static int tsens_mtc_reset_history_counter(unsigned int zone)
+int tsens_mtc_reset_history_counter(unsigned int zone)
 {
 	unsigned int reg_cntl, is_valid;
 	void __iomem *sensor_addr;

--- a/include/linux/smp.h
+++ b/include/linux/smp.h
@@ -57,7 +57,7 @@ void on_each_cpu_cond_mask(bool (*cond_func)(int cpu, void *info),
 		smp_call_func_t func, void *info, bool wait,
 		gfp_t gfp_flags, const struct cpumask *mask);
 
-int smp_call_function_single_async(int cpu, call_single_data_t *csd);
+int smp_call_function_single_async(int cpu, struct __call_single_data *csd);
 
 #ifdef CONFIG_SMP
 

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -108,12 +108,12 @@ void __init call_function_init(void)
  * previous function call. For multi-cpu calls its even more interesting
  * as we'll have to ensure no other cpu is observing our csd.
  */
-static __always_inline void csd_lock_wait(call_single_data_t *csd)
+static __always_inline void csd_lock_wait(struct __call_single_data *csd)
 {
 	smp_cond_load_acquire(&csd->flags, !(VAL & CSD_FLAG_LOCK));
 }
 
-static __always_inline void csd_lock(call_single_data_t *csd)
+static __always_inline void csd_lock(struct __call_single_data *csd)
 {
 	csd_lock_wait(csd);
 	csd->flags |= CSD_FLAG_LOCK;
@@ -126,7 +126,7 @@ static __always_inline void csd_lock(call_single_data_t *csd)
 	smp_wmb();
 }
 
-static __always_inline void csd_unlock(call_single_data_t *csd)
+static __always_inline void csd_unlock(struct __call_single_data *csd)
 {
 	WARN_ON(!(csd->flags & CSD_FLAG_LOCK));
 
@@ -143,7 +143,7 @@ static DEFINE_PER_CPU_SHARED_ALIGNED(call_single_data_t, csd_data);
  * for execution on the given CPU. data must already have
  * ->func, ->info, and ->flags set.
  */
-static int generic_exec_single(int cpu, call_single_data_t *csd,
+static int generic_exec_single(int cpu, struct __call_single_data *csd,
 			       smp_call_func_t func, void *info)
 {
 	if (cpu == smp_processor_id()) {
@@ -336,7 +336,7 @@ EXPORT_SYMBOL(smp_call_function_single);
  * NOTE: Be careful, there is unfortunately no current debugging facility to
  * validate the correctness of this serialization.
  */
-int smp_call_function_single_async(int cpu, call_single_data_t *csd)
+int smp_call_function_single_async(int cpu, struct __call_single_data *csd)
 {
 	int err = 0;
 

--- a/kernel/up.c
+++ b/kernel/up.c
@@ -24,7 +24,7 @@ int smp_call_function_single(int cpu, void (*func) (void *info), void *info,
 }
 EXPORT_SYMBOL(smp_call_function_single);
 
-int smp_call_function_single_async(int cpu, call_single_data_t *csd)
+int smp_call_function_single_async(int cpu, struct __call_single_data *csd)
 {
 	unsigned long flags;
 

--- a/lib/vdso/Makefile
+++ b/lib/vdso/Makefile
@@ -17,6 +17,6 @@ $(error ARCH_REL_TYPE_ABS is not set)
 endif
 
 quiet_cmd_vdso_check = VDSOCHK $@
-      cmd_vdso_check = if $(OBJDUMP) -R $@ | egrep -h "$(ARCH_REL_TYPE_ABS)"; \
+      cmd_vdso_check = if $(OBJDUMP) -R $@ | grep -E -h "$(ARCH_REL_TYPE_ABS)"; \
 		       then (echo >&2 "$@: dynamic relocations are not supported"; \
 			     rm -f $@; /bin/false); fi

--- a/net/core/dev.c
+++ b/net/core/dev.c
@@ -4752,7 +4752,7 @@ int (*gsb_nw_stack_recv)(struct sk_buff *skb) __rcu __read_mostly;
 EXPORT_SYMBOL(gsb_nw_stack_recv);
 #endif
 
-static int (*embms_tm_multicast_recv)(struct sk_buff *skb) __rcu __read_mostly;
+int (*embms_tm_multicast_recv)(struct sk_buff *skb) __rcu __read_mostly;
 EXPORT_SYMBOL(embms_tm_multicast_recv);
 
 void process_embms_receive_skb(struct sk_buff *skb)

--- a/net/embms_kernel/embms_kernel.h
+++ b/net/embms_kernel/embms_kernel.h
@@ -49,8 +49,6 @@ static dev_t device;
 /* The name of the device file*/
 #define EMBMS_DEVICE_NAME "embms_tm_device"
 
-extern int (*embms_tm_multicast_recv)(struct sk_buff *skb);
-
 /**
  * enum embms_action_type - Describes action to perform
  * @ADD_CLIENT_ENTRY: add client entry to TMGI

--- a/samples/bpf/test_cgrp2_tc.sh
+++ b/samples/bpf/test_cgrp2_tc.sh
@@ -115,7 +115,7 @@ do_exit() {
     if [ "$DEBUG" == "yes" ] && [ "$MODE" != 'cleanuponly' ]
     then
 	echo "------ DEBUG ------"
-	echo "mount: "; mount | egrep '(cgroup2|bpf)'; echo
+	echo "mount: "; mount | grep -E '(cgroup2|bpf)'; echo
 	echo "$CGRP2_TC_LEAF: "; ls -l $CGRP2_TC_LEAF; echo
 	if [ -d "$BPF_FS_TC_SHARE" ]
 	then

--- a/scripts/coccicheck
+++ b/scripts/coccicheck
@@ -48,7 +48,7 @@ FLAGS="--very-quiet"
 # inspected there.
 #
 # --profile will not output if --very-quiet is used, so avoid it.
-echo $SPFLAGS | egrep -e "--profile|--show-trying" 2>&1 > /dev/null
+echo $SPFLAGS | grep -E -e "--profile|--show-trying" 2>&1 > /dev/null
 if [ $? -eq 0 ]; then
 	FLAGS="--quiet"
 fi

--- a/tools/memory-model/scripts/checkghlitmus.sh
+++ b/tools/memory-model/scripts/checkghlitmus.sh
@@ -35,13 +35,13 @@ fi
 # Create a list of the C-language litmus tests previously run.
 ( cd $LKMM_DESTDIR; find litmus -name '*.litmus.out' -print ) |
 	sed -e 's/\.out$//' |
-	xargs -r egrep -l '^ \* Result: (Never|Sometimes|Always|DEADLOCK)' |
+	xargs -r grep -E -l '^ \* Result: (Never|Sometimes|Always|DEADLOCK)' |
 	xargs -r grep -L "^P${LKMM_PROCS}"> $T/list-C-already
 
 # Create a list of C-language litmus tests with "Result:" commands and
 # no more than the specified number of processes.
 find litmus -name '*.litmus' -exec grep -l -m 1 "^C " {} \; > $T/list-C
-xargs < $T/list-C -r egrep -l '^ \* Result: (Never|Sometimes|Always|DEADLOCK)' > $T/list-C-result
+xargs < $T/list-C -r grep -E -l '^ \* Result: (Never|Sometimes|Always|DEADLOCK)' > $T/list-C-result
 xargs < $T/list-C-result -r grep -L "^P${LKMM_PROCS}" > $T/list-C-result-short
 
 # Form list of tests without corresponding .litmus.out files

--- a/tools/perf/Makefile
+++ b/tools/perf/Makefile
@@ -25,7 +25,7 @@ unexport MAKEFLAGS
 # (To override it, run 'make JOBS=1' and similar.)
 #
 ifeq ($(JOBS),)
-  JOBS := $(shell (getconf _NPROCESSORS_ONLN || egrep -c '^processor|^CPU[0-9]' /proc/cpuinfo) 2>/dev/null)
+  JOBS := $(shell (getconf _NPROCESSORS_ONLN || grep -E -c '^processor|^CPU[0-9]' /proc/cpuinfo) 2>/dev/null)
   ifeq ($(JOBS),0)
     JOBS := 1
   endif

--- a/tools/perf/builtin-trace.c
+++ b/tools/perf/builtin-trace.c
@@ -1482,7 +1482,7 @@ static int syscall__set_arg_fmts(struct syscall *sc)
 			 len >= 2 && strcmp(field->name + len - 2, "fd") == 0) {
 			/*
 			 * /sys/kernel/tracing/events/syscalls/sys_enter*
-			 * egrep 'field:.*fd;' .../format|sed -r 's/.*field:([a-z ]+) [a-z_]*fd.+/\1/g'|sort|uniq -c
+			 * grep -E 'field:.*fd;' .../format|sed -r 's/.*field:([a-z ]+) [a-z_]*fd.+/\1/g'|sort|uniq -c
 			 * 65 int
 			 * 23 unsigned int
 			 * 7 unsigned long

--- a/tools/perf/tests/make
+++ b/tools/perf/tests/make
@@ -28,7 +28,7 @@ endif
 
 PARALLEL_OPT=
 ifeq ($(SET_PARALLEL),1)
-  cores := $(shell (getconf _NPROCESSORS_ONLN || egrep -c '^processor|^CPU[0-9]' /proc/cpuinfo) 2>/dev/null)
+  cores := $(shell (getconf _NPROCESSORS_ONLN || grep -E -c '^processor|^CPU[0-9]' /proc/cpuinfo) 2>/dev/null)
   ifeq ($(cores),0)
     cores := 1
   endif

--- a/tools/perf/tests/shell/lib/probe_vfs_getname.sh
+++ b/tools/perf/tests/shell/lib/probe_vfs_getname.sh
@@ -12,13 +12,13 @@ cleanup_probe_vfs_getname() {
 add_probe_vfs_getname() {
 	local verbose=$1
 	if [ $had_vfs_getname -eq 1 ] ; then
-		line=$(perf probe -L getname_flags 2>&1 | egrep 'result.*=.*filename;' | sed -r 's/[[:space:]]+([[:digit:]]+)[[:space:]]+result->uptr.*/\1/')
+		line=$(perf probe -L getname_flags 2>&1 | grep -E 'result.*=.*filename;' | sed -r 's/[[:space:]]+([[:digit:]]+)[[:space:]]+result->uptr.*/\1/')
 		perf probe -q       "vfs_getname=getname_flags:${line} pathname=result->name:string" || \
 		perf probe $verbose "vfs_getname=getname_flags:${line} pathname=filename:ustring"
 	fi
 }
 
 skip_if_no_debuginfo() {
-	add_probe_vfs_getname -v 2>&1 | egrep -q "^(Failed to find the path for kernel|Debuginfo-analysis is not supported)" && return 2
+	add_probe_vfs_getname -v 2>&1 | grep -E -q "^(Failed to find the path for kernel|Debuginfo-analysis is not supported)" && return 2
 	return 1
 }

--- a/tools/perf/tests/shell/record+probe_libc_inet_pton.sh
+++ b/tools/perf/tests/shell/record+probe_libc_inet_pton.sh
@@ -64,7 +64,7 @@ trace_libc_inet_pton_backtrace() {
 	while read line <&3 && read -r pattern <&4; do
 		[ -z "$pattern" ] && break
 		echo $line
-		echo "$line" | egrep -q "$pattern"
+		echo "$line" | grep -E -q "$pattern"
 		if [ $? -ne 0 ] ; then
 			printf "FAIL: expected backtrace entry \"%s\" got \"%s\"\n" "$pattern" "$line"
 			return 1

--- a/tools/perf/tests/shell/record+script_probe_vfs_getname.sh
+++ b/tools/perf/tests/shell/record+script_probe_vfs_getname.sh
@@ -26,7 +26,7 @@ record_open_file() {
 perf_script_filenames() {
 	echo "Looking at perf.data file for vfs_getname records for the file we touched:"
 	perf script -i ${perfdata} | \
-	egrep " +touch +[0-9]+ +\[[0-9]+\] +[0-9]+\.[0-9]+: +probe:vfs_getname: +\([[:xdigit:]]+\) +pathname=\"${file}\""
+	grep -E " +touch +[0-9]+ +\[[0-9]+\] +[0-9]+\.[0-9]+: +probe:vfs_getname: +\([[:xdigit:]]+\) +pathname=\"${file}\""
 }
 
 add_probe_vfs_getname || skip_if_no_debuginfo

--- a/tools/perf/tests/shell/trace+probe_vfs_getname.sh
+++ b/tools/perf/tests/shell/trace+probe_vfs_getname.sh
@@ -20,9 +20,9 @@ skip_if_no_perf_trace || exit 2
 file=$(mktemp /tmp/temporary_file.XXXXX)
 
 trace_open_vfs_getname() {
-	evts=$(echo $(perf list syscalls:sys_enter_open* 2>&1 | egrep 'open(at)? ' | sed -r 's/.*sys_enter_([a-z]+) +\[.*$/\1/') | sed 's/ /,/')
+	evts=$(echo $(perf list syscalls:sys_enter_open* 2>&1 | grep -E 'open(at)? ' | sed -r 's/.*sys_enter_([a-z]+) +\[.*$/\1/') | sed 's/ /,/')
 	perf trace -e $evts touch $file 2>&1 | \
-	egrep " +[0-9]+\.[0-9]+ +\( +[0-9]+\.[0-9]+ ms\): +touch\/[0-9]+ open(at)?\((dfd: +CWD, +)?filename: +${file}, +flags: CREAT\|NOCTTY\|NONBLOCK\|WRONLY, +mode: +IRUGO\|IWUGO\) += +[0-9]+$"
+	grep -E " +[0-9]+\.[0-9]+ +\( +[0-9]+\.[0-9]+ ms\): +touch\/[0-9]+ open(at)?\((dfd: +CWD, +)?filename: +${file}, +flags: CREAT\|NOCTTY\|NONBLOCK\|WRONLY, +mode: +IRUGO\|IWUGO\) += +[0-9]+$"
 }
 
 

--- a/tools/perf/trace/beauty/fadvise.sh
+++ b/tools/perf/trace/beauty/fadvise.sh
@@ -6,7 +6,7 @@
 printf "static const char *fadvise_advices[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+POSIX_FADV_(\w+)[[:space:]]+([[:digit:]]+)[[:space:]]+.*'
 
-egrep $regex ${header_dir}/fadvise.h | \
+grep -E $regex ${header_dir}/fadvise.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n" | \
 	grep -v "[6].*DONTNEED" | grep -v "[7].*NOREUSE"

--- a/tools/perf/trace/beauty/fsmount.sh
+++ b/tools/perf/trace/beauty/fsmount.sh
@@ -16,7 +16,7 @@ linux_mount=${linux_header_dir}/mount.h
 
 printf "static const char *fsmount_attr_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MOUNT_ATTR_([[:alnum:]][[:alnum:]_]+)[[:space:]]+(0x[[:xdigit:]]+)[[:space:]]*.*'
-egrep $regex ${linux_mount} | grep -v MOUNT_ATTR_RELATIME | \
+grep -E $regex ${linux_mount} | grep -v MOUNT_ATTR_RELATIME | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/fspick.sh
+++ b/tools/perf/trace/beauty/fspick.sh
@@ -11,7 +11,7 @@ linux_mount=${linux_header_dir}/mount.h
 
 printf "static const char *fspick_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+FSPICK_([[:alnum:]_]+)[[:space:]]+(0x[[:xdigit:]]+)[[:space:]]*.*'
-egrep $regex ${linux_mount} | \
+grep -E $regex ${linux_mount} | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/kcmp_type.sh
+++ b/tools/perf/trace/beauty/kcmp_type.sh
@@ -5,7 +5,7 @@
 
 printf "static const char *kcmp_types[] = {\n"
 regex='^[[:space:]]+(KCMP_(\w+)),'
-egrep $regex ${header_dir}/kcmp.h | grep -v KCMP_TYPES, | \
+grep -E $regex ${header_dir}/kcmp.h | grep -v KCMP_TYPES, | \
 	sed -r "s/$regex/\1 \2/g" | \
 	xargs printf "\t[%s]\t= \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/kvm_ioctl.sh
+++ b/tools/perf/trace/beauty/kvm_ioctl.sh
@@ -5,8 +5,8 @@
 
 printf "static const char *kvm_ioctl_cmds[] = {\n"
 regex='^#[[:space:]]*define[[:space:]]+KVM_(\w+)[[:space:]]+_IO[RW]*\([[:space:]]*KVMIO[[:space:]]*,[[:space:]]*(0x[[:xdigit:]]+).*'
-egrep $regex ${header_dir}/kvm.h	| \
+grep -E $regex ${header_dir}/kvm.h	| \
 	sed -r "s/$regex/\2 \1/g"	| \
-	egrep -v " ((ARM|PPC|S390)_|[GS]ET_(DEBUGREGS|PIT2|XSAVE|TSC_KHZ)|CREATE_SPAPR_TCE_64)" | \
+	grep -E -v " ((ARM|PPC|S390)_|[GS]ET_(DEBUGREGS|PIT2|XSAVE|TSC_KHZ)|CREATE_SPAPR_TCE_64)" | \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/madvise_behavior.sh
+++ b/tools/perf/trace/beauty/madvise_behavior.sh
@@ -5,7 +5,7 @@
 
 printf "static const char *madvise_advices[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MADV_([[:alnum:]_]+)[[:space:]]+([[:digit:]]+)[[:space:]]*.*'
-egrep $regex ${header_dir}/mman-common.h | \
+grep -E $regex ${header_dir}/mman-common.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort -n | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/mmap_flags.sh
+++ b/tools/perf/trace/beauty/mmap_flags.sh
@@ -15,26 +15,26 @@ fi
 linux_mman=${linux_header_dir}/mman.h
 arch_mman=${arch_header_dir}/mman.h
 
-# those in egrep -vw are flags, we want just the bits
+# those in grep -E -vw are flags, we want just the bits
 
 printf "static const char *mmap_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MAP_([[:alnum:]_]+)[[:space:]]+(0x[[:xdigit:]]+)[[:space:]]*.*'
-egrep -q $regex ${arch_mman} && \
-(egrep $regex ${arch_mman} | \
+grep -E -q $regex ${arch_mman} && \
+(grep -E $regex ${arch_mman} | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n")
-egrep -q $regex ${linux_mman} && \
-(egrep $regex ${linux_mman} | \
-	egrep -vw 'MAP_(UNINITIALIZED|TYPE|SHARED_VALIDATE)' | \
+grep -E -q $regex ${linux_mman} && \
+(grep -E $regex ${linux_mman} | \
+	grep -E -vw 'MAP_(UNINITIALIZED|TYPE|SHARED_VALIDATE)' | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n")
-([ ! -f ${arch_mman} ] || egrep -q '#[[:space:]]*include[[:space:]]+<uapi/asm-generic/mman.*' ${arch_mman}) &&
-(egrep $regex ${header_dir}/mman-common.h | \
-	egrep -vw 'MAP_(UNINITIALIZED|TYPE|SHARED_VALIDATE)' | \
+([ ! -f ${arch_mman} ] || grep -E -q '#[[:space:]]*include[[:space:]]+<uapi/asm-generic/mman.*' ${arch_mman}) &&
+(grep -E $regex ${header_dir}/mman-common.h | \
+	grep -E -vw 'MAP_(UNINITIALIZED|TYPE|SHARED_VALIDATE)' | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n")
-([ ! -f ${arch_mman} ] || egrep -q '#[[:space:]]*include[[:space:]]+<uapi/asm-generic/mman.h>.*' ${arch_mman}) &&
-(egrep $regex ${header_dir}/mman.h | \
+([ ! -f ${arch_mman} ] || grep -E -q '#[[:space:]]*include[[:space:]]+<uapi/asm-generic/mman.h>.*' ${arch_mman}) &&
+(grep -E $regex ${header_dir}/mman.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n")
 printf "};\n"

--- a/tools/perf/trace/beauty/mount_flags.sh
+++ b/tools/perf/trace/beauty/mount_flags.sh
@@ -5,11 +5,11 @@
 
 printf "static const char *mount_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MS_([[:alnum:]_]+)[[:space:]]+([[:digit:]]+)[[:space:]]*.*'
-egrep $regex ${header_dir}/mount.h | egrep -v '(MSK|VERBOSE|MGC_VAL)\>' | \
+grep -E $regex ${header_dir}/mount.h | grep -E -v '(MSK|VERBOSE|MGC_VAL)\>' | \
 	sed -r "s/$regex/\2 \2 \1/g" | sort -n | \
 	xargs printf "\t[%s ? (ilog2(%s) + 1) : 0] = \"%s\",\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MS_([[:alnum:]_]+)[[:space:]]+\(1<<([[:digit:]]+)\)[[:space:]]*.*'
-egrep $regex ${header_dir}/mount.h | \
+grep -E $regex ${header_dir}/mount.h | \
 	sed -r "s/$regex/\2 \1/g" | \
 	xargs printf "\t[%s + 1] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/move_mount_flags.sh
+++ b/tools/perf/trace/beauty/move_mount_flags.sh
@@ -11,7 +11,7 @@ linux_mount=${linux_header_dir}/mount.h
 
 printf "static const char *move_mount_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+MOVE_MOUNT_([FT]_[[:alnum:]_]+)[[:space:]]+(0x[[:xdigit:]]+)[[:space:]]*.*'
-egrep $regex ${linux_mount} | \
+grep -E $regex ${linux_mount} | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/perf_ioctl.sh
+++ b/tools/perf/trace/beauty/perf_ioctl.sh
@@ -5,7 +5,7 @@
 
 printf "static const char *perf_ioctl_cmds[] = {\n"
 regex='^#[[:space:]]*define[[:space:]]+PERF_EVENT_IOC_(\w+)[[:space:]]+_IO[RW]*[[:space:]]*\([[:space:]]*.\$.[[:space:]]*,[[:space:]]*([[:digit:]]+).*'
-egrep $regex ${header_dir}/perf_event.h	| \
+grep -E $regex ${header_dir}/perf_event.h	| \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/pkey_alloc_access_rights.sh
+++ b/tools/perf/trace/beauty/pkey_alloc_access_rights.sh
@@ -5,7 +5,7 @@
 
 printf "static const char *pkey_alloc_access_rights[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+PKEY_([[:alnum:]_]+)[[:space:]]+(0x[[:xdigit:]]+)[[:space:]]*'
-egrep $regex ${header_dir}/mman-common.h	| \
+grep -E $regex ${header_dir}/mman-common.h	| \
 	sed -r "s/$regex/\2 \2 \1/g"	| \
 	sort | xargs printf "\t[%s ? (ilog2(%s) + 1) : 0] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/prctl_option.sh
+++ b/tools/perf/trace/beauty/prctl_option.sh
@@ -5,14 +5,14 @@
 
 printf "static const char *prctl_options[] = {\n"
 regex='^#define[[:space:]]+PR_(\w+)[[:space:]]*([[:xdigit:]]+).*'
-egrep $regex ${header_dir}/prctl.h | grep -v PR_SET_PTRACER | \
+grep -E $regex ${header_dir}/prctl.h | grep -v PR_SET_PTRACER | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort -n | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"
 
 printf "static const char *prctl_set_mm_options[] = {\n"
 regex='^#[[:space:]]+define[[:space:]]+PR_SET_MM_(\w+)[[:space:]]*([[:digit:]]+).*'
-egrep $regex ${header_dir}/prctl.h | \
+grep -E $regex ${header_dir}/prctl.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort -n | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/rename_flags.sh
+++ b/tools/perf/trace/beauty/rename_flags.sh
@@ -8,8 +8,8 @@ fs_header=${header_dir}/fs.h
 
 printf "static const char *rename_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+RENAME_([[:alnum:]_]+)[[:space:]]+\(1[[:space:]]*<<[[:space:]]*([[:xdigit:]]+)[[:space:]]*\)[[:space:]]*.*'
-egrep -q $regex ${fs_header} && \
-(egrep $regex ${fs_header} | \
+grep -E -q $regex ${fs_header} && \
+(grep -E $regex ${fs_header} | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[%d + 1] = \"%s\",\n")
 printf "};\n"

--- a/tools/perf/trace/beauty/socket_ipproto.sh
+++ b/tools/perf/trace/beauty/socket_ipproto.sh
@@ -6,7 +6,7 @@
 printf "static const char *socket_ipproto[] = {\n"
 regex='^[[:space:]]+IPPROTO_(\w+)[[:space:]]+=[[:space:]]+([[:digit:]]+),.*'
 
-egrep $regex ${header_dir}/in.h | \
+grep -E $regex ${header_dir}/in.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/sync_file_range.sh
+++ b/tools/perf/trace/beauty/sync_file_range.sh
@@ -11,7 +11,7 @@ linux_fs=${linux_header_dir}/fs.h
 
 printf "static const char *sync_file_range_flags[] = {\n"
 regex='^[[:space:]]*#[[:space:]]*define[[:space:]]+SYNC_FILE_RANGE_([[:alnum:]_]+)[[:space:]]+([[:xdigit:]]+)[[:space:]]*.*'
-egrep $regex ${linux_fs} | \
+grep -E $regex ${linux_fs} | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	xargs printf "\t[ilog2(%s) + 1] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/usbdevfs_ioctl.sh
+++ b/tools/perf/trace/beauty/usbdevfs_ioctl.sh
@@ -8,14 +8,14 @@
 
 printf "static const char *usbdevfs_ioctl_cmds[] = {\n"
 regex="^#[[:space:]]*define[[:space:]]+USBDEVFS_(\w+)(\(\w+\))?[[:space:]]+_IO[CWR]{0,2}\([[:space:]]*(_IOC_\w+,[[:space:]]*)?'U'[[:space:]]*,[[:space:]]*([[:digit:]]+).*"
-egrep "$regex" ${header_dir}/usbdevice_fs.h | egrep -v 'USBDEVFS_\w+32[[:space:]]' | \
+grep -E "$regex" ${header_dir}/usbdevice_fs.h | grep -E -v 'USBDEVFS_\w+32[[:space:]]' | \
 	sed -r "s/$regex/\4 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n\n"
 printf "#if 0\n"
 printf "static const char *usbdevfs_ioctl_32_cmds[] = {\n"
 regex="^#[[:space:]]*define[[:space:]]+USBDEVFS_(\w+)[[:space:]]+_IO[WR]{0,2}\([[:space:]]*'U'[[:space:]]*,[[:space:]]*([[:digit:]]+).*"
-egrep $regex ${header_dir}/usbdevice_fs.h | egrep 'USBDEVFS_\w+32[[:space:]]' | \
+grep -E $regex ${header_dir}/usbdevice_fs.h | grep -E 'USBDEVFS_\w+32[[:space:]]' | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/vhost_virtio_ioctl.sh
+++ b/tools/perf/trace/beauty/vhost_virtio_ioctl.sh
@@ -5,14 +5,14 @@
 
 printf "static const char *vhost_virtio_ioctl_cmds[] = {\n"
 regex='^#[[:space:]]*define[[:space:]]+VHOST_(\w+)[[:space:]]+_IOW?\([[:space:]]*VHOST_VIRTIO[[:space:]]*,[[:space:]]*(0x[[:xdigit:]]+).*'
-egrep $regex ${header_dir}/vhost.h | \
+grep -E $regex ${header_dir}/vhost.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"
 
 printf "static const char *vhost_virtio_ioctl_read_cmds[] = {\n"
 regex='^#[[:space:]]*define[[:space:]]+VHOST_(\w+)[[:space:]]+_IOW?R\([[:space:]]*VHOST_VIRTIO[[:space:]]*,[[:space:]]*(0x[[:xdigit:]]+).*'
-egrep $regex ${header_dir}/vhost.h | \
+grep -E $regex ${header_dir}/vhost.h | \
 	sed -r "s/$regex/\2 \1/g"	| \
 	sort | xargs printf "\t[%s] = \"%s\",\n"
 printf "};\n"

--- a/tools/perf/trace/beauty/x86_arch_prctl.sh
+++ b/tools/perf/trace/beauty/x86_arch_prctl.sh
@@ -15,8 +15,8 @@ print_range () {
 	printf "static const char *x86_arch_prctl_codes_%d[] = {\n" $idx
 	regex=`printf '^[[:space:]]*#[[:space:]]*define[[:space:]]+ARCH_([[:alnum:]_]+)[[:space:]]+(%s[[:xdigit:]]+).*' ${prefix}`
 	fmt="\t[%#x - ${first_entry}]= \"%s\",\n"
-	egrep -q $regex ${prctl_arch_header} && \
-	(egrep $regex ${prctl_arch_header} | \
+	grep -E -q $regex ${prctl_arch_header} && \
+	(grep -E $regex ${prctl_arch_header} | \
 		sed -r "s/$regex/\2 \1/g"	| \
 		xargs printf "$fmt")
 	printf "};\n\n"

--- a/tools/testing/selftests/ftrace/test.d/preemptirq/irqsoff_tracer.tc
+++ b/tools/testing/selftests/ftrace/test.d/preemptirq/irqsoff_tracer.tc
@@ -41,10 +41,10 @@ cat trace
 grep -q "tracer: preemptoff" trace || fail
 
 # Check the end of the section
-egrep -q "5.....us : <stack trace>" trace || fail
+grep -E -q "5.....us : <stack trace>" trace || fail
 
 # Check for 500ms of latency
-egrep -q "latency: 5..... us" trace || fail
+grep -E -q "latency: 5..... us" trace || fail
 
 reset_tracer
 
@@ -64,10 +64,10 @@ cat trace
 grep -q "tracer: irqsoff" trace || fail
 
 # Check the end of the section
-egrep -q "5.....us : <stack trace>" trace || fail
+grep -E -q "5.....us : <stack trace>" trace || fail
 
 # Check for 500ms of latency
-egrep -q "latency: 5..... us" trace || fail
+grep -E -q "latency: 5..... us" trace || fail
 
 reset_tracer
 exit 0

--- a/tools/testing/selftests/powerpc/scripts/hmi.sh
+++ b/tools/testing/selftests/powerpc/scripts/hmi.sh
@@ -36,7 +36,7 @@ trap "ppc64_cpu --smt-snooze-delay=100" 0 1
 
 # for each chip+core combination
 # todo - less fragile parsing
-egrep -o 'OCC: Chip [0-9a-f]+ Core [0-9a-f]' < /sys/firmware/opal/msglog |
+grep -E -o 'OCC: Chip [0-9a-f]+ Core [0-9a-f]' < /sys/firmware/opal/msglog |
 while read chipcore; do
 	chip=$(echo "$chipcore"|awk '{print $3}')
 	core=$(echo "$chipcore"|awk '{print $5}')

--- a/tools/testing/selftests/rcutorture/bin/kvm-build.sh
+++ b/tools/testing/selftests/rcutorture/bin/kvm-build.sh
@@ -37,10 +37,10 @@ fi
 ncpus=`cpus2use.sh`
 make -j$ncpus $TORTURE_KMAKE_ARG > $resdir/Make.out 2>&1
 retval=$?
-if test $retval -ne 0 || grep "rcu[^/]*": < $resdir/Make.out | egrep -q "Stop|Error|error:|warning:" || egrep -q "Stop|Error|error:" < $resdir/Make.out
+if test $retval -ne 0 || grep "rcu[^/]*": < $resdir/Make.out | grep -E -q "Stop|Error|error:|warning:" || grep -E -q "Stop|Error|error:" < $resdir/Make.out
 then
 	echo Kernel build error
-	egrep "Stop|Error|error:|warning:" < $resdir/Make.out
+	grep -E "Stop|Error|error:|warning:" < $resdir/Make.out
 	echo Run aborted.
 	exit 3
 fi

--- a/tools/testing/selftests/rcutorture/bin/kvm-find-errors.sh
+++ b/tools/testing/selftests/rcutorture/bin/kvm-find-errors.sh
@@ -28,9 +28,9 @@ editor=${EDITOR-vi}
 files=
 for i in ${rundir}/*/Make.out
 do
-	if egrep -q "error:|warning:" < $i
+	if grep -E -q "error:|warning:" < $i
 	then
-		egrep "error:|warning:" < $i > $i.diags
+		grep -E "error:|warning:" < $i > $i.diags
 		files="$files $i.diags $i"
 	fi
 done

--- a/tools/testing/selftests/rcutorture/bin/kvm.sh
+++ b/tools/testing/selftests/rcutorture/bin/kvm.sh
@@ -462,7 +462,7 @@ then
 elif test "$dryrun" = sched
 then
 	# Extract the test run schedule from the script.
-	egrep 'Start batch|Starting build\.' $T/script |
+	grep -E 'Start batch|Starting build\.' $T/script |
 		grep -v ">>" |
 		sed -e 's/:.*$//' -e 's/^echo //'
 	exit 0

--- a/tools/testing/selftests/rcutorture/bin/parse-console.sh
+++ b/tools/testing/selftests/rcutorture/bin/parse-console.sh
@@ -53,7 +53,7 @@ then
 	fi
 
 	grep --binary-files=text 'torture:.*ver:' $file |
-	egrep --binary-files=text -v '\(null\)|rtc: 000000000* ' |
+	grep -E --binary-files=text -v '\(null\)|rtc: 000000000* ' |
 	sed -e 's/^(initramfs)[^]]*] //' -e 's/^\[[^]]*] //' |
 	awk '
 	BEGIN	{
@@ -104,7 +104,7 @@ then
 	fi
 fi | tee -a $file.diags
 
-egrep 'Badness|WARNING:|Warn|BUG|===========|Call Trace:|Oops:|detected stalls on CPUs/tasks:|self-detected stall on CPU|Stall ended before state dump start|\?\?\? Writer stall state|rcu_.*kthread starved for' < $file |
+grep -E 'Badness|WARNING:|Warn|BUG|===========|Call Trace:|Oops:|detected stalls on CPUs/tasks:|self-detected stall on CPU|Stall ended before state dump start|\?\?\? Writer stall state|rcu_.*kthread starved for' < $file |
 grep -v 'ODEBUG: ' |
 grep -v 'This means that this is a DEBUG kernel and it is' |
 grep -v 'Warning: unable to open an initial console' > $T.diags
@@ -118,12 +118,12 @@ then
 	then
 		summary="$summary  Badness: $n_badness"
 	fi
-	n_warn=`grep -v 'Warning: unable to open an initial console' $file | egrep -c 'WARNING:|Warn'`
+	n_warn=`grep -v 'Warning: unable to open an initial console' $file | grep -E -c 'WARNING:|Warn'`
 	if test "$n_warn" -ne 0
 	then
 		summary="$summary  Warnings: $n_warn"
 	fi
-	n_bugs=`egrep -c 'BUG|Oops:' $file`
+	n_bugs=`grep -E -c 'BUG|Oops:' $file`
 	if test "$n_bugs" -ne 0
 	then
 		summary="$summary  Bugs: $n_bugs"
@@ -138,7 +138,7 @@ then
 	then
 		summary="$summary  lockdep: $n_badness"
 	fi
-	n_stalls=`egrep -c 'detected stalls on CPUs/tasks:|self-detected stall on CPU|Stall ended before state dump start|\?\?\? Writer stall state' $file`
+	n_stalls=`grep -E -c 'detected stalls on CPUs/tasks:|self-detected stall on CPU|Stall ended before state dump start|\?\?\? Writer stall state' $file`
 	if test "$n_stalls" -ne 0
 	then
 		summary="$summary  Stalls: $n_stalls"

--- a/tools/vm/slabinfo-gnuplot.sh
+++ b/tools/vm/slabinfo-gnuplot.sh
@@ -150,7 +150,7 @@ do_preprocess()
 	let lines=3
 	out=`basename "$in"`"-slabs-by-loss"
 	`cat "$in" | grep -A "$lines" 'Slabs sorted by loss' |\
-		egrep -iv '\-\-|Name|Slabs'\
+		grep -E -iv '\-\-|Name|Slabs'\
 		| awk '{print $1" "$4+$2*$3" "$4}' > "$out"`
 	if [ $? -eq 0 ]; then
 		do_slabs_plotting "$out"
@@ -159,7 +159,7 @@ do_preprocess()
 	let lines=3
 	out=`basename "$in"`"-slabs-by-size"
 	`cat "$in" | grep -A "$lines" 'Slabs sorted by size' |\
-		egrep -iv '\-\-|Name|Slabs'\
+		grep -E -iv '\-\-|Name|Slabs'\
 		| awk '{print $1" "$4" "$4-$2*$3}' > "$out"`
 	if [ $? -eq 0 ]; then
 		do_slabs_plotting "$out"


### PR DESCRIPTION
A set of changes to successfully compile the kernel without warnings using Сlang 14.0.6 (clang-r450784d).
This is one of the initial patches of my 9.16 journey.