### PR TITLE
[1.0.r1] Revert UAPI changes for Elite audio HAL

### DIFF
--- a/include/uapi/sound/compress_params.h
+++ b/include/uapi/sound/compress_params.h
@@ -82,12 +82,7 @@
 #define SND_AUDIOCODEC_BESPOKE               ((__u32) 0x0000000E)
 #define SND_AUDIOCODEC_ALAC                  ((__u32) 0x0000000F)
 #define SND_AUDIOCODEC_APE                   ((__u32) 0x00000010)
-#define SND_AUDIOCODEC_TRUEHD                ((__u32) 0x00001001)
-#define SND_AUDIOCODEC_MP2                   ((__u32) 0x00001006)
-#define SND_AUDIOCODEC_AC3                   ((__u32) 0x00001008)
-#define SND_AUDIOCODEC_DTS                   ((__u32) 0x0000100A)
-#define SND_AUDIOCODEC_EAC3                  ((__u32) 0x0000100B)
-#define SND_AUDIOCODEC_MAX                   SND_AUDIOCODEC_EAC3
+#define SND_AUDIOCODEC_MAX                   SND_AUDIOCODEC_APE
 
 /*
  * Profile and modes are listed with bit masks. This allows for a

--- a/include/uapi/sound/compress_params.h
+++ b/include/uapi/sound/compress_params.h
@@ -60,11 +60,6 @@
 #define MAX_NUM_BITRATES 32
 #define MAX_NUM_SAMPLE_RATES 32
 
-/* Timestamp flag */
-/* Bit-0 - 1 : Enable Timestamp mode */
-/* Bit-0 - 0 : Disable Timestamp mode */
-#define COMPRESSED_TIMESTAMP_FLAG 0x0001
-
 /* Codecs are listed linearly to allow for extensibility */
 #define SND_AUDIOCODEC_PCM                   ((__u32) 0x00000001)
 #define SND_AUDIOCODEC_MP3                   ((__u32) 0x00000002)
@@ -450,23 +445,7 @@ struct snd_codec {
 	__u32 format;
 	__u32 align;
 	union snd_codec_options options;
-	__u32 flags;
-	__u32 reserved[2];
+	__u32 reserved[3];
 } __attribute__((packed, aligned(4)));
-
-/** struct snd_codec_metadata
- * @length: Length of the encoded buffer.
- * @offset: Offset from the buffer address to the first byte of the first
- *		encoded frame. All encoded frames are consecutive starting
- *		from this offset.
- * @timestamp: Session time in microseconds of the first sample in the buffer.
- * @reserved: Reserved for future use.
- */
-struct snd_codec_metadata {
-	__u32 length;
-	__u32 offset;
-	__u64 timestamp;
-	__u32 reserved[4];
-};
 
 #endif


### PR DESCRIPTION
Revert PR https://github.com/sonyxperiadev/kernel/pull/2632

The headers required for Audio HAL require way more changes to support
all the features. Instead of deeply modifying the original headers, export
headers from techpack-audio as it was done previously.