### PR TITLE
[7.1.r1] arm64: dts: SoMC: Akatsuki: Set SDE to max performance mode

### DIFF
--- a/arch/arm64/boot/dts/qcom/dsi-panel-somc-akatsuki.dtsi
+++ b/arch/arm64/boot/dts/qcom/dsi-panel-somc-akatsuki.dtsi
@@ -20,6 +20,11 @@
 #include "dsi-panel-somc-atmel-lgd-1440p2880-cmd.dtsi"
 #include "dsi-panel-somc-akatsuki-id5_pcc.dtsi"
 
+&mdss_mdp {
+	/* Set SDE MAX performance */
+	qcom,sde-perf-default-mode = <3>;
+};
+
 &mdss_dsi0 {
 	/delete-property/ qcom,null-insertion-enabled;
 };


### PR DESCRIPTION
Turns out that akatsuki's clock calculation shenanigans do not only apply to 4.19.

See https://github.com/sailfishos-sony-tama/main/issues/150 and https://github.com/sailfishos-sony-tama/main/issues/203 for context (and epic artifacts).
