### PR TITLE
[1.0.r1] dts: somc: columbia: Add OIS VDD to camera sensor0 node

### DIFF
--- a/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
+++ b/arch/arm64/boot/dts/qcom/somc-columbia-camera-pdx246.dtsi
@@ -52,9 +52,6 @@
 		rgltr-min-voltage = <2800000>;
 		rgltr-max-voltage = <2800000>;
 		rgltr-load-current = <0>;
-		pinctrl-names = "cam_default", "cam_suspend";
-		pinctrl-0 = <&cam_ois_vdd_active>;
-		pinctrl-1 = <&cam_ois_vdd_suspend>;
 		status = "ok";
 	};
 
@@ -109,13 +106,14 @@
 		rgltr-load-current = <0 0 0 0>;
 		gpio-no-mux = <0>;
 		pinctrl-names = "cam_default", "cam_suspend";
-		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0>;
-		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0>;
-		gpios = <&tlmm 39 0>, <&tlmm 44 0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0 &cam_ois_vdd_active>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0 &cam_ois_vdd_suspend>;
+		gpios = <&tlmm 39 0>, <&tlmm 44 0>, <&tlmm 43 0>;
 		gpio-reset = <1>;
-		gpio-req-tbl-num = <0 1>;
-		gpio-req-tbl-flags = <1 0>;
-		gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0";
+		gpio-standby = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK0", "CAM_RESET0", "CAM_OIS_VDD0";
 		cci-master = <CCI_MASTER_0>;
 		clocks = <&camcc CAM_CC_MCLK0_CLK>;
 		clock-names = "cam_clk";


### PR DESCRIPTION
OIS VDD GPIO must be handled by a sensor device
for successful I2C communication.

Test: AOSP camera app open, sensor 0 works, image taken