### PR TITLE
[1.0.r1] SoMC Murray audio support + some other fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
@@ -178,6 +178,8 @@
 };
 
 &tlmm {
+	qcom,gpios-reserved = <13 14 15 16>;
+
 	pmx_sde_en: pmx_sde_en {
 		vci_en_active: vci_en_active {
 			mux {

--- a/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
@@ -166,15 +166,6 @@
 		compatible = "sony,ext-uim-ctrl";
 		uim2_detect_en_gpio = <&tlmm 85 GPIO_ACTIVE_HIGH>;
 	};
-
-	cdc_sec_mi2s_gpios: msm_cdc_pinctrl_sec {
-		compatible = "qcom,msm-cdc-pinctrl";
-		pinctrl-names = "aud_active", "aud_sleep";
-		pinctrl-0 = <&lpi_i2s2_sck_active &lpi_i2s2_ws_active &lpi_i2s2_sd0_active &lpi_i2s2_sd1_active>;
-		pinctrl-1 = <&lpi_i2s2_sck_sleep &lpi_i2s2_ws_sleep &lpi_i2s2_sd0_sleep &lpi_i2s2_sd1_sleep>;
-		qcom,lpi-gpios;
-		#gpio-cells = <0>;
-	};
 };
 
 &tlmm {
@@ -244,23 +235,6 @@
 	#size-cells = <0>;
 	status = "okay";
 
-	aw882xx_smartpa@34 {
-		compatible = "awinic,aw882xx_smartpa";
-		reg = <0x34>;
-		irq-gpio = <&tlmm 60 0>;
-		dc-flag = <0>;
-		sound-channel = <0>;
-		rename-flag = <1>;
-		aw-tx-topo-id = <0x1000ff00>;
-		aw-rx-topo-id = <0x1000ff01>;
-		aw-tx-port-id = <0x1003>;
-		aw-rx-port-id = <0x1002>;
-		aw-re-min = <4000>;
-		aw-re-max= <30000>;
-		aw-cali-mode = "aw_attr";
-		status = "okay";
-	};
-
 	awinic_haptic@58 {
 		compatible = "awinic,haptic_nv";
 		reg = <0x58>;
@@ -318,74 +292,6 @@
 
 &sdhc_2 {
 	cd-gpios = <&tlmm 94 GPIO_ACTIVE_HIGH>;
-};
-
-&wsa881x_i2c_44 {
-	status = "disabled";
-};
-
-&wsa881x_i2c_e {
-	status = "disabled";
-};
-
-&cdc_dmic23_gpios {
-	qcom,tlmm-pins = <135 136>;
-};
-
-&holi_snd {
-	qcom,model = "holi-qrdsku1-snd-card";
-	qcom,sku-model = "holi-qrdsku1-snd-card";
-	qcom,msm-mi2s-master = <1>, <1>, <1>, <1>;
-	qcom,sec-mi2s-gpios =<&cdc_sec_mi2s_gpios>;
-	qcom,wcn-btfm = <1>;
-	qcom,audio-routing =
-		"AMIC1", "Analog Mic1",
-		"Analog Mic1", "MIC BIAS1",
-		"AMIC2", "Analog Mic2",
-		"Analog Mic2", "MIC BIAS2",
-		"AMIC3", "Analog Mic3",
-		"Analog Mic3", "MIC BIAS3",
-		"TX DMIC0", "Digital Mic0",
-		"TX DMIC0", "MIC BIAS3",
-		"TX DMIC1", "Digital Mic1",
-		"TX DMIC1", "MIC BIAS3",
-		"TX DMIC2", "Digital Mic2",
-		"TX DMIC2", "MIC BIAS1",
-		"TX DMIC3", "Digital Mic3",
-		"TX DMIC3", "MIC BIAS1",
-		"IN1_HPHL", "HPHL_OUT",
-		"IN2_HPHR", "HPHR_OUT",
-		"IN3_AUX", "AUX_OUT",
-		"RX_TX DEC0_INP", "TX DEC0 MUX",
-		"RX_TX DEC1_INP", "TX DEC1 MUX",
-		"RX_TX DEC2_INP", "TX DEC2 MUX",
-		"RX_TX DEC3_INP", "TX DEC3 MUX",
-		"TX SWR_INPUT", "WCD_TX_OUTPUT",
-		"VA SWR_INPUT", "VA_SWR_CLK",
-		"VA SWR_INPUT", "WCD_TX_OUTPUT",
-		"VA_AIF1 CAP", "VA_SWR_CLK",
-		"VA_AIF2 CAP", "VA_SWR_CLK",
-		"VA_AIF3 CAP", "VA_SWR_CLK",
-		"VA DMIC0", "Digital Mic0",
-		"VA DMIC1", "Digital Mic1",
-		"VA DMIC2", "Digital Mic2",
-		"VA DMIC3", "Digital Mic3",
-		"VA DMIC4", "Digital Mic4",
-		"VA DMIC5", "Digital Mic5",
-		"VA DMIC0", "VA MIC BIAS1",
-		"VA DMIC1", "VA MIC BIAS1",
-		"VA DMIC2", "VA MIC BIAS3",
-		"VA DMIC3", "VA MIC BIAS3";
-	qcom,msm-mbhc-hphl-swh = <1>;
-	qcom,msm-mbhc-gnd-swh = <1>;
-	qcom,cdc-dmic01-gpios = <&cdc_dmic01_gpios>;
-	qcom,cdc-dmic23-gpios = <&cdc_dmic23_gpios>;
-	asoc-codec  = <&stub_codec>, <&bolero>,
-		      <&wcd937x_codec>;
-	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
-			   "wcd937x_codec";
-	qcom,msm_audio_ssr_devs = <&audio_apr>, <&q6core>, <&lpi_tlmm>,
-				  <&bolero>;
 };
 
 &usb0 {

--- a/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-murray-common.dtsi
@@ -384,7 +384,8 @@
 		      <&wcd937x_codec>;
 	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
 			   "wcd937x_codec";
-	qcom,msm_audio_ssr_devs = <&audio_gpr>, <&lpi_tlmm>, <&bolero>;
+	qcom,msm_audio_ssr_devs = <&audio_apr>, <&q6core>, <&lpi_tlmm>,
+				  <&bolero>;
 };
 
 &usb0 {

--- a/arch/arm64/boot/dts/qcom/blair-murray-pdx225_common.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-murray-pdx225_common.dtsi
@@ -3,6 +3,8 @@
 &soc {
 };
 
+#include "somc-murray-audio-common.dtsi"
+#include "somc-murray-audio-pdx225.dtsi"
 #include "somc-murray-camera.dtsi"
 #include "somc-murray-display.dtsi"
 #include "somc-murray-display-pdx225.dtsi"

--- a/arch/arm64/boot/dts/qcom/blair-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-pinctrl.dtsi
@@ -8,6 +8,7 @@
 		interrupt-controller;
 		#interrupt-cells = <2>;
 		wakeup-parent = <&wakegic>;
+		qcom,gpios-reserved = <13 14 15 16 17 45 46 48 56 57>;
 
 		qupv3_se0_i2c_pins: qupv3_se0_i2c_pins {
 			qupv3_se0_i2c_active: qupv3_se0_i2c_active {

--- a/arch/arm64/boot/dts/qcom/blair-qrd.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair-qrd.dtsi
@@ -200,7 +200,8 @@
 		      <&wcd937x_codec>, <&wsa881x_i2c_e>;
 	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
 			   "wcd937x_codec", "wsa-codec0";
-	qcom,msm_audio_ssr_devs = <&audio_gpr>,<&lpi_tlmm>, <&bolero>;
+	qcom,msm_audio_ssr_devs = <&audio_apr>, <&q6core>, <&lpi_tlmm>,
+				  <&bolero>;
 };
 
 &soc {

--- a/arch/arm64/boot/dts/qcom/blair.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair.dtsi
@@ -569,26 +569,40 @@
 		};
 	};
 
-	slim_aud: slim@a5c0000 {
-		cell-index = <1>;
-		compatible = "qcom,slim-ngd";
-		reg = <0xa5c0000 0x2c000>,
-			<0xa584000 0x20000>, <0xa66e000 0x2000>;
-		reg-names = "slimbus_physical",
-				"slimbus_bam_physical", "slimbus_lpass_mem";
-		interrupts = <GIC_SPI 283 IRQ_TYPE_LEVEL_HIGH>,
-				<GIC_SPI 284 IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "slimbus_irq", "slimbus_bam_irq";
+	slimbam: bamdma@a584000 {
+		compatible = "qcom,bam-v1.7.0";
+		reg = <0xa584000 0x20000>, <0xa66f000 0x1000>;
+		reg-names = "bam", "bam_remote_mem";
+		num-channels  = <31>;
+		interrupts = <0 284 IRQ_TYPE_LEVEL_HIGH>;
+		#dma-cells = <1>;
+		qcom,controlled-remotely;
+		qcom,ee = <1>;
+		qcom,num-ees = <2>;
+	};
+
+	slim_msm: slim@a5c0000 {
+		compatible = "qcom,slim-ngd-v1.5.0";
+		reg = <0xa5c0000 0x2c000>, <0xa66e000 0x1000>;
+		reg-names = "ctrl", "slimbus_remote_mem";
+		interrupts = <0 283 IRQ_TYPE_LEVEL_HIGH>;
 		qcom,apps-ch-pipes = <0x0>;
 		qcom,ea-pc = <0x3b0>;
-		status = "ok";
+		dmas = <&slimbam 3>, <&slimbam 4>;
+		dma-names = "rx", "tx";
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		/* Slimbus Slave DT for WCN3990 */
-		btfmslim_codec: wcn3990 {
-			compatible = "qcom,btfmslim_slave";
-			elemental-addr = [00 01 20 02 17 02];
-			qcom,btfm-slim-ifd = "btfmslim_slave_ifd";
-			qcom,btfm-slim-ifd-elemental-addr = [00 00 20 02 17 02];
+		ngd@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* slimbus child nodes */
+			slimbus: btfmslim-driver {
+				compatible = "slim217,221";
+				reg = <1 0>;
+			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/blair.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair.dtsi
@@ -42,13 +42,15 @@
 		granule = <512>;
 	};
 
-	aliases: aliases {
+	aliases {
 		ufshc1 = &ufshc_mem; /* Embedded  UFS Slot */
 
 		sdhc0 = &sdhc_1; /*SDC1 eMMC slot*/
 		sdhc1 = &sdhc_2; /* SDC2 SD card slot */
 		serial0 = &qupv3_se9_2uart;
 		hsuart0 = &qupv3_se1_4uart;
+		swr0 = &swr0;
+		swr1 = &swr1;
 	};
 
 	firmware: firmware {};

--- a/arch/arm64/boot/dts/qcom/blair.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair.dtsi
@@ -2686,6 +2686,7 @@
 	qcom,msm-cdsp-loader {
 		compatible = "qcom,cdsp-loader";
 		qcom,proc-img-to-load = "cdsp";
+		qcom,rproc-handle = <&cdsp_pas>;
 	};
 
 	qcom,msm-adsprpc-mem {

--- a/arch/arm64/boot/dts/qcom/blair.dtsi
+++ b/arch/arm64/boot/dts/qcom/blair.dtsi
@@ -3877,6 +3877,7 @@
 		qcom,iommu-dma = "fastmap";
 		qcom,iommu-faults = "stall-disable", "HUPCF", "non-fatal";
 		qcom,wlan-msa-fixed-region = <&pil_wlan_mem>;
+		qcom,wlan;
 		qcom,iommu-dma-addr-pool = <0xa0000000 0x10000000>;
 		qcom,iommu-geometry = <0xa0000000 0x10010000>;
 		vdd-cx-mx-supply = <&L2E>;

--- a/arch/arm64/boot/dts/qcom/holi-audio-overlay.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-audio-overlay.dtsi
@@ -297,7 +297,8 @@
 	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
 			   "wcd937x_codec", "wsa-codec0",
 			   "wsa-codec1";
-	qcom,msm_audio_ssr_devs = <&audio_gpr>, <&lpi_tlmm>, <&bolero>;
+	qcom,msm_audio_ssr_devs = <&audio_apr>, <&q6core>, <&lpi_tlmm>,
+				  <&bolero>;
 };
 
 &qupv3_se10_i2c {
@@ -345,6 +346,10 @@
 		reg = <0x045>;
 		qcom,wsa-analog-clk-gpio = <&wsa881x_analog_clk_gpio>;
 	};
+};
+
+&va_cdc_dma_0_tx {
+	qcom,msm-dai-is-island-supported = <1>;
 };
 
 &soc {

--- a/arch/arm64/boot/dts/qcom/holi-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-audio.dtsi
@@ -1,5 +1,5 @@
 #include <dt-bindings/clock/qcom,audio-ext-clk.h>
-#include "msm-audio-lpass.dtsi"
+#include "msm-audio-lpass-holi.dtsi"
 
 &msm_audio_ion {
 	iommus = <&apps_smmu 0x00A1 0x0>;
@@ -157,9 +157,10 @@
 				<&dai_mi2s1_rx>, <&dai_mi2s1_tx>,
 				<&dai_mi2s2_rx>, <&dai_mi2s2_tx>,
 				<&dai_mi2s3_rx>, <&dai_mi2s3_tx>,
-				<&dai_pri_auxpcm>,
-				<&dai_sec_auxpcm>, <&dai_tert_auxpcm>,
-				<&dai_quat_auxpcm>,
+				<&dai_pri_auxpcm_rx>, <&dai_pri_auxpcm_tx>,
+				<&dai_sec_auxpcm_rx>, <&dai_sec_auxpcm_tx>,
+				<&dai_tert_auxpcm_rx>, <&dai_tert_auxpcm_tx>,
+				<&dai_quat_auxpcm_rx>, <&dai_quat_auxpcm_tx>,
 				<&afe_pcm_rx>, <&afe_pcm_tx>, <&afe_proxy_rx>,
 				<&afe_proxy_tx>, <&incall_record_rx>,
 				<&incall_record_tx>, <&incall_music_rx>,
@@ -185,9 +186,10 @@
 				"msm-dai-q6-mi2s.2", "msm-dai-q6-mi2s.3",
 				"msm-dai-q6-mi2s.4", "msm-dai-q6-mi2s.5",
 				"msm-dai-q6-mi2s.6", "msm-dai-q6-mi2s.7",
-				"msm-dai-q6-auxpcm.1",
-				"msm-dai-q6-auxpcm.2", "msm-dai-q6-auxpcm.3",
-				"msm-dai-q6-auxpcm.4",
+				"msm-dai-q6-auxpcm.1", "msm-dai-q6-auxpcm.2",
+				"msm-dai-q6-auxpcm.3", "msm-dai-q6-auxpcm.4",
+				"msm-dai-q6-auxpcm.5", "msm-dai-q6-auxpcm.6",
+				"msm-dai-q6-auxpcm.7", "msm-dai-q6-auxpcm.8",
 				"msm-dai-q6-dev.224",
 				"msm-dai-q6-dev.225", "msm-dai-q6-dev.241",
 				"msm-dai-q6-dev.240", "msm-dai-q6-dev.32771",

--- a/arch/arm64/boot/dts/qcom/holi-audio.dtsi
+++ b/arch/arm64/boot/dts/qcom/holi-audio.dtsi
@@ -1,102 +1,59 @@
 #include <dt-bindings/clock/qcom,audio-ext-clk.h>
-#include <dt-bindings/sound/qcom,gpr.h>
 #include "msm-audio-lpass.dtsi"
 
-&soc {
-	spf_core_platform: spf_core_platform {
-		compatible = "qcom,spf-core-platform";
-	};
-
-	lpass_audio_hw_vote: vote_lpass_audio_hw {
-		compatible = "qcom,audio-ref-clk";
-		qcom,codec-ext-clk-src = <AUDIO_LPASS_AUDIO_HW_VOTE>;
-		#clock-cells = <1>;
-	};
+&msm_audio_ion {
+	iommus = <&apps_smmu 0x00A1 0x0>;
+	qcom,smmu-sid-mask = /bits/ 64 <0xf>;
 };
 
-&glink_edge {
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	audio_gpr: qcom,gpr {
-		compatible = "qcom,gpr";
-		qcom,glink-channels = "adsp_apps";
-		qcom,intents = <0x200 20>;
-		reg = <GPR_DOMAIN_ADSP>;
-
+&audio_apr {
+	q6core: qcom,q6core-audio {
+		compatible = "qcom,q6core-audio";
 		#address-cells = <1>;
-		#size-cells = <0>;
+		#size-cells = <1>;
 
-		spf_core {
-			compatible = "qcom,spf_core";
-			reg = <GPR_SVC_ADSP_CORE>;
+		lpass_audio_hw_vote: vote_lpass_audio_hw {
+			compatible = "qcom,audio-ref-clk";
+			qcom,codec-ext-clk-src = <AUDIO_LPASS_AUDIO_HW_VOTE>;
+			#clock-cells = <1>;
 		};
 
-		audio-pkt {
-			compatible = "qcom,audio-pkt";
-			qcom,audiopkt-ch-name = "apr_audio_svc";
-			reg = <GPR_SVC_MAX>;
+		lpi_tlmm: lpi_pinctrl@a7c0000 {
+			compatible = "qcom,lpi-pinctrl";
+			reg = <0xa7c0000 0x0>;
+			qcom,slew-reg = <0x0a95a000 0x0>;
+			clock-names = "lpass_audio_hw_vote";
+			clocks = <&lpass_audio_hw_vote 0>;
+			qcom,gpios-count = <19>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			qcom,lpi-offset-tbl = <0x00000000>, <0x00001000>,
+					      <0x00002000>, <0x00003000>,
+					      <0x00004000>, <0x00005000>,
+					      <0x00006000>, <0x00007000>,
+					      <0x00008000>, <0x00009000>,
+					      <0x0000A000>, <0x0000B000>,
+					      <0x0000C000>, <0x0000D000>,
+					      <0x0000E000>, <0x0000F000>,
+					      <0x00010000>, <0x00011000>,
+					      <0x00012000>;
+			qcom,lpi-slew-offset-tbl = <0x00000000>, <0x00000002>,
+						   <0x00000004>, <0x00000008>,
+						   <0x0000000A>, <0x0000000C>,
+						   <0x00000000>, <0x00000000>,
+						   <0x00000000>, <0x00000000>,
+						   <0x00000010>, <0x00000012>,
+						   <0x00000000>, <0x00000000>,
+						   <0x00000000>, <0x00000000>,
+						   <0x00000000>, <0x00000000>,
+						   <0x00000014>;
+
 		};
-
-		audio_prm: q6prm {
-			compatible = "qcom,audio_prm";
-			reg = <GPR_SVC_ASM>;
-		};
-	};
-};
-
-&spf_core_platform {
-	#address-cells = <2>;
-	#size-cells = <0>;
-
-	msm_audio_ion: qcom,msm-audio-ion {
-		compatible = "qcom,msm-audio-ion";
-		qcom,smmu-version = <2>;
-		qcom,smmu-enabled;
-		iommus = <&apps_smmu 0x00A1 0x0>;
-		qcom,iommu-dma-addr-pool = <0x10000000 0x10000000>;
-		qcom,smmu-sid-mask = /bits/ 64 <0xf>;
-	};
-
-	msm_audio_ion_cma: qcom,msm-audio-ion-cma {
-		compatible = "qcom,msm-audio-ion-cma";
-	};
-
-	lpi_tlmm: lpi_pinctrl@a7c0000 {
-		compatible = "qcom,lpi-pinctrl";
-		reg = <0xa7c0000 0x0>;
-		qcom,slew-reg = <0x0a95a000 0x0>;
-		clock-names = "lpass_audio_hw_vote";
-		clocks = <&lpass_audio_hw_vote 0>;
-		qcom,gpios-count = <19>;
-		gpio-controller;
-		#gpio-cells = <2>;
-		qcom,lpi-offset-tbl = <0x00000000>, <0x00001000>,
-				      <0x00002000>, <0x00003000>,
-				      <0x00004000>, <0x00005000>,
-				      <0x00006000>, <0x00007000>,
-				      <0x00008000>, <0x00009000>,
-				      <0x0000A000>, <0x0000B000>,
-				      <0x0000C000>, <0x0000D000>,
-				      <0x0000E000>, <0x0000F000>,
-				      <0x00010000>, <0x00011000>,
-				      <0x00012000>;
-		qcom,lpi-slew-offset-tbl = <0x00000000>, <0x00000002>,
-					   <0x00000004>, <0x00000008>,
-					   <0x0000000A>, <0x0000000C>,
-					   <0x00000000>, <0x00000000>,
-					   <0x00000000>, <0x00000000>,
-					   <0x00000010>, <0x00000012>,
-					   <0x00000000>, <0x00000000>,
-					   <0x00000000>, <0x00000000>,
-					   <0x00000000>, <0x00000000>,
-					   <0x00000014>;
 	};
 };
 
 #include "holi-lpi.dtsi"
-
-&spf_core_platform {
+&q6core {
 	rx_swr_gpios: rx_swr_clk_data_pinctrl {
 		compatible = "qcom,msm-cdc-pinctrl";
 		pinctrl-names = "aud_active", "aud_sleep";
@@ -149,7 +106,9 @@
 		qcom,lpi-gpios;
 		#gpio-cells = <0>;
 	};
+};
 
+&q6core {
 	bolero: bolero-cdc {
 		compatible = "qcom,bolero-codec";
 		clock-names = "lpass_audio_hw_vote";
@@ -169,7 +128,9 @@
 		};
 
 	};
+};
 
+&q6core {
 	holi_snd: sound {
 		compatible = "qcom,holi-asoc-snd";
 		qcom,mi2s-audio-intf = <1>;
@@ -180,10 +141,83 @@
 
 		clock-names = "lpass_audio_hw_vote";
 		clocks = <&lpass_audio_hw_vote 0>;
-	};
-};
 
-&aliases {
-	swr0 = "/soc/spf_core_platform/bolero-codec/va-macro@A730000/va_swr_master";
-	swr1 = "/soc/spf_core_platform/bolero-codec/rx-macro@A600000/rx_swr_master";
+		asoc-platform = <&pcm0>, <&pcm1>, <&pcm2>, <&voip>, <&voice>,
+				<&loopback>, <&compress>, <&hostless>,
+				<&afe>, <&lsm>, <&routing>, <&compr>,
+				<&pcm_noirq>;
+		asoc-platform-names = "msm-pcm-dsp.0", "msm-pcm-dsp.1",
+				"msm-pcm-dsp.2", "msm-voip-dsp",
+				"msm-pcm-voice", "msm-pcm-loopback",
+				"msm-compress-dsp", "msm-pcm-hostless",
+				"msm-pcm-afe", "msm-lsm-client",
+				"msm-pcm-routing", "msm-compr-dsp",
+				"msm-pcm-dsp-noirq";
+		asoc-cpu = <&dai_mi2s0_rx>, <&dai_mi2s0_tx>,
+				<&dai_mi2s1_rx>, <&dai_mi2s1_tx>,
+				<&dai_mi2s2_rx>, <&dai_mi2s2_tx>,
+				<&dai_mi2s3_rx>, <&dai_mi2s3_tx>,
+				<&dai_pri_auxpcm>,
+				<&dai_sec_auxpcm>, <&dai_tert_auxpcm>,
+				<&dai_quat_auxpcm>,
+				<&afe_pcm_rx>, <&afe_pcm_tx>, <&afe_proxy_rx>,
+				<&afe_proxy_tx>, <&incall_record_rx>,
+				<&incall_record_tx>, <&incall_music_rx>,
+				<&incall_music_2_rx>,
+				<&afe_proxy_tx_1>,
+				<&proxy_rx>, <&proxy_tx>,
+				<&usb_audio_rx>, <&usb_audio_tx>,
+				<&sb_7_rx>, <&sb_7_tx>, <&sb_8_tx>,
+				<&dai_pri_tdm_rx_0>, <&dai_pri_tdm_tx_0>,
+				<&dai_sec_tdm_rx_0>, <&dai_sec_tdm_tx_0>,
+				<&dai_tert_tdm_rx_0>, <&dai_tert_tdm_tx_0>,
+				<&dai_quat_tdm_rx_0>, <&dai_quat_tdm_tx_0>,
+				<&va_cdc_dma_0_tx>, <&va_cdc_dma_1_tx>,
+				<&va_cdc_dma_2_tx>,
+				<&rx_cdc_dma_0_rx>, <&tx_cdc_dma_0_tx>,
+				<&rx_cdc_dma_1_rx>, <&tx_cdc_dma_1_tx>,
+				<&rx_cdc_dma_2_rx>, <&tx_cdc_dma_2_tx>,
+				<&rx_cdc_dma_3_rx>, <&tx_cdc_dma_3_tx>,
+				<&rx_cdc_dma_4_rx>, <&tx_cdc_dma_4_tx>,
+				<&rx_cdc_dma_5_rx>, <&tx_cdc_dma_5_tx>,
+				<&rx_cdc_dma_7_rx>,<&afe_loopback_tx>;
+		asoc-cpu-names = "msm-dai-q6-mi2s.0", "msm-dai-q6-mi2s.1",
+				"msm-dai-q6-mi2s.2", "msm-dai-q6-mi2s.3",
+				"msm-dai-q6-mi2s.4", "msm-dai-q6-mi2s.5",
+				"msm-dai-q6-mi2s.6", "msm-dai-q6-mi2s.7",
+				"msm-dai-q6-auxpcm.1",
+				"msm-dai-q6-auxpcm.2", "msm-dai-q6-auxpcm.3",
+				"msm-dai-q6-auxpcm.4",
+				"msm-dai-q6-dev.224",
+				"msm-dai-q6-dev.225", "msm-dai-q6-dev.241",
+				"msm-dai-q6-dev.240", "msm-dai-q6-dev.32771",
+				"msm-dai-q6-dev.32772", "msm-dai-q6-dev.32773",
+				"msm-dai-q6-dev.32770",
+				"msm-dai-q6-dev.242",
+				"msm-dai-q6-dev.8194", "msm-dai-q6-dev.8195",
+				"msm-dai-q6-dev.28672", "msm-dai-q6-dev.28673",
+				"msm-dai-q6-dev.16398", "msm-dai-q6-dev.16399",
+				"msm-dai-q6-dev.16401",
+				"msm-dai-q6-tdm.36864", "msm-dai-q6-tdm.36865",
+				"msm-dai-q6-tdm.36880", "msm-dai-q6-tdm.36881",
+				"msm-dai-q6-tdm.36896", "msm-dai-q6-tdm.36897",
+				"msm-dai-q6-tdm.36912", "msm-dai-q6-tdm.36913",
+				"msm-dai-cdc-dma-dev.45089",
+				"msm-dai-cdc-dma-dev.45091",
+				"msm-dai-cdc-dma-dev.45093",
+				"msm-dai-cdc-dma-dev.45104",
+				"msm-dai-cdc-dma-dev.45105",
+				"msm-dai-cdc-dma-dev.45106",
+				"msm-dai-cdc-dma-dev.45107",
+				"msm-dai-cdc-dma-dev.45108",
+				"msm-dai-cdc-dma-dev.45109",
+				"msm-dai-cdc-dma-dev.45110",
+				"msm-dai-cdc-dma-dev.45111",
+				"msm-dai-cdc-dma-dev.45112",
+				"msm-dai-cdc-dma-dev.45113",
+				"msm-dai-cdc-dma-dev.45114",
+				"msm-dai-cdc-dma-dev.45115",
+				"msm-dai-cdc-dma-dev.45118",
+				"msm-dai-q6-dev.24577";
+	};
 };

--- a/arch/arm64/boot/dts/qcom/msm-audio-lpass-holi.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm-audio-lpass-holi.dtsi
@@ -1,0 +1,999 @@
+&soc {
+	pcm0: qcom,msm-pcm {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <0>;
+	};
+
+	routing: qcom,msm-pcm-routing {
+		compatible = "qcom,msm-pcm-routing";
+	};
+
+	compr: qcom,msm-compr-dsp {
+		compatible = "qcom,msm-compr-dsp";
+	};
+
+	pcm1: qcom,msm-pcm-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <1>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "regular";
+	};
+
+	pcm2: qcom,msm-ultra-low-latency {
+		compatible = "qcom,msm-pcm-dsp";
+		qcom,msm-pcm-dsp-id = <2>;
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	pcm_noirq: qcom,msm-pcm-dsp-noirq {
+		compatible = "qcom,msm-pcm-dsp-noirq";
+		qcom,msm-pcm-low-latency;
+		qcom,latency-level = "ultra";
+	};
+
+	trans_loopback: qcom,msm-transcode-loopback {
+		compatible = "qcom,msm-transcode-loopback";
+	};
+
+	compress: qcom,msm-compress-dsp {
+		compatible = "qcom,msm-compress-dsp";
+	};
+
+	voip: qcom,msm-voip-dsp {
+		compatible = "qcom,msm-voip-dsp";
+	};
+
+	voice: qcom,msm-pcm-voice {
+		compatible = "qcom,msm-pcm-voice";
+		qcom,destroy-cvd;
+	};
+
+	stub_codec: qcom,msm-stub-codec {
+		compatible = "qcom,msm-stub-codec";
+	};
+
+	qcom,msm-dai-fe {
+		compatible = "qcom,msm-dai-fe";
+	};
+
+	afe: qcom,msm-pcm-afe {
+		compatible = "qcom,msm-pcm-afe";
+	};
+
+	dai_hdmi: qcom,msm-dai-q6-hdmi {
+		compatible = "qcom,msm-dai-q6-hdmi";
+		qcom,msm-dai-q6-dev-id = <8>;
+	};
+
+	dai_dp: qcom,msm-dai-q6-dp {
+		compatible = "qcom,msm-dai-q6-hdmi";
+		qcom,msm-dai-q6-dev-id = <0>;
+	};
+
+	dai_dp1: qcom,msm-dai-q6-dp1 {
+		compatible = "qcom,msm-dai-q6-hdmi";
+		qcom,msm-dai-q6-dev-id = <1>;
+	};
+
+	loopback: qcom,msm-pcm-loopback {
+		compatible = "qcom,msm-pcm-loopback";
+	};
+
+	loopback1: qcom,msm-pcm-loopback-low-latency {
+		compatible = "qcom,msm-pcm-loopback";
+		qcom,msm-pcm-loopback-low-latency;
+	};
+
+	pcm_dtmf: qcom,msm-pcm-dtmf {
+		compatible = "qcom,msm-pcm-dtmf";
+	};
+
+	msm_dai_mi2s: qcom,msm-dai-mi2s {
+		compatible = "qcom,msm-dai-mi2s";
+		dai_mi2s0_rx: qcom,msm-dai-q6-mi2s-prim-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <0>;
+			qcom,msm-mi2s-lines = <3>;
+		};
+
+		dai_mi2s0_tx: qcom,msm-dai-q6-mi2s-prim-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <1>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s1_rx: qcom,msm-dai-q6-mi2s-sec-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <2>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s1_tx: qcom,msm-dai-q6-mi2s-sec-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <3>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s2_rx: qcom,msm-dai-q6-mi2s-tert-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <4>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s2_tx: qcom,msm-dai-q6-mi2s-tert-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <5>;
+			qcom,msm-mi2s-lines = <3>;
+		};
+
+		dai_mi2s3_rx: qcom,msm-dai-q6-mi2s-quat-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <6>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s3_tx: qcom,msm-dai-q6-mi2s-quat-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <7>;
+			qcom,msm-mi2s-lines = <2>;
+		};
+
+		dai_mi2s4_rx: qcom,msm-dai-q6-mi2s-quin-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <8>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s4_tx: qcom,msm-dai-q6-mi2s-quin-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <9>;
+			qcom,msm-mi2s-lines = <2>;
+		};
+
+		dai_mi2s5_rx: qcom,msm-dai-q6-mi2s-senary-rx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <10>;
+			qcom,msm-mi2s-lines = <1>;
+		};
+
+		dai_mi2s5_tx: qcom,msm-dai-q6-mi2s-senary-tx {
+			compatible = "qcom,msm-dai-q6-mi2s";
+			qcom,msm-dai-q6-mi2s-dev-id = <11>;
+			qcom,msm-mi2s-lines = <3>;
+		};
+	};
+
+	msm_dai_cdc_dma: qcom,msm-dai-cdc-dma {
+		compatible = "qcom,msm-dai-cdc-dma";
+		wsa_cdc_dma_0_rx: qcom,msm-dai-wsa-cdc-dma-0-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45056>;
+		};
+
+		wsa_cdc_dma_0_tx: qcom,msm-dai-wsa-cdc-dma-0-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45057>;
+		};
+
+		wsa_cdc_dma_1_rx: qcom,msm-dai-wsa-cdc-dma-1-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45058>;
+		};
+
+		wsa_cdc_dma_1_tx: qcom,msm-dai-wsa-cdc-dma-1-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45059>;
+		};
+
+		wsa_cdc_dma_2_tx: qcom,msm-dai-wsa-cdc-dma-2-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45061>;
+		};
+
+		va_cdc_dma_0_tx: qcom,msm-dai-va-cdc-dma-0-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45089>;
+		};
+
+		va_cdc_dma_1_tx: qcom,msm-dai-va-cdc-dma-1-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45091>;
+		};
+
+		va_cdc_dma_2_tx: qcom,msm-dai-va-cdc-dma-2-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45093>;
+		};
+
+		rx_cdc_dma_0_rx: qcom,msm-dai-rx-cdc-dma-0-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45104>;
+		};
+
+		rx_cdc_dma_1_rx: qcom,msm-dai-rx-cdc-dma-1-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45106>;
+		};
+
+		rx_cdc_dma_2_rx: qcom,msm-dai-rx-cdc-dma-2-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45108>;
+		};
+
+		rx_cdc_dma_3_rx: qcom,msm-dai-rx-cdc-dma-3-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45110>;
+		};
+
+		rx_cdc_dma_4_rx: qcom,msm-dai-rx-cdc-dma-4-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45112>;
+		};
+
+		rx_cdc_dma_5_rx: qcom,msm-dai-rx-cdc-dma-5-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45114>;
+		};
+
+		rx_cdc_dma_6_rx: qcom,msm-dai-rx-cdc-dma-6-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45116>;
+			qcom,msm-cdc-dma-data-align = <1>;
+		};
+
+		rx_cdc_dma_7_rx: qcom,msm-dai-rx-cdc-dma-7-rx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45118>;
+		};
+
+		tx_cdc_dma_0_tx: qcom,msm-dai-tx-cdc-dma-0-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45105>;
+		};
+
+		tx_cdc_dma_1_tx: qcom,msm-dai-tx-cdc-dma-1-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45107>;
+		};
+
+		tx_cdc_dma_2_tx: qcom,msm-dai-tx-cdc-dma-2-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45109>;
+		};
+
+		tx_cdc_dma_3_tx: qcom,msm-dai-tx-cdc-dma-3-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45111>;
+		};
+
+		tx_cdc_dma_4_tx: qcom,msm-dai-tx-cdc-dma-4-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45113>;
+		};
+
+		tx_cdc_dma_5_tx: qcom,msm-dai-tx-cdc-dma-5-tx {
+			compatible = "qcom,msm-dai-cdc-dma-dev";
+			qcom,msm-dai-cdc-dma-dev-id = <45115>;
+		};
+	};
+
+	lsm: qcom,msm-lsm-client {
+		compatible = "qcom,msm-lsm-client";
+	};
+
+	dai_msm_q6:qcom,msm-dai-q6 {
+		compatible = "qcom,msm-dai-q6";
+		sb_7_rx: qcom,msm-dai-q6-sb-7-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16398>;
+			qcom,msm-dai-q6-slim-dev-id = <0>;
+		};
+
+		sb_7_tx: qcom,msm-dai-q6-sb-7-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16399>;
+			qcom,msm-dai-q6-slim-dev-id = <0>;
+		};
+
+		sb_8_tx: qcom,msm-dai-q6-sb-8-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <16401>;
+			qcom,msm-dai-q6-slim-dev-id = <0>;
+		};
+
+		bt_sco_rx: qcom,msm-dai-q6-bt-sco-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12288>;
+		};
+
+		bt_sco_tx: qcom,msm-dai-q6-bt-sco-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12289>;
+		};
+
+		int_fm_rx: qcom,msm-dai-q6-int-fm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12292>;
+		};
+
+		int_fm_tx: qcom,msm-dai-q6-int-fm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <12293>;
+		};
+
+		afe_pcm_rx: qcom,msm-dai-q6-be-afe-pcm-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <224>;
+		};
+
+		afe_pcm_tx: qcom,msm-dai-q6-be-afe-pcm-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <225>;
+		};
+
+		afe_proxy_rx: qcom,msm-dai-q6-afe-proxy-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <241>;
+		};
+
+		afe_proxy_tx: qcom,msm-dai-q6-afe-proxy-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <240>;
+		};
+
+		incall_record_rx: qcom,msm-dai-q6-incall-record-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32771>;
+		};
+
+		incall_record_tx: qcom,msm-dai-q6-incall-record-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32772>;
+		};
+
+		incall_music_rx: qcom,msm-dai-q6-incall-music-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32773>;
+		};
+
+		incall_music_2_rx: qcom,msm-dai-q6-incall-music-2-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <32770>;
+		};
+
+		afe_proxy_tx_1: qcom,msm-dai-q6-afe-proxy-tx-1 {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <242>;
+		};
+
+		proxy_rx: qcom,msm-dai-q6-proxy-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <8194>;
+		};
+
+		proxy_tx: qcom,msm-dai-q6-proxy-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <8195>;
+		};
+
+		usb_audio_rx: qcom,msm-dai-q6-usb-audio-rx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <28672>;
+		};
+
+		usb_audio_tx: qcom,msm-dai-q6-usb-audio-tx {
+			compatible = "qcom,msm-dai-q6-dev";
+			qcom,msm-dai-q6-dev-id = <28673>;
+		};
+	};
+
+	hostless: qcom,msm-pcm-hostless {
+		compatible = "qcom,msm-pcm-hostless";
+	};
+
+	audio_apr: qcom,msm-audio-apr {
+		compatible = "qcom,msm-audio-apr";
+		qcom,subsys-name = "apr_adsp";
+		qcom,rproc-handle = <&adsp_pas>;
+
+		msm_audio_ion: qcom,msm-audio-ion {
+			compatible = "qcom,msm-audio-ion";
+			qcom,smmu-version = <2>;
+			qcom,smmu-enabled;
+			iommus = <&apps_smmu 0x1801 0x0>;
+			qcom,iommu-dma-addr-pool = <0x10000000 0x10000000>;
+		};
+	};
+
+	dai_pri_auxpcm_rx: qcom,msm-pri-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "primaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_pri_auxpcm_tx: qcom,msm-pri-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "primaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_sec_auxpcm_rx: qcom,msm-sec-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "secondaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_sec_auxpcm_tx: qcom,msm-sec-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "secondaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_tert_auxpcm_rx: qcom,msm-tert-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "tertiaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_tert_auxpcm_tx: qcom,msm-tert-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "tertiaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_quat_auxpcm_rx: qcom,msm-quat-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "quaternaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_quat_auxpcm_tx: qcom,msm-quat-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "quaternaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_quin_auxpcm_rx: qcom,msm-quin-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "quinaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_quin_auxpcm_tx: qcom,msm-quin-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "quinaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_sen_auxpcm_rx: qcom,msm-sen-auxpcm_rx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "senaryRx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	dai_sen_auxpcm_tx: qcom,msm-sen-auxpcm_tx {
+		compatible = "qcom,msm-auxpcm-dev";
+		qcom,msm-cpudai-auxpcm-mode = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-sync = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-frame = <5>, <4>;
+		qcom,msm-cpudai-auxpcm-quant = <2>, <2>;
+		qcom,msm-cpudai-auxpcm-num-slots = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-slot-mapping = <1>, <1>;
+		qcom,msm-cpudai-auxpcm-data = <0>, <0>;
+		qcom,msm-cpudai-auxpcm-pcm-clk-rate = <2048000>, <2048000>;
+		qcom,msm-auxpcm-interface = "senaryTx";
+		qcom,msm-cpudai-afe-clk-ver = <2>;
+	};
+
+	hdmi_dba: qcom,msm-hdmi-dba-codec-rx {
+		compatible = "qcom,msm-hdmi-dba-codec-rx";
+		qcom,dba-bridge-chip = "adv7533";
+	};
+
+	adsp_loader: qcom,msm-adsp-loader {
+		status = "ok";
+		compatible = "qcom,adsp-loader";
+		qcom,rproc-handle = <&adsp_pas>;
+		qcom,adsp-state = <0>;
+	};
+
+	adsp_notify: qcom,msm-adsp-notify {
+		status = "ok";
+		compatible = "qcom,adsp-notify";
+		qcom,rproc-handle = <&adsp_pas>;
+	};
+
+	tdm_pri_rx: qcom,msm-dai-tdm-pri-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37120>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36864>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_pri_tdm_rx_0: qcom,msm-dai-q6-tdm-pri-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36864>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_pri_tx: qcom,msm-dai-tdm-pri-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37121>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36865>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_pri_tdm_tx_0: qcom,msm-dai-q6-tdm-pri-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36865>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sec_rx: qcom,msm-dai-tdm-sec-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37136>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36880>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sec_tdm_rx_0: qcom,msm-dai-q6-tdm-sec-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36880>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sec_tx: qcom,msm-dai-tdm-sec-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37137>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36881>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sec_tdm_tx_0: qcom,msm-dai-q6-tdm-sec-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36881>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_tert_rx: qcom,msm-dai-tdm-tert-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37152>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36896>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_tert_tdm_rx_0: qcom,msm-dai-q6-tdm-tert-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36896>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_tert_tx: qcom,msm-dai-tdm-tert-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37153>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36897 >;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_tert_tdm_tx_0: qcom,msm-dai-q6-tdm-tert-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36897 >;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_quat_rx: qcom,msm-dai-tdm-quat-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37168>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36912>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_quat_tdm_rx_0: qcom,msm-dai-q6-tdm-quat-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36912>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_quat_tx: qcom,msm-dai-tdm-quat-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37169>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36913 >;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_quat_tdm_tx_0: qcom,msm-dai-q6-tdm-quat-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36913 >;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_quin_rx: qcom,msm-dai-tdm-quin-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37184>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36928>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_quin_tdm_rx_0: qcom,msm-dai-q6-tdm-quin-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36928>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_quin_tx: qcom,msm-dai-tdm-quin-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37185>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36929>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_quin_tdm_tx_0: qcom,msm-dai-q6-tdm-quin-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36929>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sen_rx: qcom,msm-dai-tdm-sen-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37200>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36944>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sen_tdm_rx_0: qcom,msm-dai-q6-tdm-sen-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36944>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sen_tx: qcom,msm-dai-tdm-sen-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37201>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36945>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sen_tdm_tx_0: qcom,msm-dai-q6-tdm-sen-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36945>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sep_rx: qcom,msm-dai-tdm-sep-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37216>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36960>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sep_tdm_rx_0: qcom,msm-dai-q6-tdm-sep-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36960>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_sep_tx: qcom,msm-dai-tdm-sep-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37217>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36961>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_sep_tdm_tx_0: qcom,msm-dai-q6-tdm-sep-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36961>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif0_rx: qcom,msm-dai-tdm-hsif0-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37232>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36976>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif0_tdm_rx_0: qcom,msm-dai-q6-tdm-hsif0-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36976>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif0_tx: qcom,msm-dai-tdm-hsif0-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37233>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36977>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif0_tdm_tx_0: qcom,msm-dai-q6-tdm-hsif0-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36977>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif1_rx: qcom,msm-dai-tdm-hsif1-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37248>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36992>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif1_tdm_rx_0: qcom,msm-dai-q6-tdm-hsif1-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36992>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif1_tx: qcom,msm-dai-tdm-hsif1-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37249>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <36993>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif1_tdm_tx_0: qcom,msm-dai-q6-tdm-hsif1-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <36993>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif2_rx: qcom,msm-dai-tdm-hsif2-rx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37264>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <37008>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif2_tdm_rx_0: qcom,msm-dai-q6-tdm-hsif2-rx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <37008>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	tdm_hsif2_tx: qcom,msm-dai-tdm-hsif2-tx {
+		compatible = "qcom,msm-dai-tdm";
+		qcom,msm-cpudai-tdm-group-id = <37265>;
+		qcom,msm-cpudai-tdm-group-num-ports = <1>;
+		qcom,msm-cpudai-tdm-group-port-id = <37009>;
+		qcom,msm-cpudai-tdm-clk-rate = <1536000>;
+		qcom,msm-cpudai-tdm-clk-internal = <1>;
+		qcom,msm-cpudai-tdm-sync-mode = <1>;
+		qcom,msm-cpudai-tdm-sync-src = <1>;
+		qcom,msm-cpudai-tdm-data-out = <0>;
+		qcom,msm-cpudai-tdm-invert-sync = <1>;
+		qcom,msm-cpudai-tdm-data-delay = <1>;
+		dai_hsif2_tdm_tx_0: qcom,msm-dai-q6-tdm-hsif2-tx-0 {
+			compatible = "qcom,msm-dai-q6-tdm";
+			qcom,msm-cpudai-tdm-dev-id = <37009>;
+			qcom,msm-cpudai-tdm-data-align = <0>;
+		};
+	};
+
+	dai_pri_spdif_rx: qcom,msm-dai-q6-spdif-pri-rx {
+		compatible = "qcom,msm-dai-q6-spdif";
+		qcom,msm-dai-q6-dev-id = <20480>;
+	};
+
+	dai_pri_spdif_tx: qcom,msm-dai-q6-spdif-pri-tx {
+		compatible = "qcom,msm-dai-q6-spdif";
+		qcom,msm-dai-q6-dev-id = <20481>;
+	};
+
+	dai_sec_spdif_rx: qcom,msm-dai-q6-spdif-sec-rx {
+		compatible = "qcom,msm-dai-q6-spdif";
+		qcom,msm-dai-q6-dev-id = <20482>;
+	};
+
+	dai_sec_spdif_tx: qcom,msm-dai-q6-spdif-sec-tx {
+		compatible = "qcom,msm-dai-q6-spdif";
+		qcom,msm-dai-q6-dev-id = <20483>;
+	};
+
+	afe_loopback_tx: qcom,msm-dai-q6-afe-loopback-tx {
+		compatible = "qcom,msm-dai-q6-dev";
+		qcom,msm-dai-q6-dev-id = <24577>;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/somc-murray-audio-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-murray-audio-common.dtsi
@@ -1,0 +1,101 @@
+&qupv3_se10_i2c {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	aw882xx_smartpa@34 {
+		compatible = "awinic,aw882xx_smartpa";
+		reg = <0x34>;
+		irq-gpio = <&tlmm 60 0>;
+		dc-flag = <0>;
+		sound-channel = <0>;
+		rename-flag = <1>;
+		aw-tx-topo-id = <0x1000ff00>;
+		aw-rx-topo-id = <0x1000ff01>;
+		aw-tx-port-id = <0x1003>;
+		aw-rx-port-id = <0x1002>;
+		aw-re-min = <4000>;
+		aw-re-max= <30000>;
+		aw-cali-mode = "aw_attr";
+		status = "okay";
+	};
+};
+
+&soc {
+	cdc_sec_mi2s_gpios: msm_cdc_pinctrl_sec {
+		compatible = "qcom,msm-cdc-pinctrl";
+		pinctrl-names = "aud_active", "aud_sleep";
+		pinctrl-0 = <&lpi_i2s2_sck_active &lpi_i2s2_ws_active &lpi_i2s2_sd0_active &lpi_i2s2_sd1_active>;
+		pinctrl-1 = <&lpi_i2s2_sck_sleep &lpi_i2s2_ws_sleep &lpi_i2s2_sd0_sleep &lpi_i2s2_sd1_sleep>;
+		qcom,lpi-gpios;
+		#gpio-cells = <0>;
+	};
+};
+
+&holi_snd {
+	qcom,model = "holi-qrdsku1-snd-card";
+	qcom,sku-model = "holi-qrdsku1-snd-card";
+	qcom,msm-mi2s-master = <1>, <1>, <1>, <1>;
+	qcom,sec-mi2s-gpios =<&cdc_sec_mi2s_gpios>;
+	qcom,wcn-btfm = <1>;
+	qcom,audio-routing =
+		"AMIC1", "Analog Mic1",
+		"Analog Mic1", "MIC BIAS1",
+		"AMIC2", "Analog Mic2",
+		"Analog Mic2", "MIC BIAS2",
+		"AMIC3", "Analog Mic3",
+		"Analog Mic3", "MIC BIAS3",
+		"TX DMIC0", "Digital Mic0",
+		"TX DMIC0", "MIC BIAS3",
+		"TX DMIC1", "Digital Mic1",
+		"TX DMIC1", "MIC BIAS3",
+		"TX DMIC2", "Digital Mic2",
+		"TX DMIC2", "MIC BIAS1",
+		"TX DMIC3", "Digital Mic3",
+		"TX DMIC3", "MIC BIAS1",
+		"IN1_HPHL", "HPHL_OUT",
+		"IN2_HPHR", "HPHR_OUT",
+		"IN3_AUX", "AUX_OUT",
+		"RX_TX DEC0_INP", "TX DEC0 MUX",
+		"RX_TX DEC1_INP", "TX DEC1 MUX",
+		"RX_TX DEC2_INP", "TX DEC2 MUX",
+		"RX_TX DEC3_INP", "TX DEC3 MUX",
+		"TX SWR_INPUT", "WCD_TX_OUTPUT",
+		"VA SWR_INPUT", "VA_SWR_CLK",
+		"VA SWR_INPUT", "WCD_TX_OUTPUT",
+		"VA_AIF1 CAP", "VA_SWR_CLK",
+		"VA_AIF2 CAP", "VA_SWR_CLK",
+		"VA_AIF3 CAP", "VA_SWR_CLK",
+		"VA DMIC0", "Digital Mic0",
+		"VA DMIC1", "Digital Mic1",
+		"VA DMIC2", "Digital Mic2",
+		"VA DMIC3", "Digital Mic3",
+		"VA DMIC4", "Digital Mic4",
+		"VA DMIC5", "Digital Mic5",
+		"VA DMIC0", "VA MIC BIAS1",
+		"VA DMIC1", "VA MIC BIAS1",
+		"VA DMIC2", "VA MIC BIAS3",
+		"VA DMIC3", "VA MIC BIAS3";
+	qcom,msm-mbhc-hphl-swh = <1>;
+	qcom,msm-mbhc-gnd-swh = <1>;
+	qcom,cdc-dmic01-gpios = <&cdc_dmic01_gpios>;
+	qcom,cdc-dmic23-gpios = <&cdc_dmic23_gpios>;
+	asoc-codec  = <&stub_codec>, <&bolero>,
+		      <&wcd937x_codec>;
+	asoc-codec-names = "msm-stub-codec.1", "bolero_codec",
+			   "wcd937x_codec";
+	qcom,msm_audio_ssr_devs = <&audio_apr>, <&q6core>, <&lpi_tlmm>,
+				  <&bolero>;
+};
+
+&cdc_dmic23_gpios {
+	qcom,tlmm-pins = <135 136>;
+};
+
+&wsa881x_i2c_44 {
+	status = "disabled";
+};
+
+&wsa881x_i2c_e {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/qcom/somc-murray-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-murray-camera.dtsi
@@ -80,7 +80,7 @@
 	};
 
 	cam0_ois_vreg: cam0_ois_vreg {
-		compatible = "regulator-fixed";
+		compatible = "qti-regulator-fixed";
 		regulator-name = "cam0_ois_vreg";
 		gpio = <&tlmm 33 0>;
 		startup-delay-us = <0>;

--- a/arch/arm64/boot/dts/qcom/somc-murray-fingerprint.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-murray-fingerprint.dtsi
@@ -1,6 +1,6 @@
 &soc {
 	fpc_vdig_vreg: fpc_vdig_vreg {
-		compatible = "regulator-fixed";
+		compatible = "qti-regulator-fixed";
 		regulator-name = "fpc_vdig_fixed_reg";
 		regulator-min-microvolt = <3000000>;
 		regulator-max-microvolt = <3000000>;
@@ -10,7 +10,7 @@
 	};
 
 	fpc_vana_vreg: fpc_vana_vreg {
-		compatible = "regulator-fixed";
+		compatible = "qti-regulator-fixed";
 		regulator-name = "fpc_vana_fixed_reg";
 		regulator-min-microvolt = <3000000>;
 		regulator-max-microvolt = <3000000>;

--- a/drivers/input/misc/Kconfig
+++ b/drivers/input/misc/Kconfig
@@ -889,4 +889,10 @@ config INPUT_STPMIC1_ONKEY
 	  To compile this driver as a module, choose M here: the
 	  module will be called stpmic1_onkey.
 
+config SENSORS_ET51X
+	tristate "ET51X fingerprint sensor support"
+	help
+	  If you say yes here you get support for Egistec's
+	  fingerprint sensor ET51X.
+
 endif

--- a/drivers/input/misc/Makefile
+++ b/drivers/input/misc/Makefile
@@ -86,4 +86,4 @@ obj-$(CONFIG_INPUT_WM831X_ON)		+= wm831x-on.o
 obj-$(CONFIG_INPUT_XEN_KBDDEV_FRONTEND)	+= xen-kbdfront.o
 obj-$(CONFIG_INPUT_YEALINK)		+= yealink.o
 obj-$(CONFIG_INPUT_IDEAPAD_SLIDEBAR)	+= ideapad_slidebar.o
-
+obj-$(CONFIG_SENSORS_ET51X)		+= et51x.o

--- a/drivers/input/misc/et51x.c
+++ b/drivers/input/misc/et51x.c
@@ -1,0 +1,704 @@
+/*
+ * ET51X Fingerprint sensor device driver
+ *
+ * This driver will control the platform resources that the Egistec fingerprint
+ * sensor needs to operate. The major things are probing the sensor to check
+ * that it is actually connected and let the Kernel know this and with that also
+ * enabling and disabling of regulators. controlling the GPIO reset line and
+ * handling GPIO IRQ's.
+ *
+ * IRQ events can be received by polling on /dev/fingerprint or through the
+ * IOCTL interface. This interface is used at the same time to control the
+ * (power) state of the sensor and reset it if necessary.
+ *
+ * This driver will NOT send any SPI commands to the sensor, it only controls
+ * the electrical parts.
+ *
+ * The driver has been based on the FPC driver from the Sony Open Devices
+ * Project, and it's original cpcopyright notices have been included below to
+ * respect that.
+ *
+ * Copyright (c) 2015 Fingerprint Cards AB <tech@fingerprints.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License Version 2
+ * as published by the Free Software Foundation.
+ */
+/*
+ * IOCTL implementation for FPC driver
+ * Copyright (C) 2017 AngeloGioacchino Del Regno <angelogioacchino.delregno@somainline.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License Version 2
+ * as published by the Free Software Foundation.
+ */
+
+#include <linux/delay.h>
+#include <linux/fs.h>
+#include <linux/gpio.h>
+#include <linux/interrupt.h>
+#include <linux/ioctl.h>
+#include <linux/kernel.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/of_gpio.h>
+#include <linux/platform_device.h>
+#include <linux/pm_wakeup.h>
+#include <linux/poll.h>
+#include <linux/regulator/consumer.h>
+#include <linux/uaccess.h>
+
+
+#define ET51X_VDDANA_ON_US 10000
+#define ET51X_RESET_LOW_US 30000
+#define ET51X_RESET_HIGH1_US 1000
+#define ET51X_RESET_ACTIVE_US 20000
+#define ET51X_IRQPOLL_TIMEOUT_MS 500
+#define ET51X_MAX_HAL_PROCESSING_TIME 400
+
+#define ET51X_IOC_MAGIC 0x1145
+#define ET51X_IOC_R_BASE 0x80
+#define ET51X_IOCWPREPARE _IOW(ET51X_IOC_MAGIC, 0x01, int)
+#define ET51X_IOCWDEVWAKE _IOW(ET51X_IOC_MAGIC, 0x02, int)
+#define ET51X_IOCWRESET _IOW(ET51X_IOC_MAGIC, 0x03, int)
+#define ET51X_IOCWAWAKE _IOW(ET51X_IOC_MAGIC, 0x04, int)
+#define ET51X_IOCRPREPARE _IOR(ET51X_IOC_MAGIC, ET51X_IOC_R_BASE + 0x01, int)
+#define ET51X_IOCRDEVWAKE _IOR(ET51X_IOC_MAGIC, ET51X_IOC_R_BASE + 0x02, int)
+#define ET51X_IOCRIRQ _IOR(ET51X_IOC_MAGIC, ET51X_IOC_R_BASE + 0x03, int)
+#define ET51X_IOCRIRQPOLL _IOR(ET51X_IOC_MAGIC, ET51X_IOC_R_BASE + 0x04, int)
+#define ET51X_IOCRHWTYPE _IOR(ET51X_IOC_MAGIC, ET51X_IOC_R_BASE + 0x05, int)
+
+#define ET51X_REGULATOR_VDD_ANA "vdd_ana"
+
+static const char *const pctl_names[] = {
+	"et51x_reset_reset",
+	"et51x_reset_active",
+	"et51x_irq_active",
+};
+
+struct et51x_data {
+	struct miscdevice misc;
+	struct device *dev;
+	struct pinctrl *fingerprint_pinctrl;
+	struct pinctrl_state *pinctrl_state[ARRAY_SIZE(pctl_names)];
+	struct regulator *vdd_ana;
+
+	u32 vana_voltage;
+	int irq_gpio;
+
+	int irq;
+	bool irq_fired;
+	wait_queue_head_t irq_evt;
+
+	struct mutex intrpoll_lock;
+	struct mutex lock;
+	bool prepared;
+	bool check_sensor_type;
+	bool low_voltage_probe;
+};
+
+struct et51x_awake_args {
+	int awake;
+	unsigned int timeout;
+};
+
+
+#ifndef CONFIG_ARCH_SONY_NILE
+#define FP_HW_TYPE_EGISTEC	0
+static inline int fp_module_detect(void) { return FP_HW_TYPE_EGISTEC; }
+#else
+static inline int fp_module_detect(void) { return cei_fp_module_detect(); };
+#endif /* CONFIG_ARCH_SONY_NILE */
+
+struct et51x_data *to_et51x_data(struct file *fp)
+{
+	struct miscdevice *md = (struct miscdevice *)fp->private_data;
+
+	return container_of(md, struct et51x_data, misc);
+}
+
+static int et51x_vreg_set_voltage(struct device *dev, struct regulator *vreg,
+		int voltage)
+{
+	int rc = 0;
+
+	if (!dev || !vreg)
+		return -EINVAL;
+
+	dev_dbg(dev, "Setting regulator %s to %d volts\n",
+			ET51X_REGULATOR_VDD_ANA,
+			voltage);
+
+	if (regulator_count_voltages(vreg) > 0) {
+		rc = regulator_set_voltage(vreg, voltage, voltage);
+		if (rc)
+			dev_err(dev, "Unable to set voltage to %d: %d\n",
+					voltage, rc);
+	} else {
+		dev_warn(dev, "No voltages available");
+	}
+
+	if (!regulator_is_enabled(vreg)) {
+		rc = regulator_enable(vreg);
+		if (rc)
+			dev_err(dev, "Unable to enable: %d\n", rc);
+                usleep_range(ET51X_VDDANA_ON_US, ET51X_VDDANA_ON_US + 1000);
+	}
+
+	return rc;
+}
+
+static int vreg_setup(struct et51x_data *et51x, bool enable)
+{
+	int rc = 0;
+	struct regulator *vreg = et51x->vdd_ana;
+	struct device *dev = et51x->dev;
+
+	if (!vreg)
+		return -EINVAL;
+
+	dev_dbg(dev, "%s regulator %s\n", enable ? "enabling" : "disabling",
+			ET51X_REGULATOR_VDD_ANA);
+
+	if (enable) {
+		rc = et51x_vreg_set_voltage(dev, vreg, et51x->vana_voltage);
+	} else {
+		if (regulator_is_enabled(vreg)) {
+			regulator_disable(vreg);
+			dev_dbg(dev, "disabled %s\n", ET51X_REGULATOR_VDD_ANA);
+		}
+	}
+
+	return rc;
+}
+
+/**
+ * Will try to select the set of pins (GPIOS) defined in a pin control node of
+ * the device tree named @p name.
+ *
+ * The node can contain several eg. GPIOs that is controlled when selecting it.
+ * The node may activate or deactivate the pins it contains, the action is
+ * defined in the device tree node itself and not here. The states used
+ * internally is fetched at probe time.
+ *
+ * @see pctl_names
+ * @see et51x_probe
+ */
+static int select_pin_ctl(struct et51x_data *et51x, const char *name)
+{
+	size_t i;
+	int rc;
+	struct device *dev = et51x->dev;
+
+	for (i = 0; i < ARRAY_SIZE(et51x->pinctrl_state); i++) {
+		const char *n = pctl_names[i];
+
+		if (!strncmp(n, name, strlen(n))) {
+			rc = pinctrl_select_state(et51x->fingerprint_pinctrl,
+						  et51x->pinctrl_state[i]);
+			if (rc)
+				dev_err(dev, "cannot select '%s'\n", name);
+			else
+				dev_dbg(dev, "Selected '%s'\n", name);
+			goto exit;
+		}
+	}
+	rc = -EINVAL;
+	dev_err(dev, "%s:'%s' not found\n", __func__, name);
+exit:
+	return rc;
+}
+
+static bool et51x_get_gpio_triggered(const struct et51x_data *drvdata)
+{
+	return !gpio_get_value(drvdata->irq_gpio);
+}
+
+static int hw_reset(struct et51x_data *et51x)
+{
+	int irq_gpio;
+	struct device *dev = et51x->dev;
+	int rc = select_pin_ctl(et51x, "et51x_reset_active");
+	if (rc)
+		goto exit;
+	usleep_range(ET51X_RESET_HIGH1_US, ET51X_RESET_HIGH1_US + 1000);
+
+	rc = select_pin_ctl(et51x, "et51x_reset_reset");
+	if (rc)
+		goto exit;
+	usleep_range(ET51X_RESET_LOW_US, ET51X_RESET_LOW_US + 1000);
+
+	rc = select_pin_ctl(et51x, "et51x_reset_active");
+	if (rc)
+		goto exit;
+	usleep_range(ET51X_RESET_ACTIVE_US, ET51X_RESET_ACTIVE_US + 1000);
+
+	irq_gpio = et51x_get_gpio_triggered(et51x);
+	dev_dbg(dev, "IRQ after reset %d\n", irq_gpio);
+exit:
+	return rc;
+}
+
+static int device_prepare(struct et51x_data *et51x, bool enable)
+{
+	int rc = 0;
+
+	mutex_lock(&et51x->lock);
+	if (enable && !et51x->prepared) {
+		et51x->prepared = true;
+
+		rc = vreg_setup(et51x, true);
+		if (rc)
+			goto exit;
+	} else if (!enable && et51x->prepared) {
+		(void)vreg_setup(et51x, false);
+	exit:
+		et51x->prepared = false;
+	} else {
+		rc = 0;
+	}
+	mutex_unlock(&et51x->lock);
+	return rc;
+}
+
+static int et51x_device_open(struct inode *inode, struct file *fp)
+{
+	struct et51x_data *et51x = to_et51x_data(fp);
+	pm_wakeup_event(et51x->dev, 1);
+	return 0;
+}
+
+static int et51x_device_release(struct inode *inode, struct file *fp)
+{
+	struct et51x_data *et51x = to_et51x_data(fp);
+	pm_relax(et51x->dev);
+	return 0;
+}
+
+static inline void et51x_enable_irq_if_disabled(struct et51x_data *et51x)
+{
+	mutex_lock(&et51x->intrpoll_lock);
+
+	/* Enable the irq if not enabled: */
+	if (et51x->irq_fired) {
+		et51x->irq_fired = false;
+		dev_dbg(et51x->dev, "%s: enabling irq\n", __func__);
+		enable_irq(et51x->irq);
+	}
+
+	mutex_unlock(&et51x->intrpoll_lock);
+}
+
+static long et51x_device_ioctl(struct file *fp, unsigned int cmd,
+			       unsigned long arg)
+{
+	int8_t val = 0;
+	int rc = -EINVAL;
+	unsigned int timeout = 0;
+	struct et51x_awake_args awake_args;
+	void __user *usr = (void __user *)arg;
+	struct et51x_data *et51x = to_et51x_data(fp);
+
+	switch (cmd) {
+	case ET51X_IOCWPREPARE:
+		dev_dbg(et51x->dev, "%s device\n",
+			(arg == 0 ? "Unpreparing" : "Preparing"));
+		rc = device_prepare(et51x, !!arg);
+		break;
+	case ET51X_IOCWDEVWAKE:
+		dev_dbg(et51x->dev, "Setting devwake %lu\n", arg);
+		dev_dbg(et51x->dev, "WDEVWAKE Not implemented.\n");
+		break;
+	case ET51X_IOCWRESET:
+		dev_dbg(et51x->dev, "Resetting device\n");
+		rc = hw_reset(et51x);
+		break;
+	case ET51X_IOCWAWAKE:
+		rc = copy_from_user(&awake_args, (struct et51x_awake_args *)usr,
+				    sizeof(awake_args));
+		if (rc)
+			break;
+		timeout = min(awake_args.timeout,
+			      (unsigned int)ET51X_MAX_HAL_PROCESSING_TIME);
+		if (awake_args.awake) {
+			dev_dbg(et51x->dev, "Extending wakelock for %dms\n",
+				timeout);
+			pm_wakeup_event(et51x->dev, timeout);
+		} else {
+			dev_dbg(et51x->dev, "Relaxing wakelock\n");
+			pm_relax(et51x->dev);
+		}
+		break;
+	case ET51X_IOCRPREPARE:
+		rc = put_user((int8_t)et51x->prepared, (int *)usr);
+		break;
+	case ET51X_IOCRDEVWAKE:
+		dev_dbg(et51x->dev, "RDEVWAKE Not implemented.\n");
+		break;
+	case ET51X_IOCRIRQ:
+		val = et51x_get_gpio_triggered(et51x);
+		rc = put_user(val, (int *)usr);
+		break;
+	case ET51X_IOCRIRQPOLL:
+		val = et51x_get_gpio_triggered(et51x);
+		if (val) {
+			/* We don't need to wait: IRQ has already fired */
+			rc = put_user(val, (int *)usr);
+			return rc;
+		}
+
+		et51x_enable_irq_if_disabled(et51x);
+
+		rc = wait_event_interruptible_timeout(
+			et51x->irq_evt, et51x->irq_fired,
+			msecs_to_jiffies(ET51X_IRQPOLL_TIMEOUT_MS));
+		if (rc == -ERESTARTSYS)
+			return rc;
+
+		val = et51x_get_gpio_triggered(et51x);
+		if (val)
+			pm_wakeup_event(et51x->dev,
+					ET51X_MAX_HAL_PROCESSING_TIME);
+
+		rc = put_user(val, (int *)usr);
+		break;
+	case ET51X_IOCRHWTYPE:
+		if (et51x->check_sensor_type)
+			rc = put_user((int)FP_HW_TYPE_EGISTEC, (int *)usr);
+		else
+			rc = -ENOSYS;
+		break;
+	default:
+		rc = -ENOIOCTLCMD;
+		dev_err(et51x->dev, "Unknown IOCTL 0x%x.\n", cmd);
+		break;
+	}
+
+	return rc;
+}
+
+static unsigned int et51x_poll_interrupt(struct file *fp,
+					 struct poll_table_struct *wait)
+{
+	int val = 0;
+	struct et51x_data *et51x = to_et51x_data(fp);
+	struct device *dev = et51x->dev;
+
+	/* Add current file to the waiting list */
+	poll_wait(fp, &et51x->irq_evt, wait);
+
+	val = et51x_get_gpio_triggered(et51x);
+	if (val) {
+		dev_dbg(dev, "gpio triggered\n");
+		pm_wakeup_event(dev, ET51X_MAX_HAL_PROCESSING_TIME);
+		return POLLIN | POLLRDNORM;
+	}
+
+	/*
+	 * Nothing happened yet; make the poll wait for irq_evt.
+	 * The wakelock can be relaxed preemptively, as no processing has to
+	 * be done until the next wake-enabled IRQ fires.
+	 */
+	et51x_enable_irq_if_disabled(et51x);
+	pm_relax(dev);
+
+	return 0;
+}
+
+static int et51x_device_suspend(struct device *dev)
+{
+	struct et51x_data *et51x = dev_get_drvdata(dev);
+
+	dev_dbg(dev, "Suspending device\n");
+
+	/* Wakeup when finger detected */
+	enable_irq_wake(et51x->irq);
+
+	return 0;
+}
+
+static int et51x_device_resume(struct device *dev)
+{
+	struct et51x_data *et51x = dev_get_drvdata(dev);
+
+	dev_dbg(dev, "Resuming device\n");
+
+	disable_irq_wake(et51x->irq);
+
+	return 0;
+}
+
+static const struct file_operations et51x_device_fops = {
+	.owner = THIS_MODULE,
+	.llseek = no_llseek,
+	.open = et51x_device_open,
+	.release = et51x_device_release,
+	.unlocked_ioctl = et51x_device_ioctl,
+	.compat_ioctl = et51x_device_ioctl,
+	.poll = et51x_poll_interrupt,
+};
+
+static irqreturn_t et51x_irq_handler(int irq, void *handle)
+{
+	struct et51x_data *et51x = handle;
+
+	mutex_lock(&et51x->intrpoll_lock);
+
+	dev_dbg(et51x->dev, "%s: gpio=%d\n", __func__,
+			et51x_get_gpio_triggered(et51x));
+
+	et51x->irq_fired = true;
+
+	disable_irq_nosync(et51x->irq);
+	pm_wakeup_event(et51x->dev, ET51X_MAX_HAL_PROCESSING_TIME);
+	wake_up_interruptible(&et51x->irq_evt);
+
+	mutex_unlock(&et51x->intrpoll_lock);
+
+	return IRQ_HANDLED;
+}
+
+static int et51x_request_named_gpio(struct et51x_data *et51x, const char *label,
+				    int *gpio)
+{
+	struct device *dev = et51x->dev;
+	struct device_node *np = dev->of_node;
+	int rc = of_get_named_gpio(np, label, 0);
+
+	if (rc < 0) {
+		dev_err(dev, "failed to get '%s'\n", label);
+		return rc;
+	}
+	*gpio = rc;
+	rc = devm_gpio_request(dev, *gpio, label);
+	if (rc) {
+		dev_err(dev, "failed to request gpio %d\n", *gpio);
+		return rc;
+	}
+	dev_dbg(dev, "%s %d\n", label, *gpio);
+	return 0;
+}
+
+static int et51x_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	int rc = 0;
+	size_t i;
+	int irqf;
+	struct device_node *np = dev->of_node;
+	int hw_type = 0;
+
+	struct et51x_data *et51x =
+		devm_kzalloc(dev, sizeof(*et51x), GFP_KERNEL);
+	if (!et51x) {
+		rc = -ENOMEM;
+		goto exit;
+	}
+
+	et51x->misc = (struct miscdevice){
+		.minor = MISC_DYNAMIC_MINOR,
+		.name = "fingerprint",
+		.fops = &et51x_device_fops,
+	};
+
+	et51x->dev = dev;
+	platform_set_drvdata(pdev, et51x);
+	dev_set_drvdata(et51x->dev, et51x);
+
+	if (!np) {
+		dev_err(dev, "no of node found\n");
+		rc = -EINVAL;
+		goto exit;
+	}
+
+	et51x->vdd_ana = devm_regulator_get(dev, ET51X_REGULATOR_VDD_ANA);
+	if (IS_ERR_OR_NULL(et51x->vdd_ana)) {
+		dev_err(dev, "CRITICAL: Cannot get %s regulator: %ld\n",
+			ET51X_REGULATOR_VDD_ANA, PTR_ERR(et51x->vdd_ana));
+		if (IS_ERR(et51x->vdd_ana))
+			rc = PTR_ERR(et51x->vdd_ana);
+		else
+			rc = -EINVAL;
+		et51x->vdd_ana = NULL;
+		goto exit;
+	}
+
+	et51x->check_sensor_type = of_property_read_bool(dev->of_node,
+			"et51x,check-sensor-type");
+	/* Use low-voltage probe by default to prevent HW damage */
+	et51x->low_voltage_probe = !of_property_read_bool(dev->of_node,
+			"et51x,no-low-voltage-probe");
+
+	rc = of_property_read_u32(dev->of_node, "et51x,vana-voltage",
+				  &et51x->vana_voltage);
+	if (rc)
+		et51x->vana_voltage = 3300000;
+
+	dev_dbg(dev, "check_sensor_type: %d, low_voltage_probe: %d\n",
+			et51x->check_sensor_type, et51x->low_voltage_probe);
+
+	if (et51x->low_voltage_probe)
+		/* Start at 1.8v which is the voltage used for FPC,
+		 * to err on the side of caution:
+		 */
+		rc = et51x_vreg_set_voltage(et51x->dev, et51x->vdd_ana,
+				1800000);
+	else
+		rc = vreg_setup(et51x, true);
+
+	if (rc)
+		goto exit_powerdown;
+
+	if (et51x->check_sensor_type) {
+		hw_type = fp_module_detect();
+
+		if (hw_type != FP_HW_TYPE_EGISTEC) {
+			dev_info(dev,
+				"Egistec sensor not found, bailing out\n");
+			rc = -ENODEV;
+			goto exit_powerdown;
+		}
+
+		dev_info(dev, "Detected Egistec sensor\n");
+
+		/* Scale up to 3.3v */
+		rc = vreg_setup(et51x, true);
+		if (rc)
+			goto exit_powerdown;
+	}
+
+	rc = et51x_request_named_gpio(et51x, "et51x,gpio_irq",
+				      &et51x->irq_gpio);
+	if (rc)
+		goto exit_powerdown;
+
+	et51x->fingerprint_pinctrl = devm_pinctrl_get(dev);
+	if (IS_ERR(et51x->fingerprint_pinctrl)) {
+		if (PTR_ERR(et51x->fingerprint_pinctrl) == -EPROBE_DEFER) {
+			dev_info(dev, "pinctrl not ready\n");
+			rc = -EPROBE_DEFER;
+			goto exit_powerdown;
+		}
+		dev_err(dev, "Target does not use pinctrl\n");
+		et51x->fingerprint_pinctrl = NULL;
+		rc = -EINVAL;
+		goto exit_powerdown;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(et51x->pinctrl_state); i++) {
+		const char *n = pctl_names[i];
+		struct pinctrl_state *state =
+			pinctrl_lookup_state(et51x->fingerprint_pinctrl, n);
+		if (IS_ERR(state)) {
+			dev_err(dev, "cannot find '%s'\n", n);
+			rc = -EINVAL;
+			goto exit_powerdown;
+		}
+		dev_info(dev, "found pin control %s\n", n);
+		et51x->pinctrl_state[i] = state;
+	}
+
+	rc = select_pin_ctl(et51x, "et51x_reset_reset");
+	if (rc)
+		goto exit;
+	rc = select_pin_ctl(et51x, "et51x_irq_active");
+	if (rc)
+		goto exit;
+
+	irqf = IRQF_TRIGGER_LOW | IRQF_ONESHOT;
+	mutex_init(&et51x->lock);
+	mutex_init(&et51x->intrpoll_lock);
+
+	device_init_wakeup(dev, true);
+	init_waitqueue_head(&et51x->irq_evt);
+	et51x->irq_fired = false;
+
+	et51x->irq = gpio_to_irq(et51x->irq_gpio);
+	rc = devm_request_threaded_irq(dev, et51x->irq, NULL, et51x_irq_handler,
+				       irqf, dev_name(dev), et51x);
+	if (rc) {
+		dev_err(dev, "could not request irq %d\n", et51x->irq);
+		goto exit_powerdown;
+	}
+	dev_dbg(dev, "requested irq %d\n", et51x->irq);
+	enable_irq_wake(et51x->irq);
+
+	/* Reset the device once: */
+	hw_reset(et51x);
+
+	rc = misc_register(&et51x->misc);
+	if (rc)
+		goto exit_powerdown;
+
+	dev_info(dev, "%s: ok\n", __func__);
+
+	if (of_property_read_bool(dev->of_node, "et51x,enable-on-boot")) {
+		dev_info(dev, "Leaving power enabled\n");
+		goto exit;
+	}
+
+exit_powerdown:
+	(void)vreg_setup(et51x, false);
+exit:
+	return rc;
+}
+
+static int et51x_remove(struct platform_device *pdev)
+{
+	struct et51x_data *et51x = platform_get_drvdata(pdev);
+
+	device_init_wakeup(et51x->dev, false);
+	mutex_destroy(&et51x->lock);
+	(void)device_prepare(et51x, false);
+
+	dev_info(&pdev->dev, "%s\n", __func__);
+	return 0;
+}
+
+/* clang-format off */
+static struct of_device_id et51x_of_match[] = {
+	{ .compatible = "etspi,et510", },
+	{ .compatible = "egistec,et580", },
+	{}
+};
+/* clang-format on */
+MODULE_DEVICE_TABLE(of, et51x_of_match);
+
+static SIMPLE_DEV_PM_OPS(et51x_pm_ops, et51x_device_suspend,
+			 et51x_device_resume);
+
+static struct platform_driver et51x_driver = {
+	.driver = {
+		.name = "et51x",
+		.owner = THIS_MODULE,
+		.of_match_table = et51x_of_match,
+		.pm = &et51x_pm_ops,
+	},
+	.probe = et51x_probe,
+	.remove = et51x_remove,
+};
+
+static int __init et51x_init(void)
+{
+	int rc = platform_driver_register(&et51x_driver);
+
+	if (!rc)
+		pr_info("%s OK\n", __func__);
+	else
+		pr_err("%s %d\n", __func__, rc);
+	return rc;
+}
+
+static void __exit et51x_exit(void)
+{
+	pr_info("%s\n", __func__);
+	platform_driver_unregister(&et51x_driver);
+}
+
+module_init(et51x_init);
+module_exit(et51x_exit);
+
+MODULE_LICENSE("GPL v2");
+MODULE_DESCRIPTION("et51x Fingerprint sensor device driver.");

--- a/drivers/leds/leds-sm5038-fled.c
+++ b/drivers/leds/leds-sm5038-fled.c
@@ -545,9 +545,9 @@ static void sm5038_fled_init(struct sm5038_fled_data *fled)
 	pr_info("sm5038-fled: %s: flash init done\n", __func__);
 }
 
-int sm5038_fled_probe(struct sm5038_dev *sm5038)
+int sm5038_fled_probe(struct platform_device *pdev)
 {
-	//struct sm5038_dev *sm5038 = dev_get_drvdata(pdev->dev.parent);
+	struct sm5038_dev *sm5038 = dev_get_drvdata(pdev->dev.parent);
 	struct sm5038_fled_data *fled;
 	int ret = 0;
 
@@ -558,7 +558,7 @@ int sm5038_fled_probe(struct sm5038_dev *sm5038)
 		pr_err("sm5038-fled: %s: fail to alloc_devm\n", __func__);
 		return -ENOMEM;
 	}
-	fled->dev = sm5038->dev;
+	fled->dev = &pdev->dev;
 	fled->i2c = sm5038->charger_i2c;
 
 	fled->pdata = kzalloc(sizeof(struct sm5038_fled_platform_data), GFP_KERNEL);
@@ -607,66 +607,64 @@ int sm5038_fled_probe(struct sm5038_dev *sm5038)
 free_device:
 	device_remove_file(fled->rear_fled_dev, &dev_attr_rear_flash);
 free_pdata:
-	kfree(fled->pdata);
+	devm_kfree(&pdev->dev, fled->pdata);
 free_dev:
-	kfree(fled);
+	devm_kfree(&pdev->dev, fled);
 
 	return ret;
 }
 EXPORT_SYMBOL_GPL(sm5038_fled_probe);
 
-int sm5038_fled_remove(void)
+int sm5038_fled_remove(struct platform_device *pdev)
 {
-	struct sm5038_fled_data *fled = g_sm5038_fled;
+	struct sm5038_fled_data *fled = platform_get_drvdata(pdev);
 
 	device_remove_file(fled->rear_fled_dev, &dev_attr_rear_flash);
 
 	fled_set_mode(fled, FLEDEN_DISABLE);
 
-	//platform_set_drvdata(pdev, NULL);
+	platform_set_drvdata(pdev, NULL);
 
-	//devm_kfree(&pdev->dev, fled->pdata);
-	//devm_kfree(&pdev->dev, fled);
+	devm_kfree(&pdev->dev, fled->pdata);
+	devm_kfree(&pdev->dev, fled);
 
 	return 0;
 }
 EXPORT_SYMBOL_GPL(sm5038_fled_remove);
 
-//static struct of_device_id sm5038_fled_match_table[] = {
-//	{ .compatible = "siliconmitus,sm5038-fled",},
-//	{},
-//};
+static struct of_device_id sm5038_fled_match_table[] = {
+	{ .compatible = "siliconmitus,sm5038-fled",},
+	{},
+};
 
-//static const struct platform_device_id sm5038_fled_id[] = {
-//	{"sm5038-fled", 0},
-//	{},
-//};
+static const struct platform_device_id sm5038_fled_id[] = {
+	{"sm5038-fled", 0},
+	{},
+};
 
-//static struct platform_driver sm5038_led_driver = {
-//	.driver = {
-//		.name  = "sm5038-fled",
-//		.owner = THIS_MODULE,
-//		.of_match_table = sm5038_fled_match_table,
-//		},
-//	.probe  = sm5038_fled_probe,
-//	.remove = sm5038_fled_remove,
-//	.id_table = sm5038_fled_id,
-//};
+static struct platform_driver sm5038_led_driver = {
+	.driver = {
+		.name  = "sm5038-fled",
+		.owner = THIS_MODULE,
+		.of_match_table = sm5038_fled_match_table,
+		},
+	.probe  = sm5038_fled_probe,
+	.remove = sm5038_fled_remove,
+	.id_table = sm5038_fled_id,
+};
 
-//static int __init sm5038_led_driver_init(void)
-//{
-//	return platform_driver_register(&sm5038_led_driver);
-//}
-//late_initcall(sm5038_led_driver_init);
-//
-//static void __exit sm5038_led_driver_exit(void)
-//{
-//	platform_driver_unregister(&sm5038_led_driver);
-//}
-//module_exit(sm5038_led_driver_exit);
+static int __init sm5038_led_driver_init(void)
+{
+	return platform_driver_register(&sm5038_led_driver);
+}
+late_initcall(sm5038_led_driver_init);
 
-//MODULE_LICENSE("GPL");
-//MODULE_DESCRIPTION("Flash-LED device driver for SM5038");
-//MODULE_VERSION(SM5038_FLED_VERSION);
+static void __exit sm5038_led_driver_exit(void)
+{
+	platform_driver_unregister(&sm5038_led_driver);
+}
+module_exit(sm5038_led_driver_exit);
 
 MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Flash-LED device driver for SM5038");
+MODULE_VERSION(SM5038_FLED_VERSION);

--- a/drivers/pinctrl/qcom/pinctrl-blair.c
+++ b/drivers/pinctrl/qcom/pinctrl-blair.c
@@ -1592,16 +1592,6 @@ static const struct msm_pingroup blair_groups[] = {
 	[163] = SDC_QDSD_PINGROUP(sdc2_data, 0x1a2000, 9, 0),
 };
 
-static const int blair_reserved_gpios[] = {
-#if defined(CONFIG_ARCH_SONY_MURRAY)
-	13, 14, 15, 16, -1
-#elif defined(CONFIG_ARCH_SONY_ZAMBEZI)
-	13, 14, 15, 16, 48, -1
-#else
-	13, 14, 15, 16, 17, 45, 46, 48, 56, 57, -1
-#endif
-};
-
 static const struct msm_gpio_wakeirq_map blair_mpm_map[] = {
 	{0, 84},
 	{3, 6},
@@ -1679,7 +1669,6 @@ static const struct msm_pinctrl_soc_data blair_pinctrl = {
 	.nfunctions = ARRAY_SIZE(blair_functions),
 	.groups = blair_groups,
 	.ngroups = ARRAY_SIZE(blair_groups),
-	.reserved_gpios = blair_reserved_gpios,
 	.ngpios = 157,
 	.wakeirq_map = blair_mpm_map,
 	.nwakeirq_map = ARRAY_SIZE(blair_mpm_map),

--- a/drivers/pinctrl/qcom/pinctrl-msm.c
+++ b/drivers/pinctrl/qcom/pinctrl-msm.c
@@ -1192,6 +1192,7 @@ static int msm_gpio_irq_set_wake(struct irq_data *d, unsigned int on)
 	return irq_set_irq_wake(pctrl->irq, on);
 }
 
+#ifndef CONFIG_ARCH_BLAIR
 static int msm_gpio_irq_reqres(struct irq_data *d)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
@@ -1234,6 +1235,7 @@ static void msm_gpio_irq_relres(struct irq_data *d)
 	gpiochip_unlock_as_irq(gc, d->hwirq);
 	module_put(gc->owner);
 }
+#endif
 
 static int msm_gpio_irq_set_affinity(struct irq_data *d,
 				const struct cpumask *dest, bool force)
@@ -1362,8 +1364,10 @@ static int msm_gpio_init(struct msm_pinctrl *pctrl)
 	pctrl->irq_chip.irq_ack = msm_gpio_irq_ack;
 	pctrl->irq_chip.irq_set_type = msm_gpio_irq_set_type;
 	pctrl->irq_chip.irq_set_wake = msm_gpio_irq_set_wake;
+#ifndef CONFIG_ARCH_BLAIR
 	pctrl->irq_chip.irq_request_resources = msm_gpio_irq_reqres;
 	pctrl->irq_chip.irq_release_resources = msm_gpio_irq_relres;
+#endif
 	pctrl->irq_chip.irq_set_affinity = msm_gpio_irq_set_affinity;
 	pctrl->irq_chip.irq_set_vcpu_affinity = msm_gpio_irq_set_vcpu_affinity;
 	pctrl->irq_chip.flags = IRQCHIP_MASK_ON_SUSPEND |

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
  * Copyright (c) 2013-2020, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
  */
 
 #include <linux/delay.h>
@@ -610,6 +611,9 @@ static int msm_restart_probe(struct platform_device *pdev)
 	struct resource *mem;
 	struct device_node *np;
 	int ret = 0;
+
+	if (!qcom_scm_is_available())
+		return -EPROBE_DEFER;
 
 	nvmem_cell = devm_nvmem_cell_get(dev, "restart_reason");
 	if (PTR_ERR(nvmem_cell) == -EPROBE_DEFER)

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -28,6 +28,8 @@
 #include <soc/qcom/watchdog.h>
 #include <soc/qcom/minidump.h>
 
+#include <linux/slab.h>
+
 #define EMERGENCY_DLOAD_MAGIC1    0x322A4F99
 #define EMERGENCY_DLOAD_MAGIC2    0xC67E4350
 #define EMERGENCY_DLOAD_MAGIC3    0x77777777
@@ -67,6 +69,8 @@ static bool dload_mode_enabled;
 static void *emergency_dload_mode_addr;
 
 static bool force_warm_reboot;
+static void *rr_base;
+static int no_of_reasons;
 
 static struct notifier_block restart_nb;
 
@@ -128,10 +132,13 @@ static struct kobj_type reset_ktype = {
 	.sysfs_ops	= &reset_sysfs_ops,
 };
 
+static void msm_set_dt_restart_reason(const char *cmd);
+
 static int panic_prep_restart(struct notifier_block *this,
 			      unsigned long event, void *ptr)
 {
 	in_panic = 1;
+	msm_set_dt_restart_reason("panic");
 	return NOTIFY_DONE;
 }
 
@@ -396,10 +403,111 @@ void msm_set_restart_mode(int mode)
 EXPORT_SYMBOL(msm_set_restart_mode);
 
 
+struct restart_reason_param {
+	char cmd[256];
+	u32 pon_reg_value;
+	u32 imem_reason;
+	bool is_reboot_allowed;
+};
+
+static int msm_get_dt_restart_reason(void)
+{
+	int rc = -1;
+	struct device_node *np, *nc = NULL;
+	u32 data[2] = {0};
+	const char *cmd;
+	struct restart_reason_param *rr = NULL;
+
+	np = of_find_compatible_node(NULL, NULL, "qcom,restart-reason");
+	if (!np) {
+		pr_err("unable to find restart-reason node\n");
+		goto exit;
+	}
+
+	for_each_child_of_node(np, nc)
+		no_of_reasons++;
+
+	if (!no_of_reasons)
+		goto exit;
+
+	rr = kzalloc((no_of_reasons *
+			sizeof(struct restart_reason_param)), GFP_KERNEL);
+	if (!rr) {
+		pr_err("unable to get memory for restart reason\n");
+		goto exit;
+	}
+
+	rr_base = (void *)rr;
+
+	for_each_child_of_node(np, nc) {
+		rc = of_property_read_string(nc, "cmd", &cmd);
+		if (rc == 0) {
+			rc = of_property_read_u32_array(nc, "reg-val", data, 2);
+			if (rc != 0) {
+				pr_err("Unable to find %s reg-val\n", cmd);
+				goto exit;
+			}
+
+			strlcpy(rr->cmd, cmd, sizeof(rr->cmd));
+			rr->pon_reg_value = data[0];
+			rr->imem_reason = data[1];
+			rr->is_reboot_allowed =
+				of_property_read_bool(nc, "reboot-cmd");
+
+			rr += 1;
+		}
+	}
+
+	return 0;
+
+exit:
+	return rc;
+}
+
+static bool is_valid_msm_reboot_cmd(const char *cmd)
+{
+	int count;
+	struct restart_reason_param *rr = NULL;
+
+	if (!rr_base)
+		return false;
+
+	rr = (struct restart_reason_param *)rr_base;
+
+	for (count = 0; count < no_of_reasons; count++) {
+		if (strncmp(rr->cmd, cmd, sizeof(rr->cmd)) == 0)
+			return rr->is_reboot_allowed;
+
+		rr += 1;
+	}
+
+	return false;
+}
+
+static void msm_set_dt_restart_reason(const char *cmd)
+{
+	int count;
+	struct restart_reason_param *rr = NULL;
+
+	if (!rr_base)
+		return;
+
+	rr = (struct restart_reason_param *)rr_base;
+
+	for (count = 0; count < no_of_reasons; count++) {
+		if (strncmp(rr->cmd, cmd, sizeof(rr->cmd)) == 0) {
+			qpnp_pon_set_restart_reason(rr->pon_reg_value);
+			__raw_writel(rr->imem_reason, restart_reason);
+			break;
+		}
+
+		rr += 1;
+	}
+}
+
 static void msm_restart_prepare(const char *cmd)
 {
 	bool need_warm_reset = false;
-	u8 reason = PON_RESTART_REASON_UNKNOWN;
 	/* Write download mode flags if we're panic'ing
 	 * Write download mode flags if restart_mode says so
 	 * Kill download mode if master-kill switch is set
@@ -431,45 +539,18 @@ static void msm_restart_prepare(const char *cmd)
 	else
 		qpnp_pon_system_pwr_off(PON_POWER_OFF_HARD_RESET);
 
-	if (cmd != NULL) {
-		if (!strncmp(cmd, "bootloader", 10)) {
-			reason = PON_RESTART_REASON_BOOTLOADER;
-			__raw_writel(0x77665500, restart_reason);
-		} else if (!strncmp(cmd, "recovery", 8)) {
-			reason = PON_RESTART_REASON_RECOVERY;
-			__raw_writel(0x77665502, restart_reason);
-		} else if (!strcmp(cmd, "rtc")) {
-			reason = PON_RESTART_REASON_RTC;
-			__raw_writel(0x77665503, restart_reason);
-		} else if (!strcmp(cmd, "dm-verity device corrupted")) {
-			reason = PON_RESTART_REASON_DMVERITY_CORRUPTED;
-			__raw_writel(0x77665508, restart_reason);
-		} else if (!strcmp(cmd, "dm-verity enforcing")) {
-			reason = PON_RESTART_REASON_DMVERITY_ENFORCE;
-			__raw_writel(0x77665509, restart_reason);
-		} else if (!strcmp(cmd, "keys clear")) {
-			reason = PON_RESTART_REASON_KEYS_CLEAR;
-			__raw_writel(0x7766550a, restart_reason);
-		} else if (!strncmp(cmd, "oem-", 4)) {
-			unsigned long code;
-			int ret;
-
-			ret = kstrtoul(cmd + 4, 16, &code);
-			if (!ret)
-				__raw_writel(0x6f656d00 | (code & 0xff),
-					     restart_reason);
-		} else if (!strncmp(cmd, "edl", 3)) {
+	if (in_panic) {
+		msm_set_dt_restart_reason("panic");
+	} else if (cmd != NULL) {
+		if (!strncmp(cmd, "edl", 3)) {
 			enable_emergency_dload_mode();
+		} else if (is_valid_msm_reboot_cmd(cmd)) {
+			msm_set_dt_restart_reason(cmd);
 		} else {
-			__raw_writel(0x77665501, restart_reason);
+			msm_set_dt_restart_reason("unknown");
 		}
-
-		if (reason && nvmem_cell)
-			nvmem_cell_write(nvmem_cell, &reason, sizeof(reason));
-		else
-			qpnp_pon_set_restart_reason(
-				(enum pon_restart_reason)reason);
-	}
+	} else
+		msm_set_dt_restart_reason("unknown");
 
 	/*outer_flush_all is not supported by 64bit kernel*/
 #ifndef CONFIG_ARM64
@@ -515,6 +596,7 @@ static void do_msm_poweroff(void)
 
 	set_dload_mode(0);
 	qpnp_pon_system_pwr_off(PON_POWER_OFF_SHUTDOWN);
+	msm_set_dt_restart_reason("none");
 
 	deassert_ps_hold();
 
@@ -564,6 +646,9 @@ static int msm_restart_probe(struct platform_device *pdev)
 	restart_nb.notifier_call = do_msm_restart;
 	restart_nb.priority = 200;
 	register_restart_handler(&restart_nb);
+	ret = msm_get_dt_restart_reason();
+	if (ret)
+		pr_err("Error in getting restart reason\n");
 
 	set_dload_mode(download_mode);
 	if (!download_mode)

--- a/drivers/power/supply/Kconfig
+++ b/drivers/power/supply/Kconfig
@@ -826,6 +826,7 @@ config CHARGER_BQ256XX
 config IFPM_SM5038
 	tristate "Siliconmitus SM5038 IFPM Support"
 	depends on I2C
+	select MFD_CORE
 	help
 	  Say Y here to enable support for Siliconmitus SM5038.
 	  This is a Power Management IC with Single Flash, Charger, Type-C,

--- a/drivers/power/supply/sm5038_charger.c
+++ b/drivers/power/supply/sm5038_charger.c
@@ -1359,7 +1359,7 @@ static void psy_chg_set_online(struct sm5038_charger_data *charger, int cable_ty
 			if (!is_client_vote_enabled(charger->usb_icl_votable,
 								PD_VOTER)) {
 				vote(charger->usb_icl_votable, PD_VOTER,
-							true, MICRO_CURR_0P5A);
+							true, MICRO_CURR_3P0A);
 				vote(charger->usb_icl_votable, USB_PSY_VOTER,
 								false, 0);
 			}

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -374,9 +374,11 @@ static int adsp_start(struct rproc *rproc)
 	if (ret < 0)
 		goto disable_active_pds;
 
-	ret = adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, true);
-	if (ret)
-		goto disable_proxy_pds;
+	if (adsp->qmp) {
+		ret = adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, true);
+		if (ret)
+			goto disable_proxy_pds;
+	}
 
 	ret = clk_prepare_enable(adsp->xo);
 	if (ret)
@@ -417,7 +419,8 @@ disable_aggre2_clk:
 disable_xo_clk:
 	clk_disable_unprepare(adsp->xo);
 disable_load_state:
-	adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, false);
+	if (adsp->qmp)
+		adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, false);
 disable_proxy_pds:
 	adsp_pds_disable(adsp, adsp->proxy_pds, adsp->proxy_pd_count);
 disable_active_pds:
@@ -467,7 +470,8 @@ static int adsp_stop(struct rproc *rproc)
 
 	scm_pas_disable_bw();
 	adsp_pds_disable(adsp, adsp->active_pds, adsp->active_pd_count);
-	adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, false);
+	if (adsp->qmp)
+		adsp_toggle_load_state(adsp->qmp, adsp->qmp_name, false);
 	handover = qcom_q6v5_unprepare(&adsp->q6v5);
 	if (handover)
 		qcom_pas_handover(&adsp->q6v5);
@@ -809,8 +813,11 @@ static int adsp_probe(struct platform_device *pdev)
 	adsp->proxy_pd_count = ret;
 
 	adsp->qmp = qmp_get(adsp->dev);
-	if (IS_ERR_OR_NULL(adsp->qmp))
-		goto detach_proxy_pds;
+	if (IS_ERR_OR_NULL(adsp->qmp)) {
+		if (PTR_ERR(adsp->qmp) != -ENODEV)
+			goto detach_proxy_pds;
+		adsp->qmp = NULL;
+	}
 
 	ret = qcom_q6v5_init(&adsp->q6v5, pdev, rproc, desc->crash_reason_smem,
 			     qcom_pas_handover);

--- a/drivers/tty/serial/Kconfig
+++ b/drivers/tty/serial/Kconfig
@@ -970,6 +970,7 @@ config SERIAL_MSM_GENI
 	tristate "MSM on-chip GENI HW based serial port support"
 	depends on ARCH_QCOM
 	depends on MSM_GENI_SE
+	select SERIAL_CORE
 
 config SERIAL_MSM_GENI_CONSOLE_DEFAULT_ENABLED
 	bool "Enable MSM on-chip GENI serial port for kernel console usage"

--- a/include/sound/compress_driver.h
+++ b/include/sound/compress_driver.h
@@ -70,6 +70,7 @@ struct snd_compr_runtime {
  * @metadata_set: metadata set flag, true when set
  * @next_track: has userspace signal next track transition, true when set
  * @partial_drain: undergoing partial_drain for stream, true when set
+ * @pause_in_draining: paused during draining state, true when set
  * @private_data: pointer to DSP private data
  * @dma_buffer: allocated buffer if any
  */
@@ -83,6 +84,7 @@ struct snd_compr_stream {
 	bool metadata_set;
 	bool next_track;
 	bool partial_drain;
+	bool pause_in_draining;
 	void *private_data;
 	struct snd_dma_buffer dma_buffer;
 
@@ -149,6 +151,7 @@ struct snd_compr_ops {
  * @direction: Playback or capture direction
  * @lock: device lock
  * @device: device id
+ * @use_pause_in_draining: allow pause in draining, true when set
  */
 struct snd_compr {
 	const char *name;
@@ -159,6 +162,7 @@ struct snd_compr {
 	unsigned int direction;
 	struct mutex lock;
 	int device;
+	bool use_pause_in_draining;
 #ifdef CONFIG_SND_VERBOSE_PROCFS
 	/* private: */
 	char id[64];
@@ -173,6 +177,18 @@ int snd_compress_register(struct snd_compr *device);
 int snd_compress_deregister(struct snd_compr *device);
 int snd_compress_new(struct snd_card *card, int device,
 			int type, const char *id, struct snd_compr *compr);
+
+/**
+ * snd_compr_use_pause_in_draining - Allow pause and resume in draining state
+ * @substream: compress substream to set
+ *
+ * Allow pause and resume in draining state.
+ * Only HW driver supports this transition can call this API.
+ */
+static inline void snd_compr_use_pause_in_draining(struct snd_compr_stream *substream)
+{
+	substream->device->use_pause_in_draining = true;
+}
 
 /* dsp driver callback apis
  * For playback: driver should call snd_compress_fragment_elapsed() to let the

--- a/include/sound/pcm.h
+++ b/include/sound/pcm.h
@@ -1207,11 +1207,48 @@ void snd_pcm_lib_preallocate_pages_for_all(struct snd_pcm *pcm,
 int snd_pcm_lib_malloc_pages(struct snd_pcm_substream *substream, size_t size);
 int snd_pcm_lib_free_pages(struct snd_pcm_substream *substream);
 
-void snd_pcm_set_managed_buffer(struct snd_pcm_substream *substream, int type,
-				struct device *data, size_t size, size_t max);
-void snd_pcm_set_managed_buffer_all(struct snd_pcm *pcm, int type,
-				    struct device *data,
-				    size_t size, size_t max);
+int snd_pcm_set_managed_buffer(struct snd_pcm_substream *substream, int type,
+			       struct device *data, size_t size, size_t max);
+int snd_pcm_set_managed_buffer_all(struct snd_pcm *pcm, int type,
+				   struct device *data,
+				   size_t size, size_t max);
+
+/**
+ * snd_pcm_set_fixed_buffer - Preallocate and set up the fixed size PCM buffer
+ * @substream: the pcm substream instance
+ * @type: DMA type (SNDRV_DMA_TYPE_*)
+ * @data: DMA type dependent data
+ * @size: the requested pre-allocation size in bytes
+ *
+ * This is a variant of snd_pcm_set_managed_buffer(), but this pre-allocates
+ * only the given sized buffer and doesn't allow re-allocation nor dynamic
+ * allocation of a larger buffer unlike the standard one.
+ * The function may return -ENOMEM error, hence the caller must check it.
+ */
+static inline int __must_check
+snd_pcm_set_fixed_buffer(struct snd_pcm_substream *substream, int type,
+				 struct device *data, size_t size)
+{
+	return snd_pcm_set_managed_buffer(substream, type, data, size, 0);
+}
+
+/**
+ * snd_pcm_set_fixed_buffer_all - Preallocate and set up the fixed size PCM buffer
+ * @pcm: the pcm instance
+ * @type: DMA type (SNDRV_DMA_TYPE_*)
+ * @data: DMA type dependent data
+ * @size: the requested pre-allocation size in bytes
+ *
+ * Apply the set up of the fixed buffer via snd_pcm_set_fixed_buffer() for
+ * all substream.  If any of allocation fails, it returns -ENOMEM, hence the
+ * caller must check the return value.
+ */
+static inline int __must_check
+snd_pcm_set_fixed_buffer_all(struct snd_pcm *pcm, int type,
+			     struct device *data, size_t size)
+{
+	return snd_pcm_set_managed_buffer_all(pcm, type, data, size, 0);
+}
 
 int _snd_pcm_lib_alloc_vmalloc_buffer(struct snd_pcm_substream *substream,
 				      size_t size, gfp_t gfp_flags);

--- a/sound/core/compress_offload.c
+++ b/sound/core/compress_offload.c
@@ -727,11 +727,22 @@ static int snd_compr_pause(struct snd_compr_stream *stream)
 		return retval;
 	}
 
-	if (stream->runtime->state != SNDRV_PCM_STATE_RUNNING)
+	switch (stream->runtime->state) {
+	case SNDRV_PCM_STATE_RUNNING:
+		retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_PUSH);
+		if (!retval)
+			stream->runtime->state = SNDRV_PCM_STATE_PAUSED;
+		break;
+	case SNDRV_PCM_STATE_DRAINING:
+		if (!stream->device->use_pause_in_draining)
+			return -EPERM;
+		retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_PUSH);
+		if (!retval)
+			stream->pause_in_draining = true;
+		break;
+	default:
 		return -EPERM;
-	retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_PUSH);
-	if (!retval)
-		stream->runtime->state = SNDRV_PCM_STATE_PAUSED;
+	}
 	return retval;
 }
 
@@ -747,11 +758,22 @@ static int snd_compr_resume(struct snd_compr_stream *stream)
 	if (use_pause_in_drain && stream->runtime->state == SNDRV_PCM_STATE_DRAINING)
 		return stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_RELEASE);
 
-	if (stream->runtime->state != SNDRV_PCM_STATE_PAUSED)
+	switch (stream->runtime->state) {
+	case SNDRV_PCM_STATE_PAUSED:
+		retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_RELEASE);
+		if (!retval)
+			stream->runtime->state = SNDRV_PCM_STATE_RUNNING;
+		break;
+	case SNDRV_PCM_STATE_DRAINING:
+		if (!stream->pause_in_draining)
+			return -EPERM;
+		retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_RELEASE);
+		if (!retval)
+			stream->pause_in_draining = false;
+		break;
+	default:
 		return -EPERM;
-	retval = stream->ops->trigger(stream, SNDRV_PCM_TRIGGER_PAUSE_RELEASE);
-	if (!retval)
-		stream->runtime->state = SNDRV_PCM_STATE_RUNNING;
+	}
 	return retval;
 }
 
@@ -794,6 +816,7 @@ static int snd_compr_stop(struct snd_compr_stream *stream)
 		/* clear flags and stop any drain wait */
 		stream->partial_drain = false;
 		stream->metadata_set = false;
+		stream->pause_in_draining = false;
 		snd_compr_drain_notify(stream);
 		stream->runtime->total_bytes_available = 0;
 		stream->runtime->total_bytes_transferred = 0;

--- a/sound/core/pcm_memory.c
+++ b/sound/core/pcm_memory.c
@@ -95,7 +95,8 @@ static void do_free_pages(struct snd_card *card, struct snd_dma_buffer *dmab)
  *
  * the minimum size is snd_minimum_buffer.  it should be power of 2.
  */
-static int preallocate_pcm_pages(struct snd_pcm_substream *substream, size_t size)
+static int preallocate_pcm_pages(struct snd_pcm_substream *substream,
+				 size_t size, bool no_fallback)
 {
 	struct snd_dma_buffer *dmab = &substream->dma_buffer;
 	struct snd_card *card = substream->pcm->card;
@@ -107,6 +108,8 @@ static int preallocate_pcm_pages(struct snd_pcm_substream *substream, size_t siz
 				     size, dmab);
 		if (err != -ENOMEM)
 			return err;
+		if (no_fallback)
+			break;
 		size >>= 1;
 	} while (size >= snd_minimum_buffer);
 	dmab->bytes = 0; /* tell error */
@@ -114,7 +117,7 @@ static int preallocate_pcm_pages(struct snd_pcm_substream *substream, size_t siz
 		substream->pcm->card->number, substream->pcm->device,
 		substream->stream ? 'c' : 'p', substream->number,
 		substream->pcm->name, orig_size);
-	return 0;
+	return -ENOMEM;
 }
 
 /*
@@ -256,18 +259,31 @@ static inline void preallocate_info_init(struct snd_pcm_substream *substream)
 /*
  * pre-allocate the buffer and create a proc file for the substream
  */
-static void preallocate_pages(struct snd_pcm_substream *substream,
+static int preallocate_pages(struct snd_pcm_substream *substream,
 			      int type, struct device *data,
 			      size_t size, size_t max, bool managed)
 {
+	int err;
+
 	if (snd_BUG_ON(substream->dma_buffer.dev.type))
-		return;
+		return -EINVAL;
 
 	substream->dma_buffer.dev.type = type;
 	substream->dma_buffer.dev.dev = data;
 
-	if (size > 0 && preallocate_dma && substream->number < maximum_substreams)
-		preallocate_pcm_pages(substream, size);
+	if (size > 0) {
+		if (!max) {
+			/* no fallback, only also inform -ENOMEM */
+			err = preallocate_pcm_pages(substream, size, true);
+			if (err < 0)
+				return err;
+		} else if (preallocate_dma &&
+			   substream->number < maximum_substreams) {
+			err = preallocate_pcm_pages(substream, size, false);
+			if (err < 0 && err != -ENOMEM)
+				return err;
+		}
+	}
 
 	if (substream->dma_buffer.bytes > 0)
 		substream->buffer_bytes_max = substream->dma_buffer.bytes;
@@ -276,20 +292,26 @@ static void preallocate_pages(struct snd_pcm_substream *substream,
 		preallocate_info_init(substream);
 	if (managed)
 		substream->managed_buffer_alloc = 1;
+	return 0;
 }
 
-static void preallocate_pages_for_all(struct snd_pcm *pcm, int type,
+static int preallocate_pages_for_all(struct snd_pcm *pcm, int type,
 				      void *data, size_t size, size_t max,
 				      bool managed)
 {
 	struct snd_pcm_substream *substream;
-	int stream;
+	int stream, err;
 
-	for (stream = 0; stream < 2; stream++)
+	for (stream = 0; stream < 2; stream++) {
 		for (substream = pcm->streams[stream].substream; substream;
-		     substream = substream->next)
-			preallocate_pages(substream, type, data, size, max,
+		     substream = substream->next) {
+			err = preallocate_pages(substream, type, data, size, max,
 					  managed);
+			if (err < 0)
+				return err;
+		}
+	}
+	return 0;
 }
 
 /**
@@ -346,11 +368,22 @@ EXPORT_SYMBOL(snd_pcm_lib_preallocate_pages_for_all);
  * When a buffer is actually allocated before the PCM hw_params call, it
  * turns on the runtime buffer_changed flag for drivers changing their h/w
  * parameters accordingly.
+ *
+ * When @size is non-zero and @max is zero, this tries to allocate for only
+ * the exact buffer size without fallback, and may return -ENOMEM.
+ * Otherwise, the function tries to allocate smaller chunks if the allocation
+ * fails.  This is the behavior of snd_pcm_set_fixed_buffer().
+ *
+ * When both @size and @max are zero, the function only sets up the buffer
+ * for later dynamic allocations. It's used typically for buffers with
+ * SNDRV_DMA_TYPE_VMALLOC type.
+ *
+ * Upon successful buffer allocation and setup, the function returns 0.
  */
-void snd_pcm_set_managed_buffer(struct snd_pcm_substream *substream, int type,
+int snd_pcm_set_managed_buffer(struct snd_pcm_substream *substream, int type,
 				struct device *data, size_t size, size_t max)
 {
-	preallocate_pages(substream, type, data, size, max, true);
+	return preallocate_pages(substream, type, data, size, max, true);
 }
 EXPORT_SYMBOL(snd_pcm_set_managed_buffer);
 
@@ -366,11 +399,11 @@ EXPORT_SYMBOL(snd_pcm_set_managed_buffer);
  * Do pre-allocation to all substreams of the given pcm for the specified DMA
  * type and size, and set the managed_buffer_alloc flag to each substream.
  */
-void snd_pcm_set_managed_buffer_all(struct snd_pcm *pcm, int type,
-				    struct device *data,
-				    size_t size, size_t max)
+int snd_pcm_set_managed_buffer_all(struct snd_pcm *pcm, int type,
+				   struct device *data,
+				   size_t size, size_t max)
 {
-	preallocate_pages_for_all(pcm, type, data, size, max, true);
+	return preallocate_pages_for_all(pcm, type, data, size, max, true);
 }
 EXPORT_SYMBOL(snd_pcm_set_managed_buffer_all);
 
@@ -434,6 +467,9 @@ int snd_pcm_lib_malloc_pages(struct snd_pcm_substream *substream, size_t size)
 	    substream->dma_buffer.bytes >= size) {
 		dmab = &substream->dma_buffer; /* use the pre-allocated buffer */
 	} else {
+		/* dma_max=0 means the fixed size preallocation */
+		if (substream->dma_buffer.area && !substream->dma_max)
+			return -ENOMEM;
 		dmab = kzalloc(sizeof(*dmab), GFP_KERNEL);
 		if (! dmab)
 			return -ENOMEM;


### PR DESCRIPTION
This PR provides audio support for SoC Blair and Murray platform.
Unfortunately, due to incompatibility with the ADSP firmware supplied with our devices,
we are forced to switch back to the legacy Elite audio framework.

The change includes the full set of modifications necessary for the proper functioning of
the audio subsystem. It also contains fixes for DSP/modem firmware initialization, restart
reasons, Wi-Fi fix, as well as a snapshot of the fingerprint driver.

The remaining part of the patch will be submitted to the techpack audio repository.