### PR TITLE
[2.0.r1] BACKPORT: kallsyms: increase maximum kernel symbol length to 512

### DIFF
--- a/include/linux/kallsyms.h
+++ b/include/linux/kallsyms.h
@@ -15,7 +15,7 @@
 
 #include <asm/sections.h>
 
-#define KSYM_NAME_LEN 128
+#define KSYM_NAME_LEN 512
 #define KSYM_SYMBOL_LEN (sizeof("%s+%#lx/%#lx [%s %s]") + \
 			(KSYM_NAME_LEN - 1) + \
 			2*(BITS_PER_LONG*3/10) + (MODULE_NAME_LEN - 1) + \

--- a/kernel/livepatch/core.c
+++ b/kernel/livepatch/core.c
@@ -213,7 +213,7 @@ static int klp_resolve_symbols(Elf_Shdr *sechdrs, const char *strtab,
 	 * we use the smallest/strictest upper bound possible (56, based on
 	 * the current definition of MODULE_NAME_LEN) to prevent overflows.
 	 */
-	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 128);
+	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 512);
 
 	relas = (Elf_Rela *) relasec->sh_addr;
 	/* For each rela in this klp relocation section */
@@ -227,7 +227,7 @@ static int klp_resolve_symbols(Elf_Shdr *sechdrs, const char *strtab,
 
 		/* Format: .klp.sym.sym_objname.sym_name,sympos */
 		cnt = sscanf(strtab + sym->st_name,
-			     ".klp.sym.%55[^.].%127[^,],%lu",
+			     ".klp.sym.%55[^.].%511[^,],%lu",
 			     sym_objname, sym_name, &sympos);
 		if (cnt != 3) {
 			pr_err("symbol %s has an incorrectly formatted name\n",

--- a/scripts/kallsyms.c
+++ b/scripts/kallsyms.c
@@ -27,7 +27,7 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
-#define KSYM_NAME_LEN		128
+#define KSYM_NAME_LEN		512
 
 struct sym_entry {
 	unsigned long long addr;

--- a/tools/include/linux/kallsyms.h
+++ b/tools/include/linux/kallsyms.h
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#define KSYM_NAME_LEN 128
+#define KSYM_NAME_LEN 512
 
 struct module;
 

--- a/tools/lib/perf/include/perf/event.h
+++ b/tools/lib/perf/include/perf/event.h
@@ -95,7 +95,7 @@ struct perf_record_throttle {
 };
 
 #ifndef KSYM_NAME_LEN
-#define KSYM_NAME_LEN 256
+#define KSYM_NAME_LEN 512
 #endif
 
 struct perf_record_ksymbol {

--- a/tools/lib/symbol/kallsyms.h
+++ b/tools/lib/symbol/kallsyms.h
@@ -7,7 +7,7 @@
 #include <linux/types.h>
 
 #ifndef KSYM_NAME_LEN
-#define KSYM_NAME_LEN 256
+#define KSYM_NAME_LEN 512
 #endif
 
 static inline u8 kallsyms2elf_binding(char type)


### PR DESCRIPTION
Backported from the mainline kernel because some QCOM driver symbols can have a large length.

`Symbol __typeid__ZTSFijPFiPvP36ipa_wdi_opt_dpath_flt_rsrv_cb_paramsEPFiS_EPFiS_P35ipa_wdi_opt_dpath_flt_add_cb_paramsEPFiS_P35ipa_wdi_opt_dpath_flt_rem_cb_paramsEE_global_addr too long for kallsyms (168 >= 128).
Please increase KSYM_NAME_LEN both in kernel and kallsyms.c`

`Symbol __typeid__ZTSFi17ipa_hdr_proc_typePvjjyP20ipa_hdr_offset_entryP28ipa_l2tp_hdr_proc_ctx_paramsP29ipa_eogre_hdr_proc_ctx_paramsP34ipa_eth_II_to_eth_II_ex_procparamsbE_global_addr too long for kallsyms (176 >= 128).
Please increase KSYM_NAME_LEN both in kernel and kallsyms.c`

`Symbol __typeid__ZTSFP11mmrm_clientP12mmrm_clk_mgr20mmrm_clk_client_desc20mmrm_client_priorityPvPFiP25mmrm_client_notifier_dataEE_global_addr too long for kallsyms (134 >= 128).
Please increase KSYM_NAME_LEN both in kernel and kallsyms.c`