### PR TITLE
[9.16.r1] Audio support for SoMC Zambezi

### DIFF
--- a/arch/arm64/boot/dts/qcom/blair-sony-base.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-sony-base.dtsi
@@ -14,15 +14,6 @@
  * way from the devicetree overlay but must be removed from the base DTS
  */
 
-/ {
-	aliases {
-		i2c0 = &qupv3_se7_i2c;
-		i2c1 = &qupv3_se8_i2c;
-		i2c2 = &qupv3_se10_i2c;
-		i2c3 = &qupv3_se0_i2c;
-	};
-};
-
 &reserved_memory {
 	/delete-node/ ramoops;
 };

--- a/arch/arm64/boot/dts/somc/blair-murray-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-murray-common.dtsi
@@ -250,6 +250,7 @@
 		irq-gpio = <&tlmm 60 0>;
 		dc-flag = <0>;
 		sound-channel = <0>;
+		rename-flag = <1>;
 		aw-tx-topo-id = <0x1000ff00>;
 		aw-rx-topo-id = <0x1000ff01>;
 		aw-tx-port-id = <0x1003>;

--- a/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
@@ -215,6 +215,7 @@
 		irq-gpio = <&tlmm 99 0>;
 		dc-flag = <0>;
 		sound-channel = <0>;
+		rename-flag = <1>;
 		aw-tx-topo-id = <0x1000ff00>;
 		aw-rx-topo-id = <0x1000ff01>;
 		aw-tx-port-id = <0x1003>;
@@ -278,6 +279,7 @@
 		irq-gpio = <&tlmm 60 0>;
 		dc-flag = <0>;
 		sound-channel = <1>;
+		rename-flag = <1>;
 		aw-tx-topo-id = <0x1000ff00>;
 		aw-rx-topo-id = <0x1000ff01>;
 		aw-tx-port-id = <0x1003>;

--- a/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
@@ -386,6 +386,10 @@
 	};
 };
 
+&smb1394 {
+	status = "disabled";
+};
+
 &pm6125_pon {
 	qcom,pon_2 {
 		linux,code = <KEY_VOLUMEUP>;


### PR DESCRIPTION
Adds audio support and is part of this patch https://github.com/sonyxperiadev/kernel-techpack-audio/pull/57

The patch set has been successfully tested on Murray PDX225 and Zambezi PDX235 devices.