### PR TITLE
[2.0.r1] SoC Waipio changes for camera framework

### DIFF
--- a/arch/arm64/boot/dts/qcom/waipio-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/waipio-camera.dtsi
@@ -2493,10 +2493,10 @@
 
 	qcom,cam-icp {
 		compatible = "qcom,cam-icp";
-		compat-hw-name = "qcom,lx7",
+		compat-hw-name = "qcom,icp",
 			"qcom,ipe0",
 			"qcom,bps";
-		num-lx7 = <1>;
+		num-icp = <1>;
 		num-ipe = <1>;
 		num-bps = <1>;
 		status = "ok";
@@ -2505,15 +2505,16 @@
 		ipe_bps_pc_en;
 	};
 
-	cam_lx7: qcom,lx7 {
+	cam_icp: qcom,icp {
 		cell-index = <0>;
-		compatible = "qcom,cam-lx7";
+		compatible = "qcom,cam-icp_v2";
+		icp-version = <0x0200>;
 		reg = <0xac01000 0x400>,
 			<0xac01800 0x400>,
 			<0x0ac04000 0x1000>;
-		reg-names = "lx7_csr", "lx7_cirq", "lx7_wd0";
+		reg-names = "icp_csr", "icp_cirq", "icp_wd0";
 		reg-cam-base = <0x1000 0x1800 0x4000>;
-		interrupt-names = "lx7";
+		interrupt-names = "icp";
 		interrupts = <GIC_SPI 463 IRQ_TYPE_EDGE_RISING>;
 		regulator-names = "gdsc";
 		gdsc-supply = <&cam_cc_titan_top_gdsc>;

--- a/arch/arm64/boot/dts/qcom/waipio-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/waipio-camera.dtsi
@@ -2637,10 +2637,11 @@
 
 	cam_jpeg_enc: qcom,jpegenc@ac2a000 {
 		cell-index = <0>;
-		compatible = "qcom,cam_jpeg_enc";
-		reg-names = "jpege_hw";
-		reg = <0xac2a000 0x1000>;
-		reg-cam-base = <0x2a000>;
+		compatible = "qcom,cam_jpeg_enc_680";
+		reg-names = "jpege_hw", "cam_camnoc";
+		reg = <0xac2a000 0x1000>,
+			<0x0ac19000 0x9000>;
+		reg-cam-base = <0x2a000 0x19000>;
 		interrupt-names = "jpeg";
 		interrupts = <GIC_SPI 474 IRQ_TYPE_EDGE_RISING>;
 		regulator-names = "gdsc";
@@ -2664,10 +2665,11 @@
 
 	cam_jpeg_dma: qcom,jpegdma@ac2b000 {
 		cell-index = <0>;
-		compatible = "qcom,cam_jpeg_dma";
-		reg-names = "jpegdma_hw";
-		reg = <0xac2b000 0x1000>;
-		reg-cam-base = <0x2b000>;
+		compatible = "qcom,cam_jpeg_dma_680";
+		reg-names = "jpegdma_hw", "cam_camnoc";
+		reg = <0xac2b000 0x1000>,
+			<0x0ac19000 0x9000>;
+		reg-cam-base = <0x2b000 0x19000>;
 		interrupt-names = "jpegdma";
 		interrupts = <GIC_SPI 475 IRQ_TYPE_EDGE_RISING>;
 		regulator-names = "gdsc";


### PR DESCRIPTION
The patch contains a set of changes required to work with the current
version of the camera framework on the SoC Waipio.
Sensor configuration for the SoMС Nagara will arrive in the next patch.