### PR TITLE
[9.16.r1] dts: somc: Zambezi: Restore default qupv3_se8_i2c_sleep drive-strength

### DIFF
--- a/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
+++ b/arch/arm64/boot/dts/somc/blair-zambezi-common.dtsi
@@ -192,12 +192,6 @@
 	};
 };
 
-&qupv3_se8_i2c_sleep {
-	config {
-		drive-strength = <0>;
-	};
-};
-
 &qupv3_se0_i2c {
 	nq@28 {
 		status = "disabled";


### PR DESCRIPTION
Remove drive-strength=0 for GPIO pins 19 and 20 on SONY Xperia 10 V, which caused pinctrl configuration failures:
 \- blair-pinctrl 400000.pinctrl: config 9: ffffffff is invalid
 \- blair-pinctrl 400000.pinctrl: pin_config_group_set op failed for group 19
 \- i2c_geni 4c88000.i2c: Error applying setting, reverse things back

Using drive-strength=2 consistently resolves these issues.