### PR TITLE
[2.0.r1] input: ts: sec_ts_incell: Remove extra argument

### DIFF
--- a/drivers/input/touchscreen/sec_ts_incell/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts_incell/sec_ts.c
@@ -2079,7 +2079,7 @@ err:
 	return -EINVAL;
 }
 
-static void sec_ts_register_for_panel_events(struct sec_ts_data *ts, struct device *dev)
+static void sec_ts_register_for_panel_events(struct sec_ts_data *ts)
 {
 	void *cookie;
 


### PR DESCRIPTION
Remove extra argument from sec_ts_register_for_panel_events().
This was missed by me during the rebase, sorry.

Fixes:
https://github.com/sonyxperiadev/kernel/commit/fa2b97a6956eb7a42950ef21437cdfad72fa0a02