### PR TITLE
soc/qcom/minidump: Provide type of `md_align_offset` `static` global var

### DIFF
--- a/drivers/soc/qcom/minidump_log.c
+++ b/drivers/soc/qcom/minidump_log.c
@@ -108,7 +108,7 @@ static bool minidump_ftrace_dump = true;
 
 static bool md_in_oops_handler;
 static struct seq_buf *md_runq_seq_buf;
-static md_align_offset;
+static int md_align_offset;
 
 /* CPU context information */
 #ifdef CONFIG_QCOM_MINIDUMP_PANIC_CPU_CONTEXT


### PR DESCRIPTION
    kernel/sony/msm-5.10/kernel/drivers/soc/qcom/minidump_log.c:111:8: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
    static md_align_offset;
    ~~~~~~ ^
    int
    1 error generated.

Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
