### PR TITLE
[9.16.r1] leds: qpnp-flash-v2: Fix -Wvoid-pointer-to-int-cast

### DIFF
--- a/drivers/leds/leds-qpnp-flash-v2.c
+++ b/drivers/leds/leds-qpnp-flash-v2.c
@@ -2970,7 +2970,7 @@ static int qpnp_flash_led_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	led->pmic_type = (u8)of_device_get_match_data(&pdev->dev);
+	led->pmic_type = (uintptr_t)of_device_get_match_data(&pdev->dev);
 
 	if (led->pmic_type == PM6150L)
 		led->wa_flags |= PM6150L_IRES_WA;


### PR DESCRIPTION
drivers/leds/leds-qpnp-flash-v2.c:2973:19: warning: cast to smaller integer type 'u8' (aka 'unsigned char') from 'const void *' [-Wvoid-pointer-to-int-cast] error, forbidden warning: leds-qpnp-flash-v2.c:2973.