### PR TITLE
[1.0.r1] Fix Columbia display backlight

### DIFF
--- a/arch/arm64/boot/dts/qcom/somc-columbia-display-pdx246.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-display-pdx246.dtsi
@@ -5,7 +5,7 @@
 	qcom,mdss-dsi-bl-inverted-dbv;
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-sec-bl-pmic-control-type = "bl_ctrl_dcs";
-	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-min-level = <4>;
 	qcom,mdss-dsi-bl-max-level = <4095>;
 	qcom,mdss-brightness-max-level = <4095>;
 	qcom,platform-reset-gpio = <&tlmm 127 0>;

--- a/arch/arm64/boot/dts/qcom/somc-columbia-display-pdx246.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-display-pdx246.dtsi
@@ -2,6 +2,7 @@
 
 &dsi_samsung_amoled_cmd {
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply_samsung_amoled>;
+	qcom,mdss-dsi-bl-inverted-dbv;
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-sec-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-bl-min-level = <1>;


### PR DESCRIPTION
The patch fixes the setting of the brightness value, resolves flickering
when adjusting brightness, and establishes a minimum brightness
threshold to avoid a completely black display.