### PR TITLE
[2.0.r1] dts: qcom: waipio: Fix sensors PDR location

### DIFF
--- a/arch/arm64/boot/dts/qcom/waipio.dtsi
+++ b/arch/arm64/boot/dts/qcom/waipio.dtsi
@@ -2504,7 +2504,7 @@
 		compatible = "qcom,msm-fastrpc-compute";
 		qcom,adsp-remoteheap-vmid = <22 37>;
 		qcom,fastrpc-adsp-audio-pdr;
-		qcom,fastrpc-adsp-sensors-pdr;
+		qcom,fastrpc-slpi-sensors-pdr;
 		qcom,rpc-latency-us = <235>;
 		qcom,fastrpc-gids = <2908>;
 		qcom,qos-cores = <0 1 2 3>;


### PR DESCRIPTION
For Waipio target sensors PDR is running on SLPI.

Fixes sensors on Nagara platform.