### PR TITLE
[4.0.r1] SoC Parrot DTS compilation workaround + BPF compilation fix

### DIFF
--- a/arch/arm64/boot/dts/vendor/qcom/camera/parrot-camera.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/camera/parrot-camera.dtsi
@@ -5,6 +5,11 @@
 
 #include <dt-bindings/msm/msm-camera.h>
 
+/* Feature support bit positions in feature fuse register */
+#define CAM_CPAS_SHDR_MFHDR_ENABLE	23
+/* Group name for common clock source */
+#define CAM_COMMON_TFE_SRC_CLK		1
+
 &tlmm {
 	cci_sda0_active: cci_sda0_active {
 		mux {

--- a/tools/lib/bpf/libbpf.c
+++ b/tools/lib/bpf/libbpf.c
@@ -11237,7 +11237,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
 		if (!search_paths[i])
 			continue;
 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
-			char *next_path;
+			const char *next_path;
 			int seg_len;
 
 			if (s[0] == ':')


### PR DESCRIPTION
The current camera driver does not have these features, and
it seems that CLO decided to use an old driver ported from
the 5.10 kernel for the SoC Parrot. Therefore, to fix the
compilation issue until we determine which driver version
we will use, temporarily define these constants here.