### PR TITLE
[1.0.r1] dts: somc: columbia: Fix LPASS CDC resource manager clocks

### DIFF
--- a/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
@@ -13,16 +13,16 @@
 		compatible = "qcom,lpass-cdc-clk-rsc-mngr";
 		qcom,fs-gen-sequence = <0x3000 0x1 0x1>, <0x3004 0x3 0x3>,
 					<0x3004 0x3 0x1>, <0x3080 0x2 0x2>;
-	qcom,rx_mclk_mode_muxsel = <0x033A40D8>;
-	qcom,wsa_mclk_mode_muxsel = <0x033A20E0>;
-	qcom,va_mclk_mode_muxsel = <0x03420000>;
-	clock-names = "tx_core_clk", "rx_core_clk", "wsa_core_clk",
-		"va_core_clk", "wsa2_core_clk", "rx_tx_core_clk",
-		"wsa_tx_core_clk", "wsa2_tx_core_clk";
-	clocks = <&clock_audio_tx_1 0>, <&clock_audio_rx_1 0>,
-		<&clock_audio_wsa_1 0>, <&clock_audio_va_1 0>,
-		<&clock_audio_wsa_2 0>, <&clock_audio_rx_tx 0>,
-		<&clock_audio_wsa_tx 0>, <&clock_audio_wsa2_tx 0>;
+		qcom,rx_mclk_mode_muxsel = <0x033A40D8>;
+		qcom,wsa_mclk_mode_muxsel = <0x033A20E0>;
+		qcom,va_mclk_mode_muxsel = <0x03420000>;
+		clock-names = "tx_core_clk", "rx_core_clk", "wsa_core_clk",
+			"va_core_clk", "wsa2_core_clk", "rx_tx_core_clk",
+			"wsa_tx_core_clk", "wsa2_tx_core_clk";
+		clocks = <&clock_audio_tx_1 0>, <&clock_audio_rx_1 0>,
+			<&clock_audio_wsa_1 0>, <&clock_audio_va_1 0>,
+			<&clock_audio_wsa_2 0>, <&clock_audio_rx_tx 0>,
+			<&clock_audio_wsa_tx 0>, <&clock_audio_wsa2_tx 0>;
 	};
 
 	va_macro: va-macro@33F0000 {

--- a/arch/arm64/boot/dts/qcom/somc-columbia-audio-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-audio-common.dtsi
@@ -57,10 +57,12 @@
 &lpass_cdc {
 	qcom,num-macros = <3>;
 
-	clock-names = "tx_core_clk", "rx_core_clk",
-		"va_core_clk", "rx_tx_core_clk";
-	clocks = <&clock_audio_tx_1 0>, <&clock_audio_rx_1 0>,
-		<&clock_audio_va_1 0>, <&clock_audio_rx_tx 0>;
+	lpass-cdc-clk-rsc-mngr {
+		clock-names = "tx_core_clk", "rx_core_clk",
+			"va_core_clk", "rx_tx_core_clk";
+		clocks = <&clock_audio_tx_1 0>, <&clock_audio_rx_1 0>,
+			<&clock_audio_va_1 0>, <&clock_audio_rx_tx 0>;
+	};
 };
 
 &waipio_snd {


### PR DESCRIPTION
Due to bad indentation, clocks were mistakenly placed
in the wrong device node.