### PR TITLE
[1.0.r1] Fix DTC compilation warnings

### DIFF
--- a/arch/arm64/boot/dts/qcom/blair-murray-pdx225_generic.dts
+++ b/arch/arm64/boot/dts/qcom/blair-murray-pdx225_generic.dts
@@ -3,6 +3,7 @@
 #include "blair.dtsi"
 #include "blair-qrd.dtsi"
 #include "blair-murray-pdx225_generic.dtsi"
+#include "pm7250b.dtsi"
 
 / {
 	model = "Sony Corporation. PDX225(BLAIR v4)";

--- a/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
@@ -34,7 +34,7 @@
 		qcom,va-clk-mux-select = <1>;
 		qcom,va-island-mode-muxsel = <0x03420000>;
 		qcom,default-clk-id = <TX_CORE_CLK>;
-		qcom,is-used-swr-gpio = <1>;
+		qcom,swr-gpio-is-used = <1>;
 		qcom,va-swr-gpios = <&va_swr_gpios>;
 		swr2: va_swr_master {
 			compatible = "qcom,swr-mstr";
@@ -82,7 +82,7 @@
 		reg = <0x3220000 0x0>;
 		qcom,default-clk-id = <TX_CORE_CLK>;
 		qcom,tx-dmic-sample-rate = <2400000>;
-		qcom,is-used-swr-gpio = <0>;
+		qcom,swr-gpio-is-used = <0>;
 	};
 
 	rx_macro: rx-macro@3200000 {

--- a/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-audio-overlay.dtsi
@@ -47,6 +47,7 @@
 			qcom,swr_master_id = <3>;
 			qcom,mipi-sdw-block-packing-mode = <1>;
 			swrm-io-base = <0x33b0000 0x0>;
+			interrupt-parent = <&intc>;
 			interrupts =
 				<GIC_SPI 496 IRQ_TYPE_LEVEL_HIGH>,
 				<GIC_SPI 520 IRQ_TYPE_LEVEL_HIGH>;
@@ -104,6 +105,7 @@
 			qcom,swr_master_id = <2>;
 			qcom,mipi-sdw-block-packing-mode = <1>;
 			swrm-io-base = <0x3210000 0x0>;
+			interrupt-parent = <&intc>;
 			interrupts = <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "swr_master_irq";
 			qcom,swr-num-ports = <6>;
@@ -147,6 +149,7 @@
 			qcom,swr_master_id = <1>;
 			qcom,mipi-sdw-block-packing-mode = <0>;
 			swrm-io-base = <0x3250000 0x0>;
+			interrupt-parent = <&intc>;
 			interrupts = <GIC_SPI 170 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "swr_master_irq";
 			qcom,swr-num-ports = <8>;
@@ -206,6 +209,7 @@
 			qcom,swr_master_id = <4>;
 			qcom,mipi-sdw-block-packing-mode = <0>;
 			swrm-io-base = <0x31f0000 0x0>;
+			interrupt-parent = <&intc>;
 			interrupts = <GIC_SPI 171 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "swr_master_irq";
 			qcom,swr-num-ports = <8>;

--- a/arch/arm64/boot/dts/qcom/parrot-coresight.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-coresight.dtsi
@@ -2077,7 +2077,7 @@
 				};
 			};
 
-			port@c {
+			port@b {
 				reg = <11>;
 				tpda_dl_center_11_in_funnel_ddr: endpoint {
 					remote-endpoint =
@@ -2085,7 +2085,7 @@
 				};
 			};
 
-			port@d {
+			port@c {
 				reg = <12>;
 				tpda_dl_center_12_in_funnel_ddr: endpoint {
 					remote-endpoint =
@@ -2519,7 +2519,7 @@ funnel_dl_center2: funnel@10ac4000 {
 				};
 			};
 
-			port@10 {
+			port@a {
 				reg = <10>;
 				tpda_dl_lpass_10_in_tpdm_dl_lpass: endpoint {
 					remote-endpoint =

--- a/arch/arm64/boot/dts/qcom/parrot-pm7250b.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-pm7250b.dtsi
@@ -94,6 +94,9 @@
 &spmi0_debug_bus {
 	depends-on2-supply = <&smb1394_glink_debug>;
 
+	#address-cells = <1>;
+	#size-cells = <1>;
+
 	qcom,pm7250b-debug@8 {
 		compatible = "qcom,spmi-pmic";
 		reg = <8 SPMI_USID>;

--- a/arch/arm64/boot/dts/qcom/parrot-sde-display.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-sde-display.dtsi
@@ -2,6 +2,9 @@
 #include "parrot-sde-display-common.dtsi"
 
 &soc {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
 	sde_wb: qcom,wb-display@0 {
 		compatible = "qcom,wb-display";
 		cell-index = <0>;
@@ -79,6 +82,9 @@
 };
 
 &reserved_memory {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
 	splash_memory: splash_region {
 		reg = <0x0 0xb8000000 0x0 0x02b00000>;
 		label = "cont_splash_region";

--- a/arch/arm64/boot/dts/qcom/parrot-wcn3990.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-wcn3990.dtsi
@@ -2,6 +2,9 @@
 #include <dt-bindings/gpio/gpio.h>
 
 &reserved_memory {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
 	wlan_fw_mem: wlan_fw_region@82a00000 {
 		no-map;
 		reg = <0x0 0x82a00000 0x0 0x300000>;
@@ -9,6 +12,9 @@
 };
 
 &soc {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
 	wpss_pas: remoteproc-wpss@8a00000 {
 		firmware-name = "adrastea/wpss.mdt";
 	};
@@ -19,6 +25,7 @@
 		reg-names = "membase";
 		qcom,rproc-handle = <&wpss_pas>;
 		iommus = <&apps_smmu 0x4c0 0x1>;
+		interrupt-parent = <&intc>;
 		interrupts = <GIC_SPI 389 IRQ_TYPE_LEVEL_HIGH /* CE0 */ >,
 			     <GIC_SPI 413 IRQ_TYPE_LEVEL_HIGH /* CE1 */ >,
 			     <GIC_SPI 416 IRQ_TYPE_LEVEL_HIGH /* CE2 */ >,

--- a/arch/arm64/boot/dts/qcom/pm6150l.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm6150l.dtsi
@@ -382,6 +382,9 @@
 			compatible = "qcom,qpnp-amoled-regulator";
 			status = "disabled";
 
+			#address-cells = <1>;
+			#size-cells = <0>;
+
 			oledb_vreg: oledb@e000 {
 				reg = <0xe000>;
 				reg-names = "oledb_base";

--- a/arch/arm64/boot/dts/qcom/somc-columbia-audio-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-audio-common.dtsi
@@ -1,6 +1,9 @@
 &qupv3_se0_i2c {
 	status = "okay";
 
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	aw882xx_smartpa@34 {
 		compatible = "awinic,aw882xx_smartpa";
 		reg = <0x34>;
@@ -22,6 +25,9 @@
 
 &qupv3_se2_i2c {
 	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	aw882xx_smartpa@34 {
 		compatible = "awinic,aw882xx_smartpa";

--- a/arch/arm64/boot/dts/qcom/waipio-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/waipio-audio.dtsi
@@ -21,11 +21,17 @@
 };
 
 &glink_edge {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	audio_gpr: qcom,gpr {
 		compatible = "qcom,gpr";
 		qcom,glink-channels = "adsp_apps";
 		qcom,intents = <0x200 20>;
 		reg = <GPR_DOMAIN_ADSP>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
 
 		spf_core {
 			compatible = "qcom,spf_core";
@@ -46,6 +52,8 @@
 };
 
 &spf_core_platform {
+	#address-cells = <1>;
+	#size-cells = <1>;
 
 	msm_audio_ion: qcom,msm-audio-ion {
 		compatible = "qcom,msm-audio-ion";

--- a/include/linux/kallsyms.h
+++ b/include/linux/kallsyms.h
@@ -14,7 +14,7 @@
 
 #include <asm/sections.h>
 
-#define KSYM_NAME_LEN 128
+#define KSYM_NAME_LEN 512
 #define KSYM_SYMBOL_LEN (sizeof("%s+%#lx/%#lx [%s]") + (KSYM_NAME_LEN - 1) + \
 			 2*(BITS_PER_LONG*3/10) + (MODULE_NAME_LEN - 1) + 1)
 

--- a/kernel/livepatch/core.c
+++ b/kernel/livepatch/core.c
@@ -214,7 +214,7 @@ static int klp_resolve_symbols(Elf_Shdr *sechdrs, const char *strtab,
 	 * we use the smallest/strictest upper bound possible (56, based on
 	 * the current definition of MODULE_NAME_LEN) to prevent overflows.
 	 */
-	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 128);
+	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 512);
 
 	relas = (Elf_Rela *) relasec->sh_addr;
 	/* For each rela in this klp relocation section */
@@ -228,7 +228,7 @@ static int klp_resolve_symbols(Elf_Shdr *sechdrs, const char *strtab,
 
 		/* Format: .klp.sym.sym_objname.sym_name,sympos */
 		cnt = sscanf(strtab + sym->st_name,
-			     ".klp.sym.%55[^.].%127[^,],%lu",
+			     ".klp.sym.%55[^.].%511[^,],%lu",
 			     sym_objname, sym_name, &sympos);
 		if (cnt != 3) {
 			pr_err("symbol %s has an incorrectly formatted name\n",

--- a/scripts/kallsyms.c
+++ b/scripts/kallsyms.c
@@ -27,7 +27,7 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
-#define KSYM_NAME_LEN		128
+#define KSYM_NAME_LEN		512
 
 struct sym_entry {
 	unsigned long long addr;

--- a/tools/include/linux/kallsyms.h
+++ b/tools/include/linux/kallsyms.h
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#define KSYM_NAME_LEN 128
+#define KSYM_NAME_LEN 512
 
 struct module;
 

--- a/tools/include/linux/lockdep.h
+++ b/tools/include/linux/lockdep.h
@@ -47,7 +47,7 @@ static inline int debug_locks_off(void)
 
 #define task_pid_nr(tsk) ((tsk)->pid)
 
-#define KSYM_NAME_LEN 128
+#define KSYM_NAME_LEN 512
 #define printk(...) dprintf(STDOUT_FILENO, __VA_ARGS__)
 #define pr_err(format, ...) fprintf (stderr, format, ## __VA_ARGS__)
 #define pr_warn pr_err

--- a/tools/lib/perf/include/perf/event.h
+++ b/tools/lib/perf/include/perf/event.h
@@ -85,7 +85,7 @@ struct perf_record_throttle {
 };
 
 #ifndef KSYM_NAME_LEN
-#define KSYM_NAME_LEN 256
+#define KSYM_NAME_LEN 512
 #endif
 
 struct perf_record_ksymbol {

--- a/tools/lib/symbol/kallsyms.h
+++ b/tools/lib/symbol/kallsyms.h
@@ -7,7 +7,7 @@
 #include <linux/types.h>
 
 #ifndef KSYM_NAME_LEN
-#define KSYM_NAME_LEN 256
+#define KSYM_NAME_LEN 512
 #endif
 
 static inline u8 kallsyms2elf_binding(char type)


### PR DESCRIPTION
Add #address-cells, #size-cells and interrupt-parent
properties to fix dtc warnings.

Depends on: https://github.com/sonyxperiadev/kernel-techpack-audio/pull/66