### PR TITLE
[9.16.r1] Add missing qseecom patch to fix suspending

### DIFF
--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -9750,7 +9750,8 @@ static int qseecom_suspend(struct platform_device *pdev, pm_message_t state)
 
 	mutex_unlock(&clk_access_lock);
 	mutex_unlock(&qsee_bw_mutex);
-	cancel_work_sync(&qseecom.bw_inactive_req_ws);
+	if (qseecom.support_bus_scaling)
+		cancel_work_sync(&qseecom.bw_inactive_req_ws);
 
 	return 0;
 }


### PR DESCRIPTION
The commit "qseecom: Add flush_work based on flag" from aosp/LA.UM.9.12.r1 branch is needed to make suspend work properly on Xperia 10 IV and V. Without this patch the following stackstace appears in kernel logs when device tries to suspend.

    kernel: ------------[ cut here ]------------
    kernel: WARNING: CPU: 7 PID: 228 at kernel/workqueue.c:3063 __flush_work+0x25c/0x27c
    kernel: Modules linked in:
    kernel: CPU: 7 PID: 228 Comm: kworker/u16:2 Tainted: G S      W         5.4.210-qgki #1
    kernel: Hardware name: Sony Mobile Communications. PDX235(BLAIR v1) (DT)
    kernel: Workqueue: autosleep try_to_suspend
    kernel: pstate: 60c00005 (nZCv daif +PAN +UAO) 
    kernel: pc : __flush_work+0x25c/0x27c
    kernel: lr : __cancel_work_timer+0x114/0x1a4
    kernel: sp : ffffffc0146a39f0 
    kernel: x29: ffffffc0146a3a50 x28: ffffffdac15c4000 
    kernel: x27: ffffffdac10fe000 x26: ffffffdabe2e3154 
    kernel: x25: ffffffc0146a3aa8 x24: 0000000000000014 
    kernel: x23: ffffffa0d75fbf00 x22: ffffffdac10f68f8 
    kernel: x21: 0000000000000000 x20: ffffffdac15c75a8
    kernel: x19: ffffffdac15c75a8 x18: 0000000006acfc00 
    kernel: x17: 0000000005f5e100 x16: 000000000049ce86 
    kernel: x15: ffffffdac17c9000 x14: 0000000000000008 
    kernel: x13: 003d5e8ba0ffffff x12: 34071705069b8df7 
    kernel: x11: ffffffc639540000 x10: 0000000000000000 
    kernel: x9 : ffffffdac1522000 x8 : 0000000000000000 
    kernel: x7 : ffffffffffffffff x6 : ffffffa0d5127340 
    kernel: x5 : 0000000000000040 x4 : ffffffa0fa5f75e0 
    kernel: x3 : ffffffdac093c94f x2 : ffffffc0146a3ac0 
    kernel: x1 : 0000000000000001 x0 : 0000000000000000
    kernel: Call trace: 
    kernel:  __flush_work+0x25c/0x27c
    kernel:  __cancel_work_timer+0x114/0x1a4
    kernel:  cancel_work_sync+0x10/0x1c
    kernel:  qseecom_suspend+0x104/0x150
    kernel:  platform_pm_suspend+0x40/0x54
    kernel:  dpm_run_callback+0x4c/0x348
    kernel:  __device_suspend+0x34c/0x4ac
    kernel:  dpm_suspend+0x108/0x548
    kernel:  dpm_suspend_start+0x80/0x1b4
    kernel:  suspend_devices_and_enter+0xb4/0x6c8
    kernel:  enter_state+0x11c/0x404
    kernel:  pm_suspend+0x50/0xbc
    kernel:  try_to_suspend+0x64/0x100
    kernel:  process_one_work+0x190/0x35c
    kernel:  worker_thread+0x274/0x4cc
    kernel:  kthread+0x134/0x22c
    kernel:  ret_from_fork+0x10/0x18
    kernel: ---[ end trace 371e384a5b24ce72 ]---
    kernel: [kworke][0xd69ce15fc0][07:56:48.116284] wlan: [228:I:HDD] __wlan_hdd_bus_suspend: starting bus suspend