### PR TITLE
[9.16.r1] dts: somc: Sagami: Disable hv_haptics driver

### DIFF
--- a/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
+++ b/arch/arm64/boot/dts/somc/lahaina-sagami-common.dtsi
@@ -3722,6 +3722,10 @@
 
 };
 
+&pm8350b_haptics {
+	status = "disabled";
+};
+
 &pm8350c_rgb {
 	red {
 		somc,color_variation_max_num = <4>;


### PR DESCRIPTION
Sagami platform devices use CS40l2A haptic. Probing of
multiple haptics drivers may result in the first of them
and not necessarily the correct one will be registered
as a led vibrator class device.