### PR TITLE
[9.16.r1] power: supply: sm5038: Hardcode USB PD current to 3A

### DIFF
--- a/drivers/power/supply/sm5038_charger.c
+++ b/drivers/power/supply/sm5038_charger.c
@@ -1299,7 +1299,7 @@ static void psy_chg_set_online(struct sm5038_charger_data *charger, int cable_ty
 			if (!is_client_vote_enabled(charger->usb_icl_votable,
 								PD_VOTER)) {
 				vote(charger->usb_icl_votable, PD_VOTER,
-							true, MICRO_CURR_0P5A);
+							true, MICRO_CURR_3P0A);
 				vote(charger->usb_icl_votable, USB_PSY_VOTER,
 								false, 0);
 			}


### PR DESCRIPTION
This restores original SM5038 behavior where max charging current is
determined by the cable type, in this case MICRO_CURR_3P0A is used for
POWER_SUPPLY_TYPE_USB_PD. Prior to this change, max charging current
was intended to be set by proprietary SOMC charge_service daemon.
