### PR TITLE
[9.16.r1] Minidump table overflow fix for Sagami, Murray and Zambezi

### DIFF
--- a/arch/arm64/boot/dts/qcom/lahaina.dtsi
+++ b/arch/arm64/boot/dts/qcom/lahaina.dtsi
@@ -567,39 +567,6 @@
 		alignment = <0x0 0x400000>;
 		size = <0x0 0x6400000>;
 	};
-
-	debug_region: debug_region@ffb00000 {
-		compatible = "removed-dma-pool", "qcom,debug_memory";
-		no-map;
-		reg = <0 0xffb00000 0 0xc0000>;
-		label = "debug_mem";
-	};
-
-	last_log_region: last_log_region@ffbc0000 {
-		compatible = "removed-dma-pool", "qcom,last_log_memory";
-		no-map;
-		reg = <0 0xffbc0000 0 0x40000>;
-		label = "last_log";
-		phandle = "log";
-	};
-
-	ramoops: ramoops@ffc00000 {
-		compatible = "removed-dma-pool", "ramoops";
-		no-map;
-		reg = <0 0xffc00000 0 0x00100000>;
-		record-size = <0x1000>;
-		console-size = <0x40000>;
-		ftrace-size = <0x0>;
-		msg-size = <0x20000 0x20000>;
-		ecc-size = <16>;
-	};
-
-	cmdline_region: cmdline_region@ffd00000 {
-		compatible = "removed-dma-pool", "cmdline_region";
-		no-map;
-		reg = <0 0xffd00000 0 0x1000>;
-		label = "cmdline_region";
-	};
 };
 
 &soc {

--- a/arch/arm64/boot/dts/somc/blair-murray-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-murray-common.dtsi
@@ -6,10 +6,10 @@
 		compatible = "removed-dma-pool", "ramoops";
 		no-map;
 		reg = <0 0xffc40000 0 0x000b0000>;
-		record-size = <0x1000>;
+		record-size = <0x10000>;
 		console-size = <0x40000>;
-		ftrace-size = <0x0>;
-		msg-size = <0x20000 0x20000>;
+		ftrace-size = <0x10000>;
+		pmsg-size = <0x40000>;
 		ecc-size = <16>;
 	};
 };

--- a/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
@@ -6,10 +6,10 @@
 		compatible = "removed-dma-pool", "ramoops";
 		no-map;
 		reg = <0 0xffc40000 0 0x000b0000>;
-		record-size = <0x1000>;
+		record-size = <0x10000>;
 		console-size = <0x40000>;
-		ftrace-size = <0x0>;
-		msg-size = <0x20000 0x20000>;
+		ftrace-size = <0x10000>;
+		pmsg-size = <0x40000>;
 		ecc-size = <16>;
 	};
 };

--- a/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
@@ -2,6 +2,44 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
+&reserved_memory {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	debug_region: debug_region@ffb00000 {
+		compatible = "removed-dma-pool", "qcom,debug_memory";
+		no-map;
+		reg = <0 0xffb00000 0 0xc0000>;
+		label = "debug_mem";
+	};
+
+	last_log_region: last_log_region@ffbc0000 {
+		compatible = "removed-dma-pool", "qcom,last_log_memory";
+		no-map;
+		reg = <0 0xffbc0000 0 0x40000>;
+		label = "last_log";
+		phandle = "log";
+	};
+
+	ramoops: ramoops@ffc00000 {
+		compatible = "removed-dma-pool", "ramoops";
+		no-map;
+		reg = <0 0xffc00000 0 0x00100000>;
+		record-size = <0x1000>;
+		console-size = <0x40000>;
+		ftrace-size = <0x0>;
+		msg-size = <0x20000 0x20000>;
+		ecc-size = <16>;
+	};
+
+	cmdline_region: cmdline_region@ffd00000 {
+		compatible = "removed-dma-pool", "cmdline_region";
+		no-map;
+		reg = <0 0xffd00000 0 0x1000>;
+		label = "cmdline_region";
+	};
+};
+
 &soc {
 	somc_pinctrl: somc_pinctrl {
 		compatible = "somc-pinctrl";

--- a/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
@@ -25,10 +25,10 @@
 		compatible = "removed-dma-pool", "ramoops";
 		no-map;
 		reg = <0 0xffc00000 0 0x00100000>;
-		record-size = <0x1000>;
+		record-size = <0x10000>;
 		console-size = <0x40000>;
-		ftrace-size = <0x0>;
-		msg-size = <0x20000 0x20000>;
+		ftrace-size = <0x10000>;
+		pmsg-size = <0x40000>;
 		ecc-size = <16>;
 	};
 


### PR DESCRIPTION
Increase the record-size to avoid creating a large number (about 112)
oops dump zones. Also fix pmsg-size and define ftrace-size for
userspace messages and function tracing.
Without this change, a huge number of msm minidump regions will be
created, which leads to an overflow of the minidump table in SMEM.

```E Minidump: Maximum regions in minidump table reached.
E : Error: adsprpc (952): adsprpcd: fastrpc_minidump_add_region:
    Failed to add/update CMA to Minidump for phys: 0xf3c00000,
    size: 2097152, md_index 0, md_entry.name FRPC_0
W : Warning: adsprpc (991): adsprpcd: fastrpc_minidump_remove_region:
    mini-dump enabled with invalid unique id: -1
```