### PR TITLE
[2.0.r1] SoC Waipio clocks update

### DIFF
--- a/drivers/clk/qcom/Kconfig
+++ b/drivers/clk/qcom/Kconfig
@@ -776,13 +776,22 @@ config SM_TCSRCC_KALAMA
 	  such as for the PHY references.
 
 config MSM_GCC_WAIPIO
-          tristate "WAIPIO Global Clock Controller"
+	tristate "WAIPIO Global Clock Controller"
 	  depends on COMMON_CLK_QCOM
 	  help
 	    Support for the global clock controller on Qualcomm Technologies, Inc
 	    WAIPIO devices.
 	    Say Y if you want to use peripheral devices such as UART, SPI, I2C,
 	    USB, UFS, SD/eMMC, PCIe, etc.
+
+config MSM_CAMCC_WAIPIO
+	tristate "WAIPIO Camera Clock Controller"
+	depends on MSM_GCC_WAIPIO
+	help
+	  Support for the camera clock controller on Qualcomm Technologies, Inc.
+	  WAIPIO devices.
+	  Say Y if you want to support camera devices and functionality such as
+	  capturing pictures.
 
 config MSM_VIDEOCC_WAIPIO
 	tristate "WAIPIO Video Clock Controller"
@@ -795,7 +804,7 @@ config MSM_VIDEOCC_WAIPIO
 
 config MSM_GPUCC_WAIPIO
 	tristate "Waipio Graphics Clock Controller"
-	depends on COMMON_CLK_QCOM
+	depends on MSM_GCC_WAIPIO
 	help
 	  Support for the graphics clock controller on Qualcomm Technologies, Inc
 	  WAIPIO devices.

--- a/drivers/clk/qcom/camcc-waipio.c
+++ b/drivers/clk/qcom/camcc-waipio.c
@@ -1723,8 +1723,6 @@ static struct clk_rcg2 cam_cc_sleep_clk_src = {
 	.hid_width = 5,
 	.parent_map = cam_cc_parent_map_8,
 	.freq_tbl = ftbl_cam_cc_sleep_clk_src,
-	.enable_safe_config = true,
-	.flags = HW_CLK_CTRL_MODE,
 	.clkr.hw.init = &(struct clk_init_data){
 		.name = "cam_cc_sleep_clk_src",
 		.parent_data = cam_cc_parent_data_8,
@@ -3066,7 +3064,7 @@ static struct clk_branch cam_cc_sleep_clk = {
 			},
 			.num_parents = 1,
 			.flags = CLK_SET_RATE_PARENT,
-			.ops = &clk_branch2_ops,
+			.ops = &clk_branch2_aon_ops,
 		},
 	},
 };

--- a/drivers/clk/qcom/camcc-waipio.c
+++ b/drivers/clk/qcom/camcc-waipio.c
@@ -222,7 +222,7 @@ static const struct alpha_pll_config cam_cc_pll2_config = {
 	.config_ctl_hi1_val = 0x00000217,
 };
 
-static const struct alpha_pll_config cam_cc_pll2_config_sm8450_v2 = {
+static const struct alpha_pll_config cam_cc_pll2_config_waipio_v2 = {
 	.l = 0x32,
 	.cal_l = 0x32,
 	.alpha = 0x0,
@@ -3236,7 +3236,7 @@ MODULE_DEVICE_TABLE(of, cam_cc_waipio_match_table);
 
 static void cam_cc_waipio_fixup_waipiov2(struct regmap *regmap)
 {
-	clk_rivian_evo_pll_configure(&cam_cc_pll2, regmap, &cam_cc_pll2_config_sm8450_v2);
+	clk_rivian_evo_pll_configure(&cam_cc_pll2, regmap, &cam_cc_pll2_config_waipio_v2);
 	cam_cc_ife_0_clk_src.freq_tbl = ftbl_cam_cc_ife_0_clk_src_waipio_v2;
 	cam_cc_ife_0_clk_src.clkr.vdd_data.rate_max[VDD_NOMINAL] = 727000000;
 	cam_cc_ife_1_clk_src.freq_tbl = ftbl_cam_cc_ife_1_clk_src_waipio_v2;

--- a/drivers/clk/qcom/camcc-waipio.c
+++ b/drivers/clk/qcom/camcc-waipio.c
@@ -18,6 +18,7 @@
 #include "clk-alpha-pll.h"
 #include "clk-branch.h"
 #include "clk-pll.h"
+#include "clk-pm.h"
 #include "clk-rcg.h"
 #include "clk-regmap.h"
 #include "clk-regmap-divider.h"
@@ -66,7 +67,7 @@ static struct pll_vco rivian_evo_vco[] = {
 	{ 864000000, 1056000000, 0 },
 };
 
-static const struct alpha_pll_config cam_cc_pll0_config = {
+static struct alpha_pll_config cam_cc_pll0_config = {
 	.l = 0x3E,
 	.cal_l = 0x44,
 	.alpha = 0x8000,
@@ -82,6 +83,7 @@ static struct clk_alpha_pll cam_cc_pll0 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll0_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll0",
@@ -151,7 +153,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll0_out_odd = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll1_config = {
+static struct alpha_pll_config cam_cc_pll1_config = {
 	.l = 0x25,
 	.cal_l = 0x44,
 	.alpha = 0xEAAA,
@@ -167,6 +169,7 @@ static struct clk_alpha_pll cam_cc_pll1 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll1_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll1",
@@ -213,7 +216,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll1_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll2_config = {
+static struct alpha_pll_config cam_cc_pll2_config = {
 	.l = 0x32,
 	.cal_l = 0x32,
 	.alpha = 0x0,
@@ -222,7 +225,7 @@ static const struct alpha_pll_config cam_cc_pll2_config = {
 	.config_ctl_hi1_val = 0x00000247,
 };
 
-static const struct alpha_pll_config cam_cc_pll2_config_waipio_v2 = {
+static struct alpha_pll_config cam_cc_pll2_config_waipio_v2 = {
 	.l = 0x32,
 	.cal_l = 0x32,
 	.alpha = 0x0,
@@ -236,6 +239,7 @@ static struct clk_alpha_pll cam_cc_pll2 = {
 	.vco_table = rivian_evo_vco,
 	.num_vco = ARRAY_SIZE(rivian_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_RIVIAN_EVO],
+	.config = &cam_cc_pll2_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll2",
@@ -254,7 +258,7 @@ static struct clk_alpha_pll cam_cc_pll2 = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll3_config = {
+static struct alpha_pll_config cam_cc_pll3_config = {
 	.l = 0x2D,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -270,6 +274,7 @@ static struct clk_alpha_pll cam_cc_pll3 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll3_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll3",
@@ -316,7 +321,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll3_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll4_config = {
+static struct alpha_pll_config cam_cc_pll4_config = {
 	.l = 0x2D,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -332,6 +337,7 @@ static struct clk_alpha_pll cam_cc_pll4 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll4_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll4",
@@ -378,7 +384,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll4_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll5_config = {
+static struct alpha_pll_config cam_cc_pll5_config = {
 	.l = 0x2D,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -394,6 +400,7 @@ static struct clk_alpha_pll cam_cc_pll5 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll5_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll5",
@@ -440,7 +447,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll5_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll6_config = {
+static struct alpha_pll_config cam_cc_pll6_config = {
 	.l = 0x2D,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -456,6 +463,7 @@ static struct clk_alpha_pll cam_cc_pll6 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll6_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll6",
@@ -502,7 +510,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll6_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll7_config = {
+static struct alpha_pll_config cam_cc_pll7_config = {
 	.l = 0x2D,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -518,6 +526,7 @@ static struct clk_alpha_pll cam_cc_pll7 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll7_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll7",
@@ -564,7 +573,7 @@ static struct clk_alpha_pll_postdiv cam_cc_pll7_out_even = {
 	},
 };
 
-static const struct alpha_pll_config cam_cc_pll8_config = {
+static struct alpha_pll_config cam_cc_pll8_config = {
 	.l = 0x32,
 	.cal_l = 0x44,
 	.alpha = 0x0,
@@ -580,6 +589,7 @@ static struct clk_alpha_pll cam_cc_pll8 = {
 	.vco_table = lucid_evo_vco,
 	.num_vco = ARRAY_SIZE(lucid_evo_vco),
 	.regs = clk_alpha_pll_regs[CLK_ALPHA_PLL_TYPE_LUCID_EVO],
+	.config = &cam_cc_pll8_config,
 	.clkr = {
 		.hw.init = &(struct clk_init_data){
 			.name = "cam_cc_pll8",
@@ -3069,6 +3079,14 @@ static struct clk_branch cam_cc_sleep_clk = {
 	},
 };
 
+/*
+ * Keep clocks always enabled:
+ *	cam_cc_gdsc_clk
+ */
+static struct critical_clk_offset cam_cc_waipio_critical_clocks[] = {
+	{ .offset = 0x1320c, .mask = BIT(0) },
+};
+
 static struct clk_regmap *cam_cc_waipio_clocks[] = {
 	[CAM_CC_BPS_AHB_CLK] = &cam_cc_bps_ahb_clk.clkr,
 	[CAM_CC_BPS_CLK] = &cam_cc_bps_clk.clkr,
@@ -3225,6 +3243,8 @@ static struct qcom_cc_desc cam_cc_waipio_desc = {
 	.num_resets = ARRAY_SIZE(cam_cc_waipio_resets),
 	.clk_regulators = cam_cc_waipio_regulators,
 	.num_clk_regulators = ARRAY_SIZE(cam_cc_waipio_regulators),
+	.critical_clk_en = cam_cc_waipio_critical_clocks,
+	.num_critical_clk = ARRAY_SIZE(cam_cc_waipio_critical_clocks),
 };
 
 static const struct of_device_id cam_cc_waipio_match_table[] = {
@@ -3237,6 +3257,8 @@ MODULE_DEVICE_TABLE(of, cam_cc_waipio_match_table);
 static void cam_cc_waipio_fixup_waipiov2(struct regmap *regmap)
 {
 	clk_rivian_evo_pll_configure(&cam_cc_pll2, regmap, &cam_cc_pll2_config_waipio_v2);
+	cam_cc_pll2.config = &cam_cc_pll2_config_waipio_v2;
+
 	cam_cc_ife_0_clk_src.freq_tbl = ftbl_cam_cc_ife_0_clk_src_waipio_v2;
 	cam_cc_ife_0_clk_src.clkr.vdd_data.rate_max[VDD_NOMINAL] = 727000000;
 	cam_cc_ife_1_clk_src.freq_tbl = ftbl_cam_cc_ife_1_clk_src_waipio_v2;
@@ -3273,13 +3295,9 @@ static int cam_cc_waipio_probe(struct platform_device *pdev)
 	if (IS_ERR(regmap))
 		return PTR_ERR(regmap);
 
-	ret = qcom_cc_runtime_init(pdev, &cam_cc_waipio_desc);
+	ret = register_qcom_clks_pm(pdev, true, &cam_cc_waipio_desc);
 	if (ret)
-		return ret;
-
-	ret = pm_runtime_get_sync(&pdev->dev);
-	if (ret)
-		return ret;
+		dev_err(&pdev->dev, "Failed to register for pm ops\n");
 
 	clk_lucid_evo_pll_configure(&cam_cc_pll0, regmap, &cam_cc_pll0_config);
 	clk_lucid_evo_pll_configure(&cam_cc_pll1, regmap, &cam_cc_pll1_config);
@@ -3295,11 +3313,8 @@ static int cam_cc_waipio_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	/*
-	 * Keep clocks always enabled:
-	 *	cam_cc_gdsc_clk
-	 */
-	regmap_update_bits(regmap, 0x1320c, BIT(0), BIT(0));
+	/* Enabling always ON clocks */
+	clk_restore_critical_clocks(&pdev->dev);
 
 	ret = qcom_cc_really_probe(pdev, &cam_cc_waipio_desc, regmap);
 	if (ret) {
@@ -3318,19 +3333,12 @@ static void cam_cc_waipio_sync_state(struct device *dev)
 	qcom_cc_sync_state(dev, &cam_cc_waipio_desc);
 }
 
-static const struct dev_pm_ops cam_cc_waipio_pm_ops = {
-	SET_RUNTIME_PM_OPS(qcom_cc_runtime_suspend, qcom_cc_runtime_resume, NULL)
-	SET_SYSTEM_SLEEP_PM_OPS(pm_runtime_force_suspend,
-				pm_runtime_force_resume)
-};
-
 static struct platform_driver cam_cc_waipio_driver = {
 	.probe = cam_cc_waipio_probe,
 	.driver = {
 		.name = "cam_cc-waipio",
 		.of_match_table = cam_cc_waipio_match_table,
 		.sync_state = cam_cc_waipio_sync_state,
-		.pm = &cam_cc_waipio_pm_ops,
 	},
 };
 

--- a/drivers/clk/qcom/camcc-waipio.c
+++ b/drivers/clk/qcom/camcc-waipio.c
@@ -219,7 +219,7 @@ static const struct alpha_pll_config cam_cc_pll2_config = {
 	.alpha = 0x0,
 	.config_ctl_val = 0x90008830,
 	.config_ctl_hi_val = 0x00890263,
-	.config_ctl_hi1_val = 0x00000217,
+	.config_ctl_hi1_val = 0x00000247,
 };
 
 static const struct alpha_pll_config cam_cc_pll2_config_waipio_v2 = {
@@ -228,7 +228,7 @@ static const struct alpha_pll_config cam_cc_pll2_config_waipio_v2 = {
 	.alpha = 0x0,
 	.config_ctl_val = 0x90008820,
 	.config_ctl_hi_val = 0x00890263,
-	.config_ctl_hi1_val = 0x00000217,
+	.config_ctl_hi1_val = 0x00000247,
 };
 
 static struct clk_alpha_pll cam_cc_pll2 = {

--- a/drivers/clk/qcom/debugcc-waipio.c
+++ b/drivers/clk/qcom/debugcc-waipio.c
@@ -57,6 +57,7 @@ static struct clk_debug_mux apss_cc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 4,
 	.mux_sels = apss_cc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(apss_cc_debug_mux_sels),
 	.pre_div_vals = apss_cc_debug_mux_pre_divs,
 	.hw.init = &(struct clk_init_data){
 		.name = "apss_cc_debug_mux",
@@ -227,6 +228,7 @@ static struct clk_debug_mux cam_cc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 4,
 	.mux_sels = cam_cc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(cam_cc_debug_mux_sels),
 	.hw.init = &(struct clk_init_data){
 		.name = "cam_cc_debug_mux",
 		.ops = &clk_debug_mux_ops,
@@ -348,6 +350,7 @@ static struct clk_debug_mux disp_cc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 4,
 	.mux_sels = disp_cc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(disp_cc_debug_mux_sels),
 	.hw.init = &(struct clk_init_data){
 		.name = "disp_cc_debug_mux",
 		.ops = &clk_debug_mux_ops,
@@ -627,6 +630,7 @@ static struct clk_debug_mux gcc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 2,
 	.mux_sels = gcc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(gcc_debug_mux_sels),
 	.hw.init = &(struct clk_init_data){
 		.name = "gcc_debug_mux",
 		.ops = &clk_debug_mux_ops,
@@ -698,6 +702,7 @@ static struct clk_debug_mux gpu_cc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 2,
 	.mux_sels = gpu_cc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(gpu_cc_debug_mux_sels),
 	.hw.init = &(struct clk_init_data){
 		.name = "gpu_cc_debug_mux",
 		.ops = &clk_debug_mux_ops,
@@ -737,6 +742,7 @@ static struct clk_debug_mux video_cc_debug_mux = {
 	.post_div_shift = 0,
 	.post_div_val = 3,
 	.mux_sels = video_cc_debug_mux_sels,
+	.num_mux_sels = ARRAY_SIZE(video_cc_debug_mux_sels),
 	.hw.init = &(struct clk_init_data){
 		.name = "video_cc_debug_mux",
 		.ops = &clk_debug_mux_ops,
@@ -763,10 +769,10 @@ static struct mux_regmap_names mux_list[] = {
 	{ .mux = &apss_cc_debug_mux, .regmap_name = "qcom,apsscc" },
 	{ .mux = &cam_cc_debug_mux, .regmap_name = "qcom,camcc" },
 	{ .mux = &disp_cc_debug_mux, .regmap_name = "qcom,dispcc" },
-	{ .mux = &gcc_debug_mux, .regmap_name = "qcom,gcc" },
 	{ .mux = &gpu_cc_debug_mux, .regmap_name = "qcom,gpucc" },
 	{ .mux = &mc_cc_debug_mux, .regmap_name = "qcom,mccc" },
 	{ .mux = &video_cc_debug_mux, .regmap_name = "qcom,videocc" },
+	{ .mux = &gcc_debug_mux, .regmap_name = "qcom,gcc" },
 };
 
 static struct clk_dummy measure_only_apcs_gold_post_acd_clk = {
@@ -923,16 +929,6 @@ static int clk_debug_waipio_probe(struct platform_device *pdev)
 		}
 	}
 
-	for (i = 0; i < ARRAY_SIZE(mux_list); i++) {
-		ret = devm_clk_register_debug_mux(&pdev->dev, mux_list[i].mux);
-		if (ret) {
-			dev_err(&pdev->dev, "Unable to register mux clk %s, err:(%d)\n",
-				qcom_clk_hw_get_name(&mux_list[i].mux->hw),
-				ret);
-			return ret;
-		}
-	}
-
 	for (i = 0; i < ARRAY_SIZE(debugcc_waipio_hws); i++) {
 		clk = devm_clk_register(&pdev->dev, debugcc_waipio_hws[i]);
 		if (IS_ERR(clk)) {
@@ -940,6 +936,16 @@ static int clk_debug_waipio_probe(struct platform_device *pdev)
 				clk_hw_get_name(debugcc_waipio_hws[i]),
 				PTR_ERR(clk));
 			return PTR_ERR(clk);
+		}
+	}
+
+	for (i = 0; i < ARRAY_SIZE(mux_list); i++) {
+		ret = devm_clk_register_debug_mux(&pdev->dev, mux_list[i].mux);
+		if (ret) {
+			dev_err(&pdev->dev, "Unable to register mux clk %s, err:(%d)\n",
+				qcom_clk_hw_get_name(&mux_list[i].mux->hw),
+				ret);
+			return ret;
 		}
 	}
 

--- a/drivers/clk/qcom/gcc-waipio.c
+++ b/drivers/clk/qcom/gcc-waipio.c
@@ -3514,7 +3514,7 @@ static struct clk_branch gcc_video_axi0_clk = {
 		.enable_mask = BIT(0),
 		.hw.init = &(struct clk_init_data){
 			.name = "gcc_video_axi0_clk",
-			.ops = &clk_branch2_ops,
+			.ops = &clk_branch2_force_off_ops,
 		},
 	},
 };
@@ -3529,7 +3529,7 @@ static struct clk_branch gcc_video_axi1_clk = {
 		.enable_mask = BIT(0),
 		.hw.init = &(struct clk_init_data){
 			.name = "gcc_video_axi1_clk",
-			.ops = &clk_branch2_ops,
+			.ops = &clk_branch2_force_off_ops,
 		},
 	},
 };

--- a/drivers/clk/qcom/gpucc-waipio.c
+++ b/drivers/clk/qcom/gpucc-waipio.c
@@ -63,7 +63,7 @@ static const struct alpha_pll_config gpu_cc_pll0_config = {
 	.user_ctl_hi_val = 0x00000805,
 };
 
-static const struct alpha_pll_config gpu_cc_pll0_config_sm8450_v2 = {
+static const struct alpha_pll_config gpu_cc_pll0_config_waipio_v2 = {
 	.l = 0x1D,
 	.cal_l = 0x44,
 	.alpha = 0xB000,
@@ -790,7 +790,7 @@ MODULE_DEVICE_TABLE(of, gpu_cc_waipio_match_table);
 
 static void gpu_cc_waipio_fixup_waipiov2(struct regmap *regmap)
 {
-	clk_lucid_evo_pll_configure(&gpu_cc_pll0, regmap, &gpu_cc_pll0_config_sm8450_v2);
+	clk_lucid_evo_pll_configure(&gpu_cc_pll0, regmap, &gpu_cc_pll0_config_waipio_v2);
 	gpu_cc_ff_clk_src.clkr.vdd_data.rate_max[VDD_LOWER_D1] = 200000000;
 	gpu_cc_gmu_clk_src.clkr.vdd_data.rate_max[VDD_LOWER_D1] = 200000000;
 	gpu_cc_hub_clk_src.clkr.vdd_data.rate_max[VDD_LOWER_D1] = 150000000;

--- a/drivers/clk/qcom/gpucc-waipio.c
+++ b/drivers/clk/qcom/gpucc-waipio.c
@@ -518,7 +518,7 @@ static struct clk_branch gpu_cc_demet_clk = {
 			},
 			.num_parents = 1,
 			.flags = CLK_SET_RATE_PARENT,
-			.ops = &clk_branch2_ops,
+			.ops = &clk_branch2_aon_ops,
 		},
 	},
 };

--- a/drivers/clk/qcom/gpucc-waipio.c
+++ b/drivers/clk/qcom/gpucc-waipio.c
@@ -761,6 +761,7 @@ static const struct qcom_reset_map gpu_cc_waipio_resets[] = {
 	[GPUCC_GPU_CC_GMU_BCR] = { 0x9314 },
 	[GPUCC_GPU_CC_GX_BCR] = { 0x9058 },
 	[GPUCC_GPU_CC_XO_BCR] = { 0x9000 },
+	[GPUCC_GPU_CC_FREQUENCY_LIMITER_IRQ_CLEAR] = { 0x9538, 0 },
 };
 
 static const struct regmap_config gpu_cc_waipio_regmap_config = {
@@ -824,6 +825,8 @@ static int gpu_cc_waipio_probe(struct platform_device *pdev)
 
 	clk_lucid_evo_pll_configure(&gpu_cc_pll0, regmap, &gpu_cc_pll0_config);
 	clk_lucid_evo_pll_configure(&gpu_cc_pll1, regmap, &gpu_cc_pll1_config);
+
+	regmap_write(regmap, 0x9534, 0x0);
 
 	ret = gpu_cc_waipio_fixup(pdev, regmap);
 	if (ret)

--- a/include/dt-bindings/clock/qcom,gpucc-waipio.h
+++ b/include/dt-bindings/clock/qcom,gpucc-waipio.h
@@ -49,5 +49,6 @@
 #define GPUCC_GPU_CC_GMU_BCR					5
 #define GPUCC_GPU_CC_GX_BCR					6
 #define GPUCC_GPU_CC_XO_BCR					7
+#define GPUCC_GPU_CC_FREQUENCY_LIMITER_IRQ_CLEAR		8
 
 #endif


### PR DESCRIPTION
Contains the following changes:
- clk: qcom: waipio: Register CCs with clk pm framework
- clk: qcom: Kconfig: Add cam cc clock driver for Waipio
- clk: qcom: gpucc: Keep gpu_cc_demet_clk always ON
- clk: qcom: camcc-waipio: Update cam_cc_pll2 settings
- clk: qcom: gpucc: Add support for reset for waipio
- bindings: clk: gpucc: Add support for LIMITER reset for Waipio
- clk: qcom: debugcc-waipio: Allow parent caching during init
- clk: qcom: waipio: Use correct chip name in fixup
- clk: qcom: gcc-waipio: Update video_axi clks to clk_branch2_force_off_ops
- clk: qcom: camcc-waipio: Fix cam_cc_sleep_clk_src prepare failure

Most of the changes were forward ported from msm-5.10, except (clk pm framework).