### PR TITLE
[2.0.r1] msm: mhi_dev: Fix incorrect logging level in mhi_dev_net_log

### DIFF
--- a/drivers/platform/msm/mhi_dev/mhi_dev_net.c
+++ b/drivers/platform/msm/mhi_dev/mhi_dev_net.c
@@ -791,9 +791,9 @@ static void mhi_dev_net_state_cb(struct mhi_dev_client_cb_data *cb_data)
 			mhi_client->out_chan);
 		return;
 	}
-	mhi_dev_net_log(mhi_client->vf_id, MHI_MSG_VERBOSE, "IN ch_id::%d, state :%d\n",
+	mhi_dev_net_log(mhi_client->vf_id, MHI_VERBOSE, "IN ch_id::%d, state :%d\n",
 			mhi_client->in_chan, info_in_ch);
-	mhi_dev_net_log(mhi_client->vf_id, MHI_MSG_VERBOSE, "OUT ch_id:%d, state :%d\n",
+	mhi_dev_net_log(mhi_client->vf_id, MHI_VERBOSE, "OUT ch_id:%d, state :%d\n",
 			mhi_client->out_chan, info_out_ch);
 	if (info_in_ch == MHI_STATE_CONNECTED &&
 		info_out_ch == MHI_STATE_CONNECTED) {


### PR DESCRIPTION
Members of enum mhi_dev_net_dbg_lvl should be used as logging param
in mhi_dev_net_log. With warnings enabled, get the below warning -
comparison between 'enum mhi_msg_level' and 'enum mhi_dev_net_dbg_lvl'.