### PR TITLE
[1.0.r1] Initial camera support for Columbia platform

### DIFF
--- a/arch/arm64/boot/dts/qcom/parrot-columbia-pdx246_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/parrot-columbia-pdx246_common.dtsi
@@ -5,6 +5,8 @@
 
 #include "somc-columbia-audio-common.dtsi"
 #include "somc-columbia-audio-pdx246.dtsi"
+#include "somc-columbia-camera-common.dtsi"
+#include "somc-columbia-camera-pdx246.dtsi"
 #include "somc-columbia-charger-common.dtsi"
 #include "somc-columbia-charger-pdx246.dtsi"
 #include "somc-columbia-display-common.dtsi"

--- a/arch/arm64/boot/dts/qcom/somc-columbia-camera-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-camera-common.dtsi
@@ -1,0 +1,111 @@
+&pm6450_gpios {
+	wl2868c_pins_default: wl2868c_pins_default {
+		pins = "gpio3";
+		function = "normal";
+		output-high;
+		bias-disable;
+		power-source = <0>;
+	};
+};
+
+&qupv3_se2_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pm8010i@8 {
+		status = "disabled";
+	};
+
+	pm8010i@9 {
+		status = "disabled";
+	};
+
+	pm8010j@c {
+		status = "disabled";
+	};
+
+	pm8010j@d {
+		status = "disabled";
+	};
+
+	wl2868c@2f {
+		compatible = "willsemi,wl2868c";
+		reg = <0x2f>;
+
+		rstn-gpio = <&pm6450_gpios 3 0>;
+
+		regulators {
+			wl2868c_l1: ldo1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt  = <496000>;
+				regulator-max-microvolt  = <1512000>;
+			};
+
+			wl2868c_l2: ldo2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <496000>;
+				regulator-max-microvolt = <1512000>;
+			};
+
+			wl2868c_l3: ldo3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <1504000>;
+				regulator-max-microvolt = <3544000>;
+			};
+
+			wl2868c_l4: ldo4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <1504000>;
+				regulator-max-microvolt = <3544000>;
+			};
+
+			wl2868c_l5: ldo5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <1504000>;
+				regulator-max-microvolt = <3544000>;
+			};
+
+			wl2868c_l6: ldo6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <1504000>;
+				regulator-max-microvolt = <3544000>;
+			};
+
+			wl2868c_l7: ldo7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <1504000>;
+				regulator-max-microvolt = <3544000>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	cam_ois_vdd_active: cam_ois_vdd_active {
+		/* OIS VDD */
+		mux {
+			pins = "gpio43";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio43";
+			bias-disable; /* No PULL */
+			drive-strength = <6>; /* 6 MA */
+		};
+	};
+
+	cam_ois_vdd_suspend: cam_ois_vdd_suspend {
+		/* OIS VDD */
+		mux {
+			pins = "gpio43";
+			function = "gpio";
+		};
+
+		config {
+			pins = "gpio43";
+			bias-pull-down; /* PULL DOWN */
+			drive-strength = <6>; /* 6 MA */
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
@@ -1,0 +1,218 @@
+#include <dt-bindings/clock/qcom,camcc-parrot.h>
+#include <dt-bindings/msm/msm-camera.h>
+
+&soc {
+	qcom,cam-res-mgr {
+		compatible = "qcom,cam-res-mgr";
+		status = "ok";
+	};
+
+	led_flash_wide: qcom,camera-flash@0 {
+		cell-index = <0>;
+		compatible = "qcom,camera-flash";
+		flash-source = <&pm6150l_flash0>;
+		torch-source = <&pm6150l_torch0>;
+		switch-source = <&pm6150l_switch0>;
+		status = "ok";
+	};
+
+	led_flash_uwide: qcom,camera-flash@1 {
+		cell-index = <1>;
+		compatible = "qcom,camera-flash";
+		flash-source = <&pm6150l_flash0>;
+		torch-source = <&pm6150l_torch0>;
+		switch-source = <&pm6150l_switch0>;
+		status = "ok";
+	};
+};
+
+&cam_cci0 {
+	// wide camera
+	actuator_wide: qcom,actuator@0 {
+		cell-index = <0>;
+		compatible = "qcom,actuator";
+		cci-master = <CCI_MASTER_0>;
+		cam_vaf-supply = <&wl2868c_l5>;
+		regulator-names = "cam_vaf";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <2800000>;
+		rgltr-max-voltage = <2800000>;
+		rgltr-load-current = <0>;
+		status = "ok";
+	};
+
+	ois_wide: qcom,ois@0 {
+		cell-index = <0>;
+		compatible = "qcom,ois";
+		cci-master = <CCI_MASTER_0>;
+		cam_vaf-supply = <&wl2868c_l5>;
+		regulator-names = "cam_vaf";
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <2800000>;
+		rgltr-max-voltage = <2800000>;
+		rgltr-load-current = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_ois_vdd_active>;
+		pinctrl-1 = <&cam_ois_vdd_suspend>;
+		status = "ok";
+	};
+
+	eeprom_wide: qcom,eeprom@0 {
+		cell-index = <0>;
+		compatible = "qcom,eeprom";
+		cci-master = <CCI_MASTER_0>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l3>;
+		cam_vdig-supply = <&wl2868c_l2>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2900000 1100000>;
+		rgltr-max-voltage = <1800000 2900000 1100000>;
+		rgltr-load-current = <0 0 0>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor@0 {
+		cell-index = <0>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <0>;
+		sensor-position-roll = <90>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		actuator-src = <&actuator_wide>;
+		eeprom-src = <&eeprom_wide>;
+		led-flash-src = <&led_flash_wide>;
+		ois-src = <&ois_wide>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l3>;
+		cam_vdig-supply = <&wl2868c_l2>;
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2900000 1100000 0>;
+		rgltr-max-voltage = <1800000 2900000 1100000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 39 0>,
+			<&tlmm 44 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0";
+		cci-master = <CCI_MASTER_0>;
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		status = "ok";
+	};
+
+	// uwide camera
+	eeprom_uwide: qcom,eeprom@2 {
+		cell-index = <2>;
+		compatible = "qcom,eeprom";
+		cci-master = <CCI_MASTER_1>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l4>;
+		cam_vdig-supply = <&wl2868c_l1>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000>;
+		rgltr-max-voltage = <1800000 2800000 1200000>;
+		rgltr-load-current = <0 0 0>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor@2 {
+		cell-index = <2>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <90>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_uwide>;
+		led-flash-src = <&led_flash_uwide>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l4>;
+		cam_vdig-supply = <&wl2868c_l1>;
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_suspend_rst1>;
+		gpios = <&tlmm 40 0>,
+			<&tlmm 45 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1", "CAM_RESET1";
+		cci-master = <CCI_MASTER_1>;
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		status = "ok";
+	};
+};
+
+&cam_cci1 {
+	// front camera
+	eeprom_front: qcom,eeprom@1 {
+		cell-index = <1>;
+		compatible = "qcom,eeprom";
+		cci-master = <CCI_MASTER_1>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l6>;
+		cam_vdig-supply = <&wl2868c_l1>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000>;
+		rgltr-max-voltage = <1800000 2800000 1200000>;
+		rgltr-load-current = <0 0 0>;
+		status = "ok";
+	};
+
+	qcom,cam-sensor@1 {
+		cell-index = <1>;
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <3>;
+		sensor-position-roll = <270>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <0>;
+		eeprom-src = <&eeprom_front>;
+		cam_vio-supply = <&wl2868c_l7>;
+		cam_vana-supply = <&wl2868c_l6>;
+		cam_vdig-supply = <&wl2868c_l1>;
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
+		rgltr-cntrl-support;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk3_active &cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend &cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 42 0>,
+			<&tlmm 47 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK3", "CAM_RESET3";
+		cci-master = <CCI_MASTER_1>;
+		clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		status = "ok";
+	};
+};

--- a/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
@@ -65,11 +65,25 @@
 		cam_vio-supply = <&wl2868c_l7>;
 		cam_vana-supply = <&wl2868c_l3>;
 		cam_vdig-supply = <&wl2868c_l2>;
-		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
 		rgltr-cntrl-support;
-		rgltr-min-voltage = <1800000 2900000 1100000>;
-		rgltr-max-voltage = <1800000 2900000 1100000>;
-		rgltr-load-current = <0 0 0>;
+		rgltr-min-voltage = <1800000 2900000 1100000 0>;
+		rgltr-max-voltage = <1800000 2900000 1100000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 39 0>, <&tlmm 44 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0";
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
 		status = "ok";
 	};
 
@@ -97,8 +111,7 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0>;
 		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0>;
-		gpios = <&tlmm 39 0>,
-			<&tlmm 44 0>;
+		gpios = <&tlmm 39 0>, <&tlmm 44 0>;
 		gpio-reset = <1>;
 		gpio-req-tbl-num = <0 1>;
 		gpio-req-tbl-flags = <1 0>;
@@ -119,11 +132,25 @@
 		cam_vio-supply = <&wl2868c_l7>;
 		cam_vana-supply = <&wl2868c_l4>;
 		cam_vdig-supply = <&wl2868c_l1>;
-		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
 		rgltr-cntrl-support;
-		rgltr-min-voltage = <1800000 2800000 1200000>;
-		rgltr-max-voltage = <1800000 2800000 1200000>;
-		rgltr-load-current = <0 0 0>;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_suspend_rst1>;
+		gpios = <&tlmm 40 0>, <&tlmm 45 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1", "CAM_RESET1";
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
 		status = "ok";
 	};
 
@@ -149,8 +176,7 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk1_active &cam_sensor_active_rst1>;
 		pinctrl-1 = <&cam_sensor_mclk1_suspend &cam_sensor_suspend_rst1>;
-		gpios = <&tlmm 40 0>,
-			<&tlmm 45 0>;
+		gpios = <&tlmm 40 0>, <&tlmm 45 0>;
 		gpio-reset = <1>;
 		gpio-req-tbl-num = <0 1>;
 		gpio-req-tbl-flags = <1 0>;
@@ -173,11 +199,25 @@
 		cam_vio-supply = <&wl2868c_l7>;
 		cam_vana-supply = <&wl2868c_l6>;
 		cam_vdig-supply = <&wl2868c_l1>;
-		regulator-names = "cam_vio", "cam_vana", "cam_vdig";
+		cam_clk-supply = <&cam_cc_camss_top_gdsc>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_clk";
 		rgltr-cntrl-support;
-		rgltr-min-voltage = <1800000 2800000 1200000>;
-		rgltr-max-voltage = <1800000 2800000 1200000>;
-		rgltr-load-current = <0 0 0>;
+		rgltr-min-voltage = <1800000 2800000 1200000 0>;
+		rgltr-max-voltage = <1800000 2800000 1200000 0>;
+		rgltr-load-current = <0 0 0 0>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk3_active &cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend &cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 42 0>, <&tlmm 47 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK3", "CAM_RESET3";
+		clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
 		status = "ok";
 	};
 
@@ -202,8 +242,7 @@
 		pinctrl-names = "cam_default", "cam_suspend";
 		pinctrl-0 = <&cam_sensor_mclk3_active &cam_sensor_active_rst3>;
 		pinctrl-1 = <&cam_sensor_mclk3_suspend &cam_sensor_suspend_rst3>;
-		gpios = <&tlmm 42 0>,
-			<&tlmm 47 0>;
+		gpios = <&tlmm 42 0>, <&tlmm 47 0>;
 		gpio-reset = <1>;
 		gpio-req-tbl-num = <0 1>;
 		gpio-req-tbl-flags = <1 0>;

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -1327,6 +1327,15 @@ config REGULATOR_VQMMC_IPQ4019
 	  This driver provides support for the VQMMC LDO I/0
 	  voltage regulator of the IPQ4019 SD/EMMC controller.
 
+config REGULATOR_WL2868C
+	tristate "WILLSEMI (Will Semicon) WL2868C regulator driver"
+	depends on I2C
+	select REGMAP_I2C
+	help
+	  This driver supports WILLSEMI (Will Semicon) WL2868C regulator.
+	  The regulator is a programmable power management IC (PMIC), it
+	  is controlled by I2C and provides seven LDO outputs.
+
 config REGULATOR_WM831X
 	tristate "Wolfson Microelectronics WM831x PMIC regulators"
 	depends on MFD_WM831X

--- a/drivers/regulator/Makefile
+++ b/drivers/regulator/Makefile
@@ -159,6 +159,7 @@ obj-$(CONFIG_REGULATOR_UNIPHIER) += uniphier-regulator.o
 obj-$(CONFIG_REGULATOR_VCTRL) += vctrl-regulator.o
 obj-$(CONFIG_REGULATOR_VEXPRESS) += vexpress-regulator.o
 obj-$(CONFIG_REGULATOR_VQMMC_IPQ4019) += vqmmc-ipq4019-regulator.o
+obj-$(CONFIG_REGULATOR_WL2868C) += wl2868c-regulator.o
 obj-$(CONFIG_REGULATOR_WM831X) += wm831x-dcdc.o
 obj-$(CONFIG_REGULATOR_WM831X) += wm831x-isink.o
 obj-$(CONFIG_REGULATOR_WM831X) += wm831x-ldo.o

--- a/drivers/regulator/wl2868c-regulator.c
+++ b/drivers/regulator/wl2868c-regulator.c
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * WILLSEMI (Will Semicon) WL2868C regulator driver
+ * Copyright (C) 2023, 2025 Pavel Dubrova <pashadubrova@gmail.com>
+ */
+
+#define pr_fmt(fmt)	" WL2868C: %s: " fmt, __func__
+
+#include <linux/i2c.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_gpio.h>
+#include <linux/regmap.h>
+#include <linux/regulator/driver.h>
+#include <linux/regulator/machine.h>
+#include <linux/regulator/of_regulator.h>
+
+#include "wl2868c-regulator.h"
+
+static const struct regmap_range wl2868c_readable_ranges[] = {
+	regmap_reg_range(WL2868C_REG_CHIP_ID, WL2868C_REG_RESERVED_0),
+	regmap_reg_range(WL2868C_REG_INT_EN_SET, WL2868C_REG_RESERVED_1),
+};
+
+static const struct regmap_range wl2868c_writable_ranges[] = {
+	regmap_reg_range(WL2868C_REG_DISCHARGE, WL2868C_REG_SEQUENCING),
+	regmap_reg_range(WL2868C_REG_LDO1_OCP_CTL, WL2868C_REG_LDO1_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO2_OCP_CTL, WL2868C_REG_LDO2_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO3_OCP_CTL, WL2868C_REG_LDO3_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO4_OCP_CTL, WL2868C_REG_LDO4_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO5_OCP_CTL, WL2868C_REG_LDO5_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO6_OCP_CTL, WL2868C_REG_LDO6_OCP_CTL),
+	regmap_reg_range(WL2868C_REG_LDO7_OCP_CTL, WL2868C_REG_INT_EN_SET),
+	regmap_reg_range(WL2868C_REG_UVLO_CTL, WL2868C_REG_RESERVED_1),
+};
+
+static const struct regmap_range et5907_readable_ranges[] = {
+	regmap_reg_range(ET5907_REG_CHIP_ID, ET5907_REG_TSD_UVLO_INTMA),
+};
+
+static const struct regmap_range et5907_writable_ranges[] = {
+	regmap_reg_range(ET5907_REG_LDO_ILIMIT, ET5907_REG_I2C_ADDR),
+	regmap_reg_range(ET5907_REG_UVP_INTMA, ET5907_REG_TSD_UVLO_INTMA),
+};
+
+static const struct regmap_range fan53870_readable_ranges[] = {
+	regmap_reg_range(FAN53870_REG_CHIP_ID, FAN53870_REG_MINT3),
+};
+
+static const struct regmap_range fan53870_writable_ranges[] = {
+	regmap_reg_range(FAN53870_REG_IOUT, FAN53870_REG_LDO_COMP1),
+	regmap_reg_range(FAN53870_REG_MINT1, FAN53870_REG_MINT3),
+};
+
+static const struct regmap_config wl2868c_regmap_config[REGULATOR_MAX] = {
+	[REGULATOR_WL2868C] = {
+		.reg_bits = 8,
+		.val_bits = 8,
+		.max_register = WL2868C_REG_RESERVED_1,
+		.rd_table = &(struct regmap_access_table) {
+			.yes_ranges = wl2868c_readable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(wl2868c_readable_ranges),
+		},
+		.wr_table = &(struct regmap_access_table) {
+			.yes_ranges = wl2868c_writable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(wl2868c_writable_ranges),
+		},
+	},
+	[REGULATOR_ET5907] = {
+		.reg_bits = 8,
+		.val_bits = 8,
+		.max_register = ET5907_REG_TSD_UVLO_INTMA,
+		.rd_table = &(struct regmap_access_table) {
+			.yes_ranges = et5907_readable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(et5907_readable_ranges),
+		},
+		.wr_table = &(struct regmap_access_table) {
+			.yes_ranges = et5907_writable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(et5907_writable_ranges),
+		},
+	},
+	[REGULATOR_FAN53870] = {
+		.reg_bits = 8,
+		.val_bits = 8,
+		.max_register = FAN53870_REG_MINT3,
+		.rd_table = &(struct regmap_access_table) {
+			.yes_ranges = fan53870_readable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(fan53870_readable_ranges),
+		},
+		.wr_table = &(struct regmap_access_table) {
+			.yes_ranges = fan53870_writable_ranges,
+			.n_yes_ranges = ARRAY_SIZE(fan53870_writable_ranges),
+		},
+	},
+};
+
+static int wl2868c_read(struct regmap *regmap, u16 reg, u8 *val, int count)
+{
+	int ret;
+
+	ret = regmap_bulk_read(regmap, reg, val, count);
+	if (ret < 0)
+		pr_err("failed to read 0x%02x\n", reg);
+
+	pr_debug("read 0x%02x from 0x%02x\n", *val, reg);
+
+	return ret;
+}
+
+static int wl2868c_write(struct regmap *regmap, u16 reg, u8*val, int count)
+{
+	int ret;
+
+	pr_debug("write 0x%02x to 0x%02x\n", *val, reg);
+
+	ret = regmap_bulk_write(regmap, reg, val, count);
+	if (ret < 0)
+		pr_err("failed to write 0x%02x\n", reg);
+
+	return ret;
+}
+
+static struct wl2868c_regulator_data reg_data[REGULATOR_MAX][CAMERA_LDO_MAX] = {
+	[REGULATOR_WL2868C] = {
+		/* name, supply_name, min_uV, max_uV, default_uV, base_mV, step_mV, en_time, ldo_reg */
+		{ "ldo1", "vdd_l1_l2",  496000, 1512000, 1200000,  496, 8, 60, WL2868C_REG_LDO1 },
+		{ "ldo2", "vdd_l1_l2",  496000, 1512000, 1200000,  496, 8, 60, WL2868C_REG_LDO2 },
+		{ "ldo3", "vdd_l3_l4", 1504000, 3544000, 2800000, 1504, 8, 80, WL2868C_REG_LDO3 },
+		{ "ldo4", "vdd_l3_l4", 1504000, 3544000, 2800000, 1504, 8, 80, WL2868C_REG_LDO4 },
+		{ "ldo5", "vdd_l5",    1504000, 3544000, 2800000, 1504, 8, 80, WL2868C_REG_LDO5 },
+		{ "ldo6", "vdd_l6",    1504000, 3544000, 2800000, 1504, 8, 80, WL2868C_REG_LDO6 },
+		{ "ldo7", "vdd_l7",    1504000, 3544000, 2800000, 1504, 8, 80, WL2868C_REG_LDO7 },
+	},
+	[REGULATOR_ET5907] = {
+		/* name, supply_name, min_uV, max_uV, default_uV, base_mV, step_mV, en_time, ldo_reg */
+		{ "ldo1", "vdd_l1_l2",  600000, 1800000, 1200000,  600,  6, 300, ET5907_REG_LDO1 },
+		{ "ldo2", "vdd_l1_l2",  600000, 1800000, 1200000,  600,  6, 300, ET5907_REG_LDO2 },
+		{ "ldo3", "vdd_l3_l4", 1200000, 3750000, 2800000, 1200, 10, 130, ET5907_REG_LDO3 },
+		{ "ldo4", "vdd_l3_l4", 1200000, 3750000, 2800000, 1200, 10, 130, ET5907_REG_LDO4 },
+		{ "ldo5", "vdd_l5",    1200000, 3750000, 2800000, 1200, 10, 130, ET5907_REG_LDO5 },
+		{ "ldo6", "vdd_l6",    1200000, 3750000, 2800000, 1200, 10, 130, ET5907_REG_LDO6 },
+		{ "ldo7", "vdd_l7",    1200000, 3750000, 2800000, 1200, 10, 130, ET5907_REG_LDO7 },
+	},
+	[REGULATOR_FAN53870] = {
+		/* name, supply_name, min_uV, max_uV, default_uV, base_mV, step_mV, en_time, ldo_reg */
+		{ "ldo1", "vdd_l1_l2",  800000, 1504000, 1050000,  800, 8, 400, FAN53870_REG_LDO1 },
+		{ "ldo2", "vdd_l1_l2",  800000, 1504000, 1050000,  800, 8, 400, FAN53870_REG_LDO2 },
+		{ "ldo3", "vdd_l3_l4", 1500000, 3412000, 2800000, 1500, 8, 100, FAN53870_REG_LDO3 },
+		{ "ldo4", "vdd_l3_l4", 1500000, 3412000, 2800000, 1500, 8, 100, FAN53870_REG_LDO4 },
+		{ "ldo5", "vdd_l5",    1500000, 3412000, 1800000, 1500, 8, 100, FAN53870_REG_LDO5 },
+		{ "ldo6", "vdd_l6",    1500000, 3412000, 2800000, 1500, 8, 100, FAN53870_REG_LDO6 },
+		{ "ldo7", "vdd_l7",    1500000, 3412000, 2800000, 1500, 8, 100, FAN53870_REG_LDO7 },
+	},
+};
+
+static int wl2868c_get_voltage(struct regulator_dev *rdev)
+{
+	struct wl2868c_chip *chip = rdev_get_drvdata(rdev);
+	struct wl2868c_regulator_data *rdata
+			= &reg_data[chip->chip_id][rdev->desc->id];
+	int ret, uv;
+	u8 val;
+
+	ret = wl2868c_read(chip->regmap, rdev->desc->vsel_reg, &val, 1);
+	if (ret < 0) {
+		pr_err("failed to read regulator voltage, ret = %d\n", ret);
+		return ret;
+	}
+
+	/*
+	 * FAN53870 regulator has specific voltage equations:
+	 * LDO1-LDO2: Vout = 0.800 V + [(d − 99) x 8 mV]
+	 * LDO3-LDO7: Vout = 1.500 V + [(d − 16) x 8 mV]
+	 */
+	if (chip->chip_id == REGULATOR_FAN53870)
+		val -= (rdev->desc->vsel_reg < FAN53870_REG_LDO3) ? 99 : 16;
+
+	uv = (rdata->base_mV + val * rdata->step_mV) * 1000;
+
+	pr_debug("%s regulator voltage is: %duV\n", rdev->desc->name, uv);
+
+	return uv;
+}
+
+static int wl2868c_set_voltage(struct regulator_dev *rdev,
+	int min_uv, int max_uv, unsigned int* selector)
+{
+	struct wl2868c_chip *chip = rdev_get_drvdata(rdev);
+	struct wl2868c_regulator_data *rdata
+			= &reg_data[chip->chip_id][rdev->desc->id];
+	int ret, mv;
+	u8 val;
+
+	mv = DIV_ROUND_UP(min_uv, 1000);
+	if (mv * 1000 > max_uv) {
+		pr_err("requested voltage above maximum limit\n");
+		return -EINVAL;
+	}
+
+	val = DIV_ROUND_UP(mv - rdata->base_mV, rdata->step_mV);
+
+	/*
+	 * FAN53870 regulator has specific voltage equations:
+	 * LDO1-LDO2: d = ((Vin - 0.800 V) / 8 mV) - 99
+	 * LDO3-LDO7: d = ((Vin - 1.500 V) / 8 mV) - 16
+	 */
+	if (chip->chip_id == REGULATOR_FAN53870)
+		val += (rdev->desc->vsel_reg < FAN53870_REG_LDO3) ? 99 : 16;
+
+	ret = wl2868c_write(chip->regmap, rdev->desc->vsel_reg, &val, 1);
+	if (ret < 0) {
+		pr_err("failed to write voltage ret = %d\n", ret);
+		return ret;
+	}
+
+	pr_debug("regulator voltage set to %duV (0x%02x)\n", mv * 1000, val);
+
+	return ret;
+}
+
+static const struct regulator_ops wl2868c_ops = {
+	.enable	= regulator_enable_regmap,
+	.disable = regulator_disable_regmap,
+	.is_enabled = regulator_is_enabled_regmap,
+	.get_voltage = wl2868c_get_voltage,
+	.set_voltage = wl2868c_set_voltage,
+};
+
+static int wl2868c_register_ldo(struct wl2868c_chip *chip,
+		const char *name, struct device_node *np)
+{
+	struct regulator_config reg_config = {};
+	struct regulator_init_data *init_data;
+	struct regulator_desc *rdesc;
+	struct wl2868c_regulator_data *rdata;
+	struct device *dev = chip->dev;
+	int i, ret;
+
+	for (i = 0; i < CAMERA_LDO_MAX; i++) {
+		if (strstr(name, reg_data[chip->chip_id][i].name))
+			break;
+	}
+
+	if (i == CAMERA_LDO_MAX) {
+		pr_err("%s: invalid regulator name\n", name);
+		return -EINVAL;
+	}
+
+	rdesc = &chip->rdesc[i];
+	rdata = &reg_data[chip->chip_id][i];
+
+	init_data = of_get_regulator_init_data(dev, np, rdesc);
+	if (init_data == NULL) {
+		pr_err("%s: failed to get regulator data\n", name);
+		return -ENODATA;
+	}
+
+	if (!init_data->constraints.name) {
+		pr_err("%s: regulator name is missing\n", name);
+		return -EINVAL;
+	}
+
+	init_data->constraints.valid_ops_mask |= REGULATOR_CHANGE_STATUS
+			| REGULATOR_CHANGE_VOLTAGE;
+	init_data->constraints.min_uV = rdata->min_uV;
+	init_data->constraints.max_uV = rdata->max_uV;
+
+	reg_config.dev = dev;
+	reg_config.init_data = init_data;
+	reg_config.driver_data = chip;
+	reg_config.of_node = np;
+	reg_config.regmap = chip->regmap;
+	reg_config.ena_gpiod = NULL;
+
+	rdesc->name				= rdata->name;
+	rdesc->supply_name		= rdata->supply_name;
+	rdesc->of_match			= rdata->name;
+	rdesc->regulators_node	= "regulators";
+	rdesc->id				= i;
+	rdesc->n_voltages		= (rdata->max_uV - rdata->min_uV)
+			/ rdesc->uV_step + 1;
+	rdesc->ops				= &wl2868c_ops;
+	rdesc->type				= REGULATOR_VOLTAGE;
+	rdesc->owner			= THIS_MODULE;
+	rdesc->min_uV			= rdata->min_uV;
+	rdesc->uV_step			= rdata->step_mV * 1000;
+	rdesc->vsel_reg			= rdata->ldo_reg;
+	rdesc->vsel_mask		= 0xff;
+	/* ET5907 and FAN53870 share the same enable register (0x03) */
+	rdesc->enable_reg		= (chip->chip_id == REGULATOR_WL2868C)
+			? WL2868C_REG_LDO_ENABLE : ET5907_REG_LDO_ENABLE;
+	rdesc->enable_mask		= BIT(i);
+	rdesc->enable_time		= rdata->en_time;
+
+	chip->rdev[i] = devm_regulator_register(dev,
+			rdesc, &reg_config);
+	if (IS_ERR(chip->rdev[i])) {
+		ret = PTR_ERR(chip->rdev[i]);
+		pr_err("%s: failed to register regulator, ret = %d\n", name, ret);
+		return ret;
+	}
+
+	pr_debug("%s regulator registered\n", name);
+
+	return 0;
+}
+
+static int wl2868c_parse_regulator(struct wl2868c_chip *chip)
+{
+	struct device_node *parent;
+	struct device_node *child;
+	const char *name;
+	int ret;
+
+	parent = of_find_node_by_name(chip->dev->of_node, "regulators");
+	if (!parent) {
+		pr_err("no regulators node found\n");
+		return -EINVAL;
+	}
+
+	/* Iterate through each child node of the "regulators" subnode */
+	for_each_available_child_of_node(parent, child) {
+		ret = of_property_read_string(child, "regulator-name", &name);
+		if (ret)
+			continue;
+
+		ret = wl2868c_register_ldo(chip, name, child);
+		if (ret < 0) {
+			pr_err("failed to register regulator %s ret = %d\n", name, ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static const struct regulator_chip_info reg_chip[REGULATOR_MAX] = {
+	/* name, i2c_addr, chip_id, chip_id_addr */
+	{ "WL2868C",  0x2f, 0x82, 0x00 },
+	{ "ET5907",   0x35, 0x00, 0x01 },
+	{ "FAN53870", 0x35, 0x01, 0x01 },
+};
+
+static int wl2868c_chip_id(struct i2c_client *client) {
+	int i, chip_id;
+
+	for (i = 0; i < ARRAY_SIZE(reg_chip); i++) {
+		pr_debug("trying regulator chip at: 0x%02x, chip_id: 0x%02x, chip_id_addr: 0x%02x\n",
+				reg_chip[i].i2c_addr, reg_chip[i].chip_id, reg_chip[i].chip_id_addr);
+
+		client->addr = reg_chip[i].i2c_addr;
+		chip_id = i2c_smbus_read_byte_data(client, reg_chip[i].chip_id_addr);
+		if (chip_id < 0) {
+			pr_debug("failed to read chip id: 0x%02x, chip_addr: 0x%02x, addr: 0x%02x",
+					reg_chip[i].i2c_addr, reg_chip[i].chip_id, reg_chip[i].chip_id_addr);
+			continue;
+		}
+
+		if (chip_id == reg_chip[i].chip_id) {
+			pr_info("regulator chip is: %s\n", reg_chip[i].name);
+			return i;
+		}
+	}
+
+	return -ENODEV;
+}
+
+static int wl2868c_regulator_probe(struct i2c_client *client,
+		const struct i2c_device_id *id)
+{
+	struct wl2868c_chip *chip;
+	struct device *dev = &client->dev;
+	int ret;
+
+	chip = devm_kzalloc(dev, sizeof(*chip), GFP_KERNEL);
+	if (!chip)
+		return -ENOMEM;
+
+	chip->rstn_gpio = of_get_named_gpio(dev->of_node, "rstn-gpio", 0);
+	if (gpio_is_valid(chip->rstn_gpio)) {
+		ret = devm_gpio_request_one(dev, chip->rstn_gpio,
+			GPIOF_OUT_INIT_HIGH, "wl2868c_rstn");
+		if (ret < 0) {
+			pr_err("failed to request reset_n gpio %d: %d",
+				chip->rstn_gpio, ret);
+			return ret;
+		}
+	}
+
+	/* Wait for I2C can be accessed */
+	usleep_range(10000, 11000);
+
+	chip->chip_id = wl2868c_chip_id(client);
+	if (chip->chip_id < 0) {
+		pr_err("unknown regulator\n");
+		return -ENODEV;
+	}
+
+	i2c_set_clientdata(client, chip);
+	chip->dev = dev;
+
+	chip->regmap = devm_regmap_init_i2c(client, &wl2868c_regmap_config[chip->chip_id]);
+	if (IS_ERR(chip->regmap)) {
+		pr_err("failed to allocate regmap\n");
+		return PTR_ERR(chip->regmap);
+	}
+
+	ret = wl2868c_parse_regulator(chip);
+	if (ret < 0) {
+		pr_err("failed to parse device tree ret = %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int wl2868c_regulator_remove(struct i2c_client *client)
+{
+	struct wl2868c_chip *chip = i2c_get_clientdata(client);
+	u16 reg;
+	u8 vset = 0x00;
+
+	/* ET5907 and FAN53870 share the same enable register (0x03) */
+	reg = (chip->chip_id == REGULATOR_WL2868C)
+			? WL2868C_REG_LDO_ENABLE : ET5907_REG_LDO_ENABLE;
+
+	/* Disable regulator to avoid current leak */
+	wl2868c_write(chip->regmap, reg, &vset, 1);
+
+	if (gpio_is_valid(chip->rstn_gpio))
+		gpio_direction_output(chip->rstn_gpio, GPIOF_INIT_LOW);
+
+	return 0;
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id wl2868c_dt_ids[] = {
+	{ .compatible = "willsemi,wl2868c", },
+	{}
+};
+MODULE_DEVICE_TABLE(of, wl2868c_dt_ids);
+#endif
+
+static const struct i2c_device_id wl2868c_i2c_id[] = {
+	{ "wl2868c", },
+	{},
+};
+MODULE_DEVICE_TABLE(i2c, wl2868c_i2c_id);
+
+static struct i2c_driver wl2868c_driver = {
+	.driver = {
+		.name = "wl2868c-regulator",
+		.of_match_table = of_match_ptr(wl2868c_dt_ids),
+	},
+	.probe = wl2868c_regulator_probe,
+	.remove = wl2868c_regulator_remove,
+	.id_table = wl2868c_i2c_id,
+};
+module_i2c_driver(wl2868c_driver);
+
+MODULE_AUTHOR("Pavel Dubrova <pashadubrova@gmail.com>");
+MODULE_DESCRIPTION("WILLSEMI (Will Semicon) WL2868C regulator driver");
+MODULE_LICENSE("GPL v2");

--- a/drivers/regulator/wl2868c-regulator.h
+++ b/drivers/regulator/wl2868c-regulator.h
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * WILLSEMI (Will Semicon) WL2868C regulator driver
+ * Copyright (C) 2023, 2025 Pavel Dubrova <pashadubrova@gmail.com>
+ */
+
+#ifndef __WL2868C_REGULATOR_H__
+#define __WL2868C_REGULATOR_H__
+
+enum regulator_chip_id {
+	REGULATOR_WL2868C = 0,
+	REGULATOR_ET5907,
+	REGULATOR_FAN53870,
+	REGULATOR_MAX,
+};
+
+enum regulator_ldo_id {
+	CAMERA_LDO1 = 0,
+	CAMERA_LDO2,
+	CAMERA_LDO3,
+	CAMERA_LDO4,
+	CAMERA_LDO5,
+	CAMERA_LDO6,
+	CAMERA_LDO7,
+	CAMERA_LDO_MAX,
+};
+
+struct regulator_chip_info {
+	char *name;
+	unsigned short i2c_addr;
+	unsigned short chip_id;
+	unsigned short chip_id_addr;
+};
+
+struct wl2868c_chip {
+	struct device		*dev;
+	struct regmap		*regmap;
+	struct regulator_dev	*rdev[CAMERA_LDO_MAX];
+	struct regulator_desc	rdesc[CAMERA_LDO_MAX];
+	int			chip_id;
+	int			rstn_gpio;
+};
+
+struct wl2868c_regulator_data {
+	char	*name;
+	char	*supply_name;
+	int	min_uV;
+	int	max_uV;
+	int	default_uV;
+	int	base_mV;
+	int	step_mV;
+	int	en_time;
+	int	ldo_reg;
+};
+
+/* WL2868C registers */
+#define WL2868C_REG_CHIP_ID		0x00
+#define WL2868C_REG_REVISION_ID		0x01
+#define WL2868C_REG_DISCHARGE		0x02
+#define WL2868C_REG_LDO1		0x03
+#define WL2868C_REG_LDO2		0x04
+#define WL2868C_REG_LDO3		0x05
+#define WL2868C_REG_LDO4		0x06
+#define WL2868C_REG_LDO5		0x07
+#define WL2868C_REG_LDO6		0x08
+#define WL2868C_REG_LDO7		0x09
+#define WL2868C_REG_LDO12_SEQ		0x0a
+#define WL2868C_REG_LDO34_SEQ		0x0b
+#define WL2868C_REG_LDO56_SEQ		0x0c
+#define WL2868C_REG_LDO7_SEQ		0x0d
+#define WL2868C_REG_LDO_ENABLE		0x0e
+#define WL2868C_REG_SEQUENCING		0x0f
+#define WL2868C_REG_LDO1_STATUS		0x10
+#define WL2868C_REG_LDO1_OCP_CTL	0x11
+#define WL2868C_REG_LDO2_STATUS		0x12
+#define WL2868C_REG_LDO2_OCP_CTL	0x13
+#define WL2868C_REG_LDO3_STATUS		0x14
+#define WL2868C_REG_LDO3_OCP_CTL	0x15
+#define WL2868C_REG_LDO4_STATUS		0x16
+#define WL2868C_REG_LDO4_OCP_CTL	0x17
+#define WL2868C_REG_LDO5_STATUS		0x18
+#define WL2868C_REG_LDO5_OCP_CTL	0x19
+#define WL2868C_REG_LDO6_STATUS		0x1a
+#define WL2868C_REG_LDO6_OCP_CTL	0x1b
+#define WL2868C_REG_LDO7_STATUS		0x1c
+#define WL2868C_REG_LDO7_OCP_CTL	0x1d
+#define WL2868C_REG_I2C_ADDR		0x1e
+#define WL2868C_REG_RESERVED_0		0x1f
+#define WL2868C_REG_INT_LATCHED_CLR	0x20
+#define WL2868C_REG_INT_EN_SET		0x21
+#define WL2868C_REG_INT_LATCHED_STS	0x22
+#define WL2868C_REG_INT_PENDING_STS	0x23
+#define WL2868C_REG_UVLO_CTL		0x24
+#define WL2868C_REG_RESERVED_1		0x25
+
+/* ET5907 registers */
+#define ET5907_REG_CHIP_ID		0x00
+#define ET5907_REG_REVISION_ID		0x01
+#define ET5907_REG_LDO_ILIMIT		0x02
+#define ET5907_REG_LDO_ENABLE		0x03
+#define ET5907_REG_LDO1			0x04
+#define ET5907_REG_LDO2			0x05
+#define ET5907_REG_LDO3			0x06
+#define ET5907_REG_LDO4			0x07
+#define ET5907_REG_LDO5			0x08
+#define ET5907_REG_LDO6			0x09
+#define ET5907_REG_LDO7			0x0a
+#define ET5907_REG_LDO12_SEQ		0x0b
+#define ET5907_REG_LDO34_SEQ		0x0c
+#define ET5907_REG_LDO56_SEQ		0x0d
+#define ET5907_REG_LDO7_SEQ		0x0e
+#define ET5907_REG_SEQUENCING		0x0f
+#define ET5907_REG_DISCHARGE		0x10
+#define ET5907_REG_RESET		0x11
+#define ET5907_REG_I2C_ADDR		0x12
+#define ET5907_REG_RESERVED_0		0x13
+#define ET5907_REG_RESERVED_1		0x14
+#define ET5907_REG_UVP_INT		0x15
+#define ET5907_REG_OCP_INT		0x16
+#define ET5907_REG_TSD_UVLO_INT		0x17
+#define ET5907_REG_UVP_STAU		0x18
+#define ET5907_REG_OCP_STAU		0x19
+#define ET5907_REG_TSD_UVLO_STAU	0x1a
+#define ET5907_REG_SUSD_STAU		0x1b
+#define ET5907_REG_UVP_INTMA		0x1c
+#define ET5907_REG_OCP_INTMA		0x1d
+#define ET5907_REG_TSD_UVLO_INTMA	0x1e
+
+/* FAN53870 registers */
+#define FAN53870_REG_CHIP_ID		0x00
+#define FAN53870_REG_REVISION_ID	0x01
+#define FAN53870_REG_IOUT		0x02
+#define FAN53870_REG_LDO_ENABLE		0x03
+#define FAN53870_REG_LDO1		0x04
+#define FAN53870_REG_LDO2		0x05
+#define FAN53870_REG_LDO3		0x06
+#define FAN53870_REG_LDO4		0x07
+#define FAN53870_REG_LDO5		0x08
+#define FAN53870_REG_LDO6		0x09
+#define FAN53870_REG_LDO7		0x0a
+#define FAN53870_REG_LDO12_SEQ		0x0b
+#define FAN53870_REG_LDO34_SEQ		0x0c
+#define FAN53870_REG_LDO56_SEQ		0x0d
+#define FAN53870_REG_LDO7_SEQ		0x0e
+#define FAN53870_REG_SEQUENCING		0x0f
+#define FAN53870_REG_DISCHARGE		0x10
+#define FAN53870_REG_RESET		0x11
+#define FAN53870_REG_I2C_ADDR		0x12
+#define FAN53870_REG_LDO_COMP0		0x13
+#define FAN53870_REG_LDO_COMP1		0x14
+#define FAN53870_REG_INTERRUPT1		0x15
+#define FAN53870_REG_INTERRUPT2		0x16
+#define FAN53870_REG_INTERRUPT3		0x17
+#define FAN53870_REG_STATUS1		0x18
+#define FAN53870_REG_STATUS2		0x19
+#define FAN53870_REG_STATUS3		0x1a
+#define FAN53870_REG_STATUS4		0x1b
+#define FAN53870_REG_MINT1		0x1c
+#define FAN53870_REG_MINT2		0x1d
+#define FAN53870_REG_MINT3		0x1e
+
+#endif


### PR DESCRIPTION
This PR contains:
- PDX-246 camera dts.
- A universal regulator driver that supports the WL2868C, FAN53870, and ET5907 7-channel LDO PMICs simultaneously. This is a forward port of my implementation written in 2023, compatible with the Murray, Zambezi, and Columbia platforms.