### PR TITLE
dts: somc: murray/zambezi: Fix maximum backlight brightness values

### DIFF
--- a/arch/arm64/boot/dts/somc/somc-murray-display-pdx225.dtsi
+++ b/arch/arm64/boot/dts/somc/somc-murray-display-pdx225.dtsi
@@ -5,8 +5,8 @@
 	qcom,mdss-dsi-bl-inverted-dbv;
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-bl-min-level = <1>;
-	qcom,mdss-dsi-bl-max-level = <4095>;
-	qcom,mdss-brightness-max-level = <4095>;
+	qcom,mdss-dsi-bl-max-level = <2047>;
+	qcom,mdss-brightness-max-level = <2047>;
 	qcom,platform-te-gpio = <&tlmm 23 0>;
 	qcom,platform-reset-gpio = <&pmr735a_gpios 2 0>;
 	somc,disp-err-flag-gpio = <&tlmm 97 0>;

--- a/arch/arm64/boot/dts/somc/somc-zambezi-display-pdx235.dtsi
+++ b/arch/arm64/boot/dts/somc/somc-zambezi-display-pdx235.dtsi
@@ -5,8 +5,8 @@
 	qcom,mdss-dsi-bl-inverted-dbv;
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-bl-min-level = <1>;
-	qcom,mdss-dsi-bl-max-level = <4095>;
-	qcom,mdss-brightness-max-level = <4095>;
+	qcom,mdss-dsi-bl-max-level = <2047>;
+	qcom,mdss-brightness-max-level = <2047>;
 	qcom,platform-te-gpio = <&tlmm 23 0>;
 	qcom,platform-reset-gpio = <&pmr735a_gpios 2 0>;
 	somc,disp-err-flag-gpio = <&tlmm 97 0>;


### PR DESCRIPTION
Fix maximum backlight brightness values for murray and zambezi. Only 11 bits are used for brightness value.

Testing on devices showed that values up to 2047 gave increasing brightness and 2048 made display turn black and higher values would start increasing the brightness as it would start from 0.